### PR TITLE
sync: smoother repositories json utils documents mapping (fixes #16643)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6931
-        versionName = "0.69.31"
+        versionCode = 6932
+        versionName = "0.69.32"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -46,6 +46,7 @@ import org.ole.planet.myplanet.utils.ExamAnswerUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.toSyncDocuments
 
 class CoursesRepositoryImpl @Inject constructor(
     private val progressRepository: ProgressRepository,
@@ -599,14 +600,7 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
-        for (j in jsonArray) {
-            val jsonDoc = JsonUtils.getJsonObject("doc", j.asJsonObject)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-            }
-        }
+        val documentList = jsonArray.toSyncDocuments().map { it.second }
         upsertRoomCoursesFromSync(documentList)
         MyCourse.saveConcatenatedLinksToPrefs(sharedPrefManager)
     }
@@ -777,18 +771,12 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun insertCertificationsFromSync(jsonArray: JsonArray) {
-        val certifications = ArrayList<Certification>(jsonArray.size())
-        for (j in jsonArray) {
-            val jsonDoc = JsonUtils.getJsonObject("doc", j.asJsonObject)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (id.startsWith("_design")) continue
-            certifications.add(
-                Certification().apply {
-                    _id = id
-                    name = JsonUtils.getString("name", jsonDoc)
-                    setCourseIds(JsonUtils.getJsonArray("courseIds", jsonDoc))
-                }
-            )
+        val certifications = jsonArray.toSyncDocuments().map { (id, jsonDoc) ->
+            Certification().apply {
+                _id = id
+                name = JsonUtils.getString("name", jsonDoc)
+                setCourseIds(JsonUtils.getJsonArray("courseIds", jsonDoc))
+            }
         }
         certificationDao.upsertAll(certifications)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -26,6 +26,7 @@ import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.UrlUtils
+import org.ole.planet.myplanet.utils.toSyncDocuments
 
 class HealthRepositoryImpl @Inject constructor(
     private val apiInterface: ApiInterface,
@@ -79,15 +80,7 @@ class HealthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
-        val examinations = ArrayList<HealthExamination>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                examinations.add(HealthExamination.fromJson(jsonDoc))
-            }
-        }
+        val examinations = jsonArray.toSyncDocuments().map { (_, doc) -> HealthExamination.fromJson(doc) }
         healthExaminationDao.upsertAll(examinations)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -17,8 +17,8 @@ import org.ole.planet.myplanet.model.NotificationPayload
 import org.ole.planet.myplanet.model.TaskNotificationResult
 import org.ole.planet.myplanet.model.TeamNotification
 import org.ole.planet.myplanet.model.TeamNotificationInfo
-import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.TimeProvider
+import org.ole.planet.myplanet.utils.toSyncDocuments
 
 private const val STORAGE_WARNING_AVAILABLE_PERCENT = 10
 
@@ -425,15 +425,7 @@ class NotificationsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-            }
-        }
+        val documentList = jsonArray.toSyncDocuments().map { it.second }
         val parsedList = documentList.mapNotNull { parseNotification(it) }
         val existingNotifications = if (parsedList.isNotEmpty()) {
             notificationDao.getByIds(parsedList.map { it.id }).associateBy { it.id }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -39,6 +39,7 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.ExamAnswerUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
+import org.ole.planet.myplanet.utils.toSyncDocuments
 
 class SubmissionsRepositoryImpl @Inject internal constructor(
     private val teamsRepositoryProvider: Provider<TeamsRepository>,
@@ -642,15 +643,7 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-            }
-        }
+        val documentList = jsonArray.toSyncDocuments().map { it.second }
         upsertRoomSubmissionsFromSync(documentList)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -58,6 +58,7 @@ import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
+import org.ole.planet.myplanet.utils.toSyncDocuments
 
 @Singleton
 class TeamsRepositoryImpl @Inject constructor(
@@ -1246,17 +1247,8 @@ class TeamsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
-        val ids = mutableListOf<String>()
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-                ids.add(id)
-            }
-        }
+        val syncDocs = jsonArray.toSyncDocuments()
+        val ids = syncDocs.map { it.first }
         val existingTeams = teamDao.getAll()
             .filter { (it._id ?: it.id) in ids }
             .associateBy { it._id ?: it.id }
@@ -1266,35 +1258,19 @@ class TeamsRepositoryImpl @Inject constructor(
         // the ~1000 docs in a heavy-table sync page would commit — and fsync — on its own,
         // turning one page into minutes of work. One transaction => one commit for the page.
         appDatabase.withTransaction {
-            documentList.forEach { jsonDoc ->
+            syncDocs.forEach { (_, jsonDoc) ->
                 insertMyTeam(jsonDoc, existingTeams)
             }
         }
     }
 
     override suspend fun bulkInsertTasksFromSync(jsonArray: JsonArray) {
-        val tasks = ArrayList<TeamTask>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                tasks.add(TeamTask.fromJson(jsonDoc))
-            }
-        }
+        val tasks = jsonArray.toSyncDocuments().map { (_, doc) -> TeamTask.fromJson(doc) }
         teamTaskDao.upsertAll(tasks)
     }
 
     override suspend fun bulkInsertTeamActivitiesFromSync(jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-            }
-        }
+        val documentList = jsonArray.toSyncDocuments().map { it.second }
         insertTeamLogs(documentList)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -58,6 +58,7 @@ import org.ole.planet.myplanet.utils.SecurePrefs
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.VersionUtils
+import org.ole.planet.myplanet.utils.toSyncDocuments
 
 class UserRepositoryImpl @Inject constructor(
     @param:AppPreferences private val settings: SharedPreferences,
@@ -1046,15 +1047,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun bulkInsertAchievementsFromSync(jsonArray: JsonArray) {
-        val achievements = ArrayList<Achievement>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                achievements.add(Achievement.fromJson(jsonDoc))
-            }
-        }
+        val achievements = jsonArray.toSyncDocuments().map { (_, doc) -> Achievement.fromJson(doc) }
         achievementDao.upsertAll(achievements)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utils/JsonUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/JsonUtils.kt
@@ -125,7 +125,7 @@ object JsonUtils {
 
     fun getJsonObject(fieldName: String, jsonObject: JsonObject?): JsonObject = safeGet({ JsonObject() }) {
         val el: JsonElement? = jsonObject?.let { getJsonElement(fieldName, it, JsonObject::class.java) }
-        if (el is JsonObject) el else JsonObject()
+        el as? JsonObject ?: JsonObject()
     }
 
     private fun getJsonElement(fieldName: String, jsonObject: JsonObject, type: Class<*>): JsonElement {
@@ -142,3 +142,10 @@ object JsonUtils {
         }
     }
 }
+
+fun JsonArray.toSyncDocuments(): List<Pair<String, JsonObject>> =
+    mapNotNull { element ->
+        val doc = JsonUtils.getJsonObject("doc", element.asJsonObject)
+        val id = JsonUtils.getString("_id", doc)
+        if (id.startsWith("_design")) null else id to doc
+    }


### PR DESCRIPTION
fixes #16643
Extract repeated CouchDB sync document parsing (get doc, filter _design) into a reusable JsonArray.toSyncDocuments() extension in JsonUtils.kt. Replace duplicated loops in 6 repository bulkInsert methods. Also clean up minor style in JsonUtils (isNotEmpty, safe cast).