### PR TITLE
Phase 115: first tests for the untested team surfaces, and the defects they found

### DIFF
--- a/flutter/PHASE_115_NOTES.md
+++ b/flutter/PHASE_115_NOTES.md
@@ -436,7 +436,140 @@ files are Lane B's.
 `flutter test` — **1860 pass**, against 1801 at the branch base: exactly the 59
 new tests, no regressions.
 
-## 13. Mutation-testing this lane's own tests
+## 13. The second audit pass, and the four defects this phase itself introduced
+
+Phase 110's lesson — an audit of the Kotlin ground truth does not audit the
+implementation — earned its keep. The second pass, pointed at this lane's own
+finished diff while it was green, found **four defects the phase introduced**
+and **two tests passing for the wrong reason**. All six are fixed below, each
+demonstrated failing first.
+
+### The four introduced defects
+
+1. **`respond(accept: true)` could strand an accepted join request. Data
+   loss, and mine.** `_userId()` was the one session read placed *after* its
+   own local write: `respondToRequest` has already converted the request row
+   into a `membership` with `isUpdated = true` by then. Awaiting `.future`
+   made that line able to **reject**, where the `.valueOrNull` it replaced
+   could only be null — so a rejecting session threw past the enqueue, and the
+   outbox is the only upload route (`TeamDao` has no pending sweep,
+   `TeamsUploader` no rescan). The accepted member existed on the leader's
+   device and nowhere else, permanently, compounded by §8.1's shadowing. The
+   user is now resolved *before* the local write, as the other four actions
+   already did.
+
+   **The general shape: `await`ing a future where a synchronous read used to
+   sit adds a throw to a code path that could not throw before.** Every such
+   swap needs its position relative to the writes re-examined, not just its
+   `try` boundary.
+
+2. **Three actions threw where they used to return `false`.** The doc comment
+   this phase wrote stated a caller contract — "callers keep the await inside
+   their own `try`" — and **not one of the five call sites satisfied it**:
+   `team_members_screen`'s `_handleMemberAction` shows its failure snackbar
+   off the returned `false`, and both the join button and the leave dialog are
+   fire-and-forget `onPressed`s. So the fix lost the user's error message and
+   escaped as an uncaught async error: strictly worse than what it replaced.
+   `_session()` now swallows the rejection and returns null, which resolves
+   the session properly *and* keeps every action's existing contract.
+
+   **A doc comment asserting a caller contract is worth nothing until the
+   callers are checked.** Writing one felt like discharging the obligation.
+
+3. **Double-tapping Send posted the comment twice.** Moving `_controller.clear()`
+   after the await — so a failed post leaves the text to retry — also let the
+   text survive the in-flight write, and the send button is never disabled.
+   Before the move, the second tap was a no-op *by accident*. A `_sending`
+   guard now holds both properties deliberately.
+
+4. **The null-`_rev` guard covered three of the four tombstones in the file.**
+   `TeamResourceActions.remove` enqueues the same
+   `{_id, _rev, _deleted: true}` payload four functions below the new helper
+   and did not use it. Worse, §6's corrected add gate *widened* the reach:
+   giving ordinary members the add FAB makes "link a resource offline, unlink
+   before the drain" a path many more users can take. **A fix that widens who
+   can reach a code path inherits that path's latent defects.**
+
+   Reported, not fixed: Kotlin's `removeResourceLink`
+   (`TeamsRepositoryImpl.kt:707-715`) does not delete or tombstone at all — it
+   blanks `resourceId = ""` and sets `updated = true`. That is a deeper
+   divergence than the guard, and it needs the §8.1 upload sweep to exist
+   first.
+
+### Corrections to claims this phase made
+
+- **The tie-break rationale was overstated.** Both the comment and the notes
+  claimed ties "could swap rank between two loads of unchanged data". They
+  could not, for a team under 32 members: Dart's `List.sort` uses a *stable*
+  insertion sort below that threshold, and `watchMembers` orders by
+  `userId ASC`, so the input order was already deterministic. `toSet()` is a
+  `LinkedHashSet` and preserves insertion order too, so the `Set` was a red
+  herring. The total order is kept — it is right for any size, and ranking
+  ties by name beats ranking them by an opaque id — but it is now documented
+  as **a deliberate choice against no specification**, not a defect fix.
+- **`skipLoadingOnReload` fixes the flash, not the work.** §4 named the defect
+  as blanking the list *and* re-running `watchCatalog` + `memberStatuses` +
+  `recentVisitCounts` per keystroke. The flag only suppresses the loading
+  branch; all three queries still run on every character, where Kotlin
+  debounces 300 ms and filters in memory. **Half of that defect is still
+  open** — a debounce on `teamsSearchProvider` is the missing piece.
+- **Two comments cited a document that does not contain the claim.** The
+  team-finances surplus is recorded in `CLAUDE.md`'s Phase 99 prose, *not* in
+  `docs/kotlin-to-flutter-migration.md`, whose deviations list has no such
+  entry. Corrected at the line and here.
+- **The leaderboard's class docs named Kotlin files that do not exist**
+  ("Port of `model/TeamLeaderboardEntry.kt`"). §3 says this correctly; the
+  source comments contradicted it, which is the version a reader finds first.
+  Now both say there is no counterpart.
+
+### One dead assertion, and what it means
+
+`team_detail_gates_test.dart` asserted `find.text('Team resources')` is absent.
+The label is `l10n.teamResources` = **"Resources"**; "Team courses" is the one
+that carries the prefix. So that negative could never match and would have
+passed with the gate removed. The gate was still pinned by the sibling
+assertions, so this was a dead line rather than a hole — but it is exactly the
+trap the brief warned about, and mutation testing found it only because a
+*different* assertion caught the mutation first. **A negative assertion that
+passes tells you nothing until you have seen it fail.**
+
+### Verified correct, so recorded rather than re-litigated
+
+- `canView = membership != null || team.isPublic` matches `buildPages` on
+  every cell of the M/P/E truth table except the one pre-existing
+  `member && !enterprise` finances surplus. Kotlin's `isMyTeam` is
+  caller-supplied, but every entry point either derives it from the same
+  membership row or hard-codes `true` on a path that already implies
+  membership — so deriving it breaks nothing, and is *better* on the dashboard
+  path, where Kotlin's `refreshTeamDetails` re-reads a stale argument.
+- `skipLoadingOnReload` genuinely does not suppress the first load
+  (`isReloading` requires `hasValue || hasError`) and does not suppress errors.
+- **CLAUDE.md's "Phase 75 harness trap" is stale for the current graph.**
+  `teamsRepositoryProvider` reaches `planetApiProvider` and
+  `appDatabaseProvider` — **not** `planetPrefsProvider`. The live trap is
+  `appDatabaseProvider → AppDatabase.open()`, which `wrapScreen` already
+  redirects to `AppDatabase.memory()`. So `team_courses_screen`'s new
+  `teamProvider` watch is safe, and the three tests that do not override it
+  get `creatorId == null` from a real empty query — the right answer for the
+  right reason.
+- `_logVisitOnce` still drops the visit for the whole mount when the user is
+  *null*, and that is parity: `createTeamLog` does nothing for a null
+  `getUserModel()` either. Only the rejecting-session case was the defect.
+
+### Still open, reported not fixed
+
+- **`voices_screen.dart:301-304` was not migrated to `initialFor`**, so the
+  duplicate the helper exists to eliminate survives. It is byte-identical and
+  therefore harmless, and `lib/ui/voices/` is outside this lane's file set —
+  unlike `team_members_screen`, which was both broken *and* in
+  `lib/ui/teams/`, and so was fixed. That is the line: cross a boundary for a
+  defect, not for tidiness.
+- **A search debounce**, per the correction above.
+- One cosmetic consequence of using the shared `displayName`: two members with
+  no name at all now both render "myPlanet learner" where they previously
+  showed distinct user ids.
+
+## 14. Mutation-testing this lane's own tests
 
 Per the brief's "the button looks usable is not the button works", every gate
 this phase added was mutated away and the suite re-run, to prove the tests fail
@@ -449,8 +582,19 @@ for the reason they claim:
 | the last-member gate removed | 1 |
 | `onPressed` calls `leave` directly, as before | 3 (dialog appears, No, Yes) |
 | `_session()` back to `.valueOrNull` | **0 — see below** |
+| `_loadToken` guard removed | **0 — see §13** |
+| `canView = true`, after the dead assertion was fixed | 2 (unchanged) |
+| the empty-creator-id sentinel removed | 1 |
 
-That last row is the one worth recording. **The four original tombstone tests
+Two rows came back 0, and both mattered.
+
+The `_loadToken` row is in §13: the guard was unobservable because `_period`
+was read *after* every await, so a stale load recomputed with the current
+period and produced the same answer. Capturing the period at load entry — the
+correct semantics anyway — makes the guard load-bearing, and the mutation now
+fails the test that claims to cover it.
+
+The `_session()` row is the one worth recording at length. **The four original tombstone tests
 could not catch a regression of the `_session()` fix**, because each one does
 `await container.read(sessionProvider.future)` before acting — which resolves
 the provider and makes `.valueOrNull` non-null, the very condition the defect

--- a/flutter/PHASE_115_NOTES.md
+++ b/flutter/PHASE_115_NOTES.md
@@ -435,3 +435,38 @@ files are Lane B's.
 `flutter analyze` — no issues.
 `flutter test` — **1860 pass**, against 1801 at the branch base: exactly the 59
 new tests, no regressions.
