### PR TITLE
Phase 116 — reachability audit of the Flutter port

### DIFF
--- a/flutter/PHASE_116_NOTES.md
+++ b/flutter/PHASE_116_NOTES.md
@@ -93,8 +93,16 @@ surveys and voices — every sibling but this one.
 
 It has no Kotlin counterpart on master (`grep -rn leaderboard app/src/main` is
 empty) — Phase 73 took it from the unmerged `14880` branch — so there is no tab
-position to copy. A tile next to the member list is where it belongs, and it is
-ungated because it ranks the whole team either way.
+position to copy. A tile next to the member list is where it belongs.
+
+**Gated on `canView`, and the first cut was not.** The second pass caught it:
+`watchMembers` is `watchTeamDocuments(teamId, 'membership')` with no viewer
+predicate, so an ungated tile put a non-member of a *private* team in front of
+its full roster with each member's course, survey and visit counts. Kotlin's
+non-member page set is Plan and Members and nothing else. `team_detail_gates_test`
+now lists `Leaderboard` among its gated entries, which is what makes that test's
+title (`a non-member of a private team sees only Plan and Members`) true of the
+leaderboard rather than merely unfalsified.
 
 ### 4 — pushing a route pattern
 
@@ -161,10 +169,10 @@ redirect targets, the public-survey deep link, and `/exam/user-info/:submissionI
 location — Phase 108's finding, now recorded as deliberate rather than lost).
 
 Deep links and notification taps are covered too. All five `deepLinkRoute`
-sections and `DeepLinkHandler.publicSurveyLocation` resolve; the notification
-destinations are built as `Routes.`-interpolated literals inside
-`notifications_screen.dart`'s `switch`, which the guard's second scanning rule
-reaches even though they reach `context.go` through a variable.
+sections and `DeepLinkHandler.publicSurveyLocation` resolve, and the seven
+notification destinations resolve through the scanner's literal and
+bare-constant rules — five as `Routes.`-interpolated strings, two as bare
+constants, all of them reached from `context.go` through a variable.
 
 ### The guard
 
@@ -186,3 +194,393 @@ placeholder in for runtime ids. A route or a `context.push` added in a later
 phase is covered without anyone remembering to come back here — which is the
 whole point, since the reason this class survived so long is that nothing
 connected the two halves.
+
+What the scanner cannot read, it says so: `_unresolvedNavigations` feeds a
+fifth test whose allowlist names the three call sites that build a location out
+of a variable, with the reason for each. That channel exists because the second
+pass (below) proved the first cut of this guard had the failure it was written
+to catch — call sites dropped in silence.
+
+---
+
+## Part 2 — data-path reachability
+
+The harder half, and the one the exam defect belonged to. For each screen: which
+table does it read, through what predicate, who writes those columns, and can a
+writer's value satisfy the reader's predicate on a document shaped like the
+server's?
+
+Four `parity-auditor` passes at `effort: max` covered the port's screens in
+disjoint groups. **Every claim below marked ✔ I re-verified myself** by grep or
+probe against the source; the rest carry the auditing pass's evidence and are
+flagged as such.
+
+### The audit table
+
+Verdicts: **live** — proved end to end on server-shaped data. **suspect** — the
+port's predicate is narrower than Kotlin's and I could not obtain a real
+document to settle it. **dead** — no writer can satisfy the reader.
+
+| Screen | Reads | Predicate | Verdict |
+|---|---|---|---|
+| resources (catalog), filter sheet, collections | `my_library`, `tag` | `is_private = 0 AND user_id NOT LIKE …` | live |
+| resources (My Library), courses (My Courses), courses progress, home library/course cards, completed-course stars | `my_library`/`courses`.`user_id` | `LIKE '%"<uid>"%'` | **dead** — D1, D2 |
+| add resource | writes `my_library` | — | **dead** — D3 |
+| resource detail — rating card; course detail rating | `ratings` | `type = ? AND item = ?` | **dead** — D4 |
+| resource viewer, path viewer, web view | `my_library.filename` + disk | `ole/<couchId>/<filename>` | suspect — D14 |
+| courses list/detail, take course, **step exam + step survey** | `courses`, `exams`, `surveys` | `step_id = '<courseId>:<i>'` | **live** ✔ (Phase 113 re-verified end to end) |
+| take exam | `exams`, `exam_questions`, `certifications` | `id`, `exam_id`, `courseIds LIKE` | live |
+| submissions list + detail; home pending-survey dialog | `submissions` | `user_id = '<uid>'` | **dead** — D5, D6 |
+| notifications list, grouping, tap destination | `notifications` | `switch (type)` | **dead** — D7 |
+| challenge dialog / mandatory-survey block | `submissions` | `parentId = '<surveyId>@<courseId>'` | **dead** — D8 |
+| voices community feed | `news` | `viewIn[]._id == viewer` | **was dead** — D9, fixed |
+| voice compose → upload | writes `news` | — | **dead** — D10 |
+| voice thread replies | `news` | `replyTo = parent.docId ?? parent.id` | **dead** for local posts — D11 |
+| community services | `teams` | `docType = 'service'` | **dead** — D12 ✔ |
+| community leaders; community name/type | `PlanetPrefs.communityLeaders` | non-empty | **dead** — D13 ✔ |
+| community finances/reports tabs | `teams` | `teamId = ''` | **dead** — D13 |
+| member detail, team leaderboard, team member names | `users` | `id = :userId` | **dead** — D15 ✔ |
+| team tasks | `team_tasks` | `teamId = ? AND status = 'active'` | **dead** for server tasks — D16 ✔ |
+| team voices | `news` | `viewIn[]._id == teamId` only | suspect — D17 |
+| team resources | `teams` → `my_library` | `docType = 'resourceLink'` exactly | suspect — D18 |
+| achievements, edit achievement, CV | `achievements` | `id = '<userId>@<planetCode>'` | **dead** — D19 ✔ |
+| add health (write side) | writes `health_examinations` | — | **dead** — D20 |
+| become member (offline) | writes `users` | — | **dead** — D21 |
+| dictionary | `dictionary` | `word_normalized = ?` | suspect — D22 |
+| public survey (load) | `surveys` | `type == 'surveys'` | suspect — D23 |
+| my health (read), add examination | `health_examinations` | `profileId = myHealth.userKey` | **live** (probed through the real cipher) |
+| teams catalog, team detail, members list, join requests, finances, reports, courses, surveys, plan, calendar | `teams`, `surveys`, `meetup` | various `docType` | **live** (probed through the real mappers) |
+| surveys list, take survey, send survey | `surveys`, `submissions` | `type`/`teamShareAllowed` | live |
+| chat history + detail | `chat_entries` | `user = <session.name>` | live |
+| feedback list/detail/create | `feedback` | `owner = <session.name>` or manager | live |
+| settings, storage breakdown, storage category | disk + `my_library` | parent dir = `couchId` | live |
+| life, personals, references, dictionary shell, maps, calendar, events | `my_life`, `my_personal`, `meetups` | `userId = session.id` | live |
+| login, server config, sync center, profile, activities, dashboard shell/drawer, onboarding, about/disclaimer, inactive dashboard | — | — | live |
+
+### The headline: five sync-in walks Kotlin has that the port does not ✔
+
+I grepped `lib/` for every `_all_docs` walk. The complete set is
+`login_activities, chat_history, configurations, courses, meetups, feedback,
+health, notifications, courses_progress, certifications, resources, submissions,
+exams, tags, news, teams`. Missing, each verified absent by grep:
+
+| missing walk | Kotlin | what dies |
+|---|---|---|
+| **`shelf`** (`SyncManager.kt:442-540` → `processShelfParallel`) | pulls each user's shelf and stamps `userId` onto their resources/courses/meetups/teams | D1: My Library, My Courses, courses progress, both home cards, completed-course stars |
+| **`tablet_users`** (`SyncManager.kt:145-149`) | upserts the planet's accounts into `users` | D15: member detail, the leaderboard, every team member's name |
+| **`ratings`** (`HeavyTableSyncWorker.kt:39-41`) | community ratings | D4: every rating average shows only this device's own rating |
+| **`tasks`** (`SyncManager.kt:145-149`) | team tasks | D16: a task made on Planet or by a teammate never arrives |
+| **`achievements`** (`TransactionSyncManager.kt:259-261`) | the achievements ledger + CV attachment | D19: a second device shows blank, and saving there 409s into the outbox's permanent-failure branch |
+
+`_users/_find` for community leaders (`LoginSyncManager.kt:123-147`) is a sixth
+absent call — D13.
+
+**This is one phase, not five.** The walks are the same shape as the sixteen the
+port already has, and four of the five have a Dart repository method already
+written and uncalled (`AchievementsRepository.syncAchievements`,
+`CoursesRepository.sync(shelfId:)`, `TeamTaskDao.upsertAll`,
+`PlanetPrefs.setCommunityLeaders`) — plumbing laid for a pull nobody wrote. That
+is the Phase 113 shape at the top of the stack: a parameter threaded end to end
+for a caller that does not exist.
+
+**Two traps for whoever closes it**, both found by the audit rather than guessed:
+
+- `TeamTaskDao.watchForTeam` is `status = 'active'` where Kotlin is
+  `status IS NULL OR status != 'archived'`, and `TeamTask.serialize` emits **no
+  `status`** — so every synced task would arrive with a null status, be rejected
+  by the port's predicate, and the screen would stay empty with the walk
+  working. ✔
+- `AchievementsRepository` rows carry no `_rev` until a sync supplies one, and
+  `OutboxDrainer` classifies the resulting 409 as permanent (`code < 500`) and
+  abandons the row with no snackbar and no log. Adding the walk fixes both ends;
+  adding only the upload makes it worse.
+
+### The defects, individually
+
+Numbered for citation. Everything here is **reported**, not fixed, except D1 and
+D9.
+
+**D1 — the resources walk cleared My Library on every sync. FIXED.**
+`my_library.userId` has two writers over one column, and
+`MyLibraryMapper.fromDoc` writes `userId: Value(existingUserIds)`
+unconditionally. Its one production caller passed none of the six `existing*`
+arguments, so every sync wrote `const []` over the shelf. Add a resource to My
+Library, tap sync, My Library is empty. The sibling walk in
+`courses_repository.dart` already did it correctly. Guarded by
+`test/repository/shelf_membership_survives_sync_test.dart` and, mechanically, by
+`test/data/local/mapper_preserves_local_columns_test.dart`.
+
+**D2 — no `shelf` walk**, so even with D1 fixed a shelf built on Planet web or on
+another device never arrives, and `CoursesRepository.sync(shelfId:)`'s parameter
+has no production caller. ✔
+
+**D3 — a locally created resource is deleted by the next sync and never
+uploaded.** `deleteNotIn` removes every local id absent from the keep set, with
+no `rev` guard and no `isPrivate` guard, where Kotlin's `deleteStalePublicNotIn`
+spares both; and there is no resources uploader at all. So Save on the
+add-resource screen (itself unreachable until this phase — see Part 1) writes a
+row that the next sync destroys, having never left the device.
+
+**D4 — no `ratings` walk.** The only writer of the table is the local `submit()`,
+whose one caller always passes the session user. So the read predicate
+(`type = ? AND item = ?`, deliberately unscoped by user) can only ever see one
+user's row. Two knock-ons: `ratings.couchId`/`rev` are structurally null, so
+every re-rating POSTs a new document where Kotlin PUTs; and `ratings` is not in
+`localAuthorityTables`, so a schema bump loses the user's own ratings with no
+sync to restore them.
+
+**D5 — the submissions list cannot show anything the server sent.**
+`upsertDocuments` reads a top-level `userId` key; Kotlin derives it from the
+nested user object (`normalizeSubmissionUserId(user._id)`) and its upload
+serializer emits no top-level `userId` at all. Worse, `deleteNotIn(savedIds)`
+keys on CouchDB `_id`s while a locally authored row is keyed by a sha1, so the
+learner's own submissions are pruned once `markUploaded` clears `isUpdated`. Only
+port-authored documents survive, because the port's own `serialize` happens to
+emit the non-standard key — which is why nothing noticed.
+
+**D6 — `submissions.parent` and `submissions.user` are stored as Dart map
+literals.** `JsonUtils.getStringOrNull` falls through to `Map.toString()`, so the
+column holds `{_id: exam-1, name: Week 1 quiz}`. That string is drawn as the list
+title and the detail headline, `jsonDecode` throws on it (silently swallowed in
+`SurveysRepository._parentSurveyId`, so team-survey adoption sees nothing), and a
+re-upload replaces Planet's `parent`/`user` objects with the literal. Same shape
+as Phase 104's `SurveyMapper.choices`. The same file's `_answerFromJson` carries
+a comment about this exact trap.
+
+**D7 — every server-originated notification is unactionable and mislabelled.**
+`NotificationParser.resolveType` — a faithful port of Kotlin's `resolveType`,
+which maps the server's raw `team`/`newTask`/`replyMessage` onto the seven
+display types — **has no caller in `lib/`** ✔. The repository stores the raw
+value, and all three readers (destination resolver, grouping, icon/title) switch
+on it, so a join request lands in "Other" with a generic bell and does nothing
+when tapped. The unread badge is unaffected, so the bell says there is something
+and the row is on screen; it just cannot be identified or opened. `subType`, which
+the repository does compute correctly, is read nowhere ✔.
+
+**D8 — the mandatory-survey block can never clear.** `hasUnfinishedSurveys`
+builds `parentId = '<surveyId>@<courseId>'`; `createSurveyDraft` writes the bare
+`survey.id`, never the suffix. Kotlin's `createSubmission` writes the suffixed
+form. So a submitted course survey still reads as outstanding — permanently
+pinning the challenge dialog's task and permanently blocking
+`take_course_screen._onFinish`'s pop.
+
+**D9 — the community feed filtered on the wrong identifier. FIXED.** ✔
+`shareToCommunity` writes `viewIn[]._id = '<planetCode>@<parentCode>'`, matching
+Kotlin's `shareNewsToCommunity`; `communityFeedProvider` filtered on
+`user.couchId ?? user.id`. The two halves of the port disagreed about one key, so
+no shared voice could reach the feed — including the sharer's own. The comment
+that justified it ("`viewIn` entries carry server ids") was true and beside the
+point: they carry a *planet* id, not a *user* id. Guarded by
+`test/repository/community_share_round_trip_test.dart`, which spans both halves,
+because each half had a passing test and only the pair was wrong.
+
+**D10 — a voice composed in the port uploads with no audience and no author.**
+`VoicesActions.createPost` passes no `viewInId`, `viewInSection`, `messageType`
+or `userJson`, so `serialize` omits `viewIn` and `user` entirely. The document is
+invisible in the port's feed, the Kotlin app's, and Planet web; and on the next
+sync `NewsMapper.fromDoc` writes `Value(null)` over `userId`/`userName` from the
+absent user object, so the author loses their own post's byline and its
+edit/delete affordance. D9's fix makes the *shared* path work; this one is the
+compose path and is a separate change.
+
+**D11 — replies to a locally composed post vanish when it uploads.** `postReply`
+writes `replyTo = parent.id` (the local row id) while both reply providers read
+with `docId ?? id` (the server id). They coincide for a synced post and diverge
+permanently for a local one.
+
+**D12 — the community Services tab reads a `docType` no writer produces.** ✔ The
+port queries `'service'`; Kotlin's `getTeamLinks()` is `getByDocType("link")`,
+and `"service"` appears nowhere in `app/src/main`. The tab always shows its empty
+state.
+
+**D13 — three preferences with no writer.** ✔ `setCommunityLeaders`,
+`setCommunityName` and `setPlanetType` have no caller anywhere in `lib/`. Kotlin
+fills them from `LoginSyncManager.syncAdmin()` and
+`SyncConfigurationCoordinator`. So the Leaders tab is permanently empty, the
+community title is always the generic fallback, and `isCommunity` is always
+false, which mislabels the leaders tab "Nation Leaders". Separately, the
+community Finances and Reports tabs query `teamId = ''` because `communityId` is
+never passed to `CommunityScreen`; Kotlin passes `"<planetCode>@<parentCode>"`.
+
+**D14 — the download key diverges from Kotlin's.** Kotlin downloads and stores by
+the `_attachments` key (`resourceLocalAddress`); the port uses the document's
+`filename` field for both URL and path. The two Dart sides agree with each other,
+so this is not self-inconsistent — but a resource whose `filename` differs from
+its attachment name 404s in the port and works in Kotlin. Two tells that it is a
+slip: `MyLibraryMapper` computes the correct Kotlin URL into
+`resourceRemoteAddress` and nothing reads that column, and the download button's
+visibility is gated on `resourceLocalAddress` while the download itself uses
+`filename`. Suspect: no real document to settle it.
+
+**D15 — no `tablet_users` walk**, so `users` holds only accounts that have signed
+in on this device ✔. Member detail shows "Unknown member" for everyone else; the
+leaderboard silently drops every member without a row, leaving a one-row board;
+the team members list falls back to rendering the raw `org.couchdb.user:bob`.
+Kotlin's `getJoinedMembers` drops such rows rather than showing an id.
+
+Worth stating because the brief flagged it: the synthetic team ids
+`/life/teams/community/members/<id>` and `/life/teams/voices/members/<id>` are
+**not** a defect. The provider renders fine with them — visits read 0 and
+`isLeader` false, correct for a non-team context. The screen dies one line
+earlier, on the `users` lookup.
+
+**D16 — no `tasks` walk** ✔, plus the `status` predicate trap above.
+
+**D17 — `teamVoicesProvider` implements half of Kotlin's query.** `NewsDao.kt:33`
+is `(viewableBy = 'teams' AND viewableId = :teamId) OR viewIn LIKE :pattern`; the
+port has only the `viewIn` half. The corroborating signal is internal: the port's
+own team-chat badge counts by exactly the branch its screen ignores, so the badge
+and the list count disjoint sets. Suspect only because no real document settles
+which shape the server writes.
+
+**D18 — team resources misses two of Kotlin's three sources.** Kotlin is
+`docType IS NULL OR '' OR 'resourceLink' OR 'link'`, unioned with team-private
+resources (`isPrivate = 1 AND privateFor = :teamId`); the port requires
+`docType = 'resourceLink'` exactly and has no private half, though both columns
+exist and are filled. Given D12 establishes `'link'` as a real server value, the
+`'link'` branch is likely live data.
+
+**D19 — no `achievements` walk** ✔, with the 409 trap above.
+
+**D20 — `AddHealthScreen` writes the health profile and never enqueues it.**
+`queuePending` has two callers: the *examination* form and a retry button that
+only appears once a row has already been abandoned. Kotlin sweeps
+`getUpdatedHealthExaminations()` on every auto-sync regardless of which screen
+dirtied the row, so the profile — and the name/dob/email/phone edits that ride
+with it — reach the server. In the port they stay on the handset unless the user
+later records an examination, which masks the bug.
+
+**D21 — an account created offline never reaches CouchDB.** `_submit` calls
+`uploadNewUser` once, synchronously; on failure it enqueues nothing.
+`UserUploader.queuePending`'s single caller is the profile editor, and neither
+`syncAll` nor the background runner calls it. Kotlin drains
+`getPendingSyncUsers` on every auto-sync. `docs/kotlin-to-flutter-migration.md`
+describes this durable path (Phase 63) as if the enqueue exists.
+
+**D22 — the dictionary import aborts on a duplicate entry.**
+`DictionaryMapper.fromJson` derives `id` from `language:word:code` where Kotlin
+uses a random UUID, so homographs collide; `replaceAll` uses `insertAll`, which
+throws `UNIQUE constraint failed` and leaves the table empty, and nothing on the
+path catches — the button spins forever with no error. Suspect because the
+shipped source file could not be fetched to confirm a duplicate exists. Same
+shape as Phase 113's defect F.
+
+**D23 — the public-survey load is stricter than Kotlin's.**
+`SurveyMapper.fromDoc` requires `type == 'surveys'`; Kotlin's
+`saveSurveyFromPublicApi` runs the document through `insertCourseStepsExams` with
+no type filter at all, defaulting a missing `type` to `"exam"`. If the public API
+returns a projection without `type`, the respondent gets "Could not load survey".
+The screen's only test hands the mapper `'type': 'surveys'`, so the guard has
+never been exercised against anything else.
+
+### Smaller divergences found in the same sweep
+
+`submissions.uploaded` reads a top-level key Kotlin derives from `rev`, so every
+synced submission renders "not turned in". `isResourceOffline` drops Kotlin's
+`_rev == downloadedRev` half, so a resource whose attachment was replaced still
+claims to be on disk. `MyLibraryMapper` reads `'tag'` where Kotlin reads
+`'tags'` (inert today). `Tag.isAttached` differs for a tag with no `attachedTo`
+(the port is more useful than Kotlin). Kotlin writes a `my_library` row per
+course-step resource with `courseId`/`stepId`; the port's table has neither
+column, and the step view's "N resources" card has a chevron with no `onTap`.
+The background auto-sync omits `notifications` and `activities`, which the
+foreground sync center runs. `notifications.title` has no producer. `InlineComments`
+never calls `queuePending`, so a task comment rides along the next unrelated
+voice action. And `course_mapper.dart:9-10` still carries the doc comment Phase
+113 proved false — the code was fixed and the sentence was not.
+
+### Two claims in the migration doc that the code does not support
+
+Recorded because a later phase will read them as settled:
+
+- *"The sync-in path is exercised end-to-end"* for achievements
+  (`docs/kotlin-to-flutter-migration.md:3588-3591`) — true of the repository
+  method, false of the app: nothing calls it.
+- *"the port's courses sync already preserves shelf membership"* (`:1550-1552`)
+  and *"the port's shelf processing holds its api via the repository"*
+  (`:1640-1641`) — there is no shelf pull.
+
+I have not edited that document; it is outside this lane's set.
+
+---
+
+## What this lane fixed, and what it reported
+
+**Fixed** (each demonstrated failing on the pre-fix code first):
+
+| | defect | files |
+|---|---|---|
+| Part 1 #1 | `AddResourceScreen` unroutable | `ui/router.dart` |
+| Part 1 #2 | `WebViewScreen` unroutable | `ui/router.dart` |
+| Part 1 #3 | `TeamLeaderboardScreen` had no entry point | `ui/router.dart`, `ui/teams/teams_screen.dart` |
+| Part 1 #4 | New chat pushed a route pattern | `ui/router.dart`, `ui/chat/chat_history_screen.dart` |
+| D1 | the resources walk cleared My Library every sync | `repository/resources_repository.dart` |
+| D9 | the community feed filtered on the wrong identifier | `providers/voices_provider.dart` |
+
+**Reported**: Part 1 #5 and #6, and D2–D8, D10–D23. The five missing sync walks
+are one phase; the notification `resolveType` gap (D7), the submissions sync-in
+shape (D5/D6) and the voice compose payload (D10) are each their own.
+
+**Files touched outside this lane's set**, all defects rather than tidying, none
+owned by Lane B (`repository/progress_repository.dart`,
+`providers/courses_providers.dart`, `ui/courses/`) or Lane C (`l10n/`,
+`test/l10n/`, `tool/`):
+`lib/ui/chat/chat_history_screen.dart`, `lib/ui/teams/teams_screen.dart`,
+`lib/repository/resources_repository.dart`, `lib/providers/voices_provider.dart`,
+`test/ui/teams/team_detail_gates_test.dart`.
+
+## The guards
+
+| file | catches |
+|---|---|
+| `test/ui/route_reachability_test.dart` | a route nothing navigates to, a navigation no route serves, a pushed `:param` pattern, an unreadable call site |
+| `test/repository/shelf_membership_survives_sync_test.dart` | a sync walk retracting what a local tap set, on resources *and* courses |
+| `test/data/local/mapper_preserves_local_columns_test.dart` | a mapper call omitting an `existing…` argument — the D1 defect, mechanically |
+| `test/repository/community_share_round_trip_test.dart` | a writer and a reader disagreeing about a key, across two files |
+
+## A second audit, on the finished implementation
+
+Phase 110's and 113's lesson, repeated exactly: **an audit of the ground truth
+does not audit the implementation.** The Part 1 fix was green — format clean,
+analyze clean, full suite passing — and a `parity-auditor` pass at `effort: max`
+aimed at my own diff found the guard materially weaker than both its doc comment
+and this file claimed.
+
+It reverted each of the four fixes and confirmed the guard went red on every one,
+including a reconstruction of Phase 113's defect C. Then it injected a *new*
+broken navigation into three call sites the scanner could not read and watched
+the suite stay green:
+
+| # | blind spot | injected defect that passed |
+|---|---|---|
+| A | the scanner read only the **first token** after `context.push(`, so a ternary, a variable and 2 of 7 notification switch arms were invisible | `context.go(session != null ? '/totally-not-a-route' : Routes.login)` |
+| B | `_stripComments` cut at `indexOf('//')`, which truncates `route.startsWith('http://')` into an unbalanced quote — one line above the `/web-view` push this phase fixed | a push on that same line |
+| C | `_resolve` dropped a glued interpolation as "must be a query string" | a `patientQuery` that adds a path segment |
+| D | the leaderboard tile was ungated where its neighbours gate on `canView`, and `watchMembers` has no viewer predicate | a non-member of a private team seeing the full roster and everyone's counts |
+
+A, B and D are fixed: the scanner now takes the **whole balanced argument** of a
+navigation call and reads every literal and constant in it; the comment stripper
+is string-aware and preserves newlines; a fourth rule reads any `/`-leading
+literal in `lib/ui/` and `lib/providers/` (scoped there because repositories and
+mappers build URLs and disk paths out of such strings — four measured false
+positives outside those layers); and the tile moved inside `canView`, with
+`team_detail_gates_test` extended so its title is true of the leaderboard rather
+than merely unfalsified. All three injected defects now fail the guard, replayed.
+
+C is not fully fixed and is now **declared** rather than silent: `_resolve`
+reports a partial resolution, and a fifth test requires every unreadable call
+site to be in an allowlist with its reason. The prefix is still checked; a
+non-query suffix on those two health-screen locations would still pass.
+
+The pass also corrected three sentences in this file, all now rewritten: the
+notification-arm claim, the "covered without anyone remembering" claim, and the
+scanner's own "the tree has none today".
+
+**The most useful thing it found is not in the table.** Eighteen test files use
+`widget_harness.dart`'s `pushTargets`, which builds a **fresh `GoRouter`
+containing only the routes the test names**. With the router reverted to the dead
+`/web-view` path, `services_screen_test.dart`'s *"an external route navigates to
+the web view screen"* still passes — it registers its own `/web-view` and asserts
+the tap lands on it. That test was green for the entire life of the dead route.
+It is Phase 113's fabricated join one layer up, and it is why a source-derived
+guard, rather than more widget tests, is the thing that closes this class.

--- a/flutter/PHASE_116_NOTES.md
+++ b/flutter/PHASE_116_NOTES.md
@@ -1,12 +1,188 @@
 # Phase 116 — the reachability audit
 
-**Status: in progress.** This lane audits, for every screen in `flutter/lib/ui/`,
-whether a live path reaches it from an app entry point *and* whether the data its
-query needs is ever written in a shape the query can match.
+Phase 113 found `TakeExamScreen` **unreachable in production** — not broken,
+unreachable. Its route was fine, its screen was fine, its tests were green, and
+no live path led to it: `CourseMapper` dropped the step's embedded exam, so the
+join `exams.stepId == course_steps.id` could never match real synced data. Three
+phases of correct exam work (the Phase 100 verification photo, the Phase 106
+choice shape, the Phase 110 retry model) were guarding a button that could not
+appear. Phase 108 separately found `Routes.userInfo` declared and routed with
+nothing navigating to it.
 
-Phase 113 found `TakeExamScreen` unreachable in production — not broken,
-unreachable — because `CourseMapper` dropped the step's embedded exam, so the
-join `exams.stepId == course_steps.id` could never match real synced data. Green
-tests could not see it: every fixture hand-faked the join.
+**Green tests cannot detect this class.** A screen test builds its screen
+directly; a repository test builds its own rows. The route table and the
+navigation calls were only ever exercised one at a time, and a fixture that
+fabricates a join makes the test pass and the feature dead. This phase audits
+reachability across the port and leaves guards behind, because a guard is worth
+more than any individual fix.
 
-The table, the evidence and the guards land here.
+Two questions, asked of every screen:
+
+1. **Route reachability.** Does a live path exist from an entry point — a tap, a
+   deep link, a notification — to this screen?
+2. **Data-path reachability.** Does the table the screen reads ever get written
+   in a shape its predicate can match, by a real writer, from a real document?
+
+---
+
+## Part 1 — route reachability
+
+### What was found
+
+Six defects, every one demonstrated failing on the pre-fix code by
+`test/ui/route_reachability_test.dart` before the fix landed.
+
+| # | screen | defect | severity |
+|---|---|---|---|
+| 1 | `AddResourceScreen` | route registered as top-level `'add'` — matched nothing, all 3 callers hit the error page | **dead** |
+| 2 | `WebViewScreen` | route registered as `Routes.webView.replaceFirst('/', '')` — same shape | **dead** |
+| 3 | `TeamLeaderboardScreen` | route registered, string translated, nothing navigates | **dead** |
+| 4 | `ChatDetailScreen` (new chat) | `context.push(Routes.chat)` pushes the *pattern* `/life/chat/:chatId` | latent |
+| 5 | `CommunityBottomSheet`, `CommunityScreen(fromLogin: true)` | the login-screen community entry point was never ported | **dead** (reported) |
+| 6 | `CustomDropdownButton`/`AlwaysNotifyDropdown`, `CheckboxList`/`CheckboxStringList` | component widgets with zero references in `lib/` or `test/` | dead code (reported) |
+
+### 1 and 2 — a top-level route's path is its whole path
+
+```dart
+GoRoute(path: 'add',                              builder: … AddResourceScreen …),
+GoRoute(path: Routes.webView.replaceFirst('/',''), builder: … WebViewScreen …),
+```
+
+Both sat in the **top-level** `routes:` list. go_router 14.8.1 has no assert
+against a relative path there (`configuration.dart:35-50` checks only for a
+trailing `/`), and `debugKnownRoutes()` prints them as `/add` and `/web-view`
+because it concatenates onto the empty parent path — so the route table *looks*
+right. The matcher does not concatenate: `RouteMatchBase._matchByNavigatorKey`
+starts a top-level route with `remainingLocation = uri.path`, i.e. `/resources/add`,
+and matches the raw pattern `add` against it. It matches nothing at all — not
+`/resources/add`, and not `/add` either.
+
+Measured on the pre-fix router, through `router.configuration.findMatch`:
+
+```
+/resources/add     -> error=true
+/web-view          -> error=true
+/add               -> error=true
+add                -> assertion: 'uri.path.startsWith(newMatchedLocation)'
+```
+
+So every caller landed on go_router's default error page:
+
+- `resources_screen.dart:139` — the My Library add-resource FAB;
+- `resource_detail_screen.dart:98` — the resource edit button;
+- `community/services_screen.dart:61` — every external link in the community
+  services list.
+
+**`AddResourceScreen` has been unreachable for as long as it has existed.**
+Phase 72 ported it (create, edit, file pick), Phase 102 gave it 33 tests and
+closed seven defects in it — including one about *which screen the FAB appears
+on* — and none of that work could ever run. It is the exam defect again, one
+layer up: the screen was audited, tested and fixed while nothing could open it.
+`WebViewScreen` (Phase 73) is the same.
+
+Fixed in `lib/ui/router.dart` by giving both routes their own constant.
+
+### 3 — a screen with a route, a string and no link
+
+`/life/teams/:teamId/leaderboard` was registered and matched fine.
+`TeamLeaderboardScreen`, `TeamLeaderboardCalculator`, the route and the
+`leaderboard` string (translated in all six locales) all landed in Phase 73, and
+nothing in `lib/` ever navigated there. `teams_screen.dart`'s team-detail list
+links to tasks, members, calendar, courses, finances, plan, reports, resources,
+surveys and voices — every sibling but this one.
+
+It has no Kotlin counterpart on master (`grep -rn leaderboard app/src/main` is
+empty) — Phase 73 took it from the unmerged `14880` branch — so there is no tab
+position to copy. A tile next to the member list is where it belongs, and it is
+ungated because it ranks the whole team either way.
+
+### 4 — pushing a route pattern
+
+`chat_history_screen.dart:48`, the New chat button:
+
+```dart
+ref.read(chatConversationProvider.notifier).startNewChat();
+context.push(Routes.chat);          // '/life/chat/:chatId'
+```
+
+go_router matches `:chatId` against the literal text `:chatId`, so this
+*succeeded* — and opened `ChatDetailScreen(chatId: ':chatId')`, whose `initState`
+then ran `loadChat(':chatId')`, undoing the `startNewChat()` two lines above it.
+It worked only because `loadChat` (`chat_provider.dart:112-115`) finds no row
+with that id and returns without touching state.
+
+This is Phase 113's defect C exactly, and the same file already carries a comment
+about it at its *other* tap site (`:179-184`) — the tap-a-conversation path was
+fixed and the New chat path beside it was not. Fixed with a `/life/chat/new`
+route registered ahead of `:chatId`, mirroring `calendar/events/new` ahead of
+`:meetupId`. Safe against collision: a chat id is the CouchDB `_id` the server
+assigns (`chat_repository_impl.dart:106-117` fails rather than mint one), so
+`new` is not a value the `:chatId` route can be asked for.
+
+### 5 — the login screen's community entry, never ported
+
+`CommunityBottomSheet` (`community_screen.dart:114`) is the port of
+`HomeCommunityDialogFragment.kt`, and **nothing constructs it — in `lib/` or in
+`test/`.** Kotlin shows it from `LoginActivity.setupAdditionalListeners`
+(`LoginActivity.kt:188-196`): an `openCommunity` button, visible whenever the
+configured URL is non-empty and not `/db`. The port's `login_screen.dart` has no
+such button.
+
+The same gap kills `CommunityScreen(fromLogin: true)` — the three-tab login
+variant. The router builds `fromLogin: false` and that is the only construction
+anywhere, so `_loginTabCount`, and both `if (!widget.fromLogin)` branches, are
+dead. `communityId` is likewise never passed.
+
+**Reported, not fixed.** Adding the button plus its visibility gate plus the
+bottom sheet's presentation is a port of a Kotlin screen affordance, not a defect
+fix, and this is an audit lane. It is a small, well-specified phase: the widget
+already exists and the Kotlin gate is two lines.
+
+### 6 — component widgets nothing calls
+
+Zero references in `lib/` and zero in `test/`:
+
+- `lib/ui/components/custom_dropdown.dart` — `CustomDropdownButton`,
+  `AlwaysNotifyDropdown` (CLAUDE.md already records `CustomDropdown` as
+  uncalled; this confirms both classes and adds that no test covers them either)
+- `lib/ui/components/checkbox_list.dart` — `CheckboxList`, `CheckboxStringList`
+
+Reported. Deleting them is a judgement about whether a later phase wants them,
+not a reachability fix.
+
+### What is reachable
+
+Everything else. The sweep is mechanical rather than narrative, and it is in the
+guard: `test/ui/route_reachability_test.dart` builds the real router, reads every
+`Routes` constant and every navigation location out of `lib/` source, and asserts
+they meet. After the fixes above, all six rules pass with an allowlist of four
+redirect targets, the public-survey deep link, and `/exam/user-info/:submissionId`
+(reachable, but through `Navigator.push` from `PublicSurveyScreen` rather than a
+location — Phase 108's finding, now recorded as deliberate rather than lost).
+
+Deep links and notification taps are covered too. All five `deepLinkRoute`
+sections and `DeepLinkHandler.publicSurveyLocation` resolve; the notification
+destinations are built as `Routes.`-interpolated literals inside
+`notifications_screen.dart`'s `switch`, which the guard's second scanning rule
+reaches even though they reach `context.go` through a variable.
+
+### The guard
+
+`test/ui/route_reachability_test.dart`, six tests, four rules:
+
+1. **Every `Routes` constant resolves to a registered route.** Catches 1 and 2.
+2. **Every navigation location in `lib/` resolves.** Catches 1 and 2 at the call
+   site, and anything whose target drifts from the route table later.
+3. **No navigation carries an unsubstituted `:param`.** Catches 4, and Phase
+   113's defect C.
+4. **Every registered route is navigated to from somewhere**, with an allowlist
+   whose entries each carry a reason. Catches 3, and makes adding an unreachable
+   route a deliberate act rather than an accident.
+
+It is **source-derived, not a hand-written list**: it parses the `Routes`
+constants out of `router.dart` and scans every `.dart` file under `lib/` for
+navigation targets, resolving `${Routes.x}` interpolations and standing a
+placeholder in for runtime ids. A route or a `context.push` added in a later
+phase is covered without anyone remembering to come back here — which is the
+whole point, since the reason this class survived so long is that nothing
+connected the two halves.

--- a/flutter/PHASE_116_NOTES.md
+++ b/flutter/PHASE_116_NOTES.md
@@ -1,0 +1,12 @@
+# Phase 116 — the reachability audit
+
+**Status: in progress.** This lane audits, for every screen in `flutter/lib/ui/`,
+whether a live path reaches it from an app entry point *and* whether the data its
+query needs is ever written in a shape the query can match.
+
+Phase 113 found `TakeExamScreen` unreachable in production — not broken,
+unreachable — because `CourseMapper` dropped the step's embedded exam, so the
+join `exams.stepId == course_steps.id` could never match real synced data. Green
+tests could not see it: every fixture hand-faked the join.
+
+The table, the evidence and the guards land here.

--- a/flutter/lib/providers/voices_provider.dart
+++ b/flutter/lib/providers/voices_provider.dart
@@ -12,6 +12,22 @@ import 'sync_state.dart';
 
 final voiceSearchProvider = StateProvider<String>((ref) => '');
 
+/// How a `viewIn` entry names the viewer: `"<planetCode>@<parentCode>"`.
+///
+/// Port of `VoicesFragment.getUserIdentifier()` (`:157-165`), and the same
+/// string `shareToCommunity` writes into the entry it creates — which is the
+/// point. This was `user.couchId ?? user.id`, the CouchDB *user* id, so the
+/// port's reader and its own writer disagreed about the key and no shared post
+/// could ever reach the feed. The comment that justified it said `viewIn`
+/// entries carry server ids; they do, but a planet's, not a user's.
+///
+/// A blank half is kept rather than trimmed: `isVisibleToUser` treats an empty
+/// or `"@"` id as the planet-wide wildcard on both sides.
+String communityViewerIdentifier({
+  required String? planetCode,
+  required String? parentCode,
+}) => '${planetCode ?? ''}@${parentCode ?? ''}';
+
 /// The community feed for the signed-in user.
 ///
 /// Visibility depends on who is asking — `isVisibleToUser` matches the viewer
@@ -26,11 +42,11 @@ final communityFeedProvider = StreamProvider<List<NewsRow>>((ref) async* {
   final query = ref.watch(voiceSearchProvider).trim().toLowerCase();
   final repository = ref.watch(voicesRepositoryProvider);
 
-  // The feed is matched against the user's CouchDB `_id` when there is one:
-  // `viewIn` entries carry server ids, so filtering by the local row id would
-  // hide every shared post.
   await for (final rows in repository.watchCommunityFeed(
-    user.couchId ?? user.id,
+    communityViewerIdentifier(
+      planetCode: user.planetCode,
+      parentCode: user.parentCode,
+    ),
   )) {
     if (query.isEmpty) {
       yield rows;

--- a/flutter/lib/repository/resources_repository.dart
+++ b/flutter/lib/repository/resources_repository.dart
@@ -353,15 +353,44 @@ class ResourcesRepository {
         break;
       }
 
+      final docs = <Map<String, dynamic>>[
+        for (final row in rows)
+          if (row is Map<String, dynamic>) ?JsonUtils.getObject('doc', row),
+      ];
+      // One batched read rather than a row at a time, as the courses walk does.
+      //
+      // Without it every `existing*` argument below defaults to `const []`, and
+      // `MyLibraryMapper.fromDoc` writes that straight over the stored column:
+      // `userId: Value(existingUserIds)`. `my_library.userId` is the shelf, and
+      // it has two writers over one column — this walk and the user's own tap —
+      // so a walk that knows nothing about membership was retracting it, and
+      // one sync emptied My Library. Kotlin cannot do this: `insertMyLibrary`
+      // is handed the existing row and only ever adds (`MyLibrary.kt:122-130`,
+      // `:218-228`). The other five lists are `mergedList` in the Kotlin for the
+      // same reason, and were being dropped the same way.
+      final existingById = {
+        for (final resource in await _dao.getByIds([
+          for (final doc in docs)
+            if (JsonUtils.getString('_id', doc) case final id
+                when id.isNotEmpty)
+              id,
+        ]))
+          resource.id: resource,
+      };
+
       final companions = <MyLibraryTableCompanion>[];
-      for (final row in rows) {
-        if (row is! Map<String, dynamic>) continue;
-        final doc = JsonUtils.getObject('doc', row);
-        if (doc == null) continue;
+      for (final doc in docs) {
+        final existing = existingById[JsonUtils.getString('_id', doc)];
 
         final companion = MyLibraryMapper.fromDoc(
           doc,
           couchDbUrl: config.couchDbUrl,
+          existingUserIds: existing?.userId ?? const [],
+          existingResourceFor: existing?.resourceFor ?? const [],
+          existingSubject: existing?.subject ?? const [],
+          existingLevel: existing?.level ?? const [],
+          existingTag: existing?.tag ?? const [],
+          existingLanguages: existing?.languages ?? const [],
         );
         if (companion == null) continue;
 

--- a/flutter/lib/ui/chat/chat_history_screen.dart
+++ b/flutter/lib/ui/chat/chat_history_screen.dart
@@ -45,7 +45,13 @@ class ChatHistoryScreen extends ConsumerWidget {
             tooltip: l10n.newChat,
             onPressed: () {
               ref.read(chatConversationProvider.notifier).startNewChat();
-              context.push(Routes.chat);
+              // `/life/chat/new`, not [Routes.chat]: that constant is the
+              // template `/life/chat/:chatId`, and go_router matches a
+              // placeholder against its own literal text, so pushing it opened
+              // the detail screen with `chatId: ':chatId'`. `loadChat` then
+              // searched for a conversation by that name, found none and
+              // returned, which is the only reason the new chat still worked.
+              context.push('${Routes.chatHistory}/new');
             },
           ),
         ],

--- a/flutter/lib/ui/router.dart
+++ b/flutter/lib/ui/router.dart
@@ -255,14 +255,23 @@ final routerProvider = Provider<GoRouter>((ref) {
         ),
       ),
       GoRoute(
-        path: 'add',
+        // `Routes.addResource`, not the bare `'add'` this carried: a top-level
+        // route's path is its whole path. go_router normalised `'add'` to
+        // `/add` when printing the table but matched the raw pattern against
+        // the incoming location, so `'add'` matched neither `/resources/add`
+        // nor `/add` and every caller landed on the error page. The screen was
+        // unreachable in production for as long as it has existed.
+        path: Routes.addResource,
         builder: (context, state) => AddResourceScreen(
           teamId: state.uri.queryParameters['teamId'],
           editResourceId: state.uri.queryParameters['edit'],
         ),
       ),
       GoRoute(
-        path: Routes.webView.replaceFirst('/', ''),
+        // Same shape as `Routes.addResource` above: stripping the leading
+        // slash left a pattern that matched nothing, so the community services
+        // list's external links opened the error page.
+        path: Routes.webView,
         builder: (context, state) => WebViewScreen(
           url: state.uri.queryParameters['url']!,
           title: state.uri.queryParameters['title'],
@@ -566,6 +575,13 @@ final routerProvider = Provider<GoRouter>((ref) {
                     path: 'chat',
                     builder: (context, state) => const ChatHistoryScreen(),
                     routes: [
+                      // Ahead of `:chatId`, as `events/new` is ahead of
+                      // `:meetupId`: go_router takes the first match, and a
+                      // new conversation has no id to carry.
+                      GoRoute(
+                        path: 'new',
+                        builder: (context, state) => const ChatDetailScreen(),
+                      ),
                       GoRoute(
                         path: ':chatId',
                         builder: (context, state) => ChatDetailScreen(

--- a/flutter/lib/ui/teams/teams_screen.dart
+++ b/flutter/lib/ui/teams/teams_screen.dart
@@ -380,21 +380,24 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                     onTap: () =>
                         context.push('${Routes.teams}/${team.id}/members'),
                   ),
-                  // The leaderboard's screen, calculator, route and translated
-                  // `leaderboard` string all landed in Phase 73 with nothing
-                  // linking to them, so it was registered and unopenable. It
-                  // has no Kotlin counterpart on master — it comes from the
-                  // unmerged `14880` branch — so there is no tab position to
-                  // copy; next to the member list is where it belongs, and it
-                  // is ungated because it ranks the whole team either way.
-                  ListTile(
-                    leading: const Icon(Icons.leaderboard_outlined),
-                    title: Text(l10n.leaderboard),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () =>
-                        context.push('${Routes.teams}/${team.id}/leaderboard'),
-                  ),
                   if (canView) ...[
+                    // The leaderboard's screen, calculator, route and
+                    // translated `leaderboard` string all landed in Phase 73
+                    // with nothing linking to them, so it was registered and
+                    // unopenable. It has no Kotlin counterpart on master — it
+                    // comes from the unmerged `14880` branch — so there is no
+                    // tab position to copy. It sits inside `canView` because
+                    // `watchMembers` has no viewer predicate: the board names
+                    // every member and their course, survey and visit counts,
+                    // which is a private team's roster.
+                    ListTile(
+                      leading: const Icon(Icons.leaderboard_outlined),
+                      title: Text(l10n.leaderboard),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () => context.push(
+                        '${Routes.teams}/${team.id}/leaderboard',
+                      ),
+                    ),
                     ListTile(
                       leading: const Icon(Icons.folder_copy_outlined),
                       // The same screen under two labels, as

--- a/flutter/lib/ui/teams/teams_screen.dart
+++ b/flutter/lib/ui/teams/teams_screen.dart
@@ -380,6 +380,20 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                     onTap: () =>
                         context.push('${Routes.teams}/${team.id}/members'),
                   ),
+                  // The leaderboard's screen, calculator, route and translated
+                  // `leaderboard` string all landed in Phase 73 with nothing
+                  // linking to them, so it was registered and unopenable. It
+                  // has no Kotlin counterpart on master — it comes from the
+                  // unmerged `14880` branch — so there is no tab position to
+                  // copy; next to the member list is where it belongs, and it
+                  // is ungated because it ranks the whole team either way.
+                  ListTile(
+                    leading: const Icon(Icons.leaderboard_outlined),
+                    title: Text(l10n.leaderboard),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () =>
+                        context.push('${Routes.teams}/${team.id}/leaderboard'),
+                  ),
                   if (canView) ...[
                     ListTile(
                       leading: const Icon(Icons.folder_copy_outlined),

--- a/flutter/test/data/local/mapper_preserves_local_columns_test.dart
+++ b/flutter/test/data/local/mapper_preserves_local_columns_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The "two writers, one column" rule, enforced mechanically.
+///
+/// A sync mapper turns one server document into one row, and some of that row's
+/// columns are not the server's to set: a shelf membership, a read flag, an
+/// emoji reaction, a stored credential. Those columns have a second writer — the
+/// user — and the walk has to carry the stored value forward rather than write
+/// over it with what the document does not say.
+///
+/// The port expresses that as a parameter: `existing`, or `existingUserIds`,
+/// `existingSubject` and so on. **The convention only works if the production
+/// call site actually passes them**, and the defect this test exists for is
+/// exactly that it did not: `MyLibraryMapper.fromDoc` declares six of them and
+/// writes `userId: Value(existingUserIds)` unconditionally, while its single
+/// caller in `resources_repository.dart` passed none — so every argument
+/// defaulted to `const []` and every sync emptied My Library. Nothing could see
+/// it, because the mapper's own tests pass those arguments and were the only
+/// callers that ever did.
+///
+/// This is the same shape as Phase 56 (a null credential wiping `derived_key`),
+/// Phase 74 (a sync erasing the user's own reaction), Phase 98 (a re-pull
+/// undoing a read) and Phase 113 (`Value.absent()` on `stepId`) — four phases
+/// finding one rule the hard way, which is what makes it worth a guard rather
+/// than a fifth comment.
+///
+/// The rule: if a mapper method declares a *named* parameter called `existing`
+/// or beginning with `existing`, every call to that method in `lib/` passes it.
+/// Named is the point — an optional positional parameter is visible in the
+/// call's arity, while a named one with a default disappears in silence.
+void main() {
+  test(
+    'every mapper call passes the local-authority columns it must preserve',
+    () {
+      final omissions = <String>[];
+
+      for (final mapper
+          in Directory('lib/data/local').listSync().whereType<File>().where(
+            (f) => f.path.endsWith('_mapper.dart'),
+          )) {
+        final source = _stripComments(mapper.readAsStringSync());
+
+        for (final method in _methodsWithExistingParams(source).entries) {
+          final expected = method.value;
+          for (final call in _callsTo(method.key)) {
+            final missing = expected
+                .where((param) => !call.arguments.contains('$param:'))
+                .toList();
+            if (missing.isEmpty) continue;
+            omissions.add(
+              '  ${call.file}:${call.line} calls ${method.key} '
+              'without ${missing.join(', ')}',
+            );
+          }
+        }
+      }
+
+      expect(
+        omissions,
+        isEmpty,
+        reason:
+            'A mapper takes an `existing…` argument because the column it feeds '
+            'has a second writer that the server document knows nothing about. '
+            'Omitting it does not leave the stored value alone — it writes the '
+            'default over it, silently, on every sync:\n'
+            '${omissions.join('\n')}',
+      );
+    },
+  );
+
+  test('the scanner finds the mappers it is meant to police', () {
+    // A guard that quietly matches nothing passes forever. Pin the two mappers
+    // that carry these parameters today, so deleting a parameter (or breaking
+    // the regex) fails here rather than going unnoticed.
+    final found = <String, Set<String>>{};
+    for (final mapper
+        in Directory('lib/data/local').listSync().whereType<File>().where(
+          (f) => f.path.endsWith('_mapper.dart'),
+        )) {
+      final methods = _methodsWithExistingParams(
+        _stripComments(mapper.readAsStringSync()),
+      );
+      for (final entry in methods.entries) {
+        found[entry.key] = entry.value;
+      }
+    }
+
+    expect(found.keys, containsAll(<String>['MyLibraryMapper.fromDoc']));
+    expect(
+      found['MyLibraryMapper.fromDoc'],
+      containsAll(<String>[
+        'existingUserIds',
+        'existingResourceFor',
+        'existingSubject',
+        'existingLevel',
+        'existingTag',
+        'existingLanguages',
+      ]),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Source scanning
+// ---------------------------------------------------------------------------
+
+/// `Class.method` -> the `existing…` parameter names it declares.
+///
+/// A mapper is a class of static factories, so the class name is the file's one
+/// top-level `class`, and a method is a `static … name(` whose parameter list
+/// runs to the matching `) {`.
+Map<String, Set<String>> _methodsWithExistingParams(String source) {
+  final className = RegExp(
+    r'^class (\w+)',
+    multiLine: true,
+  ).firstMatch(source)?.group(1);
+  if (className == null) return const {};
+
+  final result = <String, Set<String>>{};
+  // The parameter list is taken by balancing parentheses rather than by regex:
+  // a mapper's parameters are a named block, so the list contains `{`, `}` and
+  // nested generic commas that a flat pattern truncates at.
+  final signature = RegExp(r'static\s+[\w<>?,\s]+?\s(\w+)\(', multiLine: true);
+  for (final match in signature.allMatches(source)) {
+    final open = match.end - 1;
+    final close = _matchingParen(source, open);
+    if (close == -1) continue;
+    // Only the *named* block. An optional positional parameter is visible in
+    // the call's arity and cannot go missing unnoticed; a named one with a
+    // default disappears in silence, which is the failure being policed.
+    final parameters = source.substring(open + 1, close);
+    final namedFrom = parameters.indexOf('{');
+    if (namedFrom == -1) continue;
+    final params = RegExp(r'\b(existing\w*)\s*[,:=}]')
+        .allMatches(parameters.substring(namedFrom))
+        .map((m) => m.group(1)!)
+        .toSet();
+    if (params.isNotEmpty) result['$className.${match.group(1)}'] = params;
+  }
+  return result;
+}
+
+class _Call {
+  const _Call(this.file, this.line, this.arguments);
+  final String file;
+  final int line;
+  final String arguments;
+}
+
+/// Every call to `Class.method(` under `lib/`, with its argument text.
+///
+/// The argument list is taken by balancing parentheses from the opening one, so
+/// a nested call or a collection literal in an argument does not truncate it.
+List<_Call> _callsTo(String qualifiedName) {
+  final calls = <_Call>[];
+  final needle = '$qualifiedName(';
+
+  for (final file
+      in Directory('lib')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.dart'))
+          // A mapper may call its own helpers with the arguments already in hand.
+          .where((f) => !f.path.startsWith('lib/data/local/'))) {
+    final source = _stripComments(file.readAsStringSync());
+    var index = source.indexOf(needle);
+    while (index != -1) {
+      final open = index + needle.length - 1;
+      final close = _matchingParen(source, open);
+      if (close != -1) {
+        calls.add(
+          _Call(
+            file.path,
+            '\n'.allMatches(source.substring(0, index)).length + 1,
+            source.substring(open + 1, close),
+          ),
+        );
+      }
+      index = source.indexOf(needle, index + needle.length);
+    }
+  }
+  return calls;
+}
+
+int _matchingParen(String source, int open) {
+  var depth = 0;
+  for (var i = open; i < source.length; i++) {
+    if (source[i] == '(') depth++;
+    if (source[i] == ')') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  return -1;
+}
+
+String _stripComments(String source) => source
+    .replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '')
+    .split('\n')
+    .map((line) {
+      final index = line.indexOf('//');
+      return index == -1 ? line : line.substring(0, index);
+    })
+    .join('\n');

--- a/flutter/test/providers/community_feed_identifier_test.dart
+++ b/flutter/test/providers/community_feed_identifier_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/providers/voices_provider.dart';
+
+/// The community feed matches a post's `viewIn[]._id` against the viewer, and
+/// the two sides have to name the viewer the same way.
+///
+/// Kotlin's `VoicesFragment.getUserIdentifier()` (`:157-165`) is
+/// `"${planetCode}@${parentCode}"`, which is exactly what
+/// `shareNewsToCommunity` writes into the entry
+/// (`VoicesRepositoryImpl.kt:212-220`). The port's own
+/// `VoicesRepository.shareToCommunity` writes `'$planetCode@$parentCode'` too
+/// (`voices_repository.dart:354-360`) — and `communityFeedProvider` was
+/// filtering on `user.couchId ?? user.id`, the CouchDB user id
+/// (`org.couchdb.user:<name>`), so the two halves of the port disagreed about
+/// the same key and the feed could never show a shared post.
+///
+/// The comment that justified it — "`viewIn` entries carry server ids" — was
+/// true and beside the point: they carry a *planet* id, not a *user* id.
+void main() {
+  test('the viewer is named by planet, not by user', () {
+    expect(
+      communityViewerIdentifier(planetCode: 'lea', parentCode: 'ole'),
+      'lea@ole',
+    );
+  });
+
+  test('a blank half is kept, because "@" is the planet-wide wildcard', () {
+    // `isVisibleToUser` treats an empty or `"@"` id as "everyone" on both
+    // sides, which is the Planet convention for a planet-wide share. Kotlin
+    // builds the same string from possibly-blank halves before falling back.
+    expect(
+      communityViewerIdentifier(planetCode: '', parentCode: 'ole'),
+      '@ole',
+    );
+    expect(
+      communityViewerIdentifier(planetCode: 'lea', parentCode: ''),
+      'lea@',
+    );
+  });
+
+  test(
+    'both halves blank yields the wildcard rather than a bare separator',
+    () {
+      expect(communityViewerIdentifier(planetCode: '', parentCode: ''), '@');
+    },
+  );
+
+  test('a null code reads as blank', () {
+    expect(communityViewerIdentifier(planetCode: null, parentCode: null), '@');
+  });
+}

--- a/flutter/test/repository/community_share_round_trip_test.dart
+++ b/flutter/test/repository/community_share_round_trip_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/voices_provider.dart';
+import 'package:myplanet/repository/voices_repository.dart';
+
+/// Share a voice with the community, then read the community feed back.
+///
+/// The two halves are in different files — `VoicesRepository.shareToCommunity`
+/// writes the `viewIn` entry, `communityFeedProvider` supplies the identifier
+/// the feed filters on — and each half had a passing test. Nothing ran them
+/// together, and they disagreed: the writer used
+/// `'<planetCode>@<parentCode>'` (as Kotlin's `shareNewsToCommunity` does), the
+/// reader used the CouchDB user id. So no shared post could ever appear, and
+/// both tests stayed green.
+///
+/// Same shape as Phase 74's reactions round trip, where `serializeNews` wrote
+/// into a nested object and `NewsMapper.fromDoc` read the top level. **When two
+/// files have to agree on a key, the test has to span both.**
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late AppDatabase database;
+  late VoicesRepository repository;
+
+  setUp(() {
+    database = AppDatabase.memory();
+    repository = VoicesRepository(
+      MockPlanetApi(),
+      database.newsDao,
+      now: () => DateTime.fromMillisecondsSinceEpoch(5000),
+      createId: () => 'local-1',
+    );
+  });
+  tearDown(() => database.close());
+
+  test('a shared voice reaches the sharer own community feed', () async {
+    final postedId = await repository.createPost(
+      message: 'Rains are late this year',
+      userId: 'org.couchdb.user:ada',
+      userName: 'ada',
+    );
+
+    final shared = await repository.shareToCommunity(
+      newsId: postedId,
+      userId: 'org.couchdb.user:ada',
+      planetCode: 'lea',
+      parentCode: 'ole',
+    );
+    expect(shared, isTrue);
+
+    // Exactly the identifier `communityFeedProvider` hands the repository.
+    final viewer = communityViewerIdentifier(
+      planetCode: 'lea',
+      parentCode: 'ole',
+    );
+    final feed = await repository.watchCommunityFeed(viewer).first;
+
+    expect(
+      feed.map((row) => row.message),
+      ['Rains are late this year'],
+      reason:
+          'the feed filtered on a different identifier than shareToCommunity '
+          'writes, so a shared post was invisible to the person who shared it',
+    );
+  });
+
+  test('a voice shared on another planet stays out of this feed', () async {
+    final postedId = await repository.createPost(
+      message: 'Elsewhere',
+      userId: 'org.couchdb.user:bob',
+      userName: 'bob',
+    );
+    await repository.shareToCommunity(
+      newsId: postedId,
+      userId: 'org.couchdb.user:bob',
+      planetCode: 'other',
+      parentCode: 'ole',
+    );
+
+    final feed = await repository
+        .watchCommunityFeed(
+          communityViewerIdentifier(planetCode: 'lea', parentCode: 'ole'),
+        )
+        .first;
+
+    expect(
+      feed,
+      isEmpty,
+      reason:
+          'the identifier has to discriminate, or matching it proves nothing',
+    );
+  });
+}

--- a/flutter/test/repository/shelf_membership_survives_sync_test.dart
+++ b/flutter/test/repository/shelf_membership_survives_sync_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/courses_repository.dart';
+import 'package:myplanet/repository/resources_repository.dart';
+
+/// A second sync must not undo what the first one plus the user's own taps
+/// built up.
+///
+/// This is the data-path half of the Phase 116 reachability audit, and it is a
+/// shape the suite had no coverage for at all. Every shelf test in the tree
+/// runs *sync, then join, then assert* — the one order in which the defect
+/// cannot appear. `my_library.userId` is written by two parties (the server
+/// walk and the user's own shelf tap) over one column, so the walk has to carry
+/// the local value forward; `MyLibraryMapper.fromDoc` takes `existingUserIds`
+/// for exactly that, and its only production caller was not passing it.
+///
+/// Kotlin cannot have this bug: `ResourcesRepositoryImpl.batchInsertResources`
+/// (`:667-704`) pre-loads the existing rows and hands them to
+/// `MyLibrary.insertMyLibrary`, which only ever *adds* to `userId`
+/// (`MyLibrary.kt:122-130`, `:218-228`).
+///
+/// The same test runs against courses, where the pattern was already right
+/// (`courses_repository.dart` reads `existingById` and passes
+/// `existingUserIds:`), so a regression on either side fails here.
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  late AppDatabase db;
+  late MockPlanetApi api;
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+  });
+  tearDown(() => db.close());
+
+  void stubWalk(String database, List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/$database/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('$dbUrl/$database/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  test('a resource stays on the shelf across a second sync', () async {
+    final repository = ResourcesRepository(
+      api,
+      db.myLibraryDao,
+      db.removedLogDao,
+    );
+    stubWalk('resources', [
+      {'_id': 'res-1', 'title': 'Algebra'},
+    ]);
+
+    await repository.sync(config: config);
+    await repository.setShelfMemberships(['res-1'], 'user-1', joined: true);
+    expect((await db.myLibraryDao.getById('res-1'))!.userId, [
+      'user-1',
+    ], reason: 'the tap itself');
+
+    // The server document is unchanged; it carries no shelf information at all,
+    // because a shelf lives in its own `shelf/<user>` document. A walk that
+    // knows nothing about membership must not be able to retract it.
+    await repository.sync(config: config);
+
+    expect(
+      (await db.myLibraryDao.getById('res-1'))!.userId,
+      ['user-1'],
+      reason:
+          'the resources walk cleared a shelf membership it has no way to know '
+          'about, so tapping the sync icon emptied My Library',
+    );
+    expect(
+      await repository
+          .watchResources(shelfUserId: 'user-1', myLibrary: true)
+          .first,
+      isNotEmpty,
+      reason: 'and the My Library view is what the user sees empty',
+    );
+  });
+
+  test('a course stays on the shelf across a second sync', () async {
+    final repository = CoursesRepository(
+      api,
+      db.courseDao,
+      db.removedLogDao,
+      db.examDao,
+      db.surveyDao,
+    );
+    stubWalk('courses', [
+      {'_id': 'course-1', 'courseTitle': 'Algebra', 'steps': []},
+    ]);
+
+    await repository.sync(config: config);
+    await repository.setShelfMembership('course-1', 'user-1', joined: true);
+    expect((await db.courseDao.getById('course-1'))!.userId, ['user-1']);
+
+    await repository.sync(config: config);
+
+    expect(
+      (await db.courseDao.getById('course-1'))!.userId,
+      ['user-1'],
+      reason: 'courses already carried existingUserIds; keep it that way',
+    );
+  });
+}

--- a/flutter/test/ui/route_reachability_test.dart
+++ b/flutter/test/ui/route_reachability_test.dart
@@ -140,6 +140,40 @@ void main() {
     );
   });
 
+  test('every navigation this cannot read is a declared exception', () {
+    // The blind spots, named rather than dropped. Phase 116's second pass
+    // injected a broken target into three call sites this scanner could not
+    // read and watched the suite stay green; two of the three are now read,
+    // and what remains is listed here so it is reviewed rather than assumed
+    // empty.
+    const declared = <String, String>{
+      // The location arrives as a `String` parameter. Its thirteen real
+      // destinations are `Routes` constants in the same file, which rule three
+      // reads.
+      'lib/ui/dashboard/dashboard_drawer.dart': 'context.go(route)',
+      // Built in a switch and handed over as a variable; the arms themselves
+      // are read by rules two and three.
+      'lib/ui/notifications/notifications_screen.dart': 'context.go(path)',
+      // `'${Routes.addHealth}$patientQuery'` — the query string is built in a
+      // local, so the prefix is checked and the suffix is not.
+      'lib/ui/health/my_health_screen.dart': 'a query string in a local',
+    };
+
+    final undeclared = _unresolvedNavigations()
+        .where((site) => !declared.containsKey(site.file))
+        .toList();
+
+    expect(
+      undeclared,
+      isEmpty,
+      reason:
+          'These call sites build a location this scanner cannot read, so no '
+          'rule above covers them. Either make the target readable at the call '
+          "site or add the file to this test's `declared` map with the reason:"
+          '\n${undeclared.map((s) => '  $s').join('\n')}',
+    );
+  });
+
   test('every deep-link section resolves to a registered route', () {
     // `deepLinkRoute` is the port of `DashboardActivity`'s
     // `when (fragmentToOpen)`. A section whose route stopped matching would
@@ -178,6 +212,10 @@ void main() {
 // Source scanning
 // ---------------------------------------------------------------------------
 
+/// `/`-leading string literals in the navigating layers that are not in-app
+/// locations. `/db` is CouchDB's path suffix; `/` is a path separator.
+const _notALocation = <String>{'/', '/db'};
+
 /// `static const String name = '/path';` in `lib/ui/router.dart`.
 Map<String, String> _routeConstants() {
   final source = _stripComments(File('lib/ui/router.dart').readAsStringSync());
@@ -200,28 +238,62 @@ class _NavSite {
 
 /// Every in-app location `lib/` navigates to that can be resolved statically.
 ///
-/// Two rules, which between them reach every navigation in the tree:
+/// Three rules, which between them reach every navigation in the tree:
 ///
 /// - the argument of a `context.push`/`go`/`replace`/`pushReplacement` call,
 ///   whether that is a string literal or a bare `Routes.x`;
-/// - any string literal interpolating a `Routes.x` constant, wherever it sits.
-///   This second rule reaches the locations built inside a `switch` and handed
-///   to `context.go` through a variable — the shape a notification tap uses in
-///   `notifications_screen.dart`.
+/// - any string literal interpolating a `Routes.x` constant, wherever it sits;
+/// - any bare `Routes.x` reference, wherever it sits.
 ///
-/// A location built from a variable that is not a `Routes` constant cannot be
-/// resolved statically and is skipped; the tree has none today.
-List<_NavSite> _navigationSites() {
+/// The last two exist because a navigation argument is often not a literal at
+/// the call. `dashboard_drawer.dart` collects thirteen destinations into a list
+/// and calls `context.go(route)`; `notifications_screen.dart` builds a location
+/// in a `switch` and hands it over as a variable, and two of its seven arms are
+/// a bare constant rather than an interpolated string; `public_survey_screen`
+/// passes a ternary of two constants. A rule that only read the call site saw
+/// none of those four — this scanner did not, until Phase 116's second pass
+/// injected a broken target into each and watched it stay green.
+///
+/// The cost of rule three is that a `Routes` constant merely *mentioned* in
+/// `lib/` counts as reached, which makes rule 4 (below) slightly permissive.
+/// That is the right trade: rule 4 guards against forgetting an entry point,
+/// while rules 2 and 3 guard against a live navigation going nowhere, and the
+/// second failure is the one that reaches a user.
+///
+/// A location this cannot resolve is recorded in [_unresolvedNavigations]
+/// rather than dropped, because a silently skipped call site is how this class
+/// survives.
+List<_NavSite> _navigationSites() => _scan().sites;
+
+/// Locations a call site builds that cannot be read from the source.
+///
+/// Kept as a channel rather than dropped on the floor: a silently skipped call
+/// site looks exactly like a call site with nothing wrong, which is how a dead
+/// navigation survives a guard that scans for them.
+List<_NavSite> _unresolvedNavigations() => _scan().unresolved;
+
+class _Scan {
+  const _Scan(this.sites, this.unresolved);
+  final List<_NavSite> sites;
+  final List<_NavSite> unresolved;
+}
+
+_Scan _scan() {
   final constants = _routeConstants();
   final sites = <_NavSite>[];
+  final unresolved = <_NavSite>[];
 
-  // `context\s*\.\s*push` rather than `context.push`: a call with an `extra:`
-  // argument is wrapped by the formatter onto its own line.
+  // The *whole* argument list, taken by balancing parentheses. Reading only the
+  // first token missed `context.go(session != null ? Routes.resources : ...)`
+  // and every other shape where the location is not the literal that follows
+  // the paren.
   final navCall = RegExp(
-    r"context\s*\.\s*(?:push|go|replace|pushReplacement)\(\s*(?:'([^']*)'|Routes\.(\w+))",
-    dotAll: true,
+    r'context\s*\.\s*(?:push|go|replace|pushReplacement)\s*(?:<[^>]*>)?\(',
   );
+  final literal = RegExp(r"'([^']*)'");
   final interpolated = RegExp(r"'([^']*\$\{Routes\.\w+\}[^']*)'");
+  // A bare `Routes.x` not already inside an interpolation.
+  final bareConstant = RegExp(r'(?<!\$\{)\bRoutes\.(\w+)\b');
 
   final files = Directory('lib')
       .listSync(recursive: true)
@@ -232,39 +304,97 @@ List<_NavSite> _navigationSites() {
 
   for (final file in files) {
     final source = _stripComments(file.readAsStringSync());
+    final navigatingLayer =
+        file.path.startsWith('lib/ui/') ||
+        file.path.startsWith('lib/providers/');
 
-    void record(RegExpMatch match, String? raw) {
-      final resolved = raw == null ? null : _resolve(raw, constants);
-      if (resolved == null || !resolved.startsWith('/')) return;
-      sites.add(
-        _NavSite(file.path, _lineOf(source, match.start), _normalize(resolved)),
-      );
+    /// Records one location; returns whether it turned out to be one.
+    bool record(int offset, String? raw) {
+      if (raw == null) return false;
+      final resolution = _resolve(raw, constants);
+      final location = resolution.location;
+      if (location == null || !location.startsWith('/')) return false;
+      final site = _NavSite(file.path, _lineOf(source, offset), location);
+      sites.add(site);
+      if (resolution.partial) unresolved.add(site);
+      return true;
     }
 
     for (final match in navCall.allMatches(source)) {
-      final constant = match.group(2);
-      record(
-        match,
-        match.group(1) ?? (constant == null ? null : constants[constant]),
-      );
+      final open = match.end - 1;
+      final close = _matchingParen(source, open);
+      if (close == -1) continue;
+      final argument = source.substring(open + 1, close);
+
+      // Every location the argument could evaluate to: each string literal and
+      // each `Routes` constant in it. A ternary contributes both branches,
+      // which is what we want — either may be navigated to.
+      var found = false;
+      for (final hit in literal.allMatches(argument)) {
+        found |= record(open + 1 + hit.start, hit.group(1));
+      }
+      for (final hit in bareConstant.allMatches(argument)) {
+        found |= record(open + 1 + hit.start, constants[hit.group(1)!]);
+      }
+      if (!found) {
+        // A location handed over in a variable: `context.go(route)`. Its real
+        // targets are assigned elsewhere in the file, where rules two and three
+        // pick them up.
+        unresolved.add(
+          _NavSite(file.path, _lineOf(source, match.start), argument.trim()),
+        );
+      }
     }
     for (final match in interpolated.allMatches(source)) {
-      record(match, match.group(1));
+      record(match.start, match.group(1));
+    }
+    for (final match in bareConstant.allMatches(source)) {
+      record(match.start, constants[match.group(1)!]);
+    }
+    // Rule four: any '/'-leading string literal, wherever it sits.
+    //
+    // This is what reaches a destination written as a raw literal and handed to
+    // `context.go` through a variable or a data structure — the shape
+    // `dashboard_drawer.dart` uses for its thirteen entries. Rule three reads
+    // those only while they stay `Routes` constants; replace one with a typo'd
+    // literal and nothing else here would see it.
+    //
+    // Scoped to the layers that navigate. A repository, a mapper or a core
+    // utility builds URLs, disk paths and regexes out of '/'-leading strings
+    // and never calls `context.go`, so reading those is all false positives —
+    // four of them, measured. Within `ui/` and `providers/`, essentially every
+    // such literal is an in-app location, and the few that are not are named
+    // in [_notALocation] rather than inferred.
+    if (navigatingLayer) {
+      for (final match in literal.allMatches(source)) {
+        final text = match.group(1)!;
+        if (!text.startsWith('/') || _notALocation.contains(text)) continue;
+        record(match.start, text);
+      }
     }
   }
-  return sites;
+  return _Scan(sites, unresolved);
 }
 
 /// Substitutes `${Routes.x}` with the constant and reduces the rest to a path
 /// the router can be asked about. Returns null when a `Routes` name does not
 /// resolve, which only happens if this scanner and the router disagree.
-String? _resolve(String raw, Map<String, String> constants) {
+class _Resolution {
+  const _Resolution(this.location, {this.partial = false});
+  final String? location;
+
+  /// True when something had to be thrown away to reach a location, so the
+  /// answer is the prefix rather than the whole thing.
+  final bool partial;
+}
+
+_Resolution _resolve(String raw, Map<String, String> constants) {
   const unresolvable = '\u0000';
   var out = raw.replaceAllMapped(
     RegExp(r'\$\{Routes\.(\w+)\}'),
     (m) => constants[m.group(1)!] ?? unresolvable,
   );
-  if (out.contains(unresolvable)) return null;
+  if (out.contains(unresolvable)) return const _Resolution(null);
 
   // Cut the query first, so an interpolated query *value* never has to be
   // resolved: `'${Routes.addResource}?edit=${resource.id}'` navigates to
@@ -273,16 +403,21 @@ String? _resolve(String raw, Map<String, String> constants) {
   if (query != -1) out = out.substring(0, query);
 
   // An interpolation following a '/' is one path segment's worth of runtime
-  // value \u2014 an id, a tab name \u2014 and stands in as a single segment, because a
+  // value — an id, a tab name — and stands in as a single segment, because a
   // route matches on segment count and on its literal segments, and an id never
   // contains a '/'.
   out = out.replaceAll(RegExp(r'/(?:\$\{[^}]*\}|\$\w+)'), '/x');
 
-  // Anything still interpolated is glued to the end of a literal segment rather
-  // than forming one, which in this tree is always an optional query string
-  // built elsewhere (`'${Routes.addHealth}$patientQuery'`). Dropping it leaves
-  // the path without the query, which is the location being navigated to.
-  return out.replaceAll(RegExp(r'\$\{[^}]*\}|\$\w+'), '');
+  // Anything still interpolated is glued to the end of a literal segment
+  // rather than forming one, which in this tree is always an optional query
+  // string built elsewhere (`'${Routes.addHealth}$patientQuery'`). The prefix
+  // is still worth checking, but the answer is partial: whatever that variable
+  // holds is not read here, so a suffix that is *not* a query would go unseen.
+  final glued = RegExp(r'\$\{[^}]*\}|\$\w+');
+  if (glued.hasMatch(out)) {
+    return _Resolution(out.replaceAll(glued, ''), partial: true);
+  }
+  return _Resolution(out);
 }
 
 /// Drops the query string and any trailing slash.
@@ -335,17 +470,72 @@ bool _pathsMatch(String pattern, String location) {
   return true;
 }
 
+/// The index of the ')' closing the '(' at [open].
+int _matchingParen(String source, int open) {
+  var depth = 0;
+  for (var i = open; i < source.length; i++) {
+    if (source[i] == '(') depth++;
+    if (source[i] == ')') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  return -1;
+}
+
 int _lineOf(String source, int offset) =>
     '\n'.allMatches(source.substring(0, offset)).length + 1;
 
 /// Strips `//` and `/* */` comments, so a route named in prose is not mistaken
-/// for a navigation. Offsets are preserved within a line so line numbers in the
-/// failure message stay accurate.
-String _stripComments(String source) => source
-    .replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '')
-    .split('\n')
-    .map((line) {
-      final index = line.indexOf('//');
-      return index == -1 ? line : line.substring(0, index);
-    })
-    .join('\n');
+/// for a navigation.
+///
+/// **String-aware, and that is not fussiness.** A naive `indexOf('//')` cuts
+/// `route.startsWith('http://')` down to an unbalanced quote, and that exact
+/// line sits one above the `/web-view` push this phase fixed
+/// (`services_screen.dart:60-63`) — so the truncation silently swallowed the
+/// navigation below it. Twelve other lines in `lib/` truncate the same way.
+///
+/// Newlines are preserved, including a multi-line block comment's, so the line
+/// numbers in a failure message point at the real source.
+String _stripComments(String source) {
+  final out = StringBuffer();
+  var quote = '';
+  for (var i = 0; i < source.length; i++) {
+    final char = source[i];
+    if (quote.isNotEmpty) {
+      out.write(char);
+      if (char == r'\' && i + 1 < source.length) {
+        out.write(source[++i]);
+      } else if (char == quote) {
+        quote = '';
+      }
+      continue;
+    }
+    if (char == "'" || char == '"') {
+      quote = char;
+      out.write(char);
+      continue;
+    }
+    if (char == '/' && i + 1 < source.length) {
+      // A line comment: drop to the newline, which is kept so line numbers and
+      // the newline-counting in [_lineOf] stay accurate.
+      if (source[i + 1] == '/') {
+        while (i < source.length && source[i] != '\n') {
+          i++;
+        }
+        out.write('\n');
+        continue;
+      }
+      // A block comment: drop it but keep its newlines, for the same reason.
+      if (source[i + 1] == '*') {
+        final end = source.indexOf('*/', i + 2);
+        final stop = end == -1 ? source.length : end + 2;
+        out.write('\n' * '\n'.allMatches(source.substring(i, stop)).length);
+        i = stop - 1;
+        continue;
+      }
+    }
+    out.write(char);
+  }
+  return out.toString();
+}

--- a/flutter/test/ui/route_reachability_test.dart
+++ b/flutter/test/ui/route_reachability_test.dart
@@ -1,0 +1,351 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/core/deeplinks/deep_link.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/deep_link_provider.dart';
+import 'package:myplanet/ui/router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Reachability guards — the failure class Phase 113 found the hard way.
+///
+/// `TakeExamScreen` was not broken, it was *unreachable*: its route was fine,
+/// its tests were green, and no live path led to it. Nothing in the suite could
+/// see that, because a screen test builds its screen directly and a repository
+/// test builds its own rows. Both halves of the app — the route table and the
+/// navigation calls — were only ever exercised one at a time.
+///
+/// These tests exercise them together, and they read the source rather than
+/// enumerate a hand-written list, so a route or a `context.push` added later is
+/// covered without anyone remembering to come back here.
+///
+/// Four rules:
+///
+/// 1. **Every `Routes` constant resolves to a registered route.** A constant
+///    naming a path the router does not serve is a screen nobody can open.
+/// 2. **Every navigation location in `lib/` resolves.** This catches a
+///    `context.push` whose target drifted away from the route table.
+/// 3. **No navigation carries an unsubstituted `:param`.** go_router matches a
+///    placeholder against its own literal text, so this one fails silently.
+/// 4. **Every registered route is navigated to from somewhere.** A route
+///    nothing links to is a screen the user cannot reach; the allowlist is the
+///    set of deliberate exceptions, each with its reason.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ProviderContainer container;
+  late GoRouter router;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    final database = AppDatabase.memory();
+    container = ProviderContainer(
+      overrides: [
+        planetPrefsProvider.overrideWithValue(prefs),
+        appDatabaseProvider.overrideWithValue(database),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(database.close);
+    router = container.read(routerProvider);
+  });
+
+  test('every Routes constant resolves to a registered route', () {
+    final unresolved = <String, String>{};
+    _routeConstants().forEach((name, path) {
+      if (!_matches(router, _fillParams(path))) unresolved[name] = path;
+    });
+
+    expect(
+      unresolved,
+      isEmpty,
+      reason:
+          'These Routes constants name locations the router does not serve, so '
+          'every navigation through them lands on the error page:\n'
+          '${unresolved.entries.map((e) => '  Routes.${e.key} = ${e.value}').join('\n')}',
+    );
+  });
+
+  test('every navigation location in lib/ resolves to a registered route', () {
+    final broken = _navigationSites()
+        .where((site) => !_matches(router, _fillParams(site.location)))
+        .toList();
+
+    expect(
+      broken,
+      isEmpty,
+      reason:
+          'These navigation calls target a location no route matches:\n'
+          '${broken.map((s) => '  $s').join('\n')}',
+    );
+  });
+
+  test('no navigation pushes an unsubstituted route pattern', () {
+    // The Phase 113 defect-C shape: `'${Routes.exam}/${exam.id}'` concatenates
+    // the *pattern* `/courses/exam/:examId`, and `context.push(Routes.chat)`
+    // pushes one whole. go_router happily matches `:examId` against the literal
+    // text `:examId`, so the screen opens with a path parameter whose value is
+    // the placeholder's own name — a lookup that silently finds nothing.
+    final offenders = _navigationSites()
+        .where((site) => site.location.contains(':'))
+        .toList();
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'These navigations carry a `:param` placeholder into a real '
+          'location:\n${offenders.map((s) => '  $s').join('\n')}',
+    );
+  });
+
+  test('every registered route is reachable from a navigation', () {
+    /// Routes with no `context.push`/`go` in `lib/`, and why that is correct.
+    const allowed = <String, String>{
+      // Reached by the router's own redirect rather than by a navigation.
+      '/onboarding': 'redirect target on a first launch',
+      '/server': 'redirect target when no server is configured',
+      '/login': 'redirect target when there is no session',
+      '/home': 'initialLocation, and the redirect target once signed in',
+      // Built by DeepLinkHandler.publicSurveyLocation, covered by the deep-link
+      // test below.
+      '/survey/:teamId/:surveyId': 'deep-link entry point',
+      // Kotlin shows the respondent profile as a dialog over the survey and the
+      // port keeps that shape, so `PublicSurveyScreen` builds the screen with
+      // `Navigator.push` and there is no location to navigate to. The route is
+      // a spare entry point kept for a future in-app caller.
+      '/exam/user-info/:submissionId':
+          'PublicSurveyScreen builds it with Navigator.push',
+    };
+
+    final reached = _navigationSites().map((s) => s.location).toSet();
+    final unreachable = _registeredPaths(router)
+        .where((path) => !allowed.containsKey(path))
+        .where((path) => !reached.any((r) => _pathsMatch(path, r)))
+        .toList();
+
+    expect(
+      unreachable,
+      isEmpty,
+      reason:
+          'These routes are registered but nothing in lib/ navigates to them, '
+          'so the screens behind them cannot be opened. Either add the entry '
+          "point or record the route in this test's `allowed` map with its "
+          'reason:\n${unreachable.map((p) => '  $p').join('\n')}',
+    );
+  });
+
+  test('every deep-link section resolves to a registered route', () {
+    // `deepLinkRoute` is the port of `DashboardActivity`'s
+    // `when (fragmentToOpen)`. A section whose route stopped matching would
+    // send an incoming link to the error page, with nothing inside the app to
+    // say the link itself was fine.
+    for (final section in const [
+      'feedbackList',
+      'courses',
+      'resources',
+      'teams',
+      'surveys',
+    ]) {
+      final route = deepLinkRoute(section);
+      expect(route, isNotNull, reason: 'deepLinkRoute("$section")');
+      expect(
+        _matches(router, _fillParams(route!)),
+        isTrue,
+        reason: 'deep link section "$section" -> $route',
+      );
+    }
+  });
+
+  test('a public-survey deep link resolves to its route', () {
+    final location = DeepLinkHandler.publicSurveyLocation(
+      const PublicSurveyDeepLink(
+        teamId: 'team-1',
+        surveyId: 'survey-1',
+        origin: 'https://planet.example.org',
+      ),
+    );
+    expect(_matches(router, location), isTrue, reason: location);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Source scanning
+// ---------------------------------------------------------------------------
+
+/// `static const String name = '/path';` in `lib/ui/router.dart`.
+Map<String, String> _routeConstants() {
+  final source = _stripComments(File('lib/ui/router.dart').readAsStringSync());
+  final pattern = RegExp(r"static const String (\w+)\s*=\s*'([^']*)'\s*;");
+  return {
+    for (final match in pattern.allMatches(source))
+      match.group(1)!: match.group(2)!,
+  };
+}
+
+class _NavSite {
+  const _NavSite(this.file, this.line, this.location);
+  final String file;
+  final int line;
+  final String location;
+
+  @override
+  String toString() => '$file:$line -> $location';
+}
+
+/// Every in-app location `lib/` navigates to that can be resolved statically.
+///
+/// Two rules, which between them reach every navigation in the tree:
+///
+/// - the argument of a `context.push`/`go`/`replace`/`pushReplacement` call,
+///   whether that is a string literal or a bare `Routes.x`;
+/// - any string literal interpolating a `Routes.x` constant, wherever it sits.
+///   This second rule reaches the locations built inside a `switch` and handed
+///   to `context.go` through a variable — the shape a notification tap uses in
+///   `notifications_screen.dart`.
+///
+/// A location built from a variable that is not a `Routes` constant cannot be
+/// resolved statically and is skipped; the tree has none today.
+List<_NavSite> _navigationSites() {
+  final constants = _routeConstants();
+  final sites = <_NavSite>[];
+
+  // `context\s*\.\s*push` rather than `context.push`: a call with an `extra:`
+  // argument is wrapped by the formatter onto its own line.
+  final navCall = RegExp(
+    r"context\s*\.\s*(?:push|go|replace|pushReplacement)\(\s*(?:'([^']*)'|Routes\.(\w+))",
+    dotAll: true,
+  );
+  final interpolated = RegExp(r"'([^']*\$\{Routes\.\w+\}[^']*)'");
+
+  final files = Directory('lib')
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.dart'))
+      // The router declares patterns rather than navigating to them.
+      .where((f) => !f.path.endsWith('ui/router.dart'));
+
+  for (final file in files) {
+    final source = _stripComments(file.readAsStringSync());
+
+    void record(RegExpMatch match, String? raw) {
+      final resolved = raw == null ? null : _resolve(raw, constants);
+      if (resolved == null || !resolved.startsWith('/')) return;
+      sites.add(
+        _NavSite(file.path, _lineOf(source, match.start), _normalize(resolved)),
+      );
+    }
+
+    for (final match in navCall.allMatches(source)) {
+      final constant = match.group(2);
+      record(
+        match,
+        match.group(1) ?? (constant == null ? null : constants[constant]),
+      );
+    }
+    for (final match in interpolated.allMatches(source)) {
+      record(match, match.group(1));
+    }
+  }
+  return sites;
+}
+
+/// Substitutes `${Routes.x}` with the constant and reduces the rest to a path
+/// the router can be asked about. Returns null when a `Routes` name does not
+/// resolve, which only happens if this scanner and the router disagree.
+String? _resolve(String raw, Map<String, String> constants) {
+  const unresolvable = '\u0000';
+  var out = raw.replaceAllMapped(
+    RegExp(r'\$\{Routes\.(\w+)\}'),
+    (m) => constants[m.group(1)!] ?? unresolvable,
+  );
+  if (out.contains(unresolvable)) return null;
+
+  // Cut the query first, so an interpolated query *value* never has to be
+  // resolved: `'${Routes.addResource}?edit=${resource.id}'` navigates to
+  // `/resources/add`.
+  final query = out.indexOf('?');
+  if (query != -1) out = out.substring(0, query);
+
+  // An interpolation following a '/' is one path segment's worth of runtime
+  // value \u2014 an id, a tab name \u2014 and stands in as a single segment, because a
+  // route matches on segment count and on its literal segments, and an id never
+  // contains a '/'.
+  out = out.replaceAll(RegExp(r'/(?:\$\{[^}]*\}|\$\w+)'), '/x');
+
+  // Anything still interpolated is glued to the end of a literal segment rather
+  // than forming one, which in this tree is always an optional query string
+  // built elsewhere (`'${Routes.addHealth}$patientQuery'`). Dropping it leaves
+  // the path without the query, which is the location being navigated to.
+  return out.replaceAll(RegExp(r'\$\{[^}]*\}|\$\w+'), '');
+}
+
+/// Drops the query string and any trailing slash.
+String _normalize(String location) {
+  final query = location.indexOf('?');
+  var path = query == -1 ? location : location.substring(0, query);
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.substring(0, path.length - 1);
+  }
+  return path;
+}
+
+/// Replaces `:param` segments with a stand-in so a pattern can be matched.
+String _fillParams(String path) =>
+    _normalize(path).replaceAll(RegExp(r':[A-Za-z_]\w*'), 'x');
+
+bool _matches(GoRouter router, String location) =>
+    !router.configuration.findMatch(Uri.parse(location)).isError;
+
+/// Full paths of every route in the table, patterns included.
+List<String> _registeredPaths(GoRouter router) {
+  final paths = <String>[];
+  void walk(List<RouteBase> routes, String parent) {
+    for (final route in routes) {
+      var full = parent;
+      if (route is GoRoute) {
+        full = route.path.startsWith('/')
+            ? route.path
+            : '$parent/${route.path}'.replaceAll('//', '/');
+        paths.add(full);
+      }
+      walk(route.routes, full);
+    }
+  }
+
+  walk(router.configuration.routes, '');
+  return paths;
+}
+
+/// Whether a concrete location reaches a route pattern: same segment count,
+/// with every literal segment equal.
+bool _pathsMatch(String pattern, String location) {
+  final expected = pattern.split('/');
+  final actual = location.split('/');
+  if (expected.length != actual.length) return false;
+  for (var i = 0; i < expected.length; i++) {
+    if (expected[i].startsWith(':')) continue;
+    if (expected[i] != actual[i]) return false;
+  }
+  return true;
+}
+
+int _lineOf(String source, int offset) =>
+    '\n'.allMatches(source.substring(0, offset)).length + 1;
+
+/// Strips `//` and `/* */` comments, so a route named in prose is not mistaken
+/// for a navigation. Offsets are preserved within a line so line numbers in the
+/// failure message stay accurate.
+String _stripComments(String source) => source
+    .replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '')
+    .split('\n')
+    .map((line) {
+      final index = line.indexOf('//');
+      return index == -1 ? line : line.substring(0, index);
+    })
+    .join('\n');

--- a/flutter/test/ui/teams/team_detail_gates_test.dart
+++ b/flutter/test/ui/teams/team_detail_gates_test.dart
@@ -80,7 +80,18 @@ UserRow _user({String id = 'user-1', String name = 'ada'}) => UserRow(
 
 /// Every entry `buildPages` puts behind the `isMyTeam || isPublic` branch.
 /// `Members` is deliberately absent: Kotlin shows it on both sides.
-const _gatedEntries = ['Tasks', 'Team Calendar', 'Team surveys', 'Discussions'];
+///
+/// `Leaderboard` has no Kotlin counterpart — it comes from the unmerged `14880`
+/// branch — but it belongs here for the port's own reason: `watchMembers` has
+/// no viewer predicate, so the board is a private team's roster with each
+/// member's counts beside it.
+const _gatedEntries = [
+  'Tasks',
+  'Team Calendar',
+  'Team surveys',
+  'Discussions',
+  'Leaderboard',
+];
 
 void main() {
   late _MockTeamMembershipActions actions;


### PR DESCRIPTION
Lane A of the Phase 116 round: a systematic reachability audit of the Flutter port, plus guards for the class.

Phase 113 found `TakeExamScreen` **unreachable in production** — not broken, unreachable. Green tests could not see it, because a screen test builds its screen directly and a repository test builds its own rows: the route table and the navigation calls were only ever exercised one at a time, and a fixture that fabricates a join makes the test pass and the feature dead.

Full audit in `flutter/PHASE_116_NOTES.md`.

## Fixed (each demonstrated failing on the pre-fix code first)

**`AddResourceScreen` was unreachable in production** — the exam defect one layer up. Its route was registered at the top level with the relative path `'add'`. go_router prints that as `/add` in its route table but matches the raw pattern against the location, so it matched neither `/resources/add` nor `/add`; all three callers hit the error page. Phase 72 ported the screen, Phase 102 gave it 33 tests and closed seven defects in it, and none of that could ever run. **`WebViewScreen`** had the identical shape.

**`TeamLeaderboardScreen`** — route registered, string translated in six locales, nothing navigating. Added the tile, gated on `canView`.

**The chat "New chat" button pushed the route *pattern*** `/life/chat/:chatId`, opening the detail screen with `chatId: ':chatId'`; it worked only because the lookup for that id returns empty. The same file already carried a comment about this trap at its other tap site.

**The resources walk cleared My Library on every sync.** `my_library.userId` has two writers over one column, and `MyLibraryMapper.fromDoc` writes `userId: Value(existingUserIds)` unconditionally — its one caller passed none of the six `existing*` arguments. Add a resource to My Library, tap sync, it's empty. The sibling walk in `courses_repository.dart` already did this correctly.

**The community Voices feed filtered on the wrong identifier** — `user.couchId ?? user.id` where the port's own `shareToCommunity` writes `'<planetCode>@<parentCode>'`. Two halves of the port disagreeing about one key, each with a passing test.

## Reported, not fixed

**Five sync-in walks Kotlin has that the port does not** — `shelf`, `tablet_users`, `ratings`, `tasks`, `achievements` (plus `_users/_find` for leaders). Four of the five have a Dart method already written and uncalled: plumbing laid for a pull nobody wrote. That's one phase, and the notes carry two traps for whoever takes it.

Plus 18 further numbered data-path findings — the notification `resolveType` port that has no caller, the submissions sync-in reading keys CouchDB never sends, the voice-compose payload that uploads with no audience or author — each with evidence and a concrete failing input.

## Guards

| file | catches |
|---|---|
| `route_reachability_test.dart` | a route nothing navigates to, a navigation no route serves, a pushed `:param` pattern, an unreadable call site |
| `shelf_membership_survives_sync_test.dart` | a sync walk retracting what a local tap set |
| `mapper_preserves_local_columns_test.dart` | a mapper call omitting an `existing…` argument |
| `community_share_round_trip_test.dart` | a writer and a reader disagreeing about a key, across two files |

They are source-derived rather than hand-written lists, so a later route or push is covered without anyone remembering they exist.

## A second pass, on my own diff

A `parity-auditor` pass at `effort: max` aimed at this phase's own fix found the route guard weaker than its doc comment claimed — it injected three new broken navigations the scanner could not read and watched the suite stay green. Two are now read (whole-balanced-argument scanning; a string-aware comment stripper, since `indexOf('//')` truncates `route.startsWith('http://')` one line above the `/web-view` push this PR fixes), and the third is declared in an allowlist rather than dropped in silence. It also caught the leaderboard tile being ungated where `watchMembers` has no viewer predicate.

Its most useful finding isn't a defect: 18 test files use a harness that builds a **fresh router containing only the routes the test names**, so `services_screen_test.dart`'s "an external route navigates to the web view screen" passed for the entire life of the dead route. That is why the guard reads source rather than adding more widget tests.

Gate: `dart format` clean, `flutter analyze` clean, **1913 tests passing**. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZERmB9urxctdC35k31hWC