+
+## 13. Mutation-testing this lane's own tests
+
+Per the brief's "the button looks usable is not the button works", every gate
+this phase added was mutated away and the suite re-run, to prove the tests fail
+for the reason they claim:
+
+| mutation | tests that failed |
+|---|---|
+| `canView = true` | 2 (private team, private enterprise's reports) |
+| `isGuest = false` | 1 (guest not offered membership) |
+| the last-member gate removed | 1 |
+| `onPressed` calls `leave` directly, as before | 3 (dialog appears, No, Yes) |
+| `_session()` back to `.valueOrNull` | **0 — see below** |
+
+That last row is the one worth recording. **The four original tombstone tests
+could not catch a regression of the `_session()` fix**, because each one does
+`await container.read(sessionProvider.future)` before acting — which resolves
+the provider and makes `.valueOrNull` non-null, the very condition the defect
+needs to be absent. The fix was real and the tests passed; they simply were not
+guarding it. A fifth test now drives `leave` against a `_DelayedSessionNotifier`
+without pre-resolving anything, and it does fail under that mutation.
+
+Two general lessons:
+
+- **A test that sets up the happy precondition cannot detect the bug that
+  precondition hides.** Pre-resolving a provider to make a test deterministic is
+  exactly what makes it blind to a read-but-never-watched regression. If the
+  defect is "this code does not resolve X itself", the test must not resolve X
+  either.
+- **Mutation-test the gate, not just the fix.** Four of the five mutations were
+  caught, which is what made the fifth informative. Failing-first evidence
+  proves a test detects the *original* defect; it does not prove the test will
+  detect the defect coming back, because the fix may have changed the test's own
+  setup in the meantime.

--- a/flutter/PHASE_115_NOTES.md
+++ b/flutter/PHASE_115_NOTES.md
@@ -1,0 +1,13 @@
+# Phase 115 — team surfaces: coverage correction and first tests
+
+Lane C. In progress. See the final section for defects found.
+
+## Coverage measurement (correction to the brief)
+
+The brief said `lib/ui/teams/teams_screen.dart` "is referenced by exactly one
+test file — the thinnest coverage-to-size ratio left in the port". Measuring by
+symbol reference rather than filename gives a different answer: **two team files
+are referenced by no test at all**, and the one file that references
+`teams_screen.dart` covers only one of its two screens.
+
+Details to follow.

--- a/flutter/PHASE_115_NOTES.md
+++ b/flutter/PHASE_115_NOTES.md
@@ -1,13 +1,430 @@
-# Phase 115 — team surfaces: coverage correction and first tests
+# Phase 115 — the team surfaces: a coverage correction, first tests, and 23 defects
 
-Lane C. In progress. See the final section for defects found.
+Lane C. **23 defects, every one demonstrated failing on the pre-fix code before
+it was touched** — 30 failing tests across six groups, with the failing-first
+count recorded per group below. 59 new tests in total; the balance pin behaviour
+that was already correct, including two things a plausible "fix" would have
+broken (§4, §8.6).
 
-## Coverage measurement (correction to the brief)
+Two of the 23 are minor by any reading — a label and a surplus menu entry, both
+in §5 — and they are counted rather than quietly dropped so the number means
+what it says.
 
-The brief said `lib/ui/teams/teams_screen.dart` "is referenced by exactly one
-test file — the thinnest coverage-to-size ratio left in the port". Measuring by
-symbol reference rather than filename gives a different answer: **two team files
-are referenced by no test at all**, and the one file that references
-`teams_screen.dart` covers only one of its two screens.
+---
 
-Details to follow.
+## 1. What the coverage actually was (a correction to the brief)
+
+The brief said `lib/ui/teams/teams_screen.dart` "is 404 lines and is referenced
+by exactly **one** test file — the thinnest coverage-to-size ratio left in the
+port". Measuring by **symbol reference** rather than filename (the brief's own
+warning, after the Phase 108 filename heuristic missed 22 chat tests) gives a
+different and worse answer. The reference count was right; the conclusion was
+not.
+
+| file | lines | test files referencing it |
+|---|---|---|
+| `leaderboard/team_leaderboard_screen.dart` | 284 | **0** |
+| `inline_comments.dart` | 220 | **0** |
+| `teams_screen.dart` | 404 | 1 (`team_detail_screen_test.dart`) |
+| every other file in `lib/ui/teams/` | 100–646 | 1–2 |
+
+Two corrections follow.
+
+**Two team files had no test at all**, and neither is `teams_screen.dart`. The
+leaderboard's *calculator* is tested (4 tests, `test/ui/teams/leaderboard/`),
+which is what makes the screen easy to miss: the directory has a test file, just
+not one that touches the 284-line screen beside it.
+
+**And the one file referencing `teams_screen.dart` covers one of its two
+screens.** `teams_screen.dart` holds `TeamsScreen` (the catalog list, lines
+14–149) *and* `TeamDetailScreen` (150–385). `team_detail_screen_test.dart`'s two
+tests are both about `TeamDetailScreen`'s visit logging — nothing touched the
+team list, and nothing touched the detail screen's gates. So the thinnest
+surface was not one file but three screens: `TeamsScreen`, the leaderboard, and
+the comment thread.
+
+This phase covers all three, plus the detail screen's gates.
+
+---
+
+## 2. `inline_comments.dart` — 8 tests, 3 defects
+
+`test/ui/teams/inline_comments_test.dart`. Failing first: **4 of 8**
+(the submit path proves one defect twice).
+
+**An empty author name took the whole thread down.** `_CommentTile` rendered its
+avatar as `(comment.userName ?? '?').characters.first.toUpperCase()`. `??` only
+guards *null*, and `''.characters.first` throws `StateError: No element` — so a
+synced `News` row carrying `"userName": ""` threw out of `build` and took the
+comment thread, and therefore the team-tasks screen hosting it, with it. This is
+the Phase 95 shape exactly (`parts[0][0]` behind a dead `isEmpty` guard), and
+`voices_screen.dart:301-304` already had the correct sibling
+(`trimmed.isEmpty ? '?' : …`) while this file carried the broken copy.
+
+The fix adds `initialFor(String?)` to `lib/ui/components/profile_avatar.dart` —
+the file the port's own rule points at — rather than a fourth local copy. **When
+you need an initial from a bare name string, call `initialFor`; when you have a
+`UserRow`, use `ProfileAvatar` / `displayName`.**
+
+**A comment submitted before the session resolved was silently dropped.**
+`_addComment` read `ref.read(sessionProvider).valueOrNull` on a widget that
+never watches that provider, so the value was null and the `if (user == null)
+return` discarded the comment with no error, no snackbar and no row. This is
+the **fifth** independent instance of the shape CLAUDE.md already records as a
+rule. Fixed by awaiting `sessionProvider.future` **inside** the enclosing `try`,
+because a future can reject where `valueOrNull` could not.
+
+The same fix moves `_controller.clear()` to *after* the write lands, so a failed
+post leaves the text in the field to retry instead of discarding it.
+
+**A failed comment stream read as "nobody has commented."** The branch order was
+`isLoading` → `valueOrNull?.isEmpty == true` → iterate `valueOrNull ?? []`. On an
+error `valueOrNull` is null, so the empty-state line did not show and the loop
+iterated nothing: the expanded thread rendered just its input box, and the
+collapsed header said "0 comments" — affirmatively stating there are none when
+we do not know. A `comments.hasError` branch now shows `commentsUnavailable`.
+
+---
+
+## 3. `leaderboard/team_leaderboard_screen.dart` — 10 tests, 6 defects
+
+`test/ui/teams/leaderboard/team_leaderboard_screen_test.dart`. Failing first:
+**6 of 10**.
+
+Note on the specification: **this screen has no Kotlin counterpart.** There is no
+`ui/teams/leaderboard/` in `app/`, and `grep -rn "Leaderboard" --include=*.kt`
+finds nothing — Phase 73 ported it from the unmerged upstream `14880` branch. So
+these are correctness defects, not parity divergences, and they were found by
+testing rather than by comparison.
+
+1. **The current user was never highlighted.** `_load` read
+   `ref.read(sessionProvider).valueOrNull` and `_load` runs from `initState`, so
+   the value was null on every load, `currentUserId` was null, `isCurrentUser`
+   was false for every row, and the highlight the feature exists for never
+   fired. The **sixth** instance of the shape. Fixed with
+   `await ref.read(sessionProvider.future)`.
+2. **The display name omitted the middle name and was not trimmed.** The screen
+   hand-rolled `[firstName, lastName].join(' ')` falling back to
+   `user.name ?? userId`, where `profile_avatar.dart`'s `displayName` includes
+   `middleName`, trims each part, and falls back past an empty username. A
+   synced `"name": " jane "` with no first or last name rendered as `" jane "` —
+   a visually blank row. Now calls `displayName(user)`.
+3. **The visit stat carried no number.** `_Stat(label: l10n.numberOfVisits)`
+   renders the bare label "Number of visits" as the entire stat, beside two
+   siblings that both read "2/5 courses"/"1/3 surveys". `entry.visitCount` was
+   computed, passed into the entry, and never displayed. `numberOfVisits` is
+   *correct* in `member_detail_screen.dart:123-126`, where a separate `value`
+   sits beside it; here it was the whole stat. New key `visitsCount`.
+4. **A failed load spun forever.** `_load` had no error handling: any throwing
+   dependency escaped, `_loading` stayed true, and the screen sat on an
+   indefinite `CircularProgressIndicator` with no way out and nothing logged.
+   Now a `_failed` flag renders `leaderboardUnavailable`.
+5. **Tied members ranked non-deterministically.** `TeamLeaderboardCalculator`
+   sorted by courses then surveys and stopped. Member ids arrive through a
+   `Set`, and Dart's `List.sort` is not stable, so two members with identical
+   scores — most of a fresh catalog — could swap rank between two loads of
+   unchanged data. A total order (name, then id) now makes the ranking
+   reproducible.
+6. **A stale load could overwrite a fresh one.** Toggling the period starts a
+   second `_load` without cancelling the first. This one is *hardening the error
+   fix required*, not a defect found: `_period` is read after all the awaits, so
+   the late load happened to compute the new period's data. But once `_load`
+   catches, a stale load's `_loading = false` would clear the spinner for the
+   live one. A `_loadToken` generation guard closes both.
+
+One thing deliberately **not** changed: switching to "This month" filters the
+surveys column but not the courses column, because `CourseProgressSummary`
+carries no timestamps — there is no completion date to filter on. That is a data
+limitation, not a fixable gate.
+
+---
+
+## 4. `TeamsScreen` (the catalog list) — 14 tests, 3 defects
+
+`test/ui/teams/teams_screen_test.dart`. Failing first: **3** (the other 11 pin
+existing correct behaviour).
+
+**The search matched the description; Kotlin matches the name only.**
+`TeamViewModel.applyFilters` (`TeamViewModel.kt:112-118`) is
+`teams.filter { it.name?.contains(searchQuery, ignoreCase = true) == true }`.
+The port also tested `row.description`, so typing a word that appears only in a
+team's plan surfaced a team whose name does not contain the query at all.
+
+**The important half of this finding is what was *not* changed.** The obvious
+reading — "another flat `contains` that Phases 96 and 97 replaced with the
+ranked `ResourcesSearchUtils` algorithm for resources and surveys" — is wrong.
+The teams screen genuinely is the flat one: no ranking, no word splitting, no
+accent folding. Adding `text_utils.normalizeText` or startsWith-before-contains
+here would *introduce* a divergence. The port was already right on that axis and
+the tests now pin it so nobody "fixes" it.
+
+The `.trim()` on the query is **kept, deliberately**: Kotlin does not trim, so
+`"Alpha "` there filters to names containing a trailing space and shows nothing.
+That is unhelpful behaviour rather than behaviour worth reproducing, and it is
+recorded at the line.
+
+**Every keystroke replaced the list with a full-screen spinner.**
+`teamsProvider` watches `teamsSearchProvider` and `teamsTypeProvider`, so each
+character tears the provider down and rebuilds it; `AsyncValue.when`'s
+`skipLoadingOnReload` defaults to `false` and explicitly "does not skip loading
+states if triggered by `Ref.watch`". Typing "alpha" therefore blanked the list
+and flashed a centered spinner five times, once per character, re-subscribing
+`watchCatalog` and re-running `memberStatuses` + `recentVisitCounts` each time.
+Kotlin re-filters an in-memory list and never shows a loading state at all.
+`skipLoadingOnReload: true`. The same flash hit every tap of the type segment,
+covered by its own test.
+
+---
+
+## 5. `TeamDetailScreen`'s gates — 13 tests, 6 defects
+
+`test/ui/teams/team_detail_gates_test.dart`. Failing first: **9 of 13**.
+
+Gates in this area have a documented history of being subtly wrong (Phase 99
+found the finance and report screens requiring leadership where Kotlin requires
+plain membership), so every claim below was read out of the Kotlin directly
+rather than taken from the audit that surfaced it.
+
+**A private team's whole contents were open to any visitor.** `buildPages`
+(`TeamDetailFragment.kt:74-92`) branches on `isMyTeam || team?.isPublic == true`:
+a non-member of a non-public team gets exactly **two** pages, Plan/Mission and
+Members. The port's link list was unconditional apart from three entries, so a
+non-member of a private team was offered its task list, its survey list, its
+resource list and its discussion thread. The gate is now
+`canView = membership != null || team.isPublic`, which also closes the
+*other* direction the audit noted: a non-member of a **public** team gets
+Calendar in Kotlin and did not in the port.
+
+**A private enterprise's financial reports were open to non-members.** Kotlin
+puts `ReportsPage` inside the same branch (`:85`). Called out separately from
+the finding above because the payload is financial data.
+
+**A guest was offered membership.** `setupNonMyTeamButtons` (`:255-258`) hides
+the button outright for a `guest…` id, before any of the join wiring runs; the
+list row is hidden for guests too (`TeamsAdapter.kt:102`). The port had no guest
+branch and would enqueue a join request carrying the `guest_` id. Now reads
+`UserMapper.isGuest`, the port's single guest predicate.
+
+**A leader could not leave.** `onPressed: membership.isLeader ? null : …` — the
+Phase 99 shape again, and Phase 99 did not catch this one.
+`setupMyTeamButtons` (`:285-308`) attaches the leave handler with **no leader
+test**, and `markMembershipsForLeave` has none either; the members tab's own
+leave hands leadership to a successor first but still never refuses. Kotlin has
+`isTeamLeader` and pointedly does not use it here — the one place leadership
+changes the affordance is the *list row*, where a leader gets Edit instead of
+Leave.
+
+**Leaving took effect on one tap.** Every Kotlin leave is behind a
+`confirm_exit` Yes/No dialog (`:291-306`, and `TeamFragment.kt:280-287` for the
+list). The port called `leave` straight from `onPressed`, so one mis-tap dropped
+the membership and queued its tombstone. Three tests cover the dialog: that it
+appears, that No leaves the membership alone, and that Yes goes through —
+per the brief's rule that "the button looks usable" is not "the button works".
+
+**The last member was offered a leave button.** `TeamDetailFragment.kt:179-186`
+hides it once `getJoinedMemberCount(teamId) <= 1 && isMyTeam`. A null count now
+still shows the button, because the Kotlin check is async too and only hides on
+arrival.
+
+Two smaller corrections in the same file:
+
+- **The enterprise/team branching**: Courses is no longer offered for an
+  enterprise (`buildPages` swaps `CoursesPage` out for `FinancesPage`, `:84`),
+  and the resources entry is labelled Documents for an enterprise, matching
+  `DocumentsPage`/`ResourcesPage` (`TeamPageConfig.kt:63-69`). The
+  Finances-for-a-plain-team's-members surplus is kept, as
+  `docs/kotlin-to-flutter-migration.md` records it as deliberate.
+- **`memberships[team.teamId]` was dead code.**
+  `getTeamMemberStatuses` (`TeamsRepositoryImpl.kt:562-601`) keys membership on
+  the team document's `_id` alone. The fallback read the *team row's own*
+  `teamId`, which for a root team is null or `''` — and `''` can never be a key
+  because `teamMembershipsProvider` excludes empty ids. It could never resolve,
+  and if it ever had it would have reported a *parent* team's membership for a
+  sub-document. Removed.
+
+**`_logVisitOnce` set its latch before reading an unwatched provider.** The
+seventh instance of the shape, with a twist that makes it worse: `_visitLogged =
+true` is committed *before* the post-frame callback reads the session, so a null
+read dropped the visit for the entire mount with nothing to retry it — and the
+undercounted `team_log` row feeds the catalog sort. Kotlin's `createTeamLog`
+(`:426-441`) awaits its own `getUserModel()`.
+
+---
+
+## 6. The add/remove gates on the destination screens — 10 tests, 3 defects
+
+`test/ui/teams/team_add_remove_gates_test.dart`. Failing first: **5 of 10**.
+
+The port dropped Kotlin's `btnAddDoc` from the detail screen and moved the add
+action onto the destination screens — defensible — but both screens then drove
+*add and remove from one `canManage = isLeader` flag*, and neither gate is
+leadership.
+
+- **`team_resources_screen.dart`**: `TeamResourcesFragment.kt:51-52` is
+  `binding.fabAddResource.isVisible = isMember` — `isMemberFlow`, i.e.
+  `TeamsRepositoryImpl.isMember`, **plain membership** — while remove really is
+  `isTeamLeader` (`:73`). The two gates are genuinely different; the port had
+  one. An ordinary member could not link a resource Kotlin lets them link.
+- **`team_courses_screen.dart`**: Kotlin's add has **no gate in the fragment at
+  all** — it is driven by `btnAddDoc`, shown to any member
+  (`TeamDetailFragment.kt:286-289`). And remove is
+  `canRemove = currentUserId.equals(teamCreator, ignoreCase = true)`
+  (`TeamCoursesFragment.kt:44-46`), where `getTeamCreator` is the team row's
+  `userId` (`TeamsRepositoryImpl.kt:1120-1123`) — the **creator**, not the
+  leader. So the port both offered the unlink to a leader who did not create the
+  team and withheld it from a creator who is not the leader. The case-insensitive
+  comparison has its own test.
+
+`test/ui/team_courses_screen_test.dart`'s "a leader sees the add-course and
+remove buttons" was asserting the defect. It is now "the team creator sees…"
+with the session and `teamProvider` overridden so the user is both.
+
+---
+
+## 7. `TeamMembershipActions` — 4 tests, 2 defects
+
+`test/providers/team_membership_tombstone_test.dart`. Failing first: **3 of 4**.
+
+**A tombstone could be queued with a null `_rev`, failing permanently.**
+`markMembershipsForLeave` (`TeamsRepositoryImpl.kt:1323-1337`) branches on the
+revision: `if (membership._rev.isNullOrBlank())` the row is deleted locally and
+**nothing** is uploaded; only a revision-bearing row becomes a
+`{_id, _rev, _deleted: true}` document. The port enqueued unconditionally, so
+joining a team offline and leaving before the first sync sent `"_rev": null`,
+which CouchDB rejects 4xx — and the outbox's retryable rule is `code >= 500`, so
+the row failed out **permanently**, for a document the server never had. Same
+shape in `removeMember` and in `respond(accept: false)`. Guarded by
+`_serverKnowsRow`, which tests `isNullOrBlank` rather than `== null` (an empty
+string has its own test).
+
+**Every action read the session without watching it.**
+`TeamMembershipActions` is a plain `Provider`, so its `ref` never watches
+`sessionProvider`; `requestToJoin`, `leave`, `removeMember` and `makeLeader` all
+did `ref.read(sessionProvider).valueOrNull` and took a silent `return false`
+when it was null. Instances **eight through eleven** of the shape, and the first
+in a provider rather than a screen — worth noting because the "the router holds
+a `ref.listen`, so it is latent" mitigation is a property of the *screens*, and
+a provider cannot rely on its callers having one. Now `await _session()`.
+
+---
+
+## 8. Found and verified, **not** fixed — outside this lane's file set
+
+Each was read out of the Kotlin and confirmed. None is in
+`lib/ui/teams/`, `lib/providers/teams_provider.dart` or
+`lib/repository/teams_repository*.dart`, so per "one file, one owner" they are
+reported rather than edited.
+
+1. **A team edit never reaches CouchDB, and permanently shadows the server's
+   copy.** `TeamsRepository.updateTeam` sets `isUpdated: Value(true)` and
+   returns. Kotlin's `UploadManager.uploadTeams()` sweeps
+   `TeamDao.getUpdatedTeams()` (`WHERE isUpdated = 1`) on every sync; the port
+   has no sweep — write-back is per-action outbox enqueues — and
+   `TeamsUploader.types` does not include a plain team document. `updateTeam`'s
+   only caller (`team_plan_screen.dart:183-195`) awaits it and pops the dialog.
+   Two silent consequences: the edit never leaves the device, and because
+   `TeamMapper.fromDoc` keeps local values for a flagged row, **every future
+   server-side change to that team's name, description, courses, public flag,
+   services or rules is discarded on every sync from then on.** Needs
+   `lib/repository/teams_uploader.dart` and an outbox upload type. This is the
+   most consequential finding of the round and should be the next phase.
+2. **The member count is not Kotlin's member count.**
+   `TeamDao.countByTeamIdAndDocType` uses `COUNT(DISTINCT userId)`, requires
+   `userId IS NOT NULL`, and joins `users` for existence — a member whose
+   profile has not synced does not count. `TeamDao.watchMemberCount`
+   (`lib/data/local/app_database.dart:581-587`) is a plain `COUNT(id)`. It
+   compounds the last-member leave gate fixed above: the count that protects the
+   last member is now read, but the number is still wrong.
+3. **The catalog's root-team predicate is not Kotlin's.** Kotlin's root test is
+   `teamId IS NULL OR TRIM(teamId) = ''` and never consults `docType`;
+   `TeamDao.watchCatalog` (`app_database.dart:525-535`) uses
+   `t.docType.isNull()`. **A team document that carries `docType` is invisible
+   to the port's catalog entirely**, and the only in-repo evidence about the
+   server's shape — `TeamsRepositoryBulkInsertTransactionTest.kt:55-62`,
+   `CollapsedEntitiesRoundTripTest.kt:174` — builds a root team as
+   `{_id, docType: "team", …}`. Every Dart fixture omits `docType` for teams, so
+   the suite cannot catch it. **Settle this against a live Planet server before
+   the rest**: if team documents do carry `docType`, the team list is empty and
+   everything above is downstream of a screen nobody can populate.
+4. **Creating a team or an enterprise is unreachable.** `TeamFragment.kt:67`
+   wires an `addTeam` FAB to `createTeamAlert(null)` (hidden for guests), and
+   `TeamViewModel.createTeam` rejects a duplicate name via `isTeamNameExists`
+   before `createTeamAndAddMember` writes the team *and* the creator's
+   `isLeader` membership in one go. The port has no FAB, no `createTeam`, and no
+   `teamNameAlreadyExists` key. Duplicate-name validation is missing from the
+   *edit* path too (`team_plan_screen.dart:177-182` checks only for empty).
+5. **The list row has no action column.** `TeamsAdapter.showActionButton`
+   (`:90-146`) gives each row one of edit (leader) / leave (member) / a disabled
+   tinted hourglass (pending request) / join (non-member), hidden for guests,
+   plus a feedback button. The port's row has a chip and a chevron. Join and
+   leave are reachable on the detail screen, but **the "Requested" state is
+   invisible everywhere in the list** — `TeamsRepository.memberStatuses`
+   deliberately drops `hasPendingRequest` — and Edit and Feedback are reachable
+   nowhere. Kotlin's row also shows Created On, Type and Total Visits; the visit
+   count is already fetched by `teamsProvider` to feed the sort and then thrown
+   away.
+6. **`sortTeamsCatalog` uses the unstable `List.sort`** where Kotlin's
+   `sortedWith` is stable (`lib/repository/teams_repository.dart:34` — inside my
+   file set, but the ties are non-member teams with zero recent visits and
+   Kotlin's own base order is unspecified, `getRootTeamsByType` having no
+   `ORDER BY`, so there is no correct order to restore). Left alone
+   deliberately, unlike the leaderboard's, where the displayed *rank* makes
+   reproducibility visible to the user.
+7. **The `teamLeaderboard` route has no pusher.** `lib/ui/router.dart:93,505-512`
+   declares it and nothing navigates to it, so the screen this phase just tested
+   is unreachable in the app. Not a Kotlin divergence — Kotlin has no leaderboard
+   at all — but the detail screen's link list is where an entry would belong, and
+   adding one is a product decision rather than a parity fix.
+
+Also recorded, so nobody "fixes" it: `TeamFragment.showNoResultsMessage` has a
+`no_teams_found_for_search` branch whose `searchQuery` parameter is always `""`
+at its sole call site, so the search-specific message is dead code in Kotlin.
+The port's single `noTeams` matches Kotlin's actual behaviour.
+
+---
+
+## 9. Method, and what the two audit passes cost
+
+Two `parity-auditor` passes at `effort: max`, per Phase 110's lesson that an
+audit of the Kotlin ground truth does not audit the implementation.
+
+The first pass — pointed at the Kotlin — produced the finding list in §5 and §8.
+Its single most useful contribution was a **negative** one: it read
+`TeamViewModel.applyFilters` carefully enough to say that the teams search is
+genuinely flat, and that adding the Phase 96/97 ranked algorithm would be the
+divergence. Without that, "another flat `contains`" was the obvious and wrong
+fix, and this phase would have shipped it.
+
+Per Phase 106, every load-bearing Kotlin claim was re-read at source before
+acting on it — `buildPages`, `setupMyTeamButtons`, `setupNonMyTeamButtons`, the
+member-count gate, `markMembershipsForLeave`, `getTeamCreator`,
+`TeamResourcesFragment`'s two gates. All held.
+
+## 10. Test-harness notes for whoever comes next
+
+- **`SegmentedButton` hides the selected segment's icon** behind a checkmark, so
+  an icon count that includes it is wrong by one.
+- **The detail screen's link list is a `ListView(children: [...])`** — children
+  below the 600px fold are built but never mounted, so `find.text` returns 0 for
+  content that renders fine, and a *negative* assertion then passes for the
+  wrong reason. `scrollUntilVisible` was fragile here; setting
+  `view.physicalSize` to 1000×3000 for the file puts the whole list in frame and
+  makes the negative assertions in §5 mean what they say.
+- **`pumpAndSettle` does not advance a pending `Future.delayed`** if no frame is
+  scheduled — it returns immediately. A test that waits on a deliberately
+  delayed provider needs an explicit `pump(Duration(...))` first.
+- **Re-pumping `wrapScreen` with different overrides does not reliably re-emit a
+  `StreamProvider` override.** Two tests that toggled a gate by re-pumping had to
+  be split into two `testWidgets`; the second half failed for that reason and
+  not for the reason it was written.
+- **`teamsProvider`'s `await for` rethrows into the test zone as well as into
+  the provider**, and the zone report lands after the test body, so
+  `takeException` cannot catch it. Override `teamsProvider` itself to test the
+  screen's error branch.
+
+## 11. Strings
+
+New keys in `app_en.arb` only, each with its `@` placeholder block where it
+takes one: `commentsUnavailable`, `visitsCount` (`{count}`),
+`leaderboardUnavailable`, `confirmLeaveTeam`, `teamDocuments`. The five locale
+files are Lane B's.

--- a/flutter/PHASE_115_NOTES.md
+++ b/flutter/PHASE_115_NOTES.md
@@ -428,3 +428,10 @@ New keys in `app_en.arb` only, each with its `@` placeholder block where it
 takes one: `commentsUnavailable`, `visitsCount` (`{count}`),
 `leaderboardUnavailable`, `confirmLeaveTeam`, `teamDocuments`. The five locale
 files are Lane B's.
+
+## 12. Gate
+
+`dart format --output=none --set-exit-if-changed lib test` clean.
+`flutter analyze` — no issues.
+`flutter test` — **1860 pass**, against 1801 at the branch base: exactly the 59
+new tests, no regressions.

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -696,6 +696,7 @@
   "assigneeId": "Assignee ID",
   "teamDiscussions": "Discussions",
   "teamMembers": "Members",
+  "teamDocuments": "Documents",
   "members": "Members",
   "joinRequests": "Join requests",
   "noMembers": "No members yet",
@@ -706,6 +707,7 @@
   "decline": "Decline",
   "joinTeam": "Request to join",
   "leaveTeam": "Leave team",
+  "confirmLeaveTeam": "Are you sure you want to leave this team?",
   "requestPending": "Request pending",
   "teamResources": "Resources",
   "resourcesUnavailable": "Resources are unavailable",
@@ -821,6 +823,7 @@
     "placeholders": { "count": {"type": "int"} }
   },
   "noComments": "No comments yet",
+  "commentsUnavailable": "Comments are unavailable",
   "leaderboard": "Leaderboard",
   "allTime": "All time",
   "thisMonth": "This month",
@@ -832,6 +835,11 @@
   "@surveysCompleted": {
     "placeholders": { "completed": {"type": "int"}, "total": {"type": "int"} }
   },
+  "visitsCount": "{count} visits",
+  "@visitsCount": {
+    "placeholders": { "count": {"type": "int"} }
+  },
+  "leaderboardUnavailable": "The leaderboard is unavailable",
   "error": "Error",
   "close": "Close",
   "filter": "Filter",

--- a/flutter/lib/providers/teams_provider.dart
+++ b/flutter/lib/providers/teams_provider.dart
@@ -198,9 +198,32 @@ final teamFinancesActionsProvider = Provider<TeamFinancesActions>(
   TeamFinancesActions.new,
 );
 
+/// Whether a membership row the server has never seen — no `_rev` — should
+/// have a tombstone uploaded for it.
+///
+/// `markMembershipsForLeave` (`TeamsRepositoryImpl.kt:1323-1337`) branches on
+/// exactly this: `if (membership._rev.isNullOrBlank())` the row is deleted
+/// locally and **nothing** is uploaded; only a revision-bearing row becomes a
+/// `{_id, _rev, _deleted: true}` document. Enqueueing regardless sent
+/// `"_rev": null`, which CouchDB rejects 4xx — and the outbox's retryable
+/// rule is `code >= 500`, so the row failed out permanently for a document
+/// the server never had.
+bool _serverKnowsRow(String? rev) => rev != null && rev.trim().isNotEmpty;
+
 class TeamMembershipActions {
   TeamMembershipActions(this.ref);
   final Ref ref;
+
+  /// `TeamMembershipActions` is a plain `Provider`, so its `ref` never
+  /// *watches* `sessionProvider` — `ref.read(sessionProvider).valueOrNull` is
+  /// null until something else resolves it, and every action below then took
+  /// its `return false` branch silently. Latent in the app only because the
+  /// router holds a `ref.listen`; not a guarantee this class can rely on.
+  /// Callers keep the await inside their own `try`/error path, because a
+  /// future can reject where `valueOrNull` could not.
+  Future<UserRow?> _session() => ref.read(sessionProvider.future);
+
+  Future<String?> _userId() async => (await _session())?.id;
 
   String? get _endpoint {
     final config = ref.read(serverConfigProvider);
@@ -210,7 +233,7 @@ class TeamMembershipActions {
   }
 
   Future<bool> requestToJoin(TeamRow team) async {
-    final user = ref.read(sessionProvider).valueOrNull;
+    final user = await _session();
     final endpoint = _endpoint;
     if (user == null || endpoint == null) return false;
     final row = await ref
@@ -235,20 +258,22 @@ class TeamMembershipActions {
   }
 
   Future<bool> leave(String teamId) async {
-    final user = ref.read(sessionProvider).valueOrNull;
+    final user = await _session();
     final endpoint = _endpoint;
     if (user == null || endpoint == null) return false;
     final row = await ref.read(teamsRepositoryProvider).leave(teamId, user.id);
     if (row == null) return false;
-    await ref
-        .read(outboxRepositoryProvider)
-        .enqueue(
-          uploadType: 'teamMembership',
-          itemId: row.id,
-          endpoint: endpoint,
-          payload: {'_id': row.id, '_rev': row.rev, '_deleted': true},
-          userId: user.id,
-        );
+    if (_serverKnowsRow(row.rev)) {
+      await ref
+          .read(outboxRepositoryProvider)
+          .enqueue(
+            uploadType: 'teamMembership',
+            itemId: row.id,
+            endpoint: endpoint,
+            payload: {'_id': row.id, '_rev': row.rev, '_deleted': true},
+            userId: user.id,
+          );
+    }
     return true;
   }
 
@@ -257,21 +282,23 @@ class TeamMembershipActions {
   /// a tombstone is enqueued, exactly as [leave] does for the current user.
   Future<bool> removeMember(String teamId, String userId) async {
     final endpoint = _endpoint;
-    final currentUser = ref.read(sessionProvider).valueOrNull;
+    final currentUser = await _session();
     if (endpoint == null || currentUser == null) return false;
     final row = await ref
         .read(teamsRepositoryProvider)
         .removeMember(teamId, userId);
     if (row == null) return false;
-    await ref
-        .read(outboxRepositoryProvider)
-        .enqueue(
-          uploadType: 'teamMembership',
-          itemId: row.id,
-          endpoint: endpoint,
-          payload: {'_id': row.id, '_rev': row.rev, '_deleted': true},
-          userId: currentUser.id,
-        );
+    if (_serverKnowsRow(row.rev)) {
+      await ref
+          .read(outboxRepositoryProvider)
+          .enqueue(
+            uploadType: 'teamMembership',
+            itemId: row.id,
+            endpoint: endpoint,
+            payload: {'_id': row.id, '_rev': row.rev, '_deleted': true},
+            userId: currentUser.id,
+          );
+    }
     return true;
   }
 
@@ -280,7 +307,7 @@ class TeamMembershipActions {
   /// rest) and enqueues each changed row for upload.
   Future<bool> makeLeader(String teamId, String newLeaderId) async {
     final endpoint = _endpoint;
-    final currentUser = ref.read(sessionProvider).valueOrNull;
+    final currentUser = await _session();
     if (endpoint == null || currentUser == null) return false;
     final changed = await ref
         .read(teamsRepositoryProvider)
@@ -309,17 +336,20 @@ class TeamMembershipActions {
         .read(teamsRepositoryProvider)
         .respondToRequest(requestId, accept: accept);
     if (updated == null) return false;
-    await ref
-        .read(outboxRepositoryProvider)
-        .enqueue(
-          uploadType: 'teamMembership',
-          itemId: original.id,
-          endpoint: endpoint,
-          payload: accept
-              ? TeamsRepository.serializeTeamDocument(updated)
-              : {'_id': original.id, '_rev': original.rev, '_deleted': true},
-          userId: ref.read(sessionProvider).valueOrNull?.id,
-        );
+    // A declined request the server never saw needs no tombstone either.
+    if (accept || _serverKnowsRow(original.rev)) {
+      await ref
+          .read(outboxRepositoryProvider)
+          .enqueue(
+            uploadType: 'teamMembership',
+            itemId: original.id,
+            endpoint: endpoint,
+            payload: accept
+                ? TeamsRepository.serializeTeamDocument(updated)
+                : {'_id': original.id, '_rev': original.rev, '_deleted': true},
+            userId: await _userId(),
+          );
+    }
     return true;
   }
 }
@@ -474,6 +504,9 @@ final teamMembershipActionsProvider = Provider<TeamMembershipActions>(
 );
 
 final teamsProvider = StreamProvider<List<TeamRow>>((ref) async* {
+  // Trimmed, deliberately: `TeamViewModel.applyFilters` does not trim, so a
+  // trailing space in Kotlin hides the whole catalog. Every other rule below
+  // follows the Kotlin exactly.
   final search = ref.watch(teamsSearchProvider).trim().toLowerCase();
   final type = ref.watch(teamsTypeProvider);
   final userId = ref.watch(sessionProvider).valueOrNull?.id;
@@ -481,10 +514,13 @@ final teamsProvider = StreamProvider<List<TeamRow>>((ref) async* {
   await for (final rows in repo.watchCatalog(type: type)) {
     final filtered = rows
         .where(
+          // `TeamViewModel.applyFilters` (TeamViewModel.kt:112-118) is a flat,
+          // case-insensitive `contains` on **`name` only** — not the ranked
+          // `ResourcesSearchUtils` algorithm Phases 96/97 ported for resources
+          // and surveys, and not the description. Matching the description
+          // surfaced teams whose name the query does not appear in at all.
           (row) =>
-              search.isEmpty ||
-              (row.name ?? '').toLowerCase().contains(search) ||
-              (row.description ?? '').toLowerCase().contains(search),
+              search.isEmpty || (row.name ?? '').toLowerCase().contains(search),
         )
         .toList();
     // Port of `TeamsRepositoryImpl.mapToTeamDetails`'s sort: leader > member

--- a/flutter/lib/providers/teams_provider.dart
+++ b/flutter/lib/providers/teams_provider.dart
@@ -210,6 +210,16 @@ final teamFinancesActionsProvider = Provider<TeamFinancesActions>(
 /// the server never had.
 bool _serverKnowsRow(String? rev) => rev != null && rev.trim().isNotEmpty;
 
+/// The signed-in user's id, resolved rather than read — see
+/// [TeamMembershipActions._session] for why the rejection is swallowed.
+Future<String?> _sessionUserId(Ref ref) async {
+  try {
+    return (await ref.read(sessionProvider.future))?.id;
+  } catch (_) {
+    return null;
+  }
+}
+
 class TeamMembershipActions {
   TeamMembershipActions(this.ref);
   final Ref ref;
@@ -219,11 +229,23 @@ class TeamMembershipActions {
   /// null until something else resolves it, and every action below then took
   /// its `return false` branch silently. Latent in the app only because the
   /// router holds a `ref.listen`; not a guarantee this class can rely on.
-  /// Callers keep the await inside their own `try`/error path, because a
-  /// future can reject where `valueOrNull` could not.
-  Future<UserRow?> _session() => ref.read(sessionProvider.future);
-
-  Future<String?> _userId() async => (await _session())?.id;
+  ///
+  /// **The rejection is swallowed here, deliberately.** Awaiting `.future`
+  /// resolves the session properly, but a future rejects where `valueOrNull`
+  /// could only be null — and not one of the five call sites wraps the await:
+  /// `team_members_screen`'s `_handleMemberAction` shows its "operation
+  /// failed" snackbar off the returned `false`, and the join button and the
+  /// leave dialog are both fire-and-forget `onPressed`s. Throwing would lose
+  /// that message and escape as an uncaught async error, which is strictly
+  /// worse than the `false` it replaced. Returning null keeps every action's
+  /// existing contract: it reports failure, and the caller says so.
+  Future<UserRow?> _session() async {
+    try {
+      return await ref.read(sessionProvider.future);
+    } catch (_) {
+      return null;
+    }
+  }
 
   String? get _endpoint {
     final config = ref.read(serverConfigProvider);
@@ -330,6 +352,15 @@ class TeamMembershipActions {
   Future<bool> respond(String requestId, {required bool accept}) async {
     final endpoint = _endpoint;
     if (endpoint == null) return false;
+    // Resolved *before* `respondToRequest`, as the four actions above do.
+    // This was the one session read placed after its own local write, and
+    // `respondToRequest` has already converted the request row into a
+    // `membership` with `isUpdated = true` by then. The outbox is the only
+    // upload route — `TeamDao` has no pending sweep and `TeamsUploader` has
+    // no rescan — so failing between the two left the accepted member on
+    // this device and nowhere else, permanently.
+    final user = await _session();
+    if (user == null) return false;
     final original = await ref.read(teamsRepositoryProvider).getById(requestId);
     if (original == null) return false;
     final updated = await ref
@@ -347,7 +378,7 @@ class TeamMembershipActions {
             payload: accept
                 ? TeamsRepository.serializeTeamDocument(updated)
                 : {'_id': original.id, '_rev': original.rev, '_deleted': true},
-            userId: await _userId(),
+            userId: user.id,
           );
     }
     return true;
@@ -389,15 +420,22 @@ class TeamResourceActions {
         .read(teamsRepositoryProvider)
         .removeResourceLink(teamId, resource.resourceId!);
     if (row == null) return false;
-    await ref
-        .read(outboxRepositoryProvider)
-        .enqueue(
-          uploadType: 'teamResource',
-          itemId: row.id,
-          endpoint: '${UrlUtils.credentialFreeDbUrl(config)}/teams',
-          payload: {'_id': row.id, '_rev': row.rev, '_deleted': true},
-          userId: ref.read(sessionProvider).valueOrNull?.id,
-        );
+    // The fourth tombstone in this file, and it needs the same guard as the
+    // three in `TeamMembershipActions`: `removeResourceLink` hard-deletes a
+    // row that has no `rev` until it uploads. Now reachable by far more
+    // users, because the add gate this phase corrected to plain membership
+    // lets any member create such a link in the first place.
+    if (_serverKnowsRow(row.rev)) {
+      await ref
+          .read(outboxRepositoryProvider)
+          .enqueue(
+            uploadType: 'teamResource',
+            itemId: row.id,
+            endpoint: '${UrlUtils.credentialFreeDbUrl(config)}/teams',
+            payload: {'_id': row.id, '_rev': row.rev, '_deleted': true},
+            userId: (await _sessionUserId(ref)),
+          );
+    }
     return true;
   }
 }

--- a/flutter/lib/ui/components/profile_avatar.dart
+++ b/flutter/lib/ui/components/profile_avatar.dart
@@ -137,6 +137,18 @@ String displayName(UserRow user) {
   return username == null || username.isEmpty ? 'myPlanet learner' : username;
 }
 
+/// The first character of a bare display-name string, upper-cased, with `?`
+/// for a name that is absent, empty, or whitespace-only.
+///
+/// `''.characters.first` throws `StateError`, so a `name ?? '?'` guard is not
+/// enough — a synced row can carry an empty string as readily as a null. Use
+/// this wherever the only thing to hand is a name rather than a [UserRow];
+/// prefer [ProfileAvatar] when a [UserRow] is available.
+String initialFor(String? name) {
+  final trimmed = (name ?? '').trim();
+  return trimmed.isEmpty ? '?' : trimmed.characters.first.toUpperCase();
+}
+
 /// Up to two initials (first + last name), falling back to the first letter
 /// of the username, then `MP` — shared with the profile screen's own copy.
 String _initials(UserRow user) {

--- a/flutter/lib/ui/teams/inline_comments.dart
+++ b/flutter/lib/ui/teams/inline_comments.dart
@@ -6,6 +6,7 @@ import '../../l10n/app_localizations.dart';
 import '../../providers/session_provider.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/voices_provider.dart';
+import '../components/profile_avatar.dart';
 
 /// Inline comment thread for a team task or meetup. Port of the inline
 /// comments from `15112-team-tasks-meetups-comment-threads` — comments are
@@ -72,6 +73,14 @@ class _InlineCommentsState extends ConsumerState<InlineComments> {
                 child: CircularProgressIndicator(strokeWidth: 2),
               ),
             )
+          else if (comments.hasError)
+            Padding(
+              padding: const EdgeInsets.only(left: 24, bottom: 4),
+              child: Text(
+                l10n.commentsUnavailable,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            )
           else if (comments.valueOrNull?.isEmpty == true)
             Padding(
               padding: const EdgeInsets.only(left: 24, bottom: 4),
@@ -100,20 +109,32 @@ class _InlineCommentsState extends ConsumerState<InlineComments> {
   Future<void> _addComment() async {
     final text = _controller.text.trim();
     if (text.isEmpty) return;
-    final user = ref.read(sessionProvider).valueOrNull;
-    if (user == null) return;
-    _controller.clear();
-    await ref
-        .read(voicesRepositoryProvider)
-        .addComment(
-          parentId: widget.parentId,
-          teamId: widget.teamId,
-          message: text,
-          userId: user.id,
-          userName: user.name,
-          planetCode: user.planetCode,
-          parentCode: user.parentCode,
-        );
+    try {
+      // This widget never *watches* `sessionProvider`, so
+      // `ref.read(...).valueOrNull` is null until something else resolves it
+      // and the comment was dropped with no error and no record. In the app
+      // the router holds a `ref.listen`, which is what made it latent.
+      // The await sits inside the `try` because a future can reject where
+      // `valueOrNull` could not.
+      final user = await ref.read(sessionProvider.future);
+      if (user == null) return;
+      await ref
+          .read(voicesRepositoryProvider)
+          .addComment(
+            parentId: widget.parentId,
+            teamId: widget.teamId,
+            message: text,
+            userId: user.id,
+            userName: user.name,
+            planetCode: user.planetCode,
+            parentCode: user.parentCode,
+          );
+      // Cleared only once the write has landed, so a failure leaves the text
+      // in the field to retry rather than discarding it.
+      _controller.clear();
+    } catch (_) {
+      // A rejecting session or a failed write must not take the thread down.
+    }
   }
 }
 
@@ -144,7 +165,9 @@ class _CommentTile extends StatelessWidget {
           CircleAvatar(
             radius: 12,
             child: Text(
-              (comment.userName ?? '?').characters.first.toUpperCase(),
+              // `''.characters.first` throws `StateError`, and a synced `News`
+              // row can carry an empty `userName` — `??` only guards null.
+              initialFor(comment.userName),
               style: const TextStyle(fontSize: 12),
             ),
           ),

--- a/flutter/lib/ui/teams/inline_comments.dart
+++ b/flutter/lib/ui/teams/inline_comments.dart
@@ -28,6 +28,12 @@ class _InlineCommentsState extends ConsumerState<InlineComments> {
   final _controller = TextEditingController();
   bool _expanded = false;
 
+  /// The send button is never disabled and the text now survives the write
+  /// (it is cleared only on success, so a failure leaves it to retry), so
+  /// without this a second tap during an in-flight write posted the comment
+  /// twice. Before the clear moved, the second tap was a no-op by accident.
+  bool _sending = false;
+
   @override
   void dispose() {
     _controller.dispose();
@@ -107,8 +113,10 @@ class _InlineCommentsState extends ConsumerState<InlineComments> {
   }
 
   Future<void> _addComment() async {
+    if (_sending) return;
     final text = _controller.text.trim();
     if (text.isEmpty) return;
+    _sending = true;
     try {
       // This widget never *watches* `sessionProvider`, so
       // `ref.read(...).valueOrNull` is null until something else resolves it
@@ -131,9 +139,11 @@ class _InlineCommentsState extends ConsumerState<InlineComments> {
           );
       // Cleared only once the write has landed, so a failure leaves the text
       // in the field to retry rather than discarding it.
-      _controller.clear();
+      if (mounted) _controller.clear();
     } catch (_) {
       // A rejecting session or a failed write must not take the thread down.
+    } finally {
+      _sending = false;
     }
   }
 }

--- a/flutter/lib/ui/teams/leaderboard/team_leaderboard_calculator.dart
+++ b/flutter/lib/ui/teams/leaderboard/team_leaderboard_calculator.dart
@@ -76,7 +76,16 @@ class TeamLeaderboardCalculator {
     entries.sort((a, b) {
       final byCourses = b.coursesCompleted.compareTo(a.coursesCompleted);
       if (byCourses != 0) return byCourses;
-      return b.surveysCompleted.compareTo(a.surveysCompleted);
+      final bySurveys = b.surveysCompleted.compareTo(a.surveysCompleted);
+      if (bySurveys != 0) return bySurveys;
+      // Members arrive through a `Set` and `List.sort` is not stable, so
+      // without a total order two members with identical scores could swap
+      // rank between two loads of unchanged data. Name then id, so the
+      // ranking is reproducible.
+      final byName = a.displayName.toLowerCase().compareTo(
+        b.displayName.toLowerCase(),
+      );
+      return byName != 0 ? byName : a.userId.compareTo(b.userId);
     });
     return entries;
   }

--- a/flutter/lib/ui/teams/leaderboard/team_leaderboard_calculator.dart
+++ b/flutter/lib/ui/teams/leaderboard/team_leaderboard_calculator.dart
@@ -1,9 +1,15 @@
 import '../../../repository/progress_repository.dart'
     show CourseProgressSummary;
 
-/// Port of `model/TeamLeaderboardEntry.kt`. One row per team member in the
-/// leaderboard: their display name, courses completed, surveys completed,
-/// and whether they are the current user (for highlighting).
+/// One row per team member in the leaderboard: their display name, courses
+/// completed, surveys completed, and whether they are the current user (for
+/// highlighting).
+///
+/// **There is no Kotlin counterpart.** `app/` has no `ui/teams/leaderboard/`
+/// and no `TeamLeaderboardEntry.kt` — `grep -rn "eaderboard" app/src/main
+/// --include=*.kt` finds nothing. Phase 73 ported this from the unmerged
+/// upstream `14880` branch, so anything here is unverifiable against the
+/// shipping app and must not be described as parity.
 class TeamLeaderboardEntry {
   const TeamLeaderboardEntry({
     required this.userId,
@@ -28,9 +34,10 @@ class TeamLeaderboardEntry {
   final String? userImage;
 }
 
-/// Port of `TeamLeaderboardCalculator`. Pure logic: given members, course
-/// progress, and survey completion timestamps, build the ranked list sorted
-/// by courses completed then surveys completed (both descending).
+/// Pure logic: given members, course progress, and survey completion
+/// timestamps, build the ranked list sorted by courses completed then surveys
+/// completed (both descending). No Kotlin counterpart — see
+/// [TeamLeaderboardEntry].
 class TeamLeaderboardCalculator {
   const TeamLeaderboardCalculator._();
 
@@ -78,10 +85,15 @@ class TeamLeaderboardCalculator {
       if (byCourses != 0) return byCourses;
       final bySurveys = b.surveysCompleted.compareTo(a.surveysCompleted);
       if (bySurveys != 0) return bySurveys;
-      // Members arrive through a `Set` and `List.sort` is not stable, so
-      // without a total order two members with identical scores could swap
-      // rank between two loads of unchanged data. Name then id, so the
-      // ranking is reproducible.
+      // A total order, so a displayed *rank* is reproducible. The stronger
+      // claim this comment first made — that ties could shuffle between two
+      // loads of unchanged data — was overstated: Dart's `List.sort` uses a
+      // stable insertion sort below 32 elements, and `watchMembers` orders by
+      // `userId ASC`, so a team under 32 members was already deterministic
+      // (ranked by user id). This makes it deterministic for any size, and
+      // ranks ties by name rather than by an opaque id — a deliberate choice,
+      // not a port: there is no Kotlin leaderboard to match (see the class
+      // doc), so nothing specifies the tie order.
       final byName = a.displayName.toLowerCase().compareTo(
         b.displayName.toLowerCase(),
       );

--- a/flutter/lib/ui/teams/leaderboard/team_leaderboard_screen.dart
+++ b/flutter/lib/ui/teams/leaderboard/team_leaderboard_screen.dart
@@ -5,6 +5,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../providers/app_providers.dart';
 import '../../../providers/session_provider.dart';
 import '../../../providers/teams_provider.dart';
+import '../../components/profile_avatar.dart';
 import '../../../repository/progress_repository.dart'
     show CourseProgressSummary;
 import 'team_leaderboard_calculator.dart';
@@ -28,6 +29,12 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
   _Period _period = _Period.allTime;
   List<TeamLeaderboardEntry>? _entries;
   bool _loading = false;
+  bool _failed = false;
+
+  /// Bumped on every [_load]. A load whose token is stale when it finishes
+  /// must not write its result — the period toggle starts a second load
+  /// without cancelling the first, and either can complete last.
+  int _loadToken = 0;
 
   @override
   void initState() {
@@ -36,12 +43,35 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
   }
 
   Future<void> _load() async {
-    setState(() => _loading = true);
+    final token = ++_loadToken;
+    setState(() {
+      _loading = true;
+      _failed = false;
+    });
+    try {
+      await _gather(token);
+    } catch (_) {
+      // Without this the exception escaped, `_loading` stayed true, and the
+      // screen sat on an indefinite spinner with no way out.
+      if (mounted && token == _loadToken) {
+        setState(() {
+          _entries = null;
+          _loading = false;
+          _failed = true;
+        });
+      }
+    }
+  }
+
+  Future<void> _gather(int token) async {
     final db = ref.read(appDatabaseProvider);
     final teamsRepo = ref.read(teamsRepositoryProvider);
     final progressRepo = ref.read(progressRepositoryProvider);
     final surveysRepo = ref.read(surveysRepositoryProvider);
-    final currentUser = ref.read(sessionProvider).valueOrNull;
+    // `sessionProvider` is read here but never watched, and `_load` runs from
+    // `initState` — so `.valueOrNull` was null on every load and the current
+    // user was never highlighted. Awaiting the future resolves it.
+    final currentUser = await ref.read(sessionProvider.future);
 
     // Get team courses
     final courses = await ref.read(teamCoursesProvider(widget.teamId).future);
@@ -59,20 +89,17 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
     for (final userId in memberUserIds) {
       final user = await db.userDao.getById(userId);
       if (user != null) {
-        final fullName = [
-          user.firstName,
-          user.lastName,
-        ].where((p) => p != null && p.trim().isNotEmpty).join(' ');
-        final displayName = fullName.isNotEmpty
-            ? fullName
-            : (user.name ?? userId);
+        // `profile_avatar.dart`'s `displayName` is the port's single source
+        // for a user's name: it includes the middle name and trims, which the
+        // local copy this replaces did neither of.
+        final memberName = displayName(user);
         final visits = await teamsRepo.teamVisitsForUsers(widget.teamId, [
           user.name ?? '',
         ]);
         members.add(
           MemberWithProgress(
             userId: userId,
-            displayName: displayName,
+            displayName: memberName,
             visitCount: visits.length,
             userImage: user.userImage,
           ),
@@ -123,7 +150,7 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
       periodStart: periodStart,
     );
 
-    if (mounted) {
+    if (mounted && token == _loadToken) {
       setState(() {
         _entries = entries;
         _loading = false;
@@ -161,6 +188,8 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
           Expanded(
             child: _loading
                 ? const Center(child: CircularProgressIndicator())
+                : _failed
+                ? Center(child: Text(l10n.leaderboardUnavailable))
                 : _entries == null || _entries!.isEmpty
                 ? Center(child: Text(l10n.noDataAvailable))
                 : ListView.builder(
@@ -245,7 +274,11 @@ class _LeaderboardCard extends StatelessWidget {
                       if (entry.visitCount > 0)
                         _Stat(
                           icon: Icons.visibility_outlined,
-                          label: l10n.numberOfVisits,
+                          // `numberOfVisits` is a bare label — it is right in
+                          // `member_detail_screen`, where a value sits beside
+                          // it, but here it was the whole stat and the count
+                          // never reached the screen.
+                          label: l10n.visitsCount(entry.visitCount),
                         ),
                     ],
                   ),

--- a/flutter/lib/ui/teams/leaderboard/team_leaderboard_screen.dart
+++ b/flutter/lib/ui/teams/leaderboard/team_leaderboard_screen.dart
@@ -49,7 +49,12 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
       _failed = false;
     });
     try {
-      await _gather(token);
+      // Captured at entry, not read after the awaits. Reading it late meant a
+      // stale load recomputed with the *current* period and produced the same
+      // answer, which made the `_loadToken` guard below unobservable — and
+      // left a real hazard latent: any future work that depends on the period
+      // before the last await would have silently used the wrong one.
+      await _gather(token, _period);
     } catch (_) {
       // Without this the exception escaped, `_loading` stayed true, and the
       // screen sat on an indefinite spinner with no way out.
@@ -63,7 +68,7 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
     }
   }
 
-  Future<void> _gather(int token) async {
+  Future<void> _gather(int token, _Period period) async {
     final db = ref.read(appDatabaseProvider);
     final teamsRepo = ref.read(teamsRepositoryProvider);
     final progressRepo = ref.read(progressRepositoryProvider);
@@ -133,7 +138,7 @@ class _TeamLeaderboardScreenState extends ConsumerState<TeamLeaderboardScreen> {
           .toList();
     }
 
-    final periodStart = _period == _Period.thisMonth
+    final periodStart = period == _Period.thisMonth
         ? TeamLeaderboardCalculator.startOfCurrentMonth(
             DateTime.now().millisecondsSinceEpoch,
           )

--- a/flutter/lib/ui/teams/team_courses_screen.dart
+++ b/flutter/lib/ui/teams/team_courses_screen.dart
@@ -28,9 +28,15 @@ class TeamCoursesScreen extends ConsumerWidget {
     // creator who is not the leader.
     final creatorId = ref.watch(teamProvider(teamId)).valueOrNull?.userId;
     final currentUserId = ref.watch(sessionProvider).valueOrNull?.id;
+    // Both sides must be non-empty as well as non-null. Kotlin's
+    // `sharedPrefManager.getUserId().ifEmpty { "--" }` sentinel exists to
+    // stop an empty id matching an empty creator; without it a team document
+    // with no `userId` would hand the unlink to a session with no id.
     final canRemove =
         creatorId != null &&
+        creatorId.isNotEmpty &&
         currentUserId != null &&
+        currentUserId.isNotEmpty &&
         creatorId.toLowerCase() == currentUserId.toLowerCase();
     return Scaffold(
       appBar: AppBar(title: Text(l10n.teamCourses)),

--- a/flutter/lib/ui/teams/team_courses_screen.dart
+++ b/flutter/lib/ui/teams/team_courses_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/local/app_database.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/courses_providers.dart';
+import '../../providers/session_provider.dart';
 import '../../providers/teams_provider.dart';
 
 class TeamCoursesScreen extends ConsumerWidget {
@@ -14,9 +15,23 @@ class TeamCoursesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final courses = ref.watch(teamCoursesProvider(teamId));
-    final canManage =
-        ref.watch(teamMembershipsProvider).valueOrNull?[teamId]?.isLeader ??
-        false;
+    final membership = ref.watch(teamMembershipsProvider).valueOrNull?[teamId];
+    // Kotlin's add has no gate in `TeamCoursesFragment` at all — it is driven
+    // by `btnAddDoc`, which `setupMyTeamButtons` shows to any **member**
+    // (`TeamDetailFragment.kt:286-289`).
+    final canAdd = membership != null;
+    // `canRemove = currentUserId.equals(teamCreator, ignoreCase = true)`
+    // (`TeamCoursesFragment.kt:44-46`), where `getTeamCreator` is the team
+    // row's `userId` (`TeamsRepositoryImpl.kt:1120-1123`) — the **creator**,
+    // not the leader. The port gated it on `isLeader`, which both offered the
+    // unlink to a leader who did not create the team and withheld it from a
+    // creator who is not the leader.
+    final creatorId = ref.watch(teamProvider(teamId)).valueOrNull?.userId;
+    final currentUserId = ref.watch(sessionProvider).valueOrNull?.id;
+    final canRemove =
+        creatorId != null &&
+        currentUserId != null &&
+        creatorId.toLowerCase() == currentUserId.toLowerCase();
     return Scaffold(
       appBar: AppBar(title: Text(l10n.teamCourses)),
       body: courses.when(
@@ -33,7 +48,7 @@ class TeamCoursesScreen extends ConsumerWidget {
                     leading: const Icon(Icons.school_outlined),
                     title: Text(rows[index].courseTitle ?? l10n.untitledCourse),
                     subtitle: Text(rows[index].description ?? ''),
-                    trailing: canManage
+                    trailing: canRemove
                         ? IconButton(
                             tooltip: l10n.removeFromTeam,
                             icon: const Icon(Icons.link_off),
@@ -46,7 +61,7 @@ class TeamCoursesScreen extends ConsumerWidget {
                 ),
               ),
       ),
-      floatingActionButton: canManage
+      floatingActionButton: canAdd
           ? FloatingActionButton.extended(
               onPressed: () => _chooseCourse(context, ref),
               icon: const Icon(Icons.playlist_add),

--- a/flutter/lib/ui/teams/team_members_screen.dart
+++ b/flutter/lib/ui/teams/team_members_screen.dart
@@ -7,6 +7,7 @@ import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/session_provider.dart';
 import '../../providers/teams_provider.dart';
+import '../components/profile_avatar.dart';
 import '../router.dart';
 
 class TeamMembersScreen extends ConsumerWidget {
@@ -87,17 +88,15 @@ class _MembersList extends ConsumerWidget {
                 final user = userId.isEmpty
                     ? null
                     : ref.watch(userByIdProvider(userId)).valueOrNull;
-                final fullName = user == null
-                    ? ''
-                    : [user.firstName, user.lastName]
-                          .where((p) => p != null && p.trim().isNotEmpty)
-                          .join(' ');
-                final displayName = fullName.isNotEmpty
-                    ? fullName
-                    : (user?.name ?? userId);
-                final initial = displayName.isEmpty
-                    ? '?'
-                    : displayName.characters.first.toUpperCase();
+                // `profile_avatar.dart` is the port's single source for a
+                // user's name and initial. The local copies this replaces
+                // were the third in this directory and broken the same two
+                // ways the leaderboard's were: no middle name, and no trim —
+                // so a synced `"name": " jane "` rendered untrimmed behind a
+                // blank avatar, because `' '` is not empty and the
+                // `isEmpty ? '?'` guard never fired.
+                final name = user == null ? userId : displayName(user);
+                final initial = initialFor(name);
                 final currentUserId = ref
                     .watch(sessionProvider)
                     .valueOrNull
@@ -105,9 +104,7 @@ class _MembersList extends ConsumerWidget {
                 final isOwnCard = userId == currentUserId;
                 return ListTile(
                   leading: CircleAvatar(child: Text(initial)),
-                  title: Text(
-                    displayName.isEmpty ? l10n.unknownMember : displayName,
-                  ),
+                  title: Text(name.isEmpty ? l10n.unknownMember : name),
                   subtitle: row.isLeader ? Text(l10n.leader) : null,
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,

--- a/flutter/lib/ui/teams/team_resources_screen.dart
+++ b/flutter/lib/ui/teams/team_resources_screen.dart
@@ -14,9 +14,14 @@ class TeamResourcesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final resources = ref.watch(teamResourcesProvider(teamId));
-    final canManage =
-        ref.watch(teamMembershipsProvider).valueOrNull?[teamId]?.isLeader ??
-        false;
+    final membership = ref.watch(teamMembershipsProvider).valueOrNull?[teamId];
+    // Two different gates, as `TeamResourcesFragment` has: the add FAB is
+    // `isVisible = isMember` (`:51-52`, `isMemberFlow` → plain membership),
+    // while remove is `isTeamLeader` (`:73`). One `isLeader` flag drove both
+    // here, so an ordinary member could not link a resource Kotlin lets them
+    // link — the Phase 99 shape.
+    final canAdd = membership != null;
+    final canRemove = membership?.isLeader ?? false;
     return Scaffold(
       appBar: AppBar(title: Text(l10n.teamResources)),
       body: resources.when(
@@ -35,7 +40,7 @@ class TeamResourcesScreen extends ConsumerWidget {
                       leading: const Icon(Icons.description_outlined),
                       title: Text(row.title ?? l10n.untitledResource),
                       subtitle: Text(row.description ?? ''),
-                      trailing: canManage
+                      trailing: canRemove
                           ? IconButton(
                               tooltip: l10n.removeFromTeam,
                               icon: const Icon(Icons.link_off),
@@ -49,7 +54,7 @@ class TeamResourcesScreen extends ConsumerWidget {
                 },
               ),
       ),
-      floatingActionButton: canManage
+      floatingActionButton: canAdd
           ? FloatingActionButton.extended(
               onPressed: () => _chooseResource(context, ref),
               icon: const Icon(Icons.add_link),

--- a/flutter/lib/ui/teams/teams_screen.dart
+++ b/flutter/lib/ui/teams/teams_screen.dart
@@ -109,11 +109,12 @@ class TeamsScreen extends ConsumerWidget {
                         separatorBuilder: (_, _) => const SizedBox(height: 6),
                         itemBuilder: (context, index) {
                           final team = teams[index];
-                          final membership =
-                              memberships[team.id] ??
-                              (team.teamId == null
-                                  ? null
-                                  : memberships[team.teamId]);
+                          // Keyed on the team document's `_id` alone, as
+                          // `getTeamMemberStatuses` is. The
+                          // `memberships[team.teamId]` fallback removed here
+                          // could never resolve, for the reason given at the
+                          // detail screen's own lookup below.
+                          final membership = memberships[team.id];
                           return Card(
                             child: ListTile(
                               leading: Icon(
@@ -418,9 +419,10 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                             context.push('${Routes.teams}/${team.id}/reports'),
                       ),
                     // Kotlin gates `FinancesPage` on `isEnterprise`; the
-                    // port also offers it to a plain team's members, a
-                    // surplus recorded in
-                    // `docs/kotlin-to-flutter-migration.md`.
+                    // port also offers it to a plain team's members. That
+                    // surplus is recorded in `CLAUDE.md`'s Phase 99 prose —
+                    // *not* in `docs/kotlin-to-flutter-migration.md`, whose
+                    // deviations list has no team-finances entry.
                     if (isEnterprise || membership != null)
                       ListTile(
                         leading: const Icon(

--- a/flutter/lib/ui/teams/teams_screen.dart
+++ b/flutter/lib/ui/teams/teams_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../l10n/app_localizations.dart';
 import '../../data/local/app_database.dart';
 import '../../providers/app_providers.dart';
+import '../../data/local/user_mapper.dart';
 import '../../providers/teams_provider.dart';
 import '../../providers/session_provider.dart';
 import '../../providers/sync_state.dart';
@@ -81,6 +82,14 @@ class TeamsScreen extends ConsumerWidget {
             child: RefreshIndicator(
               onRefresh: () => ref.read(teamsSyncProvider.notifier).sync(),
               child: rows.when(
+                // `teamsProvider` watches the search text and the type
+                // segment, so every keystroke and every segment tap rebuilds
+                // it. Without this the list was replaced by a centered
+                // spinner once per character — `skipLoadingOnReload`
+                // defaults to false and "does not skip loading states if
+                // triggered by `Ref.watch`". Kotlin re-filters an in-memory
+                // list (`TeamViewModel.applyFilters`) and never shows one.
+                skipLoadingOnReload: true,
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (_, _) => Center(child: Text(l10n.teamsUnavailable)),
                 data: (teams) => teams.isEmpty
@@ -165,9 +174,14 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
     _visitLogged = true;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
-      final user = ref.read(sessionProvider).valueOrNull;
-      if (user == null) return;
       try {
+        // The latch above is committed before this runs, so a null read here
+        // dropped the visit for the whole mount with nothing to retry it.
+        // `createTeamLog` (`TeamDetailFragment.kt:426-441`) awaits its own
+        // `getUserModel()`; the await is inside the `try` because a future
+        // can reject where `valueOrNull` could not.
+        final user = await ref.read(sessionProvider.future);
+        if (user == null || !mounted) return;
         final config = ref.read(serverConfigProvider);
         await ref
             .read(teamsRepositoryProvider)
@@ -192,6 +206,32 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
     });
   }
 
+  /// `setupMyTeamButtons` puts every leave behind a `confirm_exit` Yes/No
+  /// dialog (`TeamDetailFragment.kt:291-306`). The port's button called
+  /// `leave` straight from `onPressed`, so one mis-tap dropped the
+  /// membership and queued its tombstone with nothing to confirm.
+  Future<void> _confirmLeave(String teamId) async {
+    final l10n = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        content: Text(l10n.confirmLeaveTeam),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.no),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.yes),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    await ref.read(teamMembershipActionsProvider).leave(teamId);
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -202,7 +242,8 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
         ref.watch(teamMembershipsProvider).valueOrNull ?? const {};
     final requests =
         ref.watch(teamRequestsProvider(widget.teamId)).valueOrNull ?? const [];
-    final currentUserId = ref.watch(sessionProvider).valueOrNull?.id;
+    final currentUser = ref.watch(sessionProvider).valueOrNull;
+    final currentUserId = currentUser?.id;
     return Scaffold(
       appBar: AppBar(title: Text(l10n.teamDetails)),
       body: ref
@@ -213,12 +254,26 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
             data: (team) {
               if (team == null) return Center(child: Text(l10n.teamNotFound));
               _logVisitOnce(team);
-              final membership =
-                  memberships[team.id] ??
-                  (team.teamId == null ? null : memberships[team.teamId]);
+              // Keyed on the team document's `_id` alone, as
+              // `getTeamMemberStatuses` (`TeamsRepositoryImpl.kt:562-601`)
+              // is. The `memberships[team.teamId]` fallback this replaces
+              // could never resolve — `teamMembershipsProvider` excludes
+              // empty ids and a root team's own `teamId` is null or `''` —
+              // and if it ever had, it would have reported a *parent* team's
+              // membership for a sub-document.
+              final membership = memberships[team.id];
               final hasPendingRequest = requests.any(
                 (row) => row.userId == currentUserId,
               );
+              final isGuest =
+                  currentUser != null && UserMapper.isGuest(currentUser);
+              // `buildPages` (`TeamDetailFragment.kt:74-92`): a non-member of
+              // a team that is not public gets exactly Plan/Mission and
+              // Members — no tasks, calendar, surveys, courses, resources,
+              // discussions, finances or reports. Without this the port
+              // offered a private team's whole contents to any visitor.
+              final canView = membership != null || team.isPublic;
+              final isEnterprise = team.type == 'enterprise';
               return ListView(
                 padding: const EdgeInsets.all(16),
                 children: [
@@ -233,7 +288,11 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                         ),
                       ),
                     ),
-                  if (membership == null && hasPendingRequest)
+                  // `setupNonMyTeamButtons` (:249-283) hides the button
+                  // outright for a `guest_` id before wiring join at all.
+                  if (membership == null && isGuest)
+                    const SizedBox.shrink()
+                  else if (membership == null && hasPendingRequest)
                     Chip(
                       avatar: const Icon(Icons.hourglass_top),
                       label: Text(l10n.requestPending),
@@ -246,13 +305,18 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                       icon: const Icon(Icons.person_add),
                       label: Text(l10n.joinTeam),
                     )
-                  else
+                  // `TeamDetailFragment.kt:179-186` hides leave once
+                  // `getJoinedMemberCount(teamId) <= 1 && isMyTeam`. A null
+                  // count has not resolved yet, so the button shows — the
+                  // Kotlin check is async too and only hides on arrival.
+                  else if (memberCount == null || memberCount > 1)
                     OutlinedButton.icon(
-                      onPressed: membership.isLeader
-                          ? null
-                          : () => ref
-                                .read(teamMembershipActionsProvider)
-                                .leave(team.id),
+                      // No leader gate: `setupMyTeamButtons` (:285-308)
+                      // attaches the handler unconditionally and
+                      // `markMembershipsForLeave` has no leader test either.
+                      // Kotlin has `isTeamLeader` and pointedly does not use
+                      // it here — the Phase 99 shape, again.
+                      onPressed: () => _confirmLeave(team.id),
                       icon: const Icon(Icons.exit_to_app),
                       label: Text(l10n.leaveTeam),
                     ),
@@ -283,11 +347,11 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                     _DetailSection(title: l10n.services, body: team.services!),
                   if (team.rules?.isNotEmpty == true)
                     _DetailSection(title: l10n.rules, body: team.rules!),
+                  // Plan/Mission and Members are the two entries Kotlin
+                  // shows on both sides of the gate.
                   ListTile(
                     leading: const Icon(Icons.assignment_outlined),
-                    title: Text(
-                      team.type == 'enterprise' ? l10n.mission : l10n.plan,
-                    ),
+                    title: Text(isEnterprise ? l10n.mission : l10n.plan),
                     trailing: const Icon(Icons.chevron_right),
                     onTap: () =>
                         context.push('${Routes.teams}/${team.id}/plan'),
@@ -315,46 +379,58 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                     onTap: () =>
                         context.push('${Routes.teams}/${team.id}/members'),
                   ),
-                  ListTile(
-                    leading: const Icon(Icons.folder_copy_outlined),
-                    title: Text(l10n.teamResources),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () =>
-                        context.push('${Routes.teams}/${team.id}/resources'),
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.school),
-                    title: Text(l10n.teamCourses),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () =>
-                        context.push('${Routes.teams}/${team.id}/courses'),
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.poll_outlined),
-                    title: Text(l10n.teamSurveys),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () =>
-                        context.push('${Routes.teams}/${team.id}/surveys'),
-                  ),
-                  if (team.type == 'enterprise')
+                  if (canView) ...[
                     ListTile(
-                      leading: const Icon(Icons.assessment_outlined),
-                      title: Text(l10n.financialReports),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap: () =>
-                          context.push('${Routes.teams}/${team.id}/reports'),
-                    ),
-                  if (membership != null)
-                    ListTile(
-                      leading: const Icon(
-                        Icons.account_balance_wallet_outlined,
+                      leading: const Icon(Icons.folder_copy_outlined),
+                      // The same screen under two labels, as
+                      // `DocumentsPage`/`ResourcesPage` are
+                      // (`TeamPageConfig.kt:63-69`).
+                      title: Text(
+                        isEnterprise ? l10n.teamDocuments : l10n.teamResources,
                       ),
-                      title: Text(l10n.finances),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () =>
-                          context.push('${Routes.teams}/${team.id}/finances'),
+                          context.push('${Routes.teams}/${team.id}/resources'),
                     ),
-                  if (membership != null)
+                    // `buildPages` swaps `CoursesPage` out for `FinancesPage`
+                    // on an enterprise (:84) — an enterprise has no courses.
+                    if (!isEnterprise)
+                      ListTile(
+                        leading: const Icon(Icons.school),
+                        title: Text(l10n.teamCourses),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () =>
+                            context.push('${Routes.teams}/${team.id}/courses'),
+                      ),
+                    ListTile(
+                      leading: const Icon(Icons.poll_outlined),
+                      title: Text(l10n.teamSurveys),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () =>
+                          context.push('${Routes.teams}/${team.id}/surveys'),
+                    ),
+                    if (isEnterprise)
+                      ListTile(
+                        leading: const Icon(Icons.assessment_outlined),
+                        title: Text(l10n.financialReports),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () =>
+                            context.push('${Routes.teams}/${team.id}/reports'),
+                      ),
+                    // Kotlin gates `FinancesPage` on `isEnterprise`; the
+                    // port also offers it to a plain team's members, a
+                    // surplus recorded in
+                    // `docs/kotlin-to-flutter-migration.md`.
+                    if (isEnterprise || membership != null)
+                      ListTile(
+                        leading: const Icon(
+                          Icons.account_balance_wallet_outlined,
+                        ),
+                        title: Text(l10n.finances),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () =>
+                            context.push('${Routes.teams}/${team.id}/finances'),
+                      ),
                     ListTile(
                       leading: const Icon(Icons.calendar_month_outlined),
                       title: Text(l10n.teamCalendar),
@@ -362,20 +438,21 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                       onTap: () =>
                           context.push('${Routes.teams}/${team.id}/calendar'),
                     ),
-                  ListTile(
-                    leading: const Icon(Icons.task_alt),
-                    title: Text(l10n.teamTasks),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () =>
-                        context.push('${Routes.teams}/${team.id}/tasks'),
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.forum_outlined),
-                    title: Text(l10n.teamDiscussions),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () =>
-                        context.push('${Routes.teams}/${team.id}/voices'),
-                  ),
+                    ListTile(
+                      leading: const Icon(Icons.task_alt),
+                      title: Text(l10n.teamTasks),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () =>
+                          context.push('${Routes.teams}/${team.id}/tasks'),
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.forum_outlined),
+                      title: Text(l10n.teamDiscussions),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () =>
+                          context.push('${Routes.teams}/${team.id}/voices'),
+                    ),
+                  ],
                 ],
               );
             },

--- a/flutter/test/providers/team_membership_tombstone_test.dart
+++ b/flutter/test/providers/team_membership_tombstone_test.dart
@@ -15,6 +15,14 @@ class _TestServerConfig extends ServerConfigNotifier {
   ServerConfig? build() => config;
 }
 
+/// A session whose `build` rejects — an unavailable `planetPrefs`, a failed
+/// `userDao` read. `.valueOrNull` was null here and every action returned
+/// `false`; a `.future` rejects instead, which is a different contract.
+class _FailingSessionNotifier extends SessionNotifier {
+  @override
+  Future<UserRow?> build() async => throw StateError('prefs unavailable');
+}
+
 /// A session that resolves only after a delay. `TeamMembershipActions` is a
 /// plain `Provider`, so nothing it holds ever *watches* `sessionProvider`; a
 /// bare `ref.read(...).valueOrNull` is null for this whole window.
@@ -181,6 +189,73 @@ void main() {
     );
     expect(queued.length, 1);
     expect(await database.teamDao.getById('m-synced'), isNull);
+  });
+
+  ProviderContainer failingSessionContainer() {
+    final c = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(database),
+        outboxRepositoryProvider.overrideWithValue(
+          OutboxRepository(database.outboxDao),
+        ),
+        serverConfigProvider.overrideWith(() => _TestServerConfig(config)),
+        sessionProvider.overrideWith(_FailingSessionNotifier.new),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('a rejecting session reports failure rather than throwing', () async {
+    // Before the session fix these returned `false` on a null read, and
+    // `team_members_screen`'s `_handleMemberAction` showed an "Operation
+    // failed" snackbar off that. A future *rejects* where `valueOrNull` could
+    // not, and no caller wraps the await — the join button and the leave
+    // dialog are both fire-and-forget — so a throw loses the message and
+    // escapes as an uncaught async error.
+    await seedMembership(id: 'm-synced', rev: '2-abc');
+    final c = failingSessionContainer();
+
+    await expectLater(
+      c.read(teamMembershipActionsProvider).leave('team-1'),
+      completion(isFalse),
+    );
+  });
+
+  test('a rejecting session cannot strand an accepted join request', () async {
+    // `respond` resolved the session *after* `respondToRequest` had already
+    // converted the request row to a `membership` with `isUpdated = true`.
+    // A rejection there threw past the enqueue, and the outbox is the only
+    // upload route — `TeamDao` has no pending sweep and `TeamsUploader` has
+    // no rescan — so the accepted member existed on the leader's device and
+    // nowhere else, permanently. Resolve the user before the local write.
+    await database.teamDao.upsert(
+      TeamsCompanion.insert(
+        id: 'req-1',
+        rev: const Value('3-def'),
+        teamId: const Value('team-1'),
+        userId: const Value('user-2'),
+        docType: const Value('request'),
+      ),
+    );
+    final c = failingSessionContainer();
+
+    final ok = await c
+        .read(teamMembershipActionsProvider)
+        .respond('req-1', accept: true);
+
+    expect(ok, isFalse, reason: 'the caller must learn it failed');
+    // Nothing was queued, so nothing may have been written either.
+    final queued = await database.outboxDao.due(
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    expect(queued, isEmpty);
+    final row = await database.teamDao.getById('req-1');
+    expect(
+      row?.docType,
+      'request',
+      reason: 'the request must not be converted with no route to upload it',
+    );
   });
 
   test('removing a member who never synced enqueues nothing', () async {

--- a/flutter/test/providers/team_membership_tombstone_test.dart
+++ b/flutter/test/providers/team_membership_tombstone_test.dart
@@ -1,0 +1,146 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
+
+class _TestServerConfig extends ServerConfigNotifier {
+  _TestServerConfig(this.config);
+  final ServerConfig? config;
+  @override
+  ServerConfig? build() => config;
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+void main() {
+  late AppDatabase database;
+  late ProviderContainer container;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: 'secret-pin',
+    couchDbUrl: 'https://satellite:secret-pin@planet.example.org',
+    id: 'config-1',
+    code: 'community-a',
+    parentCode: 'nation',
+  );
+
+  setUp(() {
+    database = AppDatabase.memory();
+    container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(database),
+        outboxRepositoryProvider.overrideWithValue(
+          OutboxRepository(database.outboxDao),
+        ),
+        serverConfigProvider.overrideWith(() => _TestServerConfig(config)),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(
+            UserRow(
+              id: 'user-1',
+              name: 'ada',
+              rolesList: const ['learner'],
+              userAdmin: false,
+              joinDate: 0,
+              isArchived: false,
+              isUpdated: false,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(database.close);
+  });
+
+  Future<void> seedMembership({required String id, String? rev}) =>
+      database.teamDao.upsert(
+        TeamsCompanion.insert(
+          id: id,
+          rev: Value(rev),
+          teamId: const Value('team-1'),
+          userId: const Value('user-1'),
+          docType: const Value('membership'),
+        ),
+      );
+
+  test(
+    'leaving a team the server knows about enqueues its tombstone',
+    () async {
+      await seedMembership(id: 'm-synced', rev: '2-abc');
+      // Resolve the session first: `TeamMembershipActions` is a plain
+      // `Provider`, so its `ref` never watches `sessionProvider`.
+      await container.read(sessionProvider.future);
+
+      final ok = await container
+          .read(teamMembershipActionsProvider)
+          .leave('team-1');
+
+      expect(ok, isTrue);
+      final queued = await database.outboxDao.due(
+        DateTime.now().millisecondsSinceEpoch,
+      );
+      expect(queued.length, 1);
+      expect(queued.single.itemId, 'm-synced');
+    },
+  );
+
+  test('leaving before the first sync enqueues nothing', () async {
+    // `markMembershipsForLeave` (`TeamsRepositoryImpl.kt:1323-1337`) branches
+    // on the revision: `if (membership._rev.isNullOrBlank())` it is a pure
+    // local delete with nothing uploaded. The port enqueued unconditionally,
+    // so the body carried `"_rev": null`, CouchDB rejected it 4xx, and the
+    // outbox's retryable rule is `code >= 500` — the row failed out
+    // permanently for a document the server never had.
+    await seedMembership(id: 'm-local', rev: null);
+    await container.read(sessionProvider.future);
+
+    final ok = await container
+        .read(teamMembershipActionsProvider)
+        .leave('team-1');
+
+    expect(ok, isTrue, reason: 'the local delete still succeeds');
+    final queued = await database.outboxDao.due(
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    expect(queued, isEmpty);
+    expect(await database.teamDao.getById('m-local'), isNull);
+  });
+
+  test('an empty revision counts as unsynced too', () async {
+    // Kotlin's test is `isNullOrBlank`, not `== null`.
+    await seedMembership(id: 'm-blank', rev: '');
+    await container.read(sessionProvider.future);
+
+    await container.read(teamMembershipActionsProvider).leave('team-1');
+
+    final queued = await database.outboxDao.due(
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    expect(queued, isEmpty);
+  });
+
+  test('removing a member who never synced enqueues nothing', () async {
+    await seedMembership(id: 'm-local', rev: null);
+    await container.read(sessionProvider.future);
+
+    await container
+        .read(teamMembershipActionsProvider)
+        .removeMember('team-1', 'user-1');
+
+    final queued = await database.outboxDao.due(
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    expect(queued, isEmpty);
+  });
+}

--- a/flutter/test/providers/team_membership_tombstone_test.dart
+++ b/flutter/test/providers/team_membership_tombstone_test.dart
@@ -15,6 +15,17 @@ class _TestServerConfig extends ServerConfigNotifier {
   ServerConfig? build() => config;
 }
 
+/// A session that resolves only after a delay. `TeamMembershipActions` is a
+/// plain `Provider`, so nothing it holds ever *watches* `sessionProvider`; a
+/// bare `ref.read(...).valueOrNull` is null for this whole window.
+class _DelayedSessionNotifier extends SessionNotifier {
+  _DelayedSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() =>
+      Future.delayed(const Duration(milliseconds: 50), () => user);
+}
+
 class _TestSessionNotifier extends SessionNotifier {
   _TestSessionNotifier(this.user);
   final UserRow? user;
@@ -128,6 +139,48 @@ void main() {
       DateTime.now().millisecondsSinceEpoch,
     );
     expect(queued, isEmpty);
+  });
+
+  test('leaving works before anything else has resolved the session', () async {
+    // The tests above `await container.read(sessionProvider.future)` first,
+    // which makes `.valueOrNull` non-null and so cannot catch a regression of
+    // the read-but-never-watched shape. This one deliberately does not
+    // pre-resolve it: `TeamMembershipActions` must resolve the session itself.
+    await seedMembership(id: 'm-synced', rev: '2-abc');
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(database),
+        outboxRepositoryProvider.overrideWithValue(
+          OutboxRepository(database.outboxDao),
+        ),
+        serverConfigProvider.overrideWith(() => _TestServerConfig(config)),
+        sessionProvider.overrideWith(
+          () => _DelayedSessionNotifier(
+            UserRow(
+              id: 'user-1',
+              name: 'ada',
+              rolesList: const ['learner'],
+              userAdmin: false,
+              joinDate: 0,
+              isArchived: false,
+              isUpdated: false,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final ok = await container
+        .read(teamMembershipActionsProvider)
+        .leave('team-1');
+
+    expect(ok, isTrue, reason: 'the leave must not take a silent failure path');
+    final queued = await database.outboxDao.due(
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    expect(queued.length, 1);
+    expect(await database.teamDao.getById('m-synced'), isNull);
   });
 
   test('removing a member who never synced enqueues nothing', () async {

--- a/flutter/test/ui/team_courses_screen_test.dart
+++ b/flutter/test/ui/team_courses_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/courses_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/providers/teams_provider.dart';
 import 'package:myplanet/ui/teams/team_courses_screen.dart';
 
@@ -29,6 +30,36 @@ TeamRow _leaderMembership(String teamId) => TeamRow(
   amount: 0,
   isUpdated: false,
 );
+
+/// A team document whose `userId` — the creator, per `getTeamCreator` — is
+/// [creatorId].
+TeamRow _teamOwnedBy(String creatorId) => TeamRow(
+  id: 'team-1',
+  userId: creatorId,
+  courses: const [],
+  createdDate: 0,
+  limit: 0,
+  isPublic: false,
+  isLeader: false,
+  beginningBalance: 0,
+  sales: 0,
+  otherIncome: 0,
+  wages: 0,
+  otherExpenses: 0,
+  startDate: 0,
+  endDate: 0,
+  updatedDate: 0,
+  date: 0,
+  amount: 0,
+  isUpdated: false,
+);
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
 
 void main() {
   testWidgets('shows the empty state when no courses are linked', (
@@ -80,9 +111,12 @@ void main() {
     expect(find.byIcon(Icons.link_off), findsNothing);
   });
 
-  testWidgets('a leader sees the add-course and remove buttons', (
+  testWidgets('the team creator sees the add-course and remove buttons', (
     tester,
   ) async {
+    // Add is gated on plain membership and remove on being the team's
+    // **creator** (`TeamCoursesFragment.kt:44-46`), not on leadership — see
+    // `test/ui/teams/team_add_remove_gates_test.dart`. This user is both.
     final rows = [buildCourseRow(id: 'c1', courseTitle: 'Algebra 1')];
     final memberships = {'team-1': _leaderMembership('team-1')};
 
@@ -93,6 +127,14 @@ void main() {
           teamCoursesProvider('team-1').overrideWith((ref) async => rows),
           teamMembershipsProvider.overrideWith(
             (ref) => Stream.value(memberships),
+          ),
+          teamProvider(
+            'team-1',
+          ).overrideWith((ref) async => _teamOwnedBy('creator-1')),
+          sessionProvider.overrideWith(
+            () => _TestSessionNotifier(
+              buildUserRow(id: 'creator-1', name: 'ada'),
+            ),
           ),
           teamCourseActionsProvider.overrideWith(
             (ref) => _MockTeamCourseActions(),

--- a/flutter/test/ui/teams/inline_comments_test.dart
+++ b/flutter/test/ui/teams/inline_comments_test.dart
@@ -272,6 +272,56 @@ void main() {
     },
   );
 
+  testWidgets('double-tapping Send posts the comment once', (tester) async {
+    // The clear moved to *after* the write so a failure leaves the text to
+    // retry — but the send button is never disabled, so the text now
+    // survives the in-flight write and a second tap re-sent it. Before the
+    // move the second tap was a no-op (`text.isEmpty`), so the retry fix
+    // needs an in-flight guard to hold both properties at once.
+    final repository = _MockVoicesRepository();
+    final gate = Completer<NewsRow>();
+    when(
+      () => repository.addComment(
+        parentId: any(named: 'parentId'),
+        teamId: any(named: 'teamId'),
+        message: any(named: 'message'),
+        userId: any(named: 'userId'),
+        userName: any(named: 'userName'),
+        planetCode: any(named: 'planetCode'),
+        parentCode: any(named: 'parentCode'),
+      ),
+    ).thenAnswer((_) => gate.future);
+
+    await tester.pumpWidget(
+      _harness(comments: const [], user: _user, repository: repository),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('0 comments'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'once please');
+    await tester.tap(find.byIcon(Icons.send_outlined));
+    await tester.pump();
+    // The first write has not landed, so the field still holds the text.
+    await tester.tap(find.byIcon(Icons.send_outlined));
+    await tester.pump();
+
+    gate.complete(_comment());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repository.addComment(
+        parentId: any(named: 'parentId'),
+        teamId: any(named: 'teamId'),
+        message: 'once please',
+        userId: any(named: 'userId'),
+        userName: any(named: 'userName'),
+        planetCode: any(named: 'planetCode'),
+        parentCode: any(named: 'parentCode'),
+      ),
+    ).called(1);
+  });
+
   testWidgets('a failed comment stream shows an error, not an empty thread', (
     tester,
   ) async {

--- a/flutter/test/ui/teams/inline_comments_test.dart
+++ b/flutter/test/ui/teams/inline_comments_test.dart
@@ -1,0 +1,295 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/voices_provider.dart';
+import 'package:myplanet/repository/voices_repository.dart';
+import 'package:myplanet/ui/teams/inline_comments.dart';
+
+import '../../support/widget_harness.dart';
+
+class _MockVoicesRepository extends Mock implements VoicesRepository {}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+/// A session that resolves only after a delay, reproducing the window a real
+/// app has before `SessionNotifier.build` completes. A screen that reads the
+/// provider without watching it sees `null` for the whole window.
+class _DelayedSessionNotifier extends SessionNotifier {
+  _DelayedSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() =>
+      Future.delayed(const Duration(seconds: 1), () => user);
+}
+
+NewsRow _comment({
+  String id = 'c1',
+  String? userName = 'alice',
+  String? message = 'looks good',
+  int time = 0,
+}) => NewsRow(
+  id: id,
+  message: message,
+  userName: userName,
+  docType: 'message',
+  messageType: 'comment',
+  replyTo: 'task-1',
+  viewableBy: 'teams',
+  viewableId: 'team-1',
+  updatedDate: 0,
+  time: time,
+  imageUrls: const [],
+  labels: const [],
+  newsCreatedDate: 0,
+  newsUpdatedDate: 0,
+  chat: false,
+  isEdited: false,
+  editedTime: 0,
+);
+
+Widget _harness({
+  required List<NewsRow> comments,
+  UserRow? user,
+  VoicesRepository? repository,
+  bool delayedSession = false,
+  Stream<List<NewsRow>>? stream,
+}) => wrapScreen(
+  const Scaffold(
+    body: InlineComments(parentId: 'task-1', teamId: 'team-1'),
+  ),
+  overrides: [
+    commentsForParentProvider.overrideWith(
+      (ref, parentId) => stream ?? Stream.value(comments),
+    ),
+    if (delayedSession)
+      sessionProvider.overrideWith(() => _DelayedSessionNotifier(user))
+    else
+      sessionProvider.overrideWith(() => _TestSessionNotifier(user)),
+    if (repository != null)
+      voicesRepositoryProvider.overrideWithValue(repository),
+  ],
+);
+
+UserRow get _user => buildUserRow(id: 'u1', name: 'alice');
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue('');
+  });
+
+  testWidgets('the header shows the comment count and starts collapsed', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        comments: [
+          _comment(id: 'c1'),
+          _comment(id: 'c2'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('2 comments'), findsOneWidget);
+    // Collapsed: neither the comment bodies nor the input are on screen.
+    expect(find.text('looks good'), findsNothing);
+    expect(find.text('Add a comment'), findsNothing);
+  });
+
+  testWidgets('tapping the header expands the thread and the input', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_harness(comments: [_comment()]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('1 comments'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('looks good'), findsOneWidget);
+    expect(find.text('alice'), findsOneWidget);
+    expect(find.text('Add a comment'), findsOneWidget);
+  });
+
+  testWidgets('an expanded empty thread shows the empty-state line', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_harness(comments: const []));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('0 comments'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No comments yet'), findsOneWidget);
+  });
+
+  testWidgets('a comment whose author name is empty still renders', (
+    tester,
+  ) async {
+    // A synced `News` row can carry `"user": {"name": ""}` — the mapper writes
+    // whatever the server sent. The avatar must not take the thread down.
+    await tester.pumpWidget(
+      _harness(
+        comments: [_comment(userName: '', message: 'anonymous note')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('1 comments'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('anonymous note'), findsOneWidget);
+  });
+
+  testWidgets('submitting a comment reaches the repository', (tester) async {
+    final repository = _MockVoicesRepository();
+    when(
+      () => repository.addComment(
+        parentId: any(named: 'parentId'),
+        teamId: any(named: 'teamId'),
+        message: any(named: 'message'),
+        userId: any(named: 'userId'),
+        userName: any(named: 'userName'),
+        planetCode: any(named: 'planetCode'),
+        parentCode: any(named: 'parentCode'),
+      ),
+    ).thenAnswer((_) async => _comment());
+
+    await tester.pumpWidget(
+      _harness(comments: const [], user: _user, repository: repository),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('0 comments'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'a new comment');
+    await tester.tap(find.byIcon(Icons.send_outlined));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repository.addComment(
+        parentId: 'task-1',
+        teamId: 'team-1',
+        message: 'a new comment',
+        userId: 'u1',
+        userName: 'alice',
+        planetCode: any(named: 'planetCode'),
+        parentCode: any(named: 'parentCode'),
+      ),
+    ).called(1);
+    // The field is cleared so the next comment starts empty.
+    expect(find.text('a new comment'), findsNothing);
+  });
+
+  testWidgets('a whitespace-only comment is not submitted', (tester) async {
+    final repository = _MockVoicesRepository();
+
+    await tester.pumpWidget(
+      _harness(comments: const [], user: _user, repository: repository),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('0 comments'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.tap(find.byIcon(Icons.send_outlined));
+    await tester.pumpAndSettle();
+
+    verifyNever(
+      () => repository.addComment(
+        parentId: any(named: 'parentId'),
+        teamId: any(named: 'teamId'),
+        message: any(named: 'message'),
+        userId: any(named: 'userId'),
+        userName: any(named: 'userName'),
+        planetCode: any(named: 'planetCode'),
+        parentCode: any(named: 'parentCode'),
+      ),
+    );
+  });
+
+  testWidgets(
+    'submitting before the session resolves still posts the comment',
+    (tester) async {
+      // `InlineComments` never *watches* `sessionProvider`, so a bare
+      // `ref.read(...).valueOrNull` is null until something else resolves it.
+      // In the app the router holds a `ref.listen`, which is why this is
+      // latent there; the comment must not be silently dropped.
+      final repository = _MockVoicesRepository();
+      when(
+        () => repository.addComment(
+          parentId: any(named: 'parentId'),
+          teamId: any(named: 'teamId'),
+          message: any(named: 'message'),
+          userId: any(named: 'userId'),
+          userName: any(named: 'userName'),
+          planetCode: any(named: 'planetCode'),
+          parentCode: any(named: 'parentCode'),
+        ),
+      ).thenAnswer((_) async => _comment());
+
+      await tester.pumpWidget(
+        _harness(
+          comments: const [],
+          user: _user,
+          repository: repository,
+          delayedSession: true,
+        ),
+      );
+      // Deliberately do not settle: the session future is still in flight.
+      await tester.pump();
+      await tester.tap(find.text('0 comments'));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'early comment');
+      await tester.tap(find.byIcon(Icons.send_outlined));
+      // Advance past the session's own delay. `pumpAndSettle` alone returns as
+      // soon as no frame is scheduled, which is before the future resolves.
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => repository.addComment(
+          parentId: 'task-1',
+          teamId: 'team-1',
+          message: 'early comment',
+          userId: 'u1',
+          userName: 'alice',
+          planetCode: any(named: 'planetCode'),
+          parentCode: any(named: 'parentCode'),
+        ),
+      ).called(1);
+    },
+  );
+
+  testWidgets('a failed comment stream shows an error, not an empty thread', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        comments: const [],
+        stream: Stream.error(StateError('database unavailable')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('0 comments'));
+    await tester.pumpAndSettle();
+
+    // Without an error branch the thread renders as if it simply had no
+    // comments, which reads as "nobody has commented" rather than "we could
+    // not load the comments".
+    expect(find.text('No comments yet'), findsNothing);
+    expect(find.text('Comments are unavailable'), findsOneWidget);
+  });
+}

--- a/flutter/test/ui/teams/leaderboard/team_leaderboard_screen_test.dart
+++ b/flutter/test/ui/teams/leaderboard/team_leaderboard_screen_test.dart
@@ -383,7 +383,9 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     // The screen must show what This month asked for, not the late all-time
-    // result: the old submission is outside the current month.
+    // result: the old submission is outside the current month. The period is
+    // captured when each load starts, so the stale load really does carry
+    // all-time numbers and only the `_loadToken` guard keeps them off screen.
     expect(find.text('0/0 surveys'), findsOneWidget);
     expect(find.text('1/0 surveys'), findsNothing);
   });

--- a/flutter/test/ui/teams/leaderboard/team_leaderboard_screen_test.dart
+++ b/flutter/test/ui/teams/leaderboard/team_leaderboard_screen_test.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/repository/progress_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+import 'package:myplanet/repository/teams_repository.dart';
+import 'package:myplanet/ui/teams/leaderboard/team_leaderboard_screen.dart';
+
+import '../../../support/widget_harness.dart';
+
+class _MockTeamsRepository extends Mock implements TeamsRepository {}
+
+class _MockProgressRepository extends Mock implements ProgressRepository {}
+
+class _MockSurveysRepository extends Mock implements SurveysRepository {}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+TeamRow _membership({String id = 'm1', String? userId}) => TeamRow(
+  id: id,
+  userId: userId,
+  isLeader: false,
+  courses: const [],
+  createdDate: 0,
+  limit: 0,
+  isPublic: false,
+  beginningBalance: 0,
+  sales: 0,
+  otherIncome: 0,
+  wages: 0,
+  otherExpenses: 0,
+  startDate: 0,
+  endDate: 0,
+  updatedDate: 0,
+  date: 0,
+  amount: 0,
+  isUpdated: false,
+);
+
+TeamLogRow _visit(String id) =>
+    TeamLogRow(id: id, teamId: 'team-1', time: 0, uploaded: false);
+
+void main() {
+  late AppDatabase database;
+  late _MockTeamsRepository teams;
+  late _MockProgressRepository progress;
+  late _MockSurveysRepository surveys;
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
+
+  setUp(() {
+    database = AppDatabase.memory();
+    teams = _MockTeamsRepository();
+    progress = _MockProgressRepository();
+    surveys = _MockSurveysRepository();
+
+    when(
+      () => surveys.teamOwnedSurveys(any()),
+    ).thenAnswer((_) async => const []);
+    when(
+      () => progress.courseProgressSummary(any(), any()),
+    ).thenAnswer((_) async => const {});
+    when(
+      () => teams.teamVisitsForUsers(any(), any()),
+    ).thenAnswer((_) async => const []);
+  });
+
+  tearDown(() => database.close());
+
+  /// Seeds one `users` row and returns its id.
+  Future<String> seedUser({
+    required String id,
+    String? name,
+    String? firstName,
+    String? middleName,
+    String? lastName,
+  }) async {
+    await database.userDao.upsert(
+      UsersCompanion.insert(
+        id: id,
+        name: Value(name),
+        firstName: Value(firstName),
+        middleName: Value(middleName),
+        lastName: Value(lastName),
+      ),
+    );
+    return id;
+  }
+
+  Widget harness({
+    UserRow? session,
+    List<CourseRow> courses = const [],
+    Future<List<CourseRow>>? coursesFuture,
+  }) => wrapScreen(
+    const TeamLeaderboardScreen(teamId: 'team-1'),
+    overrides: [
+      appDatabaseProvider.overrideWithValue(database),
+      teamsRepositoryProvider.overrideWithValue(teams),
+      progressRepositoryProvider.overrideWithValue(progress),
+      surveysRepositoryProvider.overrideWithValue(surveys),
+      sessionProvider.overrideWith(() => _TestSessionNotifier(session)),
+      teamCoursesProvider.overrideWith(
+        (ref, teamId) => coursesFuture ?? Future.value(courses),
+      ),
+    ],
+  );
+
+  testWidgets('shows the empty state when the team has no members', (
+    tester,
+  ) async {
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.value(const <TeamRow>[]));
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    expect(find.text('No data available'), findsOneWidget);
+    expect(find.text('All time'), findsOneWidget);
+    expect(find.text('This month'), findsOneWidget);
+  });
+
+  testWidgets('ranks members and medals the top three', (tester) async {
+    when(() => teams.watchMembers(any())).thenAnswer(
+      (_) => Stream.value([
+        _membership(id: 'm1', userId: 'u1'),
+        _membership(id: 'm2', userId: 'u2'),
+        _membership(id: 'm3', userId: 'u3'),
+        _membership(id: 'm4', userId: 'u4'),
+      ]),
+    );
+    await seedUser(id: 'u1', firstName: 'Ann', lastName: 'One');
+    await seedUser(id: 'u2', firstName: 'Bob', lastName: 'Two');
+    await seedUser(id: 'u3', firstName: 'Cal', lastName: 'Three');
+    await seedUser(id: 'u4', firstName: 'Dee', lastName: 'Four');
+
+    // u1 finishes both courses, u2 one, u3 and u4 none.
+    when(() => progress.courseProgressSummary(any(), 'u1')).thenAnswer(
+      (_) async => const {
+        'c1': CourseProgressSummary(max: 2, current: 2),
+        'c2': CourseProgressSummary(max: 2, current: 2),
+      },
+    );
+    when(() => progress.courseProgressSummary(any(), 'u2')).thenAnswer(
+      (_) async => const {'c1': CourseProgressSummary(max: 2, current: 2)},
+    );
+
+    await tester.pumpWidget(
+      harness(
+        courses: [
+          buildCourseRow(id: 'c1'),
+          buildCourseRow(id: 'c2'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('🥇'), findsOneWidget);
+    expect(find.text('🥈'), findsOneWidget);
+    expect(find.text('🥉'), findsOneWidget);
+    // The fourth place carries a plain numeral, not a medal.
+    expect(find.text('4'), findsOneWidget);
+    expect(find.text('2/2 courses'), findsOneWidget);
+    expect(find.text('1/2 courses'), findsOneWidget);
+  });
+
+  testWidgets('members tied on courses and surveys rank in a stable order', (
+    tester,
+  ) async {
+    // Member ids arrive through a `Set`, and `List.sort` is not stable, so
+    // without a final tiebreak two members with identical scores can swap
+    // rank between two loads of the same data. A leaderboard whose ranking
+    // shuffles on reload is worse than one that is merely arbitrary.
+    when(() => teams.watchMembers(any())).thenAnswer(
+      (_) => Stream.value([
+        _membership(id: 'm1', userId: 'u-zoe'),
+        _membership(id: 'm2', userId: 'u-amy'),
+        _membership(id: 'm3', userId: 'u-bob'),
+      ]),
+    );
+    await seedUser(id: 'u-zoe', firstName: 'Zoe', lastName: 'Zed');
+    await seedUser(id: 'u-amy', firstName: 'Amy', lastName: 'Ash');
+    await seedUser(id: 'u-bob', firstName: 'Bob', lastName: 'Bee');
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    final names = tester
+        .widgetList<Text>(find.byType(Text))
+        .map((t) => t.data)
+        .whereType<String>()
+        .where(
+          (s) =>
+              s.startsWith('Amy') || s.startsWith('Bob') || s.startsWith('Zoe'),
+        )
+        .toList();
+    expect(names, ['Amy Ash', 'Bob Bee', 'Zoe Zed']);
+  });
+
+  testWidgets('a middle name is part of the display name', (tester) async {
+    // `profile_avatar.dart`'s `displayName` is the port's single source for a
+    // user's name, and it includes the middle name.
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.value([_membership(id: 'm1', userId: 'u1')]));
+    await seedUser(
+      id: 'u1',
+      firstName: 'Ada',
+      middleName: 'Byron',
+      lastName: 'Lovelace',
+    );
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Ada Byron Lovelace'), findsOneWidget);
+  });
+
+  testWidgets('a whitespace-only name falls back rather than rendering blank', (
+    tester,
+  ) async {
+    // A synced `"name": " jane "` with no first or last name took the health
+    // screen down in Phase 95. Here it would render a blank row.
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.value([_membership(id: 'm1', userId: 'u1')]));
+    await seedUser(id: 'u1', name: ' jane ');
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('jane'), findsOneWidget);
+  });
+
+  testWidgets('the visit stat carries the visit count', (tester) async {
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.value([_membership(id: 'm1', userId: 'u1')]));
+    await seedUser(id: 'u1', firstName: 'Ann', lastName: 'One');
+    when(
+      () => teams.teamVisitsForUsers(any(), any()),
+    ).thenAnswer((_) async => [_visit('v1'), _visit('v2'), _visit('v3')]);
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    // A stat that reads only "Number of visits" tells the reader nothing —
+    // the sibling stats both carry their numbers.
+    expect(find.text('3 visits'), findsOneWidget);
+  });
+
+  testWidgets('the current user is highlighted', (tester) async {
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.value([_membership(id: 'm1', userId: 'u1')]));
+    await seedUser(id: 'u1', firstName: 'Ann', lastName: 'One');
+
+    await tester.pumpWidget(
+      harness(
+        session: buildUserRow(id: 'u1', name: 'ann'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final name = tester.widget<Text>(find.text('Ann One'));
+    expect(name.style?.fontWeight, FontWeight.bold);
+  });
+
+  testWidgets('switching to This month reloads with the month filter', (
+    tester,
+  ) async {
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.value([_membership(id: 'm1', userId: 'u1')]));
+    await seedUser(id: 'u1', firstName: 'Ann', lastName: 'One');
+    await database.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 's-old',
+        userId: const Value('u1'),
+        type: const Value('survey'),
+        status: const Value('complete'),
+        lastUpdateTime: const Value(1),
+      ),
+    ]);
+    await database.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 's-now',
+        userId: const Value('u1'),
+        type: const Value('survey'),
+        status: const Value('complete'),
+        lastUpdateTime: Value(DateTime.now().millisecondsSinceEpoch),
+      ),
+    ]);
+    when(
+      () => surveys.teamOwnedSurveys(any()),
+    ).thenAnswer((_) async => const []);
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    // All time counts both submissions.
+    expect(find.text('2/0 surveys'), findsOneWidget);
+
+    await tester.tap(find.text('This month'));
+    await tester.pumpAndSettle();
+
+    // This month counts only the recent one.
+    expect(find.text('1/0 surveys'), findsOneWidget);
+  });
+
+  testWidgets('a failed load surfaces an error instead of spinning forever', (
+    tester,
+  ) async {
+    // `_load` has no error handling: a throwing dependency leaves `_loading`
+    // true and the screen shows an indefinite spinner with no way out.
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.error(StateError('members unavailable')));
+
+    await tester.pumpWidget(harness());
+    // Bounded pumps only — an indefinite CircularProgressIndicator spins
+    // `pumpAndSettle` to its ten-minute default.
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    // And it must read as a failure, not as "this team has no members".
+    expect(find.text('No data available'), findsNothing);
+    expect(find.text('The leaderboard is unavailable'), findsOneWidget);
+  });
+
+  testWidgets('a slow load does not leave a stale period selected', (
+    tester,
+  ) async {
+    // Toggling the period restarts `_load` without cancelling the one in
+    // flight. If the first completes last, its all-time numbers overwrite the
+    // this-month ones the user asked for.
+    when(
+      () => teams.watchMembers(any()),
+    ).thenAnswer((_) => Stream.value([_membership(id: 'm1', userId: 'u1')]));
+    await seedUser(id: 'u1', firstName: 'Ann', lastName: 'One');
+    await database.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 's-old',
+        userId: const Value('u1'),
+        type: const Value('survey'),
+        status: const Value('complete'),
+        lastUpdateTime: const Value(1),
+      ),
+    ]);
+
+    final gate = Completer<List<SurveyRow>>();
+    var call = 0;
+    when(() => surveys.teamOwnedSurveys(any())).thenAnswer((_) async {
+      call++;
+      // The first load hangs until released; the second returns at once.
+      return call == 1 ? gate.future : const <SurveyRow>[];
+    });
+
+    await tester.pumpWidget(harness());
+    await tester.pump(const Duration(milliseconds: 50));
+
+    await tester.tap(find.text('This month'));
+    await tester.pump(const Duration(milliseconds: 50));
+    // Now let the stale all-time load finish last.
+    gate.complete(const []);
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // The screen must show what This month asked for, not the late all-time
+    // result: the old submission is outside the current month.
+    expect(find.text('0/0 surveys'), findsOneWidget);
+    expect(find.text('1/0 surveys'), findsNothing);
+  });
+}

--- a/flutter/test/ui/teams/team_add_remove_gates_test.dart
+++ b/flutter/test/ui/teams/team_add_remove_gates_test.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/providers/teams_provider.dart';
 import 'package:myplanet/ui/teams/team_courses_screen.dart';
+import 'package:myplanet/ui/teams/team_members_screen.dart';
 import 'package:myplanet/ui/teams/team_resources_screen.dart';
 
 import '../../support/widget_harness.dart';
@@ -46,6 +49,62 @@ TeamRow _membership({bool isLeader = false}) =>
     _row(id: 'm1', teamId: 'team-1', userId: 'user-1', isLeader: isLeader);
 
 void main() {
+  group('the members list name and avatar', () {
+    // `team_members_screen` hand-rolled `displayName` and its initial — the
+    // third copy in this directory, and broken the same two ways the
+    // leaderboard's was: no middle name, and no trim, so a synced
+    // `"name": " jane "` rendered untrimmed behind a blank avatar (`' '` is
+    // not empty, so the `isEmpty ? '?'` guard does not fire).
+    testWidgets('a middle name is shown and a padded name is trimmed', (
+      tester,
+    ) async {
+      final database = AppDatabase.memory();
+      addTearDown(database.close);
+      await database.userDao.upsert(
+        UsersCompanion.insert(
+          id: 'u-mid',
+          firstName: const Value('Ada'),
+          middleName: const Value('Byron'),
+          lastName: const Value('Lovelace'),
+        ),
+      );
+      await database.userDao.upsert(
+        UsersCompanion.insert(id: 'u-pad', name: const Value(' jane ')),
+      );
+
+      await tester.pumpWidget(
+        wrapScreen(
+          const TeamMembersScreen(teamId: 'team-1'),
+          overrides: [
+            appDatabaseProvider.overrideWithValue(database),
+            teamMembersProvider('team-1').overrideWith(
+              (ref) => Stream.value([
+                _row(id: 'm1', teamId: 'team-1', userId: 'u-mid'),
+                _row(id: 'm2', teamId: 'team-1', userId: 'u-pad'),
+              ]),
+            ),
+            teamRequestsProvider(
+              'team-1',
+            ).overrideWith((ref) => Stream.value(const <TeamRow>[])),
+            teamMembershipsProvider.overrideWith(
+              (ref) => Stream.value(const {}),
+            ),
+            sessionProvider.overrideWith(
+              () =>
+                  _TestSessionNotifier(buildUserRow(id: 'user-1', name: 'ada')),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Ada Byron Lovelace'), findsOneWidget);
+      expect(find.text('jane'), findsOneWidget);
+      // 'J', not the space that a blank avatar renders.
+      expect(find.text('J'), findsOneWidget);
+    });
+  });
+
   group('team resources', () {
     Widget harness({TeamRow? membership}) => wrapScreen(
       const TeamResourcesScreen(teamId: 'team-1'),
@@ -173,6 +232,18 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.link_off), findsOneWidget);
+    });
+
+    testWidgets('an empty creator id does not match an empty session id', (
+      tester,
+    ) async {
+      // Kotlin's `getUserId().ifEmpty { "--" }` sentinel exists for this.
+      await tester.pumpWidget(
+        harness(membership: _membership(), creatorId: '', userId: ''),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.link_off), findsNothing);
     });
 
     testWidgets('the creator match ignores case', (tester) async {

--- a/flutter/test/ui/teams/team_add_remove_gates_test.dart
+++ b/flutter/test/ui/teams/team_add_remove_gates_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/ui/teams/team_courses_screen.dart';
+import 'package:myplanet/ui/teams/team_resources_screen.dart';
+
+import '../../support/widget_harness.dart';
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+TeamRow _row({
+  String id = 'team-1',
+  String? teamId,
+  String? userId,
+  bool isLeader = false,
+}) => TeamRow(
+  id: id,
+  teamId: teamId,
+  userId: userId,
+  isLeader: isLeader,
+  courses: const [],
+  createdDate: 0,
+  limit: 0,
+  isPublic: false,
+  beginningBalance: 0,
+  sales: 0,
+  otherIncome: 0,
+  wages: 0,
+  otherExpenses: 0,
+  startDate: 0,
+  endDate: 0,
+  updatedDate: 0,
+  date: 0,
+  amount: 0,
+  isUpdated: false,
+);
+
+TeamRow _membership({bool isLeader = false}) =>
+    _row(id: 'm1', teamId: 'team-1', userId: 'user-1', isLeader: isLeader);
+
+void main() {
+  group('team resources', () {
+    Widget harness({TeamRow? membership}) => wrapScreen(
+      const TeamResourcesScreen(teamId: 'team-1'),
+      overrides: [
+        teamResourcesProvider('team-1').overrideWith(
+          (ref) => Stream.value([
+            buildLibraryRow(id: 'r1', title: 'Algebra', resourceId: 'res-1'),
+          ]),
+        ),
+        teamMembershipsProvider.overrideWith(
+          (ref) => Stream.value(
+            membership == null ? const {} : {'team-1': membership},
+          ),
+        ),
+      ],
+    );
+
+    testWidgets('an ordinary member is offered the add button', (tester) async {
+      // `TeamResourcesFragment.kt:51-52` is
+      // `binding.fabAddResource.isVisible = isMember` — `isMemberFlow`, i.e.
+      // `TeamsRepositoryImpl.isMember`, plain membership. The port required
+      // leadership, so a rank-and-file member could not link a resource the
+      // Kotlin lets them link. The Phase 99 shape.
+      await tester.pumpWidget(harness(membership: _membership()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('a leader is offered the add button too', (tester) async {
+      await tester.pumpWidget(harness(membership: _membership(isLeader: true)));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('a non-member is not', (tester) async {
+      await tester.pumpWidget(harness());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsNothing);
+    });
+
+    testWidgets('an ordinary member may not unlink a resource', (tester) async {
+      // `TeamResourcesFragment.kt:73` really is `isTeamLeader` for remove —
+      // the two gates on this screen are genuinely different.
+      await tester.pumpWidget(harness(membership: _membership()));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.link_off), findsNothing);
+    });
+
+    testWidgets('a leader may unlink a resource', (tester) async {
+      await tester.pumpWidget(harness(membership: _membership(isLeader: true)));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.link_off), findsOneWidget);
+    });
+  });
+
+  group('team courses', () {
+    Widget harness({
+      TeamRow? membership,
+      String? creatorId,
+      String userId = 'user-1',
+    }) => wrapScreen(
+      const TeamCoursesScreen(teamId: 'team-1'),
+      overrides: [
+        teamCoursesProvider('team-1').overrideWith(
+          (ref) async => [buildCourseRow(id: 'c1', courseTitle: 'Algebra')],
+        ),
+        teamMembershipsProvider.overrideWith(
+          (ref) => Stream.value(
+            membership == null ? const {} : {'team-1': membership},
+          ),
+        ),
+        teamProvider(
+          'team-1',
+        ).overrideWith((ref) async => _row(userId: creatorId)),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(buildUserRow(id: userId, name: 'ada')),
+        ),
+      ],
+    );
+
+    testWidgets('an ordinary member is offered the add button', (tester) async {
+      // Kotlin's add has no gate in `TeamCoursesFragment` at all — it is
+      // driven by `btnAddDoc`, which `setupMyTeamButtons` shows to any
+      // member (`TeamDetailFragment.kt:286-289`).
+      await tester.pumpWidget(harness(membership: _membership()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('a non-member is not', (tester) async {
+      await tester.pumpWidget(harness());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsNothing);
+    });
+
+    testWidgets('a leader who did not create the team may not unlink', (
+      tester,
+    ) async {
+      // `TeamCoursesFragment.kt:44-46`:
+      // `canRemove = currentUserId.equals(teamCreator, ignoreCase = true)`,
+      // where `getTeamCreator` is the team row's `userId`
+      // (`TeamsRepositoryImpl.kt:1120-1123`) — the creator, not the leader.
+      await tester.pumpWidget(
+        harness(
+          membership: _membership(isLeader: true),
+          creatorId: 'someone-else',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.link_off), findsNothing);
+    });
+
+    testWidgets('the creator may unlink a course', (tester) async {
+      await tester.pumpWidget(
+        harness(membership: _membership(), creatorId: 'user-1'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.link_off), findsOneWidget);
+    });
+
+    testWidgets('the creator match ignores case', (tester) async {
+      await tester.pumpWidget(
+        harness(membership: _membership(), creatorId: 'USER-1'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.link_off), findsOneWidget);
+    });
+  });
+}

--- a/flutter/test/ui/teams/team_detail_gates_test.dart
+++ b/flutter/test/ui/teams/team_detail_gates_test.dart
@@ -1,0 +1,322 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/ui/teams/teams_screen.dart';
+
+import '../../support/widget_harness.dart';
+
+class _MockTeamMembershipActions extends Mock
+    implements TeamMembershipActions {}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+TeamRow _team({
+  String id = 'team-1',
+  String? name = 'Readers',
+  String? type = 'team',
+  bool isPublic = false,
+}) => TeamRow(
+  id: id,
+  name: name,
+  type: type,
+  isPublic: isPublic,
+  isLeader: false,
+  courses: const [],
+  createdDate: 0,
+  limit: 0,
+  beginningBalance: 0,
+  sales: 0,
+  otherIncome: 0,
+  wages: 0,
+  otherExpenses: 0,
+  startDate: 0,
+  endDate: 0,
+  updatedDate: 0,
+  date: 0,
+  amount: 0,
+  isUpdated: false,
+);
+
+TeamRow _membership({String teamId = 'team-1', bool isLeader = false}) =>
+    TeamRow(
+      id: 'm-$teamId',
+      teamId: teamId,
+      userId: 'user-1',
+      isLeader: isLeader,
+      courses: const [],
+      createdDate: 0,
+      limit: 0,
+      isPublic: false,
+      beginningBalance: 0,
+      sales: 0,
+      otherIncome: 0,
+      wages: 0,
+      otherExpenses: 0,
+      startDate: 0,
+      endDate: 0,
+      updatedDate: 0,
+      date: 0,
+      amount: 0,
+      isUpdated: false,
+    );
+
+UserRow _user({String id = 'user-1', String name = 'ada'}) => UserRow(
+  id: id,
+  name: name,
+  rolesList: const ['learner'],
+  userAdmin: false,
+  joinDate: 0,
+  isArchived: false,
+  isUpdated: false,
+);
+
+/// Every entry `buildPages` puts behind the `isMyTeam || isPublic` branch.
+const _gatedEntries = [
+  'Members',
+  'Tasks',
+  'Team Calendar',
+  'Team surveys',
+  'Discussions',
+];
+
+void main() {
+  late _MockTeamMembershipActions actions;
+
+  setUpAll(() {
+    registerFallbackValue(_team());
+  });
+
+  setUp(() {
+    // The link list is a `ListView(children: [...])`: children below the
+    // 600px default fold are built but never mounted, so `find.text` reports
+    // "Found 0 widgets" for entries that render fine on a device — and a
+    // negative assertion would then pass for the wrong reason. A tall
+    // viewport puts the whole list in frame instead.
+    final view =
+        TestWidgetsFlutterBinding.instance.platformDispatcher.views.first;
+    view.physicalSize = const Size(1000, 3000);
+    view.devicePixelRatio = 1.0;
+    addTearDown(view.resetPhysicalSize);
+    addTearDown(view.resetDevicePixelRatio);
+  });
+
+  setUp(() {
+    actions = _MockTeamMembershipActions();
+    when(() => actions.leave(any())).thenAnswer((_) async => true);
+    when(() => actions.requestToJoin(any())).thenAnswer((_) async => true);
+  });
+
+  Widget harness({
+    TeamRow? team,
+    TeamRow? membership,
+    UserRow? user,
+    int memberCount = 5,
+    List<TeamRow> requests = const [],
+  }) => wrapScreen(
+    const TeamDetailScreen(teamId: 'team-1'),
+    overrides: [
+      teamProvider('team-1').overrideWith((ref) async => team ?? _team()),
+      teamMembershipsProvider.overrideWith(
+        (ref) => Stream.value(
+          membership == null ? const {} : {'team-1': membership},
+        ),
+      ),
+      teamRequestsProvider(
+        'team-1',
+      ).overrideWith((ref) => Stream.value(requests)),
+      teamMemberCountProvider(
+        'team-1',
+      ).overrideWith((ref) => Stream.value(memberCount)),
+      sessionProvider.overrideWith(() => _TestSessionNotifier(user ?? _user())),
+      teamMembershipActionsProvider.overrideWithValue(actions),
+    ],
+  );
+
+  Future<void> settle(WidgetTester tester) async {
+    await tester.pumpAndSettle();
+    await tester.pump();
+  }
+
+  group('the non-member access gate', () {
+    testWidgets('a non-member of a private team sees only Plan and Members', (
+      tester,
+    ) async {
+      // `TeamDetailFragment.buildPages` (:74-92): without
+      // `isMyTeam || team?.isPublic == true`, the page set is exactly
+      // Plan/Mission and Members.
+      await tester.pumpWidget(harness());
+      await settle(tester);
+
+      expect(find.text('Plan'), findsOneWidget);
+      expect(find.text('Members'), findsOneWidget);
+      for (final entry in _gatedEntries.where((e) => e != 'Members')) {
+        expect(
+          find.text(entry),
+          findsNothing,
+          reason: '$entry is behind the member/public gate',
+        );
+      }
+      expect(find.text('Team resources'), findsNothing);
+      expect(find.text('Team courses'), findsNothing);
+    });
+
+    testWidgets('a non-member of a public team sees the full page set', (
+      tester,
+    ) async {
+      await tester.pumpWidget(harness(team: _team(isPublic: true)));
+      await settle(tester);
+
+      for (final entry in _gatedEntries) {
+        expect(find.text(entry), findsOneWidget, reason: entry);
+      }
+    });
+
+    testWidgets('a member of a private team sees the full page set', (
+      tester,
+    ) async {
+      await tester.pumpWidget(harness(membership: _membership()));
+      await settle(tester);
+
+      for (final entry in _gatedEntries) {
+        expect(find.text(entry), findsOneWidget, reason: entry);
+      }
+    });
+
+    testWidgets(
+      "a non-member of a private enterprise cannot reach its financial reports",
+      (tester) async {
+        // `ReportsPage` is inside the `isMyTeam || isPublic` branch (:85).
+        await tester.pumpWidget(harness(team: _team(type: 'enterprise')));
+        await settle(tester);
+
+        expect(find.text('Mission & Services'), findsOneWidget);
+        expect(find.text('Financial reports'), findsNothing);
+        expect(find.text('Finances'), findsNothing);
+      },
+    );
+
+    testWidgets('a member of an enterprise reaches reports and finances', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        harness(
+          team: _team(type: 'enterprise'),
+          membership: _membership(),
+        ),
+      );
+      await settle(tester);
+
+      expect(find.text('Financial reports'), findsOneWidget);
+      expect(find.text('Finances'), findsOneWidget);
+    });
+  });
+
+  group('the join button', () {
+    testWidgets('a guest is not offered membership', (tester) async {
+      // `setupNonMyTeamButtons` (:255-258) hides the button outright for a
+      // `guest…` id, before any of the join wiring runs.
+      await tester.pumpWidget(
+        harness(
+          user: _user(id: 'guest_abc', name: 'guest_abc'),
+        ),
+      );
+      await settle(tester);
+
+      expect(find.text('Request to join'), findsNothing);
+    });
+
+    testWidgets('a signed-in non-member is offered membership', (tester) async {
+      await tester.pumpWidget(harness());
+      await settle(tester);
+
+      expect(find.text('Request to join'), findsOneWidget);
+    });
+
+    testWidgets('a pending request replaces the button with a chip', (
+      tester,
+    ) async {
+      await tester.pumpWidget(harness(requests: [_membership()]));
+      await settle(tester);
+
+      expect(find.text('Request pending'), findsOneWidget);
+      expect(find.text('Request to join'), findsNothing);
+    });
+  });
+
+  group('the leave button', () {
+    testWidgets('a leader can leave', (tester) async {
+      // `setupMyTeamButtons` (:285-308) attaches the leave handler with no
+      // leader test at all, and `markMembershipsForLeave` has none either.
+      // Kotlin has `isTeamLeader` and pointedly does not use it here.
+      await tester.pumpWidget(harness(membership: _membership(isLeader: true)));
+      await settle(tester);
+
+      final button = tester.widget<OutlinedButton>(
+        find.widgetWithText(OutlinedButton, 'Leave team'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('leaving asks for confirmation first', (tester) async {
+      // Every Kotlin leave is behind a `confirm_exit` Yes/No dialog.
+      await tester.pumpWidget(harness(membership: _membership()));
+      await settle(tester);
+
+      await tester.tap(find.text('Leave team'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Are you sure you want to leave this team?'),
+        findsOneWidget,
+      );
+      verifyNever(() => actions.leave(any()));
+    });
+
+    testWidgets('declining the confirmation leaves the membership alone', (
+      tester,
+    ) async {
+      await tester.pumpWidget(harness(membership: _membership()));
+      await settle(tester);
+
+      await tester.tap(find.text('Leave team'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('No'));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => actions.leave(any()));
+    });
+
+    testWidgets('accepting the confirmation leaves the team', (tester) async {
+      await tester.pumpWidget(harness(membership: _membership()));
+      await settle(tester);
+
+      await tester.tap(find.text('Leave team'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Yes'));
+      await tester.pumpAndSettle();
+
+      verify(() => actions.leave('team-1')).called(1);
+    });
+
+    testWidgets('the last member is not offered the leave button', (
+      tester,
+    ) async {
+      // `TeamDetailFragment.kt:179-186` hides it when
+      // `getJoinedMemberCount(teamId) <= 1 && isMyTeam`.
+      await tester.pumpWidget(
+        harness(membership: _membership(), memberCount: 1),
+      );
+      await settle(tester);
+
+      expect(find.text('Leave team'), findsNothing);
+    });
+  });
+}

--- a/flutter/test/ui/teams/team_detail_gates_test.dart
+++ b/flutter/test/ui/teams/team_detail_gates_test.dart
@@ -79,13 +79,8 @@ UserRow _user({String id = 'user-1', String name = 'ada'}) => UserRow(
 );
 
 /// Every entry `buildPages` puts behind the `isMyTeam || isPublic` branch.
-const _gatedEntries = [
-  'Members',
-  'Tasks',
-  'Team Calendar',
-  'Team surveys',
-  'Discussions',
-];
+/// `Members` is deliberately absent: Kotlin shows it on both sides.
+const _gatedEntries = ['Tasks', 'Team Calendar', 'Team surveys', 'Discussions'];
 
 void main() {
   late _MockTeamMembershipActions actions;
@@ -157,14 +152,18 @@ void main() {
 
       expect(find.text('Plan'), findsOneWidget);
       expect(find.text('Members'), findsOneWidget);
-      for (final entry in _gatedEntries.where((e) => e != 'Members')) {
+      for (final entry in _gatedEntries) {
         expect(
           find.text(entry),
           findsNothing,
           reason: '$entry is behind the member/public gate',
         );
       }
-      expect(find.text('Team resources'), findsNothing);
+      // The labels are `l10n.teamResources` = "Resources" and
+      // `l10n.teamCourses` = "Team courses". Asserting the wrong string here
+      // gave a negative that could never match, and so would have passed with
+      // the gate removed.
+      expect(find.text('Resources'), findsNothing);
       expect(find.text('Team courses'), findsNothing);
     });
 

--- a/flutter/test/ui/teams/teams_screen_test.dart
+++ b/flutter/test/ui/teams/teams_screen_test.dart
@@ -1,0 +1,369 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/repository/teams_repository.dart';
+import 'package:myplanet/ui/teams/teams_screen.dart';
+
+import '../../support/widget_harness.dart';
+
+class _MockTeamsRepository extends Mock implements TeamsRepository {}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+TeamRow _team({
+  required String id,
+  String? name,
+  String? description,
+  String? type = 'team',
+  bool isPublic = false,
+}) => TeamRow(
+  id: id,
+  name: name,
+  description: description,
+  type: type,
+  isPublic: isPublic,
+  isLeader: false,
+  courses: const [],
+  createdDate: 0,
+  limit: 0,
+  beginningBalance: 0,
+  sales: 0,
+  otherIncome: 0,
+  wages: 0,
+  otherExpenses: 0,
+  startDate: 0,
+  endDate: 0,
+  updatedDate: 0,
+  date: 0,
+  amount: 0,
+  isUpdated: false,
+);
+
+TeamRow _membership({
+  required String teamId,
+  bool isLeader = false,
+  String? userId = 'u1',
+}) => TeamRow(
+  id: 'm-$teamId',
+  teamId: teamId,
+  userId: userId,
+  isLeader: isLeader,
+  courses: const [],
+  createdDate: 0,
+  limit: 0,
+  isPublic: false,
+  beginningBalance: 0,
+  sales: 0,
+  otherIncome: 0,
+  wages: 0,
+  otherExpenses: 0,
+  startDate: 0,
+  endDate: 0,
+  updatedDate: 0,
+  date: 0,
+  amount: 0,
+  isUpdated: false,
+);
+
+void main() {
+  late _MockTeamsRepository teams;
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
+
+  setUp(() {
+    teams = _MockTeamsRepository();
+    when(
+      () => teams.memberStatuses(any(), any()),
+    ).thenAnswer((_) async => const <String, TeamMemberStatus>{});
+    when(
+      () => teams.recentVisitCounts(any()),
+    ).thenAnswer((_) async => const <String, int>{});
+    when(
+      () => teams.watchMemberships(any()),
+    ).thenAnswer((_) => Stream.value(const <TeamRow>[]));
+  });
+
+  Widget harness({
+    List<TeamRow> catalog = const [],
+    List<TeamRow> memberships = const [],
+    UserRow? session,
+    Stream<List<TeamRow>>? catalogStream,
+  }) {
+    when(
+      () => teams.watchCatalog(type: any(named: 'type')),
+    ).thenAnswer((_) => catalogStream ?? Stream.value(catalog));
+    when(
+      () => teams.watchMemberships(any()),
+    ).thenAnswer((_) => Stream.value(memberships));
+    return wrapScreen(
+      const TeamsScreen(),
+      overrides: [
+        teamsRepositoryProvider.overrideWithValue(teams),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(
+            session ?? buildUserRow(id: 'u1', name: 'ann'),
+          ),
+        ),
+      ],
+      pushTargets: {
+        '/life/teams/:id': (context) => const Scaffold(body: Text('detail')),
+      },
+    );
+  }
+
+  testWidgets('the empty catalog shows the empty state', (tester) async {
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    expect(find.text('No teams available'), findsOneWidget);
+  });
+
+  testWidgets('a team row shows its name, description and chevron', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      harness(
+        catalog: [
+          _team(id: 't1', name: 'Readers', description: 'A reading circle'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Readers'), findsOneWidget);
+    expect(find.text('A reading circle'), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+  });
+
+  testWidgets('a nameless team falls back to the untitled label', (
+    tester,
+  ) async {
+    await tester.pumpWidget(harness(catalog: [_team(id: 't1')]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Untitled team'), findsOneWidget);
+  });
+
+  testWidgets('a public team gets the public icon, a private one the group', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      harness(
+        catalog: [
+          _team(id: 't1', name: 'Open', isPublic: true),
+          _team(id: 't2', name: 'Closed'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.public), findsOneWidget);
+    // One list icon. The segmented button's own `groups` icon is replaced by
+    // a checkmark on the selected segment, so it does not count here.
+    expect(find.byIcon(Icons.groups), findsOneWidget);
+  });
+
+  testWidgets('membership shows a Member chip and leadership a Leader chip', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      harness(
+        catalog: [
+          _team(id: 't1', name: 'Led'),
+          _team(id: 't2', name: 'Joined'),
+          _team(id: 't3', name: 'Neither'),
+        ],
+        memberships: [
+          _membership(teamId: 't1', isLeader: true),
+          _membership(teamId: 't2'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(Chip, 'Leader'), findsOneWidget);
+    expect(find.widgetWithText(Chip, 'Member'), findsOneWidget);
+    expect(find.byType(Chip), findsNWidgets(2));
+  });
+
+  testWidgets('tapping a team row opens its detail route', (tester) async {
+    await tester.pumpWidget(
+      harness(
+        catalog: [_team(id: 't1', name: 'Readers')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Readers'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('detail'), findsOneWidget);
+  });
+
+  testWidgets('the search box filters on the team name', (tester) async {
+    await tester.pumpWidget(
+      harness(
+        catalog: [
+          _team(id: 't1', name: 'Readers'),
+          _team(id: 't2', name: 'Writers'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(SearchBar), 'read');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Readers'), findsOneWidget);
+    expect(find.text('Writers'), findsNothing);
+  });
+
+  testWidgets('the search box does not match on the description', (
+    tester,
+  ) async {
+    // `TeamViewModel.applyFilters` filters on `it.name` alone
+    // (TeamViewModel.kt:115-117) — a word that appears only in a description
+    // must not surface the team.
+    await tester.pumpWidget(
+      harness(
+        catalog: [
+          _team(id: 't1', name: 'Readers', description: 'poetry and prose'),
+          _team(id: 't2', name: 'Poetry club', description: 'verse'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(SearchBar), 'poetry');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Poetry club'), findsOneWidget);
+    expect(find.text('Readers'), findsNothing);
+  });
+
+  testWidgets('typing in the search box does not blank the list', (
+    tester,
+  ) async {
+    // `teamsProvider` watches `teamsSearchProvider`, so every keystroke tears
+    // the provider down and rebuilds it. `AsyncValue.when`'s
+    // `skipLoadingOnReload` defaults to false and "does not skip loading
+    // states if triggered by `Ref.watch`", so the whole list was replaced by
+    // a centered spinner once per character. Kotlin re-filters an in-memory
+    // list (`TeamViewModel.applyFilters`) and never shows a loading state.
+    await tester.pumpWidget(
+      harness(
+        catalog: [
+          _team(id: 't1', name: 'Readers'),
+          _team(id: 't2', name: 'Writers'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Readers'), findsOneWidget);
+
+    await tester.enterText(find.byType(SearchBar), 'r');
+    // One frame only — this is the frame the spinner used to occupy.
+    await tester.pump();
+
+    expect(
+      find.byType(CircularProgressIndicator),
+      findsNothing,
+      reason: 'the list must survive a keystroke',
+    );
+    expect(find.text('Readers'), findsOneWidget);
+  });
+
+  testWidgets('switching the type segment does not blank the list', (
+    tester,
+  ) async {
+    // Same mechanism: `teamsTypeProvider` is watched too.
+    await tester.pumpWidget(
+      harness(
+        catalog: [_team(id: 't1', name: 'Readers')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Enterprises'));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('the search is case-insensitive', (tester) async {
+    // Kotlin passes `ignoreCase = true`.
+    await tester.pumpWidget(
+      harness(
+        catalog: [_team(id: 't1', name: 'Readers')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(SearchBar), 'READ');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Readers'), findsOneWidget);
+  });
+
+  testWidgets('the enterprise segment retitles the screen and the search box', (
+    tester,
+  ) async {
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(AppBar, 'Teams'), findsOneWidget);
+    expect(find.text('Search teams'), findsOneWidget);
+
+    await tester.tap(find.text('Enterprises'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(AppBar, 'Enterprises'), findsOneWidget);
+    expect(find.text('Search enterprises'), findsOneWidget);
+  });
+
+  testWidgets('switching to enterprises re-queries the catalog by type', (
+    tester,
+  ) async {
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Enterprises'));
+    await tester.pumpAndSettle();
+
+    verify(() => teams.watchCatalog(type: 'enterprise')).called(1);
+  });
+
+  testWidgets('a failed catalog shows the error state', (tester) async {
+    // Overriding `teamsProvider` itself rather than erroring `watchCatalog`:
+    // the provider's `await for` rethrows into the test zone as well as into
+    // the provider, and the zone report lands after the test body.
+    await tester.pumpWidget(
+      wrapScreen(
+        const TeamsScreen(),
+        overrides: [
+          teamsRepositoryProvider.overrideWithValue(teams),
+          sessionProvider.overrideWith(
+            () => _TestSessionNotifier(buildUserRow(id: 'u1', name: 'ann')),
+          ),
+          teamsProvider.overrideWith(
+            (ref) => Stream<List<TeamRow>>.error(StateError('offline')),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Teams are unavailable'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Lane C of the Phase 115 parallel round. Draft — opened as the lane's first action so the lane has an inbound channel.

## Scope

The team surfaces in `flutter/lib/ui/teams/`. Starts by re-measuring what is actually covered (by symbol reference, not filename), then writes the first tests for whichever team surface genuinely has the thinnest coverage and fixes what they find.

Progress and findings are recorded in `flutter/PHASE_115_NOTES.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZc4FJw4km54hmmXkZ4KaS)_