### PR TITLE
Phase 118 — finish the l10n residue, and the 899 placeholders nobody had counted

### DIFF
--- a/flutter/PHASE_118_NOTES.md
+++ b/flutter/PHASE_118_NOTES.md
@@ -1,0 +1,280 @@
+# Phase 118 — the l10n residue, and the 899 placeholders nobody had counted
+
+Lane C. `lib/l10n/*.arb`, `tool/arb_from_strings_xml.dart`, `test/l10n/`. The
+Kotlin `app/src/main/res/values*/strings.xml` are the source of truth and were
+not modified.
+
+## The brief, and the rule it turned on
+
+Phase 114 recovered 431 human translations from the Kotlin `strings.xml` and
+left a residue it deliberately did not apply. This lane finishes the half of
+that residue where a user is currently looking at English, under a rule Phase
+114 arrived at the hard way and this lane inherited:
+
+> "never overwrite a human translation" was too blunt; the right rule is never
+> *degrade* one. Replacing English, a `[Language]` placeholder, or a camelCase
+> artefact with a real translation is a repair. Replacing one valid translation
+> with another is not your call.
+
+That rule is what makes the two buckets need opposite treatment, and it is also
+what turned a 20-string task into a 919-string one.
+
+## Counts
+
+**Examined:** 65 residue candidates (33 `no-unanimous`, 32 `keep-human`) plus
+10 values `--adopt` had never seen, plus a full scan of all five locale files
+for values that are English or a marker — 4,257 values in total.
+
+**Applied: 929 values.** 30 in the residue proper, 899 placeholder deletions.
+
+**Left: 42 candidates**, in three kinds, all argued below.
+
+| locale | values | x-mt | human | falls back to English |
+|---|---|---|---|---|
+| ar | 821 → 823 | 496 → 496 | 325 → **327** | 49 → 47 |
+| es | 859 → 861 | 538 → 538 | 321 → **323** | 11 → 9 |
+| fr | 859 → 861 | 545 → 545 | 314 → **316** | 11 → 9 |
+| ne | 859 → **415** | 475 → **26** | 384 → **389** | 11 → **455** |
+| so | 859 → **415** | 476 → **26** | 383 → **389** | 11 → **455** |
+
+The template is 870 keys. Nepali and Somali losing 444 values each is the point
+of the second half of this phase, not a regression — see below.
+
+---
+
+## Part 1 — the residue Phase 114 named (30 values)
+
+### `no-unanimous`: 8 of 33, the ones where English was shipping
+
+Two or more Kotlin names share one English string and disagree in translation,
+so Phase 114 had nothing to prefer and skipped all 33. But in 8 of them the
+value the port was *actually shipping* was the English itself, or the external
+translator's `[Nepali] `/`[Somali] ` marker — and there any of the disagreeing
+translations is a repair rather than a coin toss.
+
+| | before (what shipped) | after | from |
+|---|---|---|---|
+| `so:settings` | `Settings` | `Goobooyinka` | `action_settings` |
+| `so:joinRequests` | `[Somali] Join requests` | `Su'aasha xubinaha` | `join_requests` |
+| `so:addResource` | `[Somali] Add resource` | `Kudar Ilaha` | `add_resource` |
+| `so:descriptionIsRequired` | `[Somali] Description is required` | `Sharaxaadda waa loo baahan yahay` | `desc_is_required` |
+| `so:progressFilterCompleted` | `[Somali] Completed` | `Dhammaystay` | `status_completed` |
+| `ne:joinRequests` | `[Nepali] Join requests` | `सम्मिलित गर्न अनुरोधहरू` | `join_requests` |
+| `ne:addResource` | `[Nepali] Add resource` | `स्रोत थप्नुहोस्` | `add_resource` |
+| `ne:progressFilterCompleted` | `[Nepali] Completed` | `पूरा भयो` | `status_completed` |
+
+**The tie-break, so a later pass can argue with it: match the Kotlin name whose
+own usage site matches the ARB key's usage site, and never take a value that is
+itself English.** Both halves earned their keep:
+
+* `joinRequests` renders the team-members tab (`team_members_screen.dart:39`),
+  which is Kotlin's `join_requests`; `notifGroupJoinRequests` renders a
+  notification group heading, which is `notif_group_join_requests`. The two ARB
+  keys now mirror Kotlin's two names exactly, in both locales, rather than
+  collapsing onto whichever translation read better to someone who does not
+  speak the language.
+* `progressFilterCompleted` is the courses progress filter
+  (`courses_screen.dart:614`), so `status_completed`, not the bare `completed`.
+* `addResource` titles the add-resource screen, so `add_resource` — whose value
+  carries a trailing `:` that the punctuation rule strips, as the template has
+  none.
+* `so:settings` is where the usage rule had to yield, and the "never take
+  English" half decided it. `values-so` renders `settings` as the literal
+  string "Settings", so the name-match offers nothing; `action_settings` is both
+  the only Somali on offer and what Kotlin's `SettingsActivity` titles itself
+  with (`SettingsActivity.kt:57`). Capitalised upward to the template, as the
+  tool's own casing rule does.
+* `so:descriptionIsRequired` is the one place the usage rule was overruled on
+  other grounds. Usage says `description_is_required` — that is what Kotlin's
+  `AddResourceActivity.kt:218` uses, and the port's caller is the same screen.
+  Its Somali is `Sharraxaad waa loo baahan yahay`, against `desc_is_required`'s
+  `Sharaxaadda waa loo baahan yahay`. The two names' English is *identical*, so
+  the semantic tie-break has nothing to say, which frees an orthographic one:
+  `sharaxaad` appears 5 times in `values-so` and `sharraxaad` once. Took the
+  spelling that is not the outlier.
+
+None of these is a claim about which Somali or Nepali reads better. Each is a
+claim that a real translation shipping in the Android app beats English on a
+screen, which is a judgement a non-speaker is allowed to make.
+
+### `keep-human`: the presentation-case group (11 values)
+
+Phase 114's own words: *"a presentation fix somebody could just make; it is not
+a translation question."* The ARB had copied Kotlin's lowercase English, where
+`app_en.arb` capitalises. First character aligned upward, nothing else touched.
+
+| key | es | fr | so |
+|---|---|---|---|
+| `view` | `ver` → `Ver` | `afficher` → `Afficher` | `eeg` → `Eeg` |
+| `exportCancelled` | `exportación…` → `Exportación…` | `exportation…` → `Exportation…` | `dhoofinta…` → `Dhoofinta…` |
+| `failedToSaveCsvFile` | `error al…` → `Error al…` | `échec de…` → `Échec de…` | `waa lagu…` → `Waa lagu…` |
+| `complete` | `completa` → `Completa` | — | — |
+| `serverPinLabel` | `pin del servidor` → `Pin del servidor` | — | — |
+
+### One artefact (1 value)
+
+`es:myCourses` held `misCursos` — the Spanish XML's own camelCase artefact, not
+a translation. Same shape as `miProgreso`, but the *mirror image*: for
+`myProgress` the ARB holds the good value (`Mi Progreso`) and Kotlin holds the
+artefact, so that one is left alone; for `myCourses` the ARB held the artefact.
+Now `Mis cursos`, which is what `values-fr` and `values-ne` say in their own
+languages (`Mes cours`, `मेरो पाठ्यक्रमहरू`) where Spanish glitched.
+
+### 10 values the tool had never seen
+
+`teamDocuments` and `confirmLeaveTeam` are English keys added after Phase 114
+ran, and both match Kotlin exactly. `--adopt` picked them up in all five
+locales for free. Worth knowing that this recurs: **every phase that adds an
+English key should re-run `--adopt`**, because the Kotlin app may already ship
+the translation.
+
+---
+
+## Part 2 — what the measurement found: 899 markers, not two
+
+Phase 114 named two instances of the `[Language] ` marker (`ne:joinRequests`,
+`so:joinRequests`) because those are the two its candidate report could see —
+the report only surfaces a key when a Kotlin English string matches it. Scanning
+the locale files directly instead:
+
+**449 Nepali and 450 Somali values were `[Nepali] ` / `[Somali] ` followed by
+the English template verbatim.** Checked, not assumed: all 899 have the
+remainder byte-identical to `app_en.arb`, and all 899 are flagged `x-mt`. Not
+one carries a partial translation, a reordering, or a single translated word.
+
+So the record in `CLAUDE.md` was wrong in a way that mattered: **Nepali and
+Somali were never machine-translated at all.** The 475/476 strings counted there
+as "machine output" were 449/450 markers plus 26 real machine strings. Spanish,
+French and Arabic did go through the translator; those two got a tag.
+
+### Why a marker is worse than nothing
+
+`gen-l10n` falls back to `app_en.arb` for a key a locale omits — and
+`locale_coverage_test.dart` already asserts exactly that, with a comment saying
+untranslated keys "have to read as English rather than as an empty label". A
+marker *displaces* that fallback with the same English under a bracket. A Somali
+user did not see an untranslated app; they saw `[Somali] Join requests`, which
+reads as a bug.
+
+Nothing could catch it. The value is well-formed JSON with the right
+placeholders, `gen-l10n` compiles it, `flutter analyze` is silent, and every
+structural test passes: the key exists, it is non-empty, it is not a duplicate,
+and it is *honestly* flagged unreviewed. Only reading the text finds it — the
+same shape as the Phase 114 backslash artefacts and the Phase 109 `__0____`
+tokenisation, and the third instance of it. **A locale file's failures are in
+its values, and only a test that reads them will ever see one.**
+
+### What was done
+
+The 899 values and their now-empty `@key` blocks are deleted, so those keys
+fall back to English: the same words, without the tag. Guarded by a new test in
+`placeholder_integrity_test.dart` whose net is wider than the two markers that
+shipped (`^\s*\[[^\]]{1,20}\]`), because the next tool will choose a different
+one; no legitimate value in any locale, the template included, opens with a
+bracketed word.
+
+**One check worth recording, because it is what makes the deletion safe rather
+than merely tidy:** after deleting, `--candidates` reports **zero** `apply` in
+all five locales. A deleted key is "replaceable", so any of the 899 with a
+Kotlin translation available at an adoptable tier would have surfaced as an
+adoption. None did. Every string deleted here had no better source to draw on —
+English fallback was genuinely the best available value, and the marker was
+strictly worse than it.
+
+This landed as its own commit so it can be dropped alone if a reviewer prefers
+the marker's one virtue: it makes the hole visible in the file. That virtue is
+real but cheaper elsewhere — `flutter gen-l10n` prints `"so": 455 untranslated
+message(s)` on every build, and `--unreviewed` lists them — and it is not worth
+a bracket on a learner's screen.
+
+---
+
+## Residue deliberately left (42 candidates)
+
+**25 `no-unanimous`** (ar 6, es 5, fr 5, ne 2, so 7). Every one now carries a
+real translation in its locale, so the disagreement is between two valid
+renderings — `es:settings` Configuraciones/Configuración,
+`so:submit` Ku Dir/Gudbi, `fr:filter` Filtre/Filtrer. Not a non-speaker's call,
+and nothing is broken while it waits.
+
+**17 genuine `keep-human` disagreements** (es 14, plus `unselectAll` in fr, ne
+and so). Both sides valid: `es:amount` Monto/Cantidad,
+`es:noteRequired` "La nota es obligatoria"/"Se requiere una nota",
+`fr:unselectAll` "Tout désélectionner"/"Désélectionner tout". **These need a
+speaker, and this is the line where this lane stops.**
+
+**3 `keep-human` entries that are tool false positives**, listed so the next
+pass does not spend time on them:
+
+* `es:reports` — the ARB's `Informes` is the case-aligned form of Kotlin's
+  `informes`, i.e. already correct. It is reported only because the tool aligns
+  first-character case in the `casing` tier and this key matches at `exact`,
+  where no transform runs. Extending the alignment to every tier would fix this
+  and would have a blast radius across all 870 keys; measuring that is a
+  phase of its own, not a change to slip into this one.
+* `es:myProgress` and `es:myCourses` — both now hold the good value against the
+  Spanish XML's camelCase artefact, so both will be reported forever. That is
+  the correct state, not a to-do.
+
+**127 `nameOnly` + `containment` per locale.** Untouched: recovering one means
+editing `app_en.arb`, which is a judgement about what a screen should say.
+Phase 114's tables are still the place to start.
+
+**26 `x-mt` values per locale that are byte-identical to the English** (ar 27,
+es 28, fr 44, ne 26, so 26). The same "nothing here" class as the markers,
+without the tag — mostly plural and placeholder strings the translator passed
+through. Left alone deliberately: deleting them changes nothing a user sees, and
+the `x-mt` flag is a truthful record that the key went through the machine pass
+and produced nothing. Worth a sweep only if someone wants the counts to mean
+"has a translation" rather than "has a value".
+
+---
+
+## Wording for `CLAUDE.md`
+
+Replace the **Current l10n state** passage (Phase 114's suggested text is now
+wrong about ne/so, in the specific way this phase found):
+
+> **Current l10n state, and one open decision.** The template `app_en.arb` has
+> 870 keys. Arabic, Spanish and French carry 823–861 values each, of which
+> 316–327 are human translations and 496–545 are machine output flagged `x-mt`.
+> Nepali and Somali carry 415 values, 389 human — and the other 455 keys fall
+> back to English on purpose. Phase 114 raised the human share by 431 strings
+> without translating anything: it read the Kotlin `values-*/strings.xml` — real
+> human translations already shipping in the Android app — and preferred them
+> wherever the port had minted its own English for a string Kotlin already had.
+> Phase 118 finished its residue where English was shipping (30 values) and then
+> found what the residue was a sample of: **449 Nepali and 450 Somali values
+> were `[Nepali] `/`[Somali] ` plus the English template verbatim, with no
+> translation content at all** — the external pass never translated those two
+> languages, it tagged them. A marker is worse than the English fallback it
+> displaces, because a learner reads the bracket as a bug, so all 899 are
+> deleted and `test/l10n/placeholder_integrity_test.dart` fails if one returns.
+> `tool/arb_from_strings_xml.dart --candidates` reports what is left and
+> `--adopt` applies the confident ones; **re-run `--adopt` whenever a phase adds
+> an English key**, because the Kotlin app may already ship the translation.
+> **Match on English text, never on the key name** — `achievements` and Kotlin's
+> `myAchievements` are the same concept and different strings. Where two Kotlin
+> names share one English and disagree, prefer the name whose *usage site*
+> matches the ARB key's, and never adopt a value that is itself English
+> (`values-so` renders `settings` as "Settings"). What still needs a human is 17
+> two-valid-renderings disagreements and the 455 keys per locale that Nepali and
+> Somali have never had; a confidently wrong translation can mislead a learner
+> where an English fallback merely inconveniences them.
+
+And for the Migration progress table's Localisation row, which read "231–256 of
+858 keys per locale" at ~30: the honest figure is **316–327 human of 870 in
+ar/es/fr with the rest machine-translated, and 389 human of 870 in ne/so with
+the rest English**. The score should not move up on this phase — the phase
+*lowered* the value count by 899 and raised the truthfulness of the number,
+which is worth more than the number.
+
+## One thing that generalises
+
+The assigned task was 65 candidates. The finding was 899 strings, and it came
+from one scan that the candidate report structurally could not produce: the
+report only lists a key when a Kotlin string matches it, so a key with no Kotlin
+counterpart is invisible to it no matter how broken its value is. **A report
+built to answer "what can I adopt?" cannot answer "what is wrong?", and reading
+it as though it could is how 899 defects sat behind a residue of two.** The
+scan that found them is three lines of Python over the same files.

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -2315,5 +2315,7 @@
   "summaryOfAchievements": "ملخص الإنجازات - قم بتلخيص إنجازاتك بإيجاز وأضف المواد ذات الصلة أدناه",
   "myGoalsDescription": "أهدافي - ما هي أهدافك للعشر سنوات القادمة؟",
   "myPurposeDescription": "هدفي - ما هي طموحاتك التعليمية والمهنية؟",
-  "pleaseAnswerToContinue": "يرجى تحديد / كتابة إجابتك للمتابعة"
+  "pleaseAnswerToContinue": "يرجى تحديد / كتابة إجابتك للمتابعة",
+  "teamDocuments": "الوثائق",
+  "confirmLeaveTeam": "هل أنت متأكد أنك تريد مغادرة هذا الفريق؟"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -13,7 +13,7 @@
   "@serverUrlHint": {
     "x-mt": true
   },
-  "serverPinLabel": "pin del servidor",
+  "serverPinLabel": "Pin del servidor",
   "connect": "Conectar",
   "@connect": {
     "x-mt": true
@@ -280,7 +280,7 @@
     "x-mt": true
   },
   "courses": "Cursos",
-  "myCourses": "misCursos",
+  "myCourses": "Mis cursos",
   "allCourses": "Todos los cursos",
   "@allCourses": {
     "x-mt": true
@@ -618,7 +618,7 @@
   "@refresh": {
     "x-mt": true
   },
-  "complete": "completa",
+  "complete": "Completa",
   "noMatchingSubmissions": "Ningún envío coincide con este filtro",
   "@noMatchingSubmissions": {
     "x-mt": true
@@ -2271,7 +2271,7 @@
   "@viewResource": {
     "x-mt": true
   },
-  "view": "ver",
+  "view": "Ver",
   "linkNotAvailable": "Enlace no disponible",
   "noRatings": "Aún no hay valoraciones",
   "@noRatings": {
@@ -2382,8 +2382,8 @@
   "voiceUnshared": "Eliminado de la comunidad",
   "exportCsv": "Exportar CSV",
   "csvFileSavedSuccessfully": "archivo CSV guardado con éxito.",
-  "failedToSaveCsvFile": "error al guardar el archivo CSV.",
-  "exportCancelled": "exportación cancelada.",
+  "failedToSaveCsvFile": "Error al guardar el archivo CSV.",
+  "exportCancelled": "Exportación cancelada.",
   "collections": "Colecciones",
   "filterCollections": "Filtrar colecciones",
   "selectManyCollections": "Seleccionar varias colecciones",
@@ -2496,5 +2496,7 @@
   "summaryOfAchievements": "Resumen de logros - Resume brevemente tu logro y añade los materiales relacionados a continuación",
   "myGoalsDescription": "Mis Metas - ¿Cuáles son tus metas para los próximos 10 años?",
   "myPurposeDescription": "Mi Propósito - ¿Cuáles son tus ambiciones educativas y profesionales?",
-  "pleaseAnswerToContinue": "Por favor, selecciona/escribe tu respuesta para continuar"
+  "pleaseAnswerToContinue": "Por favor, selecciona/escribe tu respuesta para continuar",
+  "teamDocuments": "Documentos",
+  "confirmLeaveTeam": "¿Estás seguro/a de que quieres abandonar este equipo?"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -2292,7 +2292,7 @@
   "@viewResource": {
     "x-mt": true
   },
-  "view": "afficher",
+  "view": "Afficher",
   "linkNotAvailable": "Lien non disponible",
   "noRatings": "Aucune note pour l'instant",
   "@noRatings": {
@@ -2418,8 +2418,8 @@
   },
   "exportCsv": "Exporter CSV",
   "csvFileSavedSuccessfully": "fichier CSV enregistré avec succès.",
-  "failedToSaveCsvFile": "échec de l'enregistrement du fichier CSV.",
-  "exportCancelled": "exportation annulée.",
+  "failedToSaveCsvFile": "Échec de l'enregistrement du fichier CSV.",
+  "exportCancelled": "Exportation annulée.",
   "collections": "Collections",
   "filterCollections": "Filtrer les collections",
   "selectManyCollections": "Sélectionner plusieurs collections",
@@ -2500,5 +2500,7 @@
   "summaryOfAchievements": "Résumé des réalisations - Résumez brièvement votre réalisation et ajoutez les documents associés ci-dessous",
   "myGoalsDescription": "Mes Objectifs - Quels sont vos objectifs pour les 10 prochaines années ?",
   "myPurposeDescription": "Mon But - Quelles sont vos ambitions éducatives et professionnelles ?",
-  "pleaseAnswerToContinue": "Veuillez sélectionner/écrire votre réponse pour continuer"
+  "pleaseAnswerToContinue": "Veuillez sélectionner/écrire votre réponse pour continuer",
+  "teamDocuments": "Documents",
+  "confirmLeaveTeam": "Êtes-vous sûr de vouloir quitter cette équipe ?"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -1169,10 +1169,7 @@
   },
   "teamMembers": "सदस्यहरू",
   "members": "सदस्यहरू",
-  "joinRequests": "[Nepali] Join requests",
-  "@joinRequests": {
-    "x-mt": true
-  },
+  "joinRequests": "सम्मिलित गर्न अनुरोधहरू",
   "noMembers": "[Nepali] No members yet",
   "@noMembers": {
     "x-mt": true
@@ -1220,10 +1217,7 @@
   "@removeFromTeam": {
     "x-mt": true
   },
-  "addResource": "[Nepali] Add resource",
-  "@addResource": {
-    "x-mt": true
-  },
+  "addResource": "स्रोत थप्नुहोस्",
   "editResource": "स्रोत सम्पादन गर्नुहोस्",
   "resourceUpdated": "स्रोत अद्यावधिक गरियो",
   "resourceAddedToTeam": "स्रोत टोलीमा थपियो",
@@ -2031,10 +2025,7 @@
   "progressFilterAll": "सबै",
   "progressFilterNotStarted": "सुरु भएको छैन",
   "progressFilterInProgress": "प्रगतिमा छ",
-  "progressFilterCompleted": "[Nepali] Completed",
-  "@progressFilterCompleted": {
-    "x-mt": true
-  },
+  "progressFilterCompleted": "पूरा भयो",
   "stepProgress": "[Nepali] {current} of {max} steps",
   "@stepProgress": {
     "x-mt": true
@@ -2290,5 +2281,7 @@
   "summaryOfAchievements": "उपलब्धिहरूको सारांश - आफ्नो उपलब्धि संक्षेपमा दिनुहोस् र सम्बन्धित सामग्री तल थप्नुहोस्",
   "myGoalsDescription": "मेरा लक्ष्यहरू - आगामी १० वर्षका लागि तपाईँका लक्ष्यहरू के हुन्?",
   "myPurposeDescription": "मेरो उद्देश्य - तपाईका शैक्षिक र व्यावसायिक महत्वाकांक्षा के हुन्?",
-  "pleaseAnswerToContinue": "कृपया जारी राख्नका लागि आफ्नो उत्तर चयन गर्नुहोस् / लेख्नुहोस्"
+  "pleaseAnswerToContinue": "कृपया जारी राख्नका लागि आफ्नो उत्तर चयन गर्नुहोस् / लेख्नुहोस्",
+  "teamDocuments": "कागजातहरू",
+  "confirmLeaveTeam": "के तपाईं यस टिमबाट बाहिर निस्कन चाहानुहुन्छ?"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -1,241 +1,29 @@
 {
   "@@locale": "ne",
   "appTitle": "myPlanet",
-  "serverConfigurationTitle": "[Nepali] Connect to a Planet server",
-  "@serverConfigurationTitle": {
-    "x-mt": true
-  },
-  "serverUrlLabel": "[Nepali] Server URL",
-  "@serverUrlLabel": {
-    "x-mt": true
-  },
-  "serverUrlHint": "[Nepali] https://planet.example.org",
-  "@serverUrlHint": {
-    "x-mt": true
-  },
   "serverPinLabel": "सर्भर पिन",
-  "connect": "[Nepali] Connect",
-  "@connect": {
-    "x-mt": true
-  },
   "serverUrlNotConfigured": "सर्भर URL कन्फिगर गरिएको छैन",
   "deviceCouldNotReachLocalServer": "डिभाइसले सर्भरसम्म पुग्न सकेन। स्थानीय सर्भर (समुदाय) को लागि तपाईं सही Wi-Fi नेटवर्कमा जडित हुनुहुन्छ कि छैन जाँच गर्नुहोस्।",
   "deviceCouldNotReachNationServer": "डिभाइसले सर्भरसम्म पुग्न सकेन। इन्टरनेटमा जडित हुनुहुन्छ कि छैन जाँच गर्नुहोस् र पुन: प्रयास गर्नुहोस्।",
   "connectionFailed": "जडान असफल भयो!",
-  "connectedToCommunity": "[Nepali] Connected to {code}",
-  "@connectedToCommunity": {
-    "x-mt": true
-  },
-  "changeServer": "[Nepali] Change server",
-  "@changeServer": {
-    "x-mt": true
-  },
   "login": "लगइन",
   "name": "नाम",
   "password": "पासवर्ड",
-  "signInOffline": "[Nepali] Sign in offline",
-  "@signInOffline": {
-    "x-mt": true
-  },
-  "invalidCredentials": "[Nepali] Name or password is incorrect.",
-  "@invalidCredentials": {
-    "x-mt": true
-  },
-  "userNotFound": "[Nepali] User not found.",
-  "@userNotFound": {
-    "x-mt": true
-  },
-  "missingAuthData": "[Nepali] Server response missing authentication data.",
-  "@missingAuthData": {
-    "x-mt": true
-  },
-  "serverError": "[Nepali] Server error. Please try again later.",
-  "@serverError": {
-    "x-mt": true
-  },
-  "networkError": "[Nepali] Server not reachable. Check your internet connection.",
-  "@networkError": {
-    "x-mt": true
-  },
-  "emptyCredentials": "[Nepali] Username and password are required.",
-  "@emptyCredentials": {
-    "x-mt": true
-  },
-  "notAManager": "[Nepali] This account is not a manager.",
-  "@notAManager": {
-    "x-mt": true
-  },
-  "savedAccounts": "[Nepali] Saved accounts",
-  "@savedAccounts": {
-    "x-mt": true
-  },
   "resources": "स्रोतहरू",
   "search": "खोज्नुहोस्",
   "sync": "सिंक",
   "cancel": "रद्द गर्नुहोस्",
   "settings": "सेटिङ्स",
-  "backgroundSync": "[Nepali] Background sync",
-  "@backgroundSync": {
-    "x-mt": true
-  },
-  "backgroundSyncDescription": "[Nepali] Send pending changes and refresh learning data while the app is closed",
-  "@backgroundSyncDescription": {
-    "x-mt": true
-  },
-  "syncFrequency": "[Nepali] Sync frequency",
-  "@syncFrequency": {
-    "x-mt": true
-  },
-  "every15Minutes": "[Nepali] Every 15 minutes",
-  "@every15Minutes": {
-    "x-mt": true
-  },
-  "every30Minutes": "[Nepali] Every 30 minutes",
-  "@every30Minutes": {
-    "x-mt": true
-  },
-  "everyHour": "[Nepali] Every hour",
-  "@everyHour": {
-    "x-mt": true
-  },
-  "every6Hours": "[Nepali] Every 6 hours",
-  "@every6Hours": {
-    "x-mt": true
-  },
-  "lastBackgroundRun": "[Nepali] Last background run",
-  "@lastBackgroundRun": {
-    "x-mt": true
-  },
-  "backgroundNeverRun": "[Nepali] No background run has been recorded yet",
-  "@backgroundNeverRun": {
-    "x-mt": true
-  },
-  "backgroundSucceeded": "[Nepali] Completed successfully",
-  "@backgroundSucceeded": {
-    "x-mt": true
-  },
-  "backgroundRetryRequested": "[Nepali] Incomplete — Android will retry",
-  "@backgroundRetryRequested": {
-    "x-mt": true
-  },
-  "backgroundSkipped": "[Nepali] Skipped",
-  "@backgroundSkipped": {
-    "x-mt": true
-  },
-  "backgroundUnknown": "[Nepali] Unknown result",
-  "@backgroundUnknown": {
-    "x-mt": true
-  },
-  "backgroundScheduleFailed": "[Nepali] The preference was saved, but Android could not update the schedule. It will be retried when the app restarts.",
-  "@backgroundScheduleFailed": {
-    "x-mt": true
-  },
-  "backgroundFailedSteps": "[Nepali] Needs retry: {steps}",
-  "@backgroundFailedSteps": {
-    "x-mt": true
-  },
-  "logOut": "[Nepali] Log out",
-  "@logOut": {
-    "x-mt": true
-  },
   "noDataAvailable": "कुनै डाटा उपलब्ध छैन",
   "ok": "ठिक छ",
   "home": "होम",
-  "moreOptions": "[Nepali] More options",
-  "@moreOptions": {
-    "x-mt": true
-  },
   "appTheme": "एप थिम",
   "aiChat": "AI Chat",
   "syncNow": "अहिले सिङ्क गर्नुहोस्",
-  "syncCenter": "[Nepali] Sync center",
-  "@syncCenter": {
-    "x-mt": true
-  },
-  "syncAll": "[Nepali] Sync all",
-  "@syncAll": {
-    "x-mt": true
-  },
   "syncing": "सिङ्क हुँदैछ…",
-  "waiting": "[Nepali] Waiting",
-  "@waiting": {
-    "x-mt": true
-  },
-  "events": "[Nepali] Events",
-  "@events": {
-    "x-mt": true
-  },
   "surveys": "सर्वेक्षणहरू",
-  "syncReady": "[Nepali] Ready to sync",
-  "@syncReady": {
-    "x-mt": true
-  },
-  "syncForegroundNotice": "[Nepali] Keep myPlanet open until the sync finishes. Pending offline writes remain durable if the connection drops.",
-  "@syncForegroundNotice": {
-    "x-mt": true
-  },
-  "syncProgress": "[Nepali] Syncing {completed} of {total} areas",
-  "@syncProgress": {
-    "x-mt": true
-  },
-  "syncAllSuccessful": "[Nepali] All {count} areas synced successfully",
-  "@syncAllSuccessful": {
-    "x-mt": true
-  },
-  "syncCompletedWithFailures": "[Nepali] Sync finished: {success} succeeded, {failed} failed",
-  "@syncCompletedWithFailures": {
-    "x-mt": true
-  },
   "itemsSynced": "{count, plural, =0{Up to date} =1{1 item synced} other{{count} items synced}}",
   "@itemsSynced": {
-    "x-mt": true
-  },
-  "lastSyncTimestamp": "[Nepali] Last successful sync: {date}",
-  "@lastSyncTimestamp": {
-    "x-mt": true
-  },
-  "syncResourcesDescription": "[Nepali] Refresh the offline learning library",
-  "@syncResourcesDescription": {
-    "x-mt": true
-  },
-  "syncCoursesDescription": "[Nepali] Refresh courses, steps, and shelf membership",
-  "@syncCoursesDescription": {
-    "x-mt": true
-  },
-  "syncTeamsDescription": "[Nepali] Refresh teams, memberships, and enterprise data",
-  "@syncTeamsDescription": {
-    "x-mt": true
-  },
-  "syncEventsDescription": "[Nepali] Refresh meetups and attendance",
-  "@syncEventsDescription": {
-    "x-mt": true
-  },
-  "syncSurveysDescription": "[Nepali] Refresh survey forms and assignments",
-  "@syncSurveysDescription": {
-    "x-mt": true
-  },
-  "syncVoicesDescription": "[Nepali] Refresh community discussions and replies",
-  "@syncVoicesDescription": {
-    "x-mt": true
-  },
-  "syncFeedbackDescription": "[Nepali] Refresh feedback threads and responses",
-  "@syncFeedbackDescription": {
-    "x-mt": true
-  },
-  "syncChatDescription": "[Nepali] Refresh AI conversation history",
-  "@syncChatDescription": {
-    "x-mt": true
-  },
-  "syncHealthDescription": "[Nepali] Refresh encrypted health records",
-  "@syncHealthDescription": {
-    "x-mt": true
-  },
-  "syncActivitiesDescription": "[Nepali] Refresh login history from the server",
-  "@syncActivitiesDescription": {
-    "x-mt": true
-  },
-  "syncNotificationsDescription": "[Nepali] Refresh server notifications and upload read states",
-  "@syncNotificationsDescription": {
     "x-mt": true
   },
   "homeMyLibrary": "मेरो पुस्तकालय",
@@ -254,10 +42,6 @@
   "@surveysToComplete": {
     "x-mt": true
   },
-  "lastSynced": "[Nepali] Last synced: {time}",
-  "@lastSynced": {
-    "x-mt": true
-  },
   "neverSynced": "कहिले पनि समक्रमित भएन",
   "justNow": "अहिले नै",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
@@ -272,34 +56,14 @@
   "@daysAgo": {
     "x-mt": true
   },
-  "syncingResources": "[Nepali] Syncing resources… {completed} of {total}",
-  "@syncingResources": {
-    "x-mt": true
-  },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
   "@syncedResources": {
     "x-mt": true
   },
-  "syncFailed": "[Nepali] Sync failed: {message}",
-  "@syncFailed": {
-    "x-mt": true
-  },
-  "availableOffline": "[Nepali] Available offline",
-  "@availableOffline": {
-    "x-mt": true
-  },
   "courses": "पाठ्यक्रमहरू",
   "myCourses": "मेरो पाठ्यक्रमहरू",
-  "allCourses": "[Nepali] All courses",
-  "@allCourses": {
-    "x-mt": true
-  },
   "courseSteps": "{count, plural, =0{No steps} =1{1 step} other{{count} steps}}",
   "@courseSteps": {
-    "x-mt": true
-  },
-  "stepNumber": "[Nepali] Step {number}",
-  "@stepNumber": {
     "x-mt": true
   },
   "resourcesInStep": "{count, plural, =0{No resources} =1{1 resource} other{{count} resources}}",
@@ -307,237 +71,41 @@
     "x-mt": true
   },
   "gradeLevel": "ग्रेड स्तर",
-  "subjectLevel": "[Nepali] Subject",
-  "@subjectLevel": {
-    "x-mt": true
-  },
   "allLevels": "सबै",
-  "clearFilters": "[Nepali] Clear filters",
-  "@clearFilters": {
-    "x-mt": true
-  },
-  "joinCourse": "[Nepali] Add to my courses",
-  "@joinCourse": {
-    "x-mt": true
-  },
-  "leaveCourse": "[Nepali] Remove from my courses",
-  "@leaveCourse": {
-    "x-mt": true
-  },
   "syncedCourses": "{count, plural, =0{No courses synced} =1{1 course synced} other{{count} courses synced}}",
   "@syncedCourses": {
     "x-mt": true
   },
-  "courseNotFound": "[Nepali] Course not found",
-  "@courseNotFound": {
-    "x-mt": true
-  },
   "calendar": "पात्रो",
   "profile": "प्रोफाइल",
-  "profileUnavailable": "[Nepali] Profile unavailable",
-  "@profileUnavailable": {
-    "x-mt": true
-  },
   "username": "प्रयोगकर्तानाम",
   "email": "ईमेल",
-  "phone": "[Nepali] Phone",
-  "@phone": {
-    "x-mt": true
-  },
   "level": "स्तर",
-  "levels": "[Nepali] Levels",
-  "@levels": {
-    "x-mt": true
-  },
   "language": "भाषा",
   "languages": "भाषाहरू",
   "gender": "लिङ्ग",
   "dateOfBirth": "जन्म मिति",
-  "planetCode": "[Nepali] Planet code",
-  "@planetCode": {
-    "x-mt": true
-  },
-  "accountDetails": "[Nepali] Account details",
-  "@accountDetails": {
-    "x-mt": true
-  },
-  "noProfileDetails": "[Nepali] No profile details are available.",
-  "@noProfileDetails": {
-    "x-mt": true
-  },
-  "profilePhotoFor": "[Nepali] Profile photo for {name}",
-  "@profilePhotoFor": {
-    "x-mt": true
-  },
   "editProfile": "प्रोफाइल सम्पादन गर्नुहोस्",
-  "changePhoto": "[Nepali] Change profile photo",
-  "@changePhoto": {
-    "x-mt": true
-  },
-  "photoUpdated": "[Nepali] Profile photo updated",
-  "@photoUpdated": {
-    "x-mt": true
-  },
-  "photoUpdateFailed": "[Nepali] Could not save the photo",
-  "@photoUpdateFailed": {
-    "x-mt": true
-  },
   "firstName": "नाम",
   "middleName": "विचारको नाम",
   "lastName": "थर",
   "save": "सुरक्षित गर्नुहोस्",
-  "profileSaved": "[Nepali] Profile saved on this device",
-  "@profileSaved": {
-    "x-mt": true
-  },
-  "invalidEmail": "[Nepali] Enter a valid email address",
-  "@invalidEmail": {
-    "x-mt": true
-  },
-  "appearance": "[Nepali] Appearance",
-  "@appearance": {
-    "x-mt": true
-  },
-  "systemTheme": "[Nepali] Use device theme",
-  "@systemTheme": {
-    "x-mt": true
-  },
   "lightTheme": "उज्यालो",
   "darkTheme": "अँध्यारो",
-  "server": "[Nepali] Server",
-  "@server": {
-    "x-mt": true
-  },
-  "serverUrl": "[Nepali] Server URL",
-  "@serverUrl": {
-    "x-mt": true
-  },
-  "notConfigured": "[Nepali] Not configured",
-  "@notConfigured": {
-    "x-mt": true
-  },
-  "communityCode": "[Nepali] Community code",
-  "@communityCode": {
-    "x-mt": true
-  },
   "about": "बारेमा",
-  "offlineLearningApp": "[Nepali] Offline learning with Planet",
-  "@offlineLearningApp": {
-    "x-mt": true
-  },
-  "appVersion": "[Nepali] Version {version}",
-  "@appVersion": {
-    "x-mt": true
-  },
-  "buildNumber": "[Nepali] Build {number}",
-  "@buildNumber": {
-    "x-mt": true
-  },
-  "learningTools": "[Nepali] Learning tools",
-  "@learningTools": {
-    "x-mt": true
-  },
   "dictionary": "शब्दकोश",
-  "dictionaryDescription": "[Nepali] Search downloaded definitions offline",
-  "@dictionaryDescription": {
-    "x-mt": true
-  },
-  "dictionaryUnavailable": "[Nepali] Dictionary unavailable",
-  "@dictionaryUnavailable": {
-    "x-mt": true
-  },
-  "searchDictionary": "[Nepali] Search for a word",
-  "@searchDictionary": {
-    "x-mt": true
-  },
   "dictionaryWordCount": "{count, plural, =0{No downloaded words} =1{1 downloaded word} other{{count} downloaded words}}",
   "@dictionaryWordCount": {
     "x-mt": true
   },
-  "downloadDictionary": "[Nepali] Download dictionary",
-  "@downloadDictionary": {
-    "x-mt": true
-  },
-  "retryDownload": "[Nepali] Retry download",
-  "@retryDownload": {
-    "x-mt": true
-  },
-  "dictionaryDownloadFailed": "[Nepali] The dictionary could not be downloaded. Your existing offline data was not changed.",
-  "@dictionaryDownloadFailed": {
-    "x-mt": true
-  },
-  "wordNotFound": "[Nepali] Word not available in the offline dictionary",
-  "@wordNotFound": {
-    "x-mt": true
-  },
-  "meaning": "[Nepali] Meaning",
-  "@meaning": {
-    "x-mt": true
-  },
-  "synonyms": "[Nepali] Synonyms",
-  "@synonyms": {
-    "x-mt": true
-  },
-  "antonyms": "[Nepali] Antonyms",
-  "@antonyms": {
-    "x-mt": true
-  },
-  "notifications": "[Nepali] Notifications",
-  "@notifications": {
-    "x-mt": true
-  },
-  "notification": "[Nepali] Notification",
-  "@notification": {
-    "x-mt": true
-  },
-  "notificationsUnavailable": "[Nepali] Notifications unavailable",
-  "@notificationsUnavailable": {
-    "x-mt": true
-  },
-  "markAllRead": "[Nepali] Mark all read",
-  "@markAllRead": {
-    "x-mt": true
-  },
   "all": "सबै",
-  "read": "[Nepali] Read",
-  "@read": {
-    "x-mt": true
-  },
-  "unreadCount": "[Nepali] Unread ({count})",
-  "@unreadCount": {
-    "x-mt": true
-  },
   "noNotifications": "कुनै सूचना छैन",
   "noUnreadNotifications": "कुनै अपठित सूचना छैन",
   "noReadNotifications": "कुनै पठित सूचना छैन",
   "delete": "मेट्नुहोस्",
-  "deleteNotification": "[Nepali] Delete notification?",
-  "@deleteNotification": {
-    "x-mt": true
-  },
-  "deleteNotificationConfirmation": "[Nepali] This notification will be removed from this device.",
-  "@deleteNotificationConfirmation": {
-    "x-mt": true
-  },
-  "taskNotification": "[Nepali] Task",
-  "@taskNotification": {
-    "x-mt": true
-  },
   "chatNotification": "च्याट",
-  "replyNotification": "[Nepali] New reply",
-  "@replyNotification": {
-    "x-mt": true
-  },
   "resourceNotification": "स्रोतहरू",
-  "storageNotification": "[Nepali] Storage warning",
-  "@storageNotification": {
-    "x-mt": true
-  },
   "joinRequestNotification": "सामेल हुने अनुरोध",
-  "teamNotification": "[Nepali] Team update",
-  "@teamNotification": {
-    "x-mt": true
-  },
   "tasks": "कार्यहरू",
   "notifGroupJoinRequests": "सामेल हुने अनुरोधहरू",
   "notifGroupTeamUpdates": "टिम अपडेटहरू",
@@ -545,269 +113,29 @@
   "notifGroupVoiceReplies": "आवाज जवाफहरू",
   "notificationGroupSystem": "प्रणाली",
   "notificationGroupOther": "अन्य",
-  "myLife": "[Nepali] My life",
-  "@myLife": {
-    "x-mt": true
-  },
-  "myLifeUnavailable": "[Nepali] My life is unavailable",
-  "@myLifeUnavailable": {
-    "x-mt": true
-  },
-  "noLifeItems": "[Nepali] No My life items",
-  "@noLifeItems": {
-    "x-mt": true
-  },
-  "shownOnDashboard": "[Nepali] Shown",
-  "@shownOnDashboard": {
-    "x-mt": true
-  },
-  "hiddenFromDashboard": "[Nepali] Hidden",
-  "@hiddenFromDashboard": {
-    "x-mt": true
-  },
-  "hideItem": "[Nepali] Hide {title}",
-  "@hideItem": {
-    "x-mt": true
-  },
-  "showItem": "[Nepali] Show {title}",
-  "@showItem": {
-    "x-mt": true
-  },
-  "reorderItem": "[Nepali] Reorder {title}",
-  "@reorderItem": {
-    "x-mt": true
-  },
-  "myHealth": "[Nepali] My health",
-  "@myHealth": {
-    "x-mt": true
-  },
-  "achievements": "[Nepali] Achievements",
-  "@achievements": {
-    "x-mt": true
-  },
-  "submissions": "[Nepali] Submissions",
-  "@submissions": {
-    "x-mt": true
-  },
-  "submission": "[Nepali] Submission",
-  "@submission": {
-    "x-mt": true
-  },
-  "submissionsUnavailable": "[Nepali] Submissions are unavailable",
-  "@submissionsUnavailable": {
-    "x-mt": true
-  },
-  "noSubmissions": "[Nepali] No submissions yet",
-  "@noSubmissions": {
-    "x-mt": true
-  },
-  "pending": "[Nepali] Pending",
-  "@pending": {
-    "x-mt": true
-  },
-  "submissionGrade": "[Nepali] Grade: {grade}",
-  "@submissionGrade": {
-    "x-mt": true
-  },
-  "refresh": "[Nepali] Refresh",
-  "@refresh": {
-    "x-mt": true
-  },
   "complete": "समाप्त",
-  "noMatchingSubmissions": "[Nepali] No submissions match this filter",
-  "@noMatchingSubmissions": {
-    "x-mt": true
-  },
   "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
   "@submissionsSynced": {
-    "x-mt": true
-  },
-  "submissionDetails": "[Nepali] Submission details",
-  "@submissionDetails": {
-    "x-mt": true
-  },
-  "submissionNotFound": "[Nepali] Submission not found",
-  "@submissionNotFound": {
-    "x-mt": true
-  },
-  "unknown": "[Nepali] Unknown",
-  "@unknown": {
     "x-mt": true
   },
   "nA": "N/A",
   "otherDiagnosis": "अन्य निदानहरू",
   "add": "थप्नुहोस्",
   "status": "स्थिति",
-  "lastUpdated": "[Nepali] Last updated",
-  "@lastUpdated": {
-    "x-mt": true
-  },
-  "grade": "[Nepali] Grade",
-  "@grade": {
-    "x-mt": true
-  },
   "submittedBy": "पेश गर्ने:",
   "submissionType": "प्रकार",
-  "uploadStatus": "[Nepali] Upload status",
-  "@uploadStatus": {
-    "x-mt": true
-  },
-  "uploaded": "[Nepali] Uploaded",
-  "@uploaded": {
-    "x-mt": true
-  },
-  "answers": "[Nepali] Answers",
-  "@answers": {
-    "x-mt": true
-  },
-  "answersUnavailable": "[Nepali] Answers are unavailable",
-  "@answersUnavailable": {
-    "x-mt": true
-  },
-  "noAnswers": "[Nepali] No answers were saved with this submission",
-  "@noAnswers": {
-    "x-mt": true
-  },
-  "noAnswer": "[Nepali] No answer",
-  "@noAnswer": {
-    "x-mt": true
-  },
-  "questionNumber": "[Nepali] Question {number}",
-  "@questionNumber": {
-    "x-mt": true
-  },
-  "newSubmission": "[Nepali] New submission",
-  "@newSubmission": {
-    "x-mt": true
-  },
   "answer": "उत्तर",
-  "availableChoices": "[Nepali] Choices",
-  "@availableChoices": {
-    "x-mt": true
-  },
-  "exportPdf": "[Nepali] Export PDF",
-  "@exportPdf": {
-    "x-mt": true
-  },
-  "pdfExportFailed": "[Nepali] The PDF could not be created",
-  "@pdfExportFailed": {
-    "x-mt": true
-  },
-  "pdfSaved": "[Nepali] PDF saved to {path}",
-  "@pdfSaved": {
-    "x-mt": true
-  },
-  "mySurveys": "[Nepali] My surveys",
-  "@mySurveys": {
-    "x-mt": true
-  },
   "references": "सन्दर्भहरू",
-  "myPersonals": "[Nepali] My personals",
-  "@myPersonals": {
-    "x-mt": true
-  },
-  "featureComingSoon": "[Nepali] This feature is not ported yet",
-  "@featureComingSoon": {
-    "x-mt": true
-  },
   "maps": "नक्सा",
   "englishDictionary": "अंग्रेजी शब्दकोश",
-  "offlineMapsComingSoon": "[Nepali] Offline maps are not ported yet",
-  "@offlineMapsComingSoon": {
-    "x-mt": true
-  },
-  "addPersonal": "[Nepali] Add personal item",
-  "@addPersonal": {
-    "x-mt": true
-  },
-  "editPersonal": "[Nepali] Edit personal item",
-  "@editPersonal": {
-    "x-mt": true
-  },
-  "deletePersonal": "[Nepali] Delete personal item?",
-  "@deletePersonal": {
-    "x-mt": true
-  },
-  "deletePersonalConfirmation": "[Nepali] Delete “{title}” from this device?",
-  "@deletePersonalConfirmation": {
-    "x-mt": true
-  },
-  "personalsUnavailable": "[Nepali] Personal items are unavailable",
-  "@personalsUnavailable": {
-    "x-mt": true
-  },
-  "noPersonals": "[Nepali] No personal items yet. Add a private note to get started.",
-  "@noPersonals": {
-    "x-mt": true
-  },
-  "duplicateTitle": "[Nepali] A personal item with this title already exists",
-  "@duplicateTitle": {
-    "x-mt": true
-  },
-  "attachFile": "[Nepali] Attach file",
-  "@attachFile": {
-    "x-mt": true
-  },
-  "attachedFile": "[Nepali] Attached: {name}",
-  "@attachedFile": {
-    "x-mt": true
-  },
   "noFileSelected": "No file selected",
   "@noFileSelected": {
     "x-mt": true
   },
-  "removeFile": "[Nepali] Remove file",
-  "@removeFile": {
-    "x-mt": true
-  },
-  "savedOffline": "[Nepali] Saved offline — pending upload",
-  "@savedOffline": {
-    "x-mt": true
-  },
   "edit": "सम्पादन गर्नुहोस्",
   "title": "शीर्षक",
-  "titleRequired": "[Nepali] Enter a title",
-  "@titleRequired": {
-    "x-mt": true
-  },
-  "rateCourse": "[Nepali] Rate course",
-  "@rateCourse": {
-    "x-mt": true
-  },
-  "rateTitle": "[Nepali] Rate {title}",
-  "@rateTitle": {
-    "x-mt": true
-  },
-  "ratingsUnavailable": "[Nepali] Ratings are unavailable",
-  "@ratingsUnavailable": {
-    "x-mt": true
-  },
   "ratingSummary": "{average} from {count, plural, =1{1 rating} other{{count} ratings}}",
   "@ratingSummary": {
-    "x-mt": true
-  },
-  "ratingCompact": "[Nepali] {average} ({count})",
-  "@ratingCompact": {
-    "x-mt": true
-  },
-  "ratingOutOfFive": "[Nepali] Rating: {rating} out of 5",
-  "@ratingOutOfFive": {
-    "x-mt": true
-  },
-  "setRating": "[Nepali] Set rating to {rating}",
-  "@setRating": {
-    "x-mt": true
-  },
-  "ratingRequired": "[Nepali] Choose a rating",
-  "@ratingRequired": {
-    "x-mt": true
-  },
-  "commentOptional": "[Nepali] Comment (optional)",
-  "@commentOptional": {
-    "x-mt": true
-  },
-  "submitRating": "[Nepali] Submit rating",
-  "@submitRating": {
     "x-mt": true
   },
   "skip": "छोड्नुहोस्",
@@ -818,405 +146,53 @@
   "openLearning": "खुला सिकाइ",
   "unleashLearningPower": "सिकाईको शक्ति उत्कृष्ट बनाउनुहोस्",
   "onboardingWelcomeDescription": "सीमित शिक्षा गर्ने गेटवे",
-  "onboardingOfflineDescription": "[Nepali] Download resources for offline learning.\nAccess knowledge on the go.",
-  "@onboardingOfflineDescription": {
-    "x-mt": true
-  },
-  "onboardingOpenDescription": "[Nepali] Choose your interests and dive into interactive content.\nCraft your unique learning journey.",
-  "@onboardingOpenDescription": {
-    "x-mt": true
-  },
-  "onboardingPowerDescription": "[Nepali] Explore a world of knowledge at your fingertips.\n\n🌍 Offline Access: Learn without borders, anytime.\n🎯 Personalized: Tailor your learning path.\n📚 Interactive: Engage with videos, books, games.\n\nBegin your limitless learning journey with myPlanet!",
-  "@onboardingPowerDescription": {
-    "x-mt": true
-  },
   "onboardingServerPrepHint": "साइन इन गर्नु अघि, तपाईंलाई आफ्नो Planet सर्भर ठेगाना र PIN आवश्यक पर्नेछ। यदि तपाईंसँग अझै छैन भने आफ्नो सामुदायिक प्रशासकलाई सोध्नुहोस्।",
-  "pageProgress": "[Nepali] Page {current} of {total}",
-  "@pageProgress": {
-    "x-mt": true
-  },
-  "meetups": "[Nepali] Meetups",
-  "@meetups": {
-    "x-mt": true
-  },
-  "syncPendingMeetups": "[Nepali] Sync pending meetups",
-  "@syncPendingMeetups": {
-    "x-mt": true
-  },
-  "meetupsUnavailable": "[Nepali] Meetups are unavailable",
-  "@meetupsUnavailable": {
-    "x-mt": true
-  },
-  "noMeetups": "[Nepali] No meetups yet",
-  "@noMeetups": {
-    "x-mt": true
-  },
-  "dateNotSet": "[Nepali] Date not set",
-  "@dateNotSet": {
-    "x-mt": true
-  },
-  "untitledMeetup": "[Nepali] Untitled meetup",
-  "@untitledMeetup": {
-    "x-mt": true
-  },
   "addMeetup": "भेटघाट थप्नुहोस्",
-  "meetupDetails": "[Nepali] Meetup details",
-  "@meetupDetails": {
-    "x-mt": true
-  },
-  "meetupNotFound": "[Nepali] Meetup not found",
-  "@meetupNotFound": {
-    "x-mt": true
-  },
   "createdBy": "बनाएको",
-  "category": "[Nepali] Category",
-  "@category": {
-    "x-mt": true
-  },
   "location": "स्थान",
   "link": "लिङ्क",
   "recurring": "आवर्तमान",
   "description": "वर्णन",
-  "leaveMeetup": "[Nepali] Leave meetup",
-  "@leaveMeetup": {
-    "x-mt": true
-  },
-  "joinMeetup": "[Nepali] Join meetup",
-  "@joinMeetup": {
-    "x-mt": true
-  },
   "editMeetup": "भेटघाट सम्पादन गर्नुहोस्",
   "startTime": "सुरु समय",
   "endTime": "अन्त समय",
   "none": "कुनै पनि होइन",
   "daily": "दैनिक",
   "weekly": "साप्ताहिक",
-  "syncMeetups": "[Nepali] Sync meetups",
-  "@syncMeetups": {
-    "x-mt": true
-  },
-  "searchMeetups": "[Nepali] Search meetups",
-  "@searchMeetups": {
-    "x-mt": true
-  },
-  "sortMeetups": "[Nepali] Sort meetups",
-  "@sortMeetups": {
-    "x-mt": true
-  },
-  "sortResources": "[Nepali] Sort resources",
-  "@sortResources": {
-    "x-mt": true
-  },
-  "newestFirst": "[Nepali] Newest first",
-  "@newestFirst": {
-    "x-mt": true
-  },
-  "oldestFirst": "[Nepali] Oldest first",
-  "@oldestFirst": {
-    "x-mt": true
-  },
-  "titleAscending": "[Nepali] Title A–Z",
-  "@titleAscending": {
-    "x-mt": true
-  },
-  "titleDescending": "[Nepali] Title Z–A",
-  "@titleDescending": {
-    "x-mt": true
-  },
   "startDate": "सुरु मिति",
   "endDate": "अन्त मिति",
-  "timeNotSet": "[Nepali] Time not set",
-  "@timeNotSet": {
-    "x-mt": true
-  },
-  "syncSurveys": "[Nepali] Sync surveys",
-  "@syncSurveys": {
-    "x-mt": true
-  },
-  "searchSurveys": "[Nepali] Search surveys",
-  "@searchSurveys": {
-    "x-mt": true
-  },
-  "sortSurveys": "[Nepali] Sort surveys",
-  "@sortSurveys": {
-    "x-mt": true
-  },
-  "surveysUnavailable": "[Nepali] Surveys are unavailable",
-  "@surveysUnavailable": {
-    "x-mt": true
-  },
-  "noSurveys": "[Nepali] No surveys available",
-  "@noSurveys": {
-    "x-mt": true
-  },
-  "untitledSurvey": "[Nepali] Untitled survey",
-  "@untitledSurvey": {
-    "x-mt": true
-  },
   "takeSurvey": "सर्वेक्षण लिनुहोस्",
-  "surveyLoadFailed": "[Nepali] Survey could not be loaded",
-  "@surveyLoadFailed": {
-    "x-mt": true
-  },
-  "surveyHasNoQuestions": "[Nepali] This survey has no questions",
-  "@surveyHasNoQuestions": {
-    "x-mt": true
-  },
-  "submitSurvey": "[Nepali] Submit survey",
-  "@submitSurvey": {
-    "x-mt": true
-  },
-  "answerRequiredQuestions": "[Nepali] Answer all required questions",
-  "@answerRequiredQuestions": {
-    "x-mt": true
-  },
-  "voices": "[Nepali] Voices",
-  "@voices": {
-    "x-mt": true
-  },
-  "searchVoices": "[Nepali] Search voices",
-  "@searchVoices": {
-    "x-mt": true
-  },
-  "syncVoices": "[Nepali] Sync voices",
-  "@syncVoices": {
-    "x-mt": true
-  },
-  "noVoices": "[Nepali] No voices yet",
-  "@noVoices": {
-    "x-mt": true
-  },
-  "voicesUnavailable": "[Nepali] Voices are unavailable",
-  "@voicesUnavailable": {
-    "x-mt": true
-  },
-  "shareYourVoice": "[Nepali] Share your voice",
-  "@shareYourVoice": {
-    "x-mt": true
-  },
-  "postVoice": "[Nepali] Post",
-  "@postVoice": {
-    "x-mt": true
-  },
   "replyToVoice": "उत्तर दिनुहोस्",
-  "writeAReply": "[Nepali] Write a reply",
-  "@writeAReply": {
-    "x-mt": true
-  },
   "repliesCount": "{count, plural, =0{No replies} =1{1 reply} other{{count} replies}}",
   "@repliesCount": {
     "x-mt": true
   },
-  "edited": "[Nepali] Edited",
-  "@edited": {
-    "x-mt": true
-  },
   "editVoice": "सम्पादन गर्नुहोस्",
   "deleteVoice": "मेट्नुहोस्",
-  "deleteVoiceConfirm": "[Nepali] Delete this post and all of its replies?",
-  "@deleteVoiceConfirm": {
-    "x-mt": true
-  },
-  "voiceDeleted": "[Nepali] Post deleted",
-  "@voiceDeleted": {
-    "x-mt": true
-  },
-  "emptyMessageNotAllowed": "[Nepali] Write something first",
-  "@emptyMessageNotAllowed": {
-    "x-mt": true
-  },
-  "thread": "[Nepali] Thread",
-  "@thread": {
-    "x-mt": true
-  },
-  "surveySubmitFailed": "[Nepali] Could not save your answers",
-  "@surveySubmitFailed": {
-    "x-mt": true
-  },
-  "sendSurveyTo": "[Nepali] Select users to send survey to",
-  "@sendSurveyTo": {
-    "x-mt": true
-  },
   "sendSurvey": "सर्वेक्षण पठाउनुहोस्",
   "surveySentToUsers": "Survey sent to selected users",
   "@surveySentToUsers": {
     "x-mt": true
   },
-  "noUsersAvailable": "[Nepali] No users available",
-  "@noUsersAvailable": {
-    "x-mt": true
-  },
   "teams": "टटिमहरू",
-  "syncTeams": "[Nepali] Sync teams",
-  "@syncTeams": {
-    "x-mt": true
-  },
-  "searchTeams": "[Nepali] Search teams",
-  "@searchTeams": {
-    "x-mt": true
-  },
-  "teamsUnavailable": "[Nepali] Teams are unavailable",
-  "@teamsUnavailable": {
-    "x-mt": true
-  },
-  "noTeams": "[Nepali] No teams available",
-  "@noTeams": {
-    "x-mt": true
-  },
-  "untitledTeam": "[Nepali] Untitled team",
-  "@untitledTeam": {
-    "x-mt": true
-  },
-  "teamDetails": "[Nepali] Team details",
-  "@teamDetails": {
-    "x-mt": true
-  },
-  "teamNotFound": "[Nepali] Team not found",
-  "@teamNotFound": {
-    "x-mt": true
-  },
-  "publicTeam": "[Nepali] Public team",
-  "@publicTeam": {
-    "x-mt": true
-  },
-  "privateTeam": "[Nepali] Private team",
-  "@privateTeam": {
-    "x-mt": true
-  },
   "enterprises": "उद्यमहरू",
-  "searchEnterprises": "[Nepali] Search enterprises",
-  "@searchEnterprises": {
-    "x-mt": true
-  },
-  "leader": "[Nepali] Leader",
-  "@leader": {
-    "x-mt": true
-  },
   "leave": "छोड्नुहोस्",
   "remove": "हटाउनुहोस्",
   "makeLeader": "नेता बनाउनुहोस्",
   "leftTeam": "टोलीबाट बाहिर गएको",
-  "memberRemoved": "[Nepali] Member removed",
-  "@memberRemoved": {
-    "x-mt": true
-  },
-  "leaderUpdated": "[Nepali] Leader updated",
-  "@leaderUpdated": {
-    "x-mt": true
-  },
-  "member": "[Nepali] Member",
-  "@member": {
-    "x-mt": true
-  },
-  "teamLeader": "[Nepali] You lead this team",
-  "@teamLeader": {
-    "x-mt": true
-  },
-  "teamMember": "[Nepali] You are a member",
-  "@teamMember": {
-    "x-mt": true
-  },
   "services": "सेवाहरू",
-  "rules": "[Nepali] Rules",
-  "@rules": {
-    "x-mt": true
-  },
-  "teamCourses": "[Nepali] Team courses",
-  "@teamCourses": {
-    "x-mt": true
-  },
   "membersCount": "{count, plural, =0{No members} =1{1 member} other{{count} members}}",
   "@membersCount": {
     "x-mt": true
   },
   "teamTasks": "कार्यहरू",
-  "tasksUnavailable": "[Nepali] Tasks are unavailable",
-  "@tasksUnavailable": {
-    "x-mt": true
-  },
-  "noTeamTasks": "[Nepali] No tasks yet",
-  "@noTeamTasks": {
-    "x-mt": true
-  },
-  "noDeadline": "[Nepali] No deadline",
-  "@noDeadline": {
-    "x-mt": true
-  },
-  "untitledTask": "[Nepali] Untitled task",
-  "@untitledTask": {
-    "x-mt": true
-  },
   "addTask": "काम थप्नुहोस्",
-  "editTask": "[Nepali] Edit task",
-  "@editTask": {
-    "x-mt": true
-  },
-  "deleteTask": "[Nepali] Delete task",
-  "@deleteTask": {
-    "x-mt": true
-  },
-  "taskTitle": "[Nepali] Task title",
-  "@taskTitle": {
-    "x-mt": true
-  },
-  "assigneeId": "[Nepali] Assignee ID",
-  "@assigneeId": {
-    "x-mt": true
-  },
-  "teamDiscussions": "[Nepali] Discussions",
-  "@teamDiscussions": {
-    "x-mt": true
-  },
   "teamMembers": "सदस्यहरू",
   "members": "सदस्यहरू",
   "joinRequests": "सम्मिलित गर्न अनुरोधहरू",
-  "noMembers": "[Nepali] No members yet",
-  "@noMembers": {
-    "x-mt": true
-  },
-  "membersUnavailable": "[Nepali] Members are unavailable",
-  "@membersUnavailable": {
-    "x-mt": true
-  },
-  "unknownMember": "[Nepali] Unknown member",
-  "@unknownMember": {
-    "x-mt": true
-  },
-  "noJoinRequests": "[Nepali] No pending requests",
-  "@noJoinRequests": {
-    "x-mt": true
-  },
   "accept": "स्वीकार गर्नुहोस्",
-  "decline": "[Nepali] Decline",
-  "@decline": {
-    "x-mt": true
-  },
   "joinTeam": "सामेल हुनका लागि अनुरोध गर्नुहोस्",
-  "leaveTeam": "[Nepali] Leave team",
-  "@leaveTeam": {
-    "x-mt": true
-  },
-  "requestPending": "[Nepali] Request pending",
-  "@requestPending": {
-    "x-mt": true
-  },
   "teamResources": "स्रोतहरू",
-  "resourcesUnavailable": "[Nepali] Resources are unavailable",
-  "@resourcesUnavailable": {
-    "x-mt": true
-  },
-  "noTeamResources": "[Nepali] No resources linked to this team",
-  "@noTeamResources": {
-    "x-mt": true
-  },
-  "untitledResource": "[Nepali] Untitled resource",
-  "@untitledResource": {
-    "x-mt": true
-  },
-  "removeFromTeam": "[Nepali] Remove from team",
-  "@removeFromTeam": {
-    "x-mt": true
-  },
   "addResource": "स्रोत थप्नुहोस्",
   "editResource": "स्रोत सम्पादन गर्नुहोस्",
   "resourceUpdated": "स्रोत अद्यावधिक गरियो",
@@ -1224,174 +200,30 @@
   "descriptionIsRequired": "विवरण आवश्यक छ",
   "levelIsRequired": "स्तर आवश्यक छ",
   "subjectIsRequired": "विषय आवश्यक छ",
-  "selectFile": "[Nepali] Select a file",
-  "@selectFile": {
-    "x-mt": true
-  },
   "fileSelected": "File selected",
   "@fileSelected": {
     "x-mt": true
   },
-  "privateResource": "[Nepali] Private resource",
-  "@privateResource": {
-    "x-mt": true
-  },
   "saveChanges": "परिवर्तनहरू सुरक्षित गर्नुहोस्",
-  "selectOpenWith": "[Nepali] Select open with",
-  "@selectOpenWith": {
-    "x-mt": true
-  },
-  "selectMedia": "[Nepali] Select media",
-  "@selectMedia": {
-    "x-mt": true
-  },
-  "selectResourceType": "[Nepali] Select resource type",
-  "@selectResourceType": {
-    "x-mt": true
-  },
   "linkToLicense": "लाइसेन्समा लिङ्क",
-  "noResourcesToAdd": "[Nepali] All available resources are already linked",
-  "@noResourcesToAdd": {
-    "x-mt": true
-  },
-  "coursesUnavailable": "[Nepali] Courses are unavailable",
-  "@coursesUnavailable": {
-    "x-mt": true
-  },
-  "noTeamCourses": "[Nepali] No courses linked to this team",
-  "@noTeamCourses": {
-    "x-mt": true
-  },
   "untitledCourse": "शीर्षक नभएको पाठ्यक्रम",
-  "addCourse": "[Nepali] Add course",
-  "@addCourse": {
-    "x-mt": true
-  },
-  "noCoursesToAdd": "[Nepali] All available courses are already linked",
-  "@noCoursesToAdd": {
-    "x-mt": true
-  },
-  "financialReports": "[Nepali] Financial reports",
-  "@financialReports": {
-    "x-mt": true
-  },
-  "reportsUnavailable": "[Nepali] Reports are unavailable",
-  "@reportsUnavailable": {
-    "x-mt": true
-  },
-  "noReports": "[Nepali] No financial reports yet",
-  "@noReports": {
-    "x-mt": true
-  },
   "addReport": "रिपोर्ट थप्नुहोस्",
-  "editReport": "[Nepali] Edit report",
-  "@editReport": {
-    "x-mt": true
-  },
   "archiveReport": "आर्काइभ",
   "beginningBalance": "प्रारम्भिक मौज्दात",
   "sales": "बिक्री",
   "otherIncome": "अन्य आय",
-  "wages": "[Nepali] Wages",
-  "@wages": {
-    "x-mt": true
-  },
-  "otherExpenses": "[Nepali] Other expenses",
-  "@otherExpenses": {
-    "x-mt": true
-  },
   "totalIncome": "कुल आय",
   "totalExpenses": "कुल खर्च",
-  "profitLoss": "[Nepali] Profit / loss",
-  "@profitLoss": {
-    "x-mt": true
-  },
   "endingBalance": "अन्तिम मौज्दात",
   "negativeBalance": "हालको शेष श्रेणी नकारात्मक छ!",
-  "reportDateDetails": "[Nepali] Report created on: {created} | Updated on: {updated}",
-  "@reportDateDetails": {
-    "x-mt": true
-  },
-  "chatHistory": "[Nepali] Chat History",
-  "@chatHistory": {
-    "x-mt": true
-  },
   "chat": "च्याट",
   "newChat": "नयाँ च्याट",
-  "searchChats": "[Nepali] Search chats",
-  "@searchChats": {
-    "x-mt": true
-  },
-  "noChats": "[Nepali] No chats yet",
-  "@noChats": {
-    "x-mt": true
-  },
-  "noSearchResults": "[Nepali] No matching chats",
-  "@noSearchResults": {
-    "x-mt": true
-  },
-  "untitledChat": "[Nepali] Untitled chat",
-  "@untitledChat": {
-    "x-mt": true
-  },
   "fullConversationResponse": "पूर्ण वार्तालाप उत्तर",
   "response": "उत्तर",
-  "chatConversation": "[Nepali] Conversation",
-  "@chatConversation": {
-    "x-mt": true
-  },
-  "newConversation": "[Nepali] New conversation",
-  "@newConversation": {
-    "x-mt": true
-  },
-  "startConversation": "[Nepali] Start a new conversation",
-  "@startConversation": {
-    "x-mt": true
-  },
-  "typeMessage": "[Nepali] Type a message…",
-  "@typeMessage": {
-    "x-mt": true
-  },
-  "selectAiProvider": "[Nepali] Select AI provider",
-  "@selectAiProvider": {
-    "x-mt": true
-  },
-  "aiProviders": "[Nepali] AI providers",
-  "@aiProviders": {
-    "x-mt": true
-  },
-  "aiProviderAvailable": "[Nepali] {name} (available)",
-  "@aiProviderAvailable": {
-    "x-mt": true
-  },
-  "aiProviderUnavailable": "[Nepali] {name} (unavailable)",
-  "@aiProviderUnavailable": {
-    "x-mt": true
-  },
   "feedback": "प्रतिक्रिया",
-  "feedbackNotFound": "[Nepali] Feedback not found",
-  "@feedbackNotFound": {
-    "x-mt": true
-  },
   "feedbackSaved": "प्रतिक्रिया सुरक्षित गरियो",
-  "isUrgent": "[Nepali] Is this urgent?",
-  "@isUrgent": {
-    "x-mt": true
-  },
-  "feedbackType": "[Nepali] Feedback type",
-  "@feedbackType": {
-    "x-mt": true
-  },
   "feedbackTypeRequired": "Please select a feedback type",
   "@feedbackTypeRequired": {
-    "x-mt": true
-  },
-  "yourFeedback": "[Nepali] Your feedback",
-  "@yourFeedback": {
-    "x-mt": true
-  },
-  "pleaseEnterFeedback": "[Nepali] Please enter your feedback",
-  "@pleaseEnterFeedback": {
     "x-mt": true
   },
   "question": "प्रश्न",
@@ -1399,219 +231,43 @@
   "suggestion": "सुझाव",
   "priority": "प्राथमिकता",
   "openDate": "खोल्ने मिति",
-  "replies": "[Nepali] Replies",
-  "@replies": {
-    "x-mt": true
-  },
   "pleaseEnterReply": "कृपया जवाफ टाइप गर्नुहोस्",
-  "untitledFeedback": "[Nepali] Untitled feedback",
-  "@untitledFeedback": {
-    "x-mt": true
-  },
   "yes": "हो",
   "no": "होइन",
   "submit": "पेश गर्नुहोस्",
-  "takeTest": "[Nepali] Take test",
-  "@takeTest": {
-    "x-mt": true
-  },
   "recordSurvey": "सर्वेक्षण रेकर्ड गर्नुहोस्",
-  "react": "[Nepali] React",
-  "@react": {
-    "x-mt": true
-  },
-  "pickReaction": "[Nepali] Pick a reaction",
-  "@pickReaction": {
-    "x-mt": true
-  },
-  "comments": "[Nepali] Comments",
-  "@comments": {
-    "x-mt": true
-  },
-  "addComment": "[Nepali] Add a comment",
-  "@addComment": {
-    "x-mt": true
-  },
-  "commentsCount": "[Nepali] {count} comments",
-  "@commentsCount": {
-    "x-mt": true
-  },
-  "noComments": "[Nepali] No comments yet",
-  "@noComments": {
-    "x-mt": true
-  },
-  "leaderboard": "[Nepali] Leaderboard",
-  "@leaderboard": {
-    "x-mt": true
-  },
-  "allTime": "[Nepali] All time",
-  "@allTime": {
-    "x-mt": true
-  },
-  "thisMonth": "[Nepali] This month",
-  "@thisMonth": {
-    "x-mt": true
-  },
-  "coursesCompleted": "[Nepali] {completed}/{total} courses",
-  "@coursesCompleted": {
-    "x-mt": true
-  },
-  "surveysCompleted": "[Nepali] {completed}/{total} surveys",
-  "@surveysCompleted": {
-    "x-mt": true
-  },
-  "error": "[Nepali] Error",
-  "@error": {
-    "x-mt": true
-  },
   "close": "बन्द गर्नुहोस्",
   "filter": "फिल्टर",
   "type": "प्रकार",
-  "apply": "[Nepali] Apply",
-  "@apply": {
-    "x-mt": true
-  },
-  "unavailable": "[Nepali] unavailable",
-  "@unavailable": {
-    "x-mt": true
-  },
-  "chatsUnavailable": "[Nepali] Chats could not be loaded",
-  "@chatsUnavailable": {
-    "x-mt": true
-  },
   "community": "समुदाय",
   "communityLeaders": "सामुदायिक नेताहरू",
   "nationLeaders": "राष्ट्रका नेता",
   "ourVoices": "हाम्रो आवाजहरू",
   "finances": "वित्त",
   "reports": "रिपोर्टहरू",
-  "transaction": "[Nepali] Transaction",
-  "@transaction": {
-    "x-mt": true
-  },
-  "transactions": "[Nepali] Transactions",
-  "@transactions": {
-    "x-mt": true
-  },
   "addTransaction": "लेखा थप्नुहोस्",
-  "noTransactions": "[Nepali] No transactions yet",
-  "@noTransactions": {
-    "x-mt": true
-  },
   "debit": "नेलो",
   "credit": "श्रेय",
   "balance": "तल्लोधन",
   "amount": "रकम",
-  "note": "[Nepali] Note",
-  "@note": {
-    "x-mt": true
-  },
   "date": "मिति",
   "fromDate": "मिति देखि",
   "toDate": "मिति सम्म",
-  "reset": "[Nepali] Reset",
-  "@reset": {
-    "x-mt": true
-  },
   "noteRequired": "टिप्पणी आवश्यक छ",
-  "amountRequired": "[Nepali] Amount must be greater than 0",
-  "@amountRequired": {
-    "x-mt": true
-  },
   "transactionAdded": "लेखा थपियो",
-  "addReceipt": "[Nepali] Add receipt",
-  "@addReceipt": {
-    "x-mt": true
-  },
   "receiptSelected": "Receipt selected",
   "@receiptSelected": {
     "x-mt": true
   },
-  "noReceipt": "[Nepali] No receipt attached",
-  "@noReceipt": {
-    "x-mt": true
-  },
-  "receipt": "[Nepali] Receipt",
-  "@receipt": {
-    "x-mt": true
-  },
-  "viewReceipt": "[Nepali] View receipt",
-  "@viewReceipt": {
-    "x-mt": true
-  },
-  "noLeadersAvailable": "[Nepali] No leaders available",
-  "@noLeadersAvailable": {
-    "x-mt": true
-  },
-  "noServicesAvailable": "[Nepali] No services available",
-  "@noServicesAvailable": {
-    "x-mt": true
-  },
   "noDescriptionAvailable": "विवरण उपलब्ध छैन",
-  "takeExam": "[Nepali] Take exam",
-  "@takeExam": {
-    "x-mt": true
-  },
-  "examLoadFailed": "[Nepali] Exam could not be loaded",
-  "@examLoadFailed": {
-    "x-mt": true
-  },
-  "examHasNoQuestions": "[Nepali] This exam has no questions",
-  "@examHasNoQuestions": {
-    "x-mt": true
-  },
-  "examComplete": "[Nepali] Exam Complete",
-  "@examComplete": {
-    "x-mt": true
-  },
-  "examUnavailable": "[Nepali] Exam is unavailable",
-  "@examUnavailable": {
-    "x-mt": true
-  },
-  "submitExam": "[Nepali] Submit exam",
-  "@submitExam": {
-    "x-mt": true
-  },
   "incorrectAnswer": "तपाईंले गलत उत्तर दिएका छन्, कृपया पुन: प्रयास गर्नुहोस्",
-  "correctAnswers": "[Nepali] Correct",
-  "@correctAnswers": {
-    "x-mt": true
-  },
   "yourAnswer": "तपाईंको उत्तर",
   "previous": "अघिल्लो",
   "finish": "समाप्त",
-  "exitExam": "[Nepali] Exit exam?",
-  "@exitExam": {
-    "x-mt": true
-  },
-  "exitExamMessage": "[Nepali] Your progress will be lost.",
-  "@exitExamMessage": {
-    "x-mt": true
-  },
   "exit": "बाहिर निस्कनुस्",
   "download": "डाउनलोड गर्नुहोस्",
   "downloading": "डाउनलोड गर्दै…",
   "downloadFailed": "डाउनलोड असफल भयो",
-  "resourceNotDownloaded": "[Nepali] This resource is not on your device yet.",
-  "@resourceNotDownloaded": {
-    "x-mt": true
-  },
-  "retry": "[Nepali] Retry",
-  "@retry": {
-    "x-mt": true
-  },
-  "fieldRequired": "[Nepali] Required",
-  "@fieldRequired": {
-    "x-mt": true
-  },
-  "examSubmitFailed": "[Nepali] Could not save your exam. Please try again.",
-  "@examSubmitFailed": {
-    "x-mt": true
-  },
-  "yourInformation": "[Nepali] Your information",
-  "@yourInformation": {
-    "x-mt": true
-  },
   "showAdditionalFields": "थप क्षेत्रहरू देखाउनुहोस्",
   "hideAdditionalFields": "थप क्षेत्रहरू लुकाउनुहोस्",
   "phoneNumber": "फोन नम्बर",
@@ -1620,28 +276,8 @@
   "male": "पुरुष",
   "female": "महिला",
   "yearOfBirth": "जन्म वर्ष",
-  "yearOfBirthRequired": "[Nepali] Year of birth is required",
-  "@yearOfBirthRequired": {
-    "x-mt": true
-  },
-  "invalidYear": "[Nepali] Please enter a valid year",
-  "@invalidYear": {
-    "x-mt": true
-  },
-  "yearBetween": "[Nepali] Year must be between {min} and {max}",
-  "@yearBetween": {
-    "x-mt": true
-  },
   "thankYouForTakingSurvey": "यो सर्वेक्षण लिनको लागि धन्यवाद।",
-  "errorSavingProfile": "[Nepali] Error saving profile",
-  "@errorSavingProfile": {
-    "x-mt": true
-  },
   "videoPlayer": "भिडियो प्लेयर",
-  "audioPlayer": "[Nepali] Audio player",
-  "@audioPlayer": {
-    "x-mt": true
-  },
   "videoFileNotFound": "भिडियो फाइल स्थानीय रूपमा फेला परेन",
   "unableToLoadVideo": "भिडियो लोड गर्न असमर्थ",
   "audioFileNotFound": "अडियो फाइल स्थानीय रूपमा फेला परेन",
@@ -1657,190 +293,26 @@
   "errorOccurred": "त्रुटि: {error}",
   "openingResource": "खोल्दै: {title}",
   "loadingMedia": "लोड हुँदैछ...",
-  "resourceUnavailable": "[Nepali] This resource is not available for offline viewing",
-  "@resourceUnavailable": {
-    "x-mt": true
-  },
   "healthRecordNotAvailable": "स्वास्थ्य रेकर्ड उपलब्ध छैन।",
-  "updateHealth": "[Nepali] Update health",
-  "@updateHealth": {
-    "x-mt": true
-  },
-  "addHealthRecord": "[Nepali] Add health record",
-  "@addHealthRecord": {
-    "x-mt": true
-  },
-  "healthProfile": "[Nepali] Health profile",
-  "@healthProfile": {
-    "x-mt": true
-  },
   "specialNeeds": "विशेष आवश्यकता",
   "otherNeeds": "अन्य आवश्यकता",
   "emergencyContact": "आपतकालीन सम्पर्क",
-  "contactNumber": "[Nepali] Contact number",
-  "@contactNumber": {
-    "x-mt": true
-  },
-  "vitalSigns": "[Nepali] Vital signs",
-  "@vitalSigns": {
-    "x-mt": true
-  },
-  "temperature": "[Nepali] Temperature",
-  "@temperature": {
-    "x-mt": true
-  },
-  "pulse": "[Nepali] Pulse",
-  "@pulse": {
-    "x-mt": true
-  },
-  "height": "[Nepali] Height",
-  "@height": {
-    "x-mt": true
-  },
-  "weight": "[Nepali] Weight",
-  "@weight": {
-    "x-mt": true
-  },
-  "bloodPressure": "[Nepali] Blood pressure",
-  "@bloodPressure": {
-    "x-mt": true
-  },
   "vision": "दृष्टि",
   "hearing": "श्रवण",
-  "examinationHistory": "[Nepali] Examination history",
-  "@examinationHistory": {
-    "x-mt": true
-  },
-  "personalInformation": "[Nepali] Personal information",
-  "@personalInformation": {
-    "x-mt": true
-  },
   "birthPlace": "जन्मस्थान",
-  "contactName": "[Nepali] Contact name",
-  "@contactName": {
-    "x-mt": true
-  },
-  "contactType": "[Nepali] Contact type",
-  "@contactType": {
-    "x-mt": true
-  },
-  "healthInformation": "[Nepali] Health information",
-  "@healthInformation": {
-    "x-mt": true
-  },
-  "requiredField": "[Nepali] This field is required",
-  "@requiredField": {
-    "x-mt": true
-  },
-  "healthSavedSuccessfully": "[Nepali] Health data saved successfully",
-  "@healthSavedSuccessfully": {
-    "x-mt": true
-  },
-  "examinationDetails": "[Nepali] Examination details",
-  "@examinationDetails": {
-    "x-mt": true
-  },
   "allergies": "एलर्जीहरू",
   "diagnosis": "निदान",
   "medications": "औषधि",
   "immunizations": "प्रतिरक्षात्मक टिकाकरण",
   "treatments": "उपचारहरू",
-  "observations": "[Nepali] Observations",
-  "@observations": {
-    "x-mt": true
-  },
   "referrals": "रेफरल",
   "labTests": "प्रयोगशालामा परीक्षण",
   "xrays": "एक्सरे",
-  "conditions": "[Nepali] Conditions",
-  "@conditions": {
-    "x-mt": true
-  },
-  "selfExamination": "[Nepali] Self-examination",
-  "@selfExamination": {
-    "x-mt": true
-  },
-  "healthRecordAdded": "[Nepali] Health record added successfully",
-  "@healthRecordAdded": {
-    "x-mt": true
-  },
   "selectHealthMember": "सदस्य छान्नुहोस्",
-  "newPatient": "[Nepali] New patient",
-  "@newPatient": {
-    "x-mt": true
-  },
-  "sortJoinDateDesc": "[Nepali] Newest first",
-  "@sortJoinDateDesc": {
-    "x-mt": true
-  },
-  "sortJoinDateAsc": "[Nepali] Oldest first",
-  "@sortJoinDateAsc": {
-    "x-mt": true
-  },
-  "sortNameAsc": "[Nepali] Name A–Z",
-  "@sortNameAsc": {
-    "x-mt": true
-  },
-  "sortNameDesc": "[Nepali] Name Z–A",
-  "@sortNameDesc": {
-    "x-mt": true
-  },
-  "searchMembers": "[Nepali] Search members",
-  "@searchMembers": {
-    "x-mt": true
-  },
   "dismiss": "खारेज गर्नुहोस्",
   "addMember": "सदस्य थप्नुहोस्",
-  "invalidNumber": "[Nepali] Invalid number",
-  "@invalidNumber": {
-    "x-mt": true
-  },
-  "tempRangeError": "[Nepali] Temperature must be between 30 and 40",
-  "@tempRangeError": {
-    "x-mt": true
-  },
-  "pulseRangeError": "[Nepali] Pulse must be between 40 and 120",
-  "@pulseRangeError": {
-    "x-mt": true
-  },
-  "heightRangeError": "[Nepali] Height must be between 1 and 250",
-  "@heightRangeError": {
-    "x-mt": true
-  },
-  "weightRangeError": "[Nepali] Weight must be between 1 and 150",
-  "@weightRangeError": {
-    "x-mt": true
-  },
   "bloodPressureFormatError": "रक्तचाप सिस्टोलिक/डायस्टोलिक हुनुपर्छ",
-  "bloodPressureRangeError": "[Nepali] Blood pressure must be between 60/40 and 300/200",
-  "@bloodPressureRangeError": {
-    "x-mt": true
-  },
   "bloodPressureNotNumbers": "सिस्टोलिक र डायस्टोलिक अंशांकीय हुनुपर्छ",
-  "temp": "[Nepali] Temp",
-  "@temp": {
-    "x-mt": true
-  },
-  "bp": "[Nepali] BP",
-  "@bp": {
-    "x-mt": true
-  },
-  "offlineMaps": "[Nepali] Offline Maps",
-  "@offlineMaps": {
-    "x-mt": true
-  },
-  "centerOnDefault": "[Nepali] Center on default location",
-  "@centerOnDefault": {
-    "x-mt": true
-  },
-  "storage": "[Nepali] Storage",
-  "@storage": {
-    "x-mt": true
-  },
-  "storageManagement": "[Nepali] Storage Management",
-  "@storageManagement": {
-    "x-mt": true
-  },
   "storageTotalDownloaded": "कुल डाउनलोड",
   "storageVideos": "भिडियोहरू",
   "storageAudio": "अडियो",
@@ -1848,26 +320,14 @@
   "storageImages": "छविहरू",
   "storageOther": "अन्य",
   "fileCountOne": "१ फाइल",
-  "fileCountMany": "[Nepali] {count} files",
-  "@fileCountMany": {
-    "x-mt": true
-  },
   "storageUnknownResource": "अज्ञात स्रोत",
   "areYouSure": "के तपाईं निश्चित हुनुहुन्छ?",
   "cancelAddingExamination": "के तपाईं स्वास्थ्य परीक्षण थप्ने कार्य रद्द गर्न चाहनुहुन्छ? डेटा हराउनेछ।",
   "yesIWantToExit": "हो, म बाहिर निस्कन चाहन्छु।",
   "inactiveMessage": "प्रयोगकर्ता सक्रिय गरिएको छैन, कृपया प्रशासक वा प्रबन्धकलाई सम्पर्क गर्नुहोस् तपाईंको खाता सक्रिय गर्नको लागि।",
   "submitFeedback": "प्रतिक्रिया पेश गर्नुहोस्",
-  "failedToDelete": "[Nepali] Failed to delete: {error}",
-  "@failedToDelete": {
-    "x-mt": true
-  },
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
   "@storageDeleteSelectedConfirm": {
-    "x-mt": true
-  },
-  "storageDeleteConfirm": "[Nepali] Delete all {category} files?",
-  "@storageDeleteConfirm": {
     "x-mt": true
   },
   "storageSelectedCount": "{count} selected",
@@ -1882,82 +342,26 @@
   "leftCourses": "{count, plural, =1{१ कोर्स हटाइयो} other{{count} कोर्सहरू हटाइए}}",
   "coursesSelected": "{count, plural, =1{१ चयन भयो} other{{count} चयन भए}}",
   "leaveCoursesConfirm": "{count, plural, =1{के तपाईं यो कोर्स हटाउन निश्चित हुनुहुन्छ?} other{के तपाईं यी कोर्सहरू हटाउन निश्चित हुनुहुन्छ?}}",
-  "noStorageUsed": "[Nepali] No downloaded files found",
-  "@noStorageUsed": {
-    "x-mt": true
-  },
   "availableSpace": "उपलब्ध ठाउँ",
-  "freeUpSpace": "[Nepali] Free up space",
-  "@freeUpSpace": {
-    "x-mt": true
-  },
-  "freeUpSpaceConfirm": "[Nepali] This will delete all downloaded resources to free up storage space. Continue?",
-  "@freeUpSpaceConfirm": {
-    "x-mt": true
-  },
   "storageFreedSummary": "Freed {bytes}. {count, plural, =0{No files removed} =1{1 file removed} other{{count} files removed}}.",
   "@storageFreedSummary": {
     "x-mt": true
   },
-  "freeUpSpaceFailed": "[Nepali] Could not free up space: {error}",
-  "@freeUpSpaceFailed": {
-    "x-mt": true
-  },
   "enterUsername": "प्रयोगकर्तानाम प्रविष्ट गर्नुहोस्",
-  "enterPassword": "[Nepali] Enter password",
-  "@enterPassword": {
-    "x-mt": true
-  },
-  "retypePassword": "[Nepali] Retype password",
-  "@retypePassword": {
-    "x-mt": true
-  },
   "becomeMember": "सदस्य बन्नुहोस्",
   "toAccessThisFeatureBecomeAMember": "तपाईं हाल अतिथि प्रयोगकर्ता हुनुहुन्छ। यो सुविधा प्रयोग गर्न, सदस्य बन्नुहोस्।",
   "creatingMember": "सदस्य खाता सिर्जना गर्दै",
   "passwordsDoNotMatch": "पासवर्डहरू मिलेनन्",
   "pleaseSelectGender": "कृपया लिङ्ग चयन गर्नुहोस्",
   "pleaseEnterPassword": "कृपया पासवर्ड लेख्नुहोस्",
-  "usernameAlreadyExists": "[Nepali] Username already exists",
-  "@usernameAlreadyExists": {
-    "x-mt": true
-  },
   "usernameCannotBeEmpty": "प्रयोगकर्ता नाम खाली हुनसक्दैन",
   "invalidUsername": "अमान्य प्रयोगकर्ता नाम",
   "usernameMustStartWithLetterOrNumber": "पात्र वा नम्बरसँग सुरु गर्नु पर्दछ",
-  "usernameOnlyLettersNumbers": "[Nepali] Only letters a-z, numbers and \"_\", \".\", \"-\" are allowed",
-  "@usernameOnlyLettersNumbers": {
-    "x-mt": true
-  },
   "usernameTaken": "प्रयोगकर्ता नाम पक्रिएको छ",
-  "memberCreatedOffline": "[Nepali] Member account created offline",
-  "@memberCreatedOffline": {
-    "x-mt": true
-  },
-  "memberCreatedOnline": "[Nepali] Member account created successfully",
-  "@memberCreatedOnline": {
-    "x-mt": true
-  },
   "congratulations": "बधाई छ! चुनौती पूरा भयो",
   "dailyVoices": "५ दैनिक आवाजहरू",
-  "voicesProgress": "[Nepali] {count} of 5 Daily Voices",
-  "@voicesProgress": {
-    "x-mt": true
-  },
-  "progressLabel": "[Nepali] Progress: {percent}%",
-  "@progressLabel": {
-    "x-mt": true
-  },
-  "courseNotStarted": "[Nepali] Course: Not started",
-  "@courseNotStarted": {
-    "x-mt": true
-  },
   "syncCompletedChallenge": "सिंक सम्पन्न भयो",
   "rememberSync": "मोबाइल एप्लिकेसनलाई समक्रमण गर्न सम्झनुहोस्।",
-  "challengeDialogTitle": "[Nepali] Daily Challenge",
-  "@challengeDialogTitle": {
-    "x-mt": true
-  },
   "start": "सुरु गर्नुहोस्",
   "continuation": "जारी राख्नुहोस्",
   "plan": "योजना",
@@ -1968,56 +372,12 @@
   "entServices": "तपाईंको एन्टरप्राइजले के सेवाहरू प्रदान गर्दछ?",
   "entRules": "तपाईंको एन्टरप्राइजको नियमहरू के हुन्छन्?",
   "noMissionDefined": "एन्टरप्राइजमा मिशन र सेवाहरू छैनन्।",
-  "noPlanDefined": "[Nepali] This team has no plan defined.",
-  "@noPlanDefined": {
-    "x-mt": true
-  },
   "noDescriptionDefined": "यस टिमको कुनै विवरण परिभाषित गरिएको छैन.",
-  "enterpriseName": "[Nepali] Enterprise name",
-  "@enterpriseName": {
-    "x-mt": true
-  },
-  "teamName": "[Nepali] Team name",
-  "@teamName": {
-    "x-mt": true
-  },
-  "teamType": "[Nepali] Team type",
-  "@teamType": {
-    "x-mt": true
-  },
-  "local": "[Nepali] Local",
-  "@local": {
-    "x-mt": true
-  },
   "isPublic": "सार्वजनिक",
   "nameRequired": "नाम आवश्यक छ",
   "nameIsRequired": "कृपया नाम लेख्नुहोस्",
   "createdOn": "मा सिर्जना गरिएको",
-  "courseDetails": "[Nepali] Course Details",
-  "@courseDetails": {
-    "x-mt": true
-  },
-  "addedToCourse": "[Nepali] Added to your courses",
-  "@addedToCourse": {
-    "x-mt": true
-  },
-  "removedFromCourse": "[Nepali] Removed from your courses",
-  "@removedFromCourse": {
-    "x-mt": true
-  },
   "pleaseCompleteSurvey": "कृपया कोर्स समाप्त गर्न सर्वेक्षण पूरा गर्नुहोस्",
-  "takeCourse": "[Nepali] Take Course",
-  "@takeCourse": {
-    "x-mt": true
-  },
-  "teamCalendar": "[Nepali] Team Calendar",
-  "@teamCalendar": {
-    "x-mt": true
-  },
-  "noMeetupsOnDate": "[Nepali] No meetups on this date",
-  "@noMeetupsOnDate": {
-    "x-mt": true
-  },
   "myProgress": "मेरो प्रगति",
   "progress": "प्रगति",
   "orderByTitle": "शीर्षक अनुसार आदेश गर्नुहोस्",
@@ -2026,115 +386,23 @@
   "progressFilterNotStarted": "सुरु भएको छैन",
   "progressFilterInProgress": "प्रगतिमा छ",
   "progressFilterCompleted": "पूरा भयो",
-  "stepProgress": "[Nepali] {current} of {max} steps",
-  "@stepProgress": {
-    "x-mt": true
-  },
-  "noEnrolledCourses": "[Nepali] You are not enrolled in any courses",
-  "@noEnrolledCourses": {
-    "x-mt": true
-  },
   "mistakes": "गल्तीहरू",
   "step": "चरण",
-  "untitledResourceTitle": "[Nepali] Untitled Resource",
-  "@untitledResourceTitle": {
-    "x-mt": true
-  },
   "author": "लेखक",
   "publisher": "प्रकाशक",
   "license": "लाइसेन्स",
   "addedBy": "थपिएको",
-  "resourceInformation": "[Nepali] Resource Information",
-  "@resourceInformation": {
-    "x-mt": true
-  },
-  "resourceFor": "[Nepali] For",
-  "@resourceFor": {
-    "x-mt": true
-  },
-  "mediaType": "[Nepali] Media Type",
-  "@mediaType": {
-    "x-mt": true
-  },
   "resourceType": "स्रोत प्रकार",
-  "subject": "[Nepali] Subject",
-  "@subject": {
-    "x-mt": true
-  },
   "year": "वर्ष",
-  "timesRated": "[Nepali] Times Rated",
-  "@timesRated": {
-    "x-mt": true
-  },
-  "addToMyLibrary": "[Nepali] Add to My Library",
-  "@addToMyLibrary": {
-    "x-mt": true
-  },
-  "removeFromMyLibrary": "[Nepali] Remove from My Library",
-  "@removeFromMyLibrary": {
-    "x-mt": true
-  },
-  "addedToMyLibrary": "[Nepali] Added to My Library",
-  "@addedToMyLibrary": {
-    "x-mt": true
-  },
-  "removedFromMyLibrary": "[Nepali] Removed from My Library",
-  "@removedFromMyLibrary": {
-    "x-mt": true
-  },
-  "myLibrary": "[Nepali] My Library",
-  "@myLibrary": {
-    "x-mt": true
-  },
-  "allResources": "[Nepali] All Resources",
-  "@allResources": {
-    "x-mt": true
-  },
-  "viewResource": "[Nepali] View Resource",
-  "@viewResource": {
-    "x-mt": true
-  },
   "view": "हेर्नु",
   "linkNotAvailable": "लिंक उपलब्ध छैन",
-  "noRatings": "[Nepali] No ratings yet",
-  "@noRatings": {
-    "x-mt": true
-  },
   "basedOnRatings": "based on {count, plural, =1{1 rating} other{{count} ratings}}",
   "@basedOnRatings": {
     "x-mt": true
   },
-  "rating": "[Nepali] Rating",
-  "@rating": {
-    "x-mt": true
-  },
-  "operationFailed": "[Nepali] Operation failed",
-  "@operationFailed": {
-    "x-mt": true
-  },
-  "filterResources": "[Nepali] Filter Resources",
-  "@filterResources": {
-    "x-mt": true
-  },
   "teamSurveys": "टोली सर्वेक्षणहरू",
-  "adoptableSurveys": "[Nepali] Surveys available to adopt",
-  "@adoptableSurveys": {
-    "x-mt": true
-  },
-  "noAdoptableSurveys": "[Nepali] No surveys available to adopt",
-  "@noAdoptableSurveys": {
-    "x-mt": true
-  },
   "adoptSurvey": "सर्वेक्षण अपनाउनुहोस्",
-  "surveyAdopted": "[Nepali] Survey adopted",
-  "@surveyAdopted": {
-    "x-mt": true
-  },
   "completedCourse": "समाप्त पाठ्यक्रम",
-  "userNameWithLogins": "[Nepali] {name} ({logins})",
-  "@userNameWithLogins": {
-    "x-mt": true
-  },
   "remindMeLater": "Xasuusi hadhow",
   "remindLater": "Xasuusi hadhow",
   "setReminder": "Deji xasuusin",
@@ -2145,10 +413,6 @@
   "@reminderSurveysToComplete": {
     "x-mt": true
   },
-  "myActivities": "[Nepali] My activities",
-  "@myActivities": {
-    "x-mt": true
-  },
   "chartLabel": "लगइनहरूको संख्या",
   "selectLanguage": "भाषा चयन गर्नुहोस्",
   "english": "english",
@@ -2157,61 +421,25 @@
   "nepali": "नेपाली",
   "arabic": "عربى",
   "french": "français",
-  "activitySummary": "[Nepali] Activity",
-  "@activitySummary": {
-    "x-mt": true
-  },
   "lastLogin": "अन्तिम लगइन",
-  "memberDetail": "[Nepali] Member detail",
-  "@memberDetail": {
-    "x-mt": true
-  },
   "numberOfVisits": "भ्रमण संख्या",
-  "noLogoutRecord": "[Nepali] No logout record found",
-  "@noLogoutRecord": {
-    "x-mt": true
-  },
   "totalVisits": "कुल भ्रमण",
   "mostOpenedResource": "सबैभन्दा धेरै खोलेको स्रोत",
   "numberOfResourcesOpened": "खोलिएका स्रोतहरूको संख्या",
-  "resourceOpenedTimes": "[Nepali] {title} opened {count} times",
-  "@resourceOpenedTimes": {
-    "x-mt": true
-  },
   "resourcesOpenedTimes": "{count, plural, =1{Resource opened 1 time} other{Resource opened {count} times}}",
   "@resourcesOpenedTimes": {
-    "x-mt": true
-  },
-  "serverReachable": "[Nepali] Server reachable",
-  "@serverReachable": {
-    "x-mt": true
-  },
-  "serverUnreachable": "[Nepali] Server unreachable",
-  "@serverUnreachable": {
     "x-mt": true
   },
   "serverChecking": "सर्भर जाँच गर्दै",
   "gridView": "ग्रिड दृश्य",
   "listView": "सूची दृश्य",
   "disclaimer": "अस्वीकरण",
-  "aboutContent": "[Nepali] ### MyPlanet\n\nmyPlanet is a learning tool that is designed to work with Planet web application. It has been used to improve early education, secondary schools, village health, youth workforce development, and economic and community development.\n\nPlanet houses is a repository of free, open access and public domain resources to benefit all learners.\n\nmyPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable. It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.\n\nThis application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet. Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take. Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.\n\nThe dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.\n\nmyPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations, in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda.",
-  "@aboutContent": {
-    "x-mt": true
-  },
   "disclaimerContent": "# Disclaimer\n\nLast updated: January 10, 2020\n\n# Interpretation and Definitions\n\n## Interpretation\n\nThe words of which the initial letter is capitalized have meanings defined under the following conditions.\n\nThe following definitions shall have the same meaning regardless of whether they appear in singular or in plural.\n\n## Definitions\n\nFor the purposes of this Disclaimer:\n\n- **Company** (referred to as either \"the Company\", \"We\", \"Us\" or \"Our\" in this Cookies Policy) refers to myPlanet.\n- **You** means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.\n- **Application** means the software program provided by the Company downloaded by You on any electronic device named myPlanet.\n- **Service** refers to the Application.\n\n# Disclaimer\n\nThe information contained on the Service is for general information purposes only.\n\nThe Company assumes no responsibility for errors or omissions in the contents of the Service.\n\nIn no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.\n\nThe Company does not warrant that the Service is free of viruses or other harmful components.\n\n# Medical Information Disclaimer\n\nThe information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information, and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.\n\nInformation offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.\n\nIndividuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.\n\nThe Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.\n\nThe Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.\n\n# External Links Disclaimer\n\nThe Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.\n\nPlease note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.\n\n# Errors and Omissions Disclaimer\n\nThe information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.\n\nThe Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.\n\n# Fair Use Disclaimer\n\nThe Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.\n\nThe Company believes this constitutes a \"fair use\" of any such copyrighted material as provided for in section 107 of the United States Copyright law.\n\nIf You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.\n\n# Views Expressed Disclaimer\n\nThe Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.\n\nComments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.\n\n# No Responsibility Disclaimer\n\nThe information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.\n\nIn no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.\n\n# \"Use at Your Own Risk\" Disclaimer\n\nAll information in the Service is provided \"as is\", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.\n\nThe Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.\n\n## Contact Us\n\nIf you have any questions about this Disclaimer, You can contact Us:\n\n- By email: myplanet@ole.org\n- By visiting this page on our website: [https://ole.org/contact](https://ole.org/contact)",
   "@disclaimerContent": {
     "x-mt": true
   },
   "shareWithCommunity": "समुदायसँग साझा गर्नुहोस्",
   "confirmShareCommunity": "के तपाईं यो सामग्री समुदायसँग साझा गर्न चाहनुहुन्छ?",
-  "voiceShared": "[Nepali] Post shared with community",
-  "@voiceShared": {
-    "x-mt": true
-  },
-  "voiceUnshared": "[Nepali] Removed from community",
-  "@voiceUnshared": {
-    "x-mt": true
-  },
   "exportCsv": "CSV निर्यात गर्नुहोस्",
   "csvFileSavedSuccessfully": "CSV फाइल सफलतापूर्वक सुरक्षित गरियो।",
   "failedToSaveCsvFile": "CSV फाइल सुरक्षित गर्न असफल।",
@@ -2249,10 +477,6 @@
   "chooseFile": "फाइल चयन गर्नुहोस्",
   "currentCv": "हालको CV/रिज्युमे: {name}",
   "update": "अद्यावधिक गर्नुहोस्",
-  "fillRequiredFields": "[Nepali] Please fill required fields: {fields}",
-  "@fillRequiredFields": {
-    "x-mt": true
-  },
   "@currentCv": {
     "placeholders": {
       "name": {
@@ -2267,14 +491,6 @@
   "textSizeLarge": "ठूलो",
   "resetApp": "अनुप्रयोग रिसेट गर्नुहोस्",
   "clearAllDataConfirm": "के तपाईं सबै डाटा हटाउन निश्चित हुनुहुन्छ?",
-  "dataCleared": "[Nepali] All data cleared",
-  "@dataCleared": {
-    "x-mt": true
-  },
-  "dataManagement": "[Nepali] Data management",
-  "@dataManagement": {
-    "x-mt": true
-  },
   "resourceTitleAlreadyExists": "यस शीर्षकको स्रोत पहिले नै अवस्थित छ",
   "failedToUpdateResource": "स्रोत अद्यावधिक गर्न असफल भयो",
   "unableToAddHealthRecord": "स्वास्थ्य रेकर्ड थप्न सकिएन।",

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -73,7 +73,7 @@
   "search": "Raadi",
   "sync": "Dib u hagrees",
   "cancel": "burin",
-  "settings": "Settings",
+  "settings": "Goobooyinka",
   "backgroundSync": "[Somali] Background sync",
   "@backgroundSync": {
     "x-mt": true
@@ -1169,10 +1169,7 @@
   },
   "teamMembers": "Xubinayaasha",
   "members": "Xubinayaasha",
-  "joinRequests": "[Somali] Join requests",
-  "@joinRequests": {
-    "x-mt": true
-  },
+  "joinRequests": "Su'aasha xubinaha",
   "noMembers": "[Somali] No members yet",
   "@noMembers": {
     "x-mt": true
@@ -1220,17 +1217,11 @@
   "@removeFromTeam": {
     "x-mt": true
   },
-  "addResource": "[Somali] Add resource",
-  "@addResource": {
-    "x-mt": true
-  },
+  "addResource": "Kudar Ilaha",
   "editResource": "Wax ka beddel kheyraadka",
   "resourceUpdated": "Kheyraadka waa la cusboonaysiiyay",
   "resourceAddedToTeam": "Khayraadka waxaa lagu daray kooxda",
-  "descriptionIsRequired": "[Somali] Description is required",
-  "@descriptionIsRequired": {
-    "x-mt": true
-  },
+  "descriptionIsRequired": "Sharaxaadda waa loo baahan yahay",
   "levelIsRequired": "Heerka waa loo baahan yahay",
   "subjectIsRequired": "Mawduuca waa loo baahan yahay",
   "selectFile": "[Somali] Select a file",
@@ -2034,10 +2025,7 @@
   "progressFilterAll": "Dhammaan",
   "progressFilterNotStarted": "Lama bilaaban",
   "progressFilterInProgress": "Socda",
-  "progressFilterCompleted": "[Somali] Completed",
-  "@progressFilterCompleted": {
-    "x-mt": true
-  },
+  "progressFilterCompleted": "Dhammaystay",
   "stepProgress": "[Somali] {current} of {max} steps",
   "@stepProgress": {
     "x-mt": true
@@ -2106,7 +2094,7 @@
   "@viewResource": {
     "x-mt": true
   },
-  "view": "eeg",
+  "view": "Eeg",
   "linkNotAvailable": "Xogta lama helin",
   "noRatings": "[Somali] No ratings yet",
   "@noRatings": {
@@ -2226,8 +2214,8 @@
   },
   "exportCsv": "Dhoofinta CSV",
   "csvFileSavedSuccessfully": "faylka CSV si guul leh ayaa loo keydiyay.",
-  "failedToSaveCsvFile": "waa lagu guuldareystay in la badbaadiyo faylka CSV.",
-  "exportCancelled": "dhoofinta waa la joojiyay.",
+  "failedToSaveCsvFile": "Waa lagu guuldareystay in la badbaadiyo faylka CSV.",
+  "exportCancelled": "Dhoofinta waa la joojiyay.",
   "collections": "Ururinta",
   "filterCollections": "Uruurinta shaandhaynta",
   "selectManyCollections": "Dooro Ururo Badan",
@@ -2293,5 +2281,7 @@
   "summaryOfAchievements": "Dulmar guulo - Si kooban u soo koob guushaada oo hoos ku dar agabka la xiriira",
   "myGoalsDescription": "Hadafyadayda - Waa maxay yoolalkaaga 10-ka sano ee soo socda?",
   "myPurposeDescription": "Ujeedadayda - Waa maxay himilooyinkaaga waxbarasho iyo kuwa xirfadeed?",
-  "pleaseAnswerToContinue": "Fadlan dooro / qor jawaabtaada si aad u sii wadato"
+  "pleaseAnswerToContinue": "Fadlan dooro / qor jawaabtaada si aad u sii wadato",
+  "teamDocuments": "Documents",
+  "confirmLeaveTeam": "Ma hubtaa inaad ka tashato kooxan?"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -1,241 +1,29 @@
 {
   "@@locale": "so",
   "appTitle": "myPlanet",
-  "serverConfigurationTitle": "[Somali] Connect to a Planet server",
-  "@serverConfigurationTitle": {
-    "x-mt": true
-  },
-  "serverUrlLabel": "[Somali] Server URL",
-  "@serverUrlLabel": {
-    "x-mt": true
-  },
-  "serverUrlHint": "[Somali] https://planet.example.org",
-  "@serverUrlHint": {
-    "x-mt": true
-  },
   "serverPinLabel": "Pin-ka adeegsiga",
-  "connect": "[Somali] Connect",
-  "@connect": {
-    "x-mt": true
-  },
   "serverUrlNotConfigured": "URL-ka server-ka lama dejin",
   "deviceCouldNotReachLocalServer": "qalabku ma uusan gaari karin server-ka. hubi inaad ku xiran tahay shabakadda Wi-Fi-ga saxda ah ee server-ka maxalliga ah (bulshada).",
   "deviceCouldNotReachNationServer": "qalabku ma uusan gaari karin server-ka. hubi inaad ku xiran tahay internetka oo dib isku day.",
   "connectionFailed": "Xiriirku wuu fashilmay!",
-  "connectedToCommunity": "[Somali] Connected to {code}",
-  "@connectedToCommunity": {
-    "x-mt": true
-  },
-  "changeServer": "[Somali] Change server",
-  "@changeServer": {
-    "x-mt": true
-  },
   "login": "Giri",
   "name": "Magaca",
   "password": "Furaha Erayga Sirta",
-  "signInOffline": "[Somali] Sign in offline",
-  "@signInOffline": {
-    "x-mt": true
-  },
-  "invalidCredentials": "[Somali] Name or password is incorrect.",
-  "@invalidCredentials": {
-    "x-mt": true
-  },
-  "userNotFound": "[Somali] User not found.",
-  "@userNotFound": {
-    "x-mt": true
-  },
-  "missingAuthData": "[Somali] Server response missing authentication data.",
-  "@missingAuthData": {
-    "x-mt": true
-  },
-  "serverError": "[Somali] Server error. Please try again later.",
-  "@serverError": {
-    "x-mt": true
-  },
-  "networkError": "[Somali] Server not reachable. Check your internet connection.",
-  "@networkError": {
-    "x-mt": true
-  },
-  "emptyCredentials": "[Somali] Username and password are required.",
-  "@emptyCredentials": {
-    "x-mt": true
-  },
-  "notAManager": "[Somali] This account is not a manager.",
-  "@notAManager": {
-    "x-mt": true
-  },
-  "savedAccounts": "[Somali] Saved accounts",
-  "@savedAccounts": {
-    "x-mt": true
-  },
   "resources": "Vifijo",
   "search": "Raadi",
   "sync": "Dib u hagrees",
   "cancel": "burin",
   "settings": "Goobooyinka",
-  "backgroundSync": "[Somali] Background sync",
-  "@backgroundSync": {
-    "x-mt": true
-  },
-  "backgroundSyncDescription": "[Somali] Send pending changes and refresh learning data while the app is closed",
-  "@backgroundSyncDescription": {
-    "x-mt": true
-  },
-  "syncFrequency": "[Somali] Sync frequency",
-  "@syncFrequency": {
-    "x-mt": true
-  },
-  "every15Minutes": "[Somali] Every 15 minutes",
-  "@every15Minutes": {
-    "x-mt": true
-  },
-  "every30Minutes": "[Somali] Every 30 minutes",
-  "@every30Minutes": {
-    "x-mt": true
-  },
-  "everyHour": "[Somali] Every hour",
-  "@everyHour": {
-    "x-mt": true
-  },
-  "every6Hours": "[Somali] Every 6 hours",
-  "@every6Hours": {
-    "x-mt": true
-  },
-  "lastBackgroundRun": "[Somali] Last background run",
-  "@lastBackgroundRun": {
-    "x-mt": true
-  },
-  "backgroundNeverRun": "[Somali] No background run has been recorded yet",
-  "@backgroundNeverRun": {
-    "x-mt": true
-  },
-  "backgroundSucceeded": "[Somali] Completed successfully",
-  "@backgroundSucceeded": {
-    "x-mt": true
-  },
-  "backgroundRetryRequested": "[Somali] Incomplete — Android will retry",
-  "@backgroundRetryRequested": {
-    "x-mt": true
-  },
-  "backgroundSkipped": "[Somali] Skipped",
-  "@backgroundSkipped": {
-    "x-mt": true
-  },
-  "backgroundUnknown": "[Somali] Unknown result",
-  "@backgroundUnknown": {
-    "x-mt": true
-  },
-  "backgroundScheduleFailed": "[Somali] The preference was saved, but Android could not update the schedule. It will be retried when the app restarts.",
-  "@backgroundScheduleFailed": {
-    "x-mt": true
-  },
-  "backgroundFailedSteps": "[Somali] Needs retry: {steps}",
-  "@backgroundFailedSteps": {
-    "x-mt": true
-  },
-  "logOut": "[Somali] Log out",
-  "@logOut": {
-    "x-mt": true
-  },
   "noDataAvailable": "Wax macluumaad ah ayaa lama helin",
   "ok": "Sax",
   "home": "Guriga",
-  "moreOptions": "[Somali] More options",
-  "@moreOptions": {
-    "x-mt": true
-  },
   "appTheme": "Mawduuca app-ka",
   "aiChat": "AI Chat",
   "syncNow": "Isku-dar hadda",
-  "syncCenter": "[Somali] Sync center",
-  "@syncCenter": {
-    "x-mt": true
-  },
-  "syncAll": "[Somali] Sync all",
-  "@syncAll": {
-    "x-mt": true
-  },
   "syncing": "La waafajinayaa…",
-  "waiting": "[Somali] Waiting",
-  "@waiting": {
-    "x-mt": true
-  },
-  "events": "[Somali] Events",
-  "@events": {
-    "x-mt": true
-  },
   "surveys": "Sahaminta",
-  "syncReady": "[Somali] Ready to sync",
-  "@syncReady": {
-    "x-mt": true
-  },
-  "syncForegroundNotice": "[Somali] Keep myPlanet open until the sync finishes. Pending offline writes remain durable if the connection drops.",
-  "@syncForegroundNotice": {
-    "x-mt": true
-  },
-  "syncProgress": "[Somali] Syncing {completed} of {total} areas",
-  "@syncProgress": {
-    "x-mt": true
-  },
-  "syncAllSuccessful": "[Somali] All {count} areas synced successfully",
-  "@syncAllSuccessful": {
-    "x-mt": true
-  },
-  "syncCompletedWithFailures": "[Somali] Sync finished: {success} succeeded, {failed} failed",
-  "@syncCompletedWithFailures": {
-    "x-mt": true
-  },
   "itemsSynced": "{count, plural, =0{Up to date} =1{1 item synced} other{{count} items synced}}",
   "@itemsSynced": {
-    "x-mt": true
-  },
-  "lastSyncTimestamp": "[Somali] Last successful sync: {date}",
-  "@lastSyncTimestamp": {
-    "x-mt": true
-  },
-  "syncResourcesDescription": "[Somali] Refresh the offline learning library",
-  "@syncResourcesDescription": {
-    "x-mt": true
-  },
-  "syncCoursesDescription": "[Somali] Refresh courses, steps, and shelf membership",
-  "@syncCoursesDescription": {
-    "x-mt": true
-  },
-  "syncTeamsDescription": "[Somali] Refresh teams, memberships, and enterprise data",
-  "@syncTeamsDescription": {
-    "x-mt": true
-  },
-  "syncEventsDescription": "[Somali] Refresh meetups and attendance",
-  "@syncEventsDescription": {
-    "x-mt": true
-  },
-  "syncSurveysDescription": "[Somali] Refresh survey forms and assignments",
-  "@syncSurveysDescription": {
-    "x-mt": true
-  },
-  "syncVoicesDescription": "[Somali] Refresh community discussions and replies",
-  "@syncVoicesDescription": {
-    "x-mt": true
-  },
-  "syncFeedbackDescription": "[Somali] Refresh feedback threads and responses",
-  "@syncFeedbackDescription": {
-    "x-mt": true
-  },
-  "syncChatDescription": "[Somali] Refresh AI conversation history",
-  "@syncChatDescription": {
-    "x-mt": true
-  },
-  "syncHealthDescription": "[Somali] Refresh encrypted health records",
-  "@syncHealthDescription": {
-    "x-mt": true
-  },
-  "syncActivitiesDescription": "[Somali] Refresh login history from the server",
-  "@syncActivitiesDescription": {
-    "x-mt": true
-  },
-  "syncNotificationsDescription": "[Somali] Refresh server notifications and upload read states",
-  "@syncNotificationsDescription": {
     "x-mt": true
   },
   "homeMyLibrary": "maktabadayda",
@@ -254,10 +42,6 @@
   "@surveysToComplete": {
     "x-mt": true
   },
-  "lastSynced": "[Somali] Last synced: {time}",
-  "@lastSynced": {
-    "x-mt": true
-  },
   "neverSynced": "waligeyn la isku midayn",
   "justNow": "Hadda uun",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
@@ -272,34 +56,14 @@
   "@daysAgo": {
     "x-mt": true
   },
-  "syncingResources": "[Somali] Syncing resources… {completed} of {total}",
-  "@syncingResources": {
-    "x-mt": true
-  },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
   "@syncedResources": {
     "x-mt": true
   },
-  "syncFailed": "[Somali] Sync failed: {message}",
-  "@syncFailed": {
-    "x-mt": true
-  },
-  "availableOffline": "[Somali] Available offline",
-  "@availableOffline": {
-    "x-mt": true
-  },
   "courses": "Koorsooyin",
   "myCourses": "Korasyadayda",
-  "allCourses": "[Somali] All courses",
-  "@allCourses": {
-    "x-mt": true
-  },
   "courseSteps": "{count, plural, =0{No steps} =1{1 step} other{{count} steps}}",
   "@courseSteps": {
-    "x-mt": true
-  },
-  "stepNumber": "[Somali] Step {number}",
-  "@stepNumber": {
     "x-mt": true
   },
   "resourcesInStep": "{count, plural, =0{No resources} =1{1 resource} other{{count} resources}}",
@@ -307,237 +71,41 @@
     "x-mt": true
   },
   "gradeLevel": "Darajo Loo qoondeeyey",
-  "subjectLevel": "[Somali] Subject",
-  "@subjectLevel": {
-    "x-mt": true
-  },
   "allLevels": "Dhammaan",
-  "clearFilters": "[Somali] Clear filters",
-  "@clearFilters": {
-    "x-mt": true
-  },
-  "joinCourse": "[Somali] Add to my courses",
-  "@joinCourse": {
-    "x-mt": true
-  },
-  "leaveCourse": "[Somali] Remove from my courses",
-  "@leaveCourse": {
-    "x-mt": true
-  },
   "syncedCourses": "{count, plural, =0{No courses synced} =1{1 course synced} other{{count} courses synced}}",
   "@syncedCourses": {
     "x-mt": true
   },
-  "courseNotFound": "[Somali] Course not found",
-  "@courseNotFound": {
-    "x-mt": true
-  },
   "calendar": "Calendar",
   "profile": "Profile",
-  "profileUnavailable": "[Somali] Profile unavailable",
-  "@profileUnavailable": {
-    "x-mt": true
-  },
   "username": "Magaca isticmaalaha",
   "email": "iimayl",
-  "phone": "[Somali] Phone",
-  "@phone": {
-    "x-mt": true
-  },
   "level": "Heerka",
-  "levels": "[Somali] Levels",
-  "@levels": {
-    "x-mt": true
-  },
   "language": "Luuqad",
   "languages": "Luqadaha",
   "gender": "Jinsi",
   "dateOfBirth": "Taariikhda dhalashada",
-  "planetCode": "[Somali] Planet code",
-  "@planetCode": {
-    "x-mt": true
-  },
-  "accountDetails": "[Somali] Account details",
-  "@accountDetails": {
-    "x-mt": true
-  },
-  "noProfileDetails": "[Somali] No profile details are available.",
-  "@noProfileDetails": {
-    "x-mt": true
-  },
-  "profilePhotoFor": "[Somali] Profile photo for {name}",
-  "@profilePhotoFor": {
-    "x-mt": true
-  },
   "editProfile": "Wax ka beddel xogta",
-  "changePhoto": "[Somali] Change profile photo",
-  "@changePhoto": {
-    "x-mt": true
-  },
-  "photoUpdated": "[Somali] Profile photo updated",
-  "@photoUpdated": {
-    "x-mt": true
-  },
-  "photoUpdateFailed": "[Somali] Could not save the photo",
-  "@photoUpdateFailed": {
-    "x-mt": true
-  },
   "firstName": "Magaca koowaad",
   "middleName": "Magaca Dhexe",
   "lastName": "Magaca Dambe",
   "save": "Keyd",
-  "profileSaved": "[Somali] Profile saved on this device",
-  "@profileSaved": {
-    "x-mt": true
-  },
-  "invalidEmail": "[Somali] Enter a valid email address",
-  "@invalidEmail": {
-    "x-mt": true
-  },
-  "appearance": "[Somali] Appearance",
-  "@appearance": {
-    "x-mt": true
-  },
-  "systemTheme": "[Somali] Use device theme",
-  "@systemTheme": {
-    "x-mt": true
-  },
   "lightTheme": "Iftiin",
   "darkTheme": "Madow",
-  "server": "[Somali] Server",
-  "@server": {
-    "x-mt": true
-  },
-  "serverUrl": "[Somali] Server URL",
-  "@serverUrl": {
-    "x-mt": true
-  },
-  "notConfigured": "[Somali] Not configured",
-  "@notConfigured": {
-    "x-mt": true
-  },
-  "communityCode": "[Somali] Community code",
-  "@communityCode": {
-    "x-mt": true
-  },
   "about": "ku saabsan",
-  "offlineLearningApp": "[Somali] Offline learning with Planet",
-  "@offlineLearningApp": {
-    "x-mt": true
-  },
-  "appVersion": "[Somali] Version {version}",
-  "@appVersion": {
-    "x-mt": true
-  },
-  "buildNumber": "[Somali] Build {number}",
-  "@buildNumber": {
-    "x-mt": true
-  },
-  "learningTools": "[Somali] Learning tools",
-  "@learningTools": {
-    "x-mt": true
-  },
   "dictionary": "Qaamuus",
-  "dictionaryDescription": "[Somali] Search downloaded definitions offline",
-  "@dictionaryDescription": {
-    "x-mt": true
-  },
-  "dictionaryUnavailable": "[Somali] Dictionary unavailable",
-  "@dictionaryUnavailable": {
-    "x-mt": true
-  },
-  "searchDictionary": "[Somali] Search for a word",
-  "@searchDictionary": {
-    "x-mt": true
-  },
   "dictionaryWordCount": "{count, plural, =0{No downloaded words} =1{1 downloaded word} other{{count} downloaded words}}",
   "@dictionaryWordCount": {
     "x-mt": true
   },
-  "downloadDictionary": "[Somali] Download dictionary",
-  "@downloadDictionary": {
-    "x-mt": true
-  },
-  "retryDownload": "[Somali] Retry download",
-  "@retryDownload": {
-    "x-mt": true
-  },
-  "dictionaryDownloadFailed": "[Somali] The dictionary could not be downloaded. Your existing offline data was not changed.",
-  "@dictionaryDownloadFailed": {
-    "x-mt": true
-  },
-  "wordNotFound": "[Somali] Word not available in the offline dictionary",
-  "@wordNotFound": {
-    "x-mt": true
-  },
-  "meaning": "[Somali] Meaning",
-  "@meaning": {
-    "x-mt": true
-  },
-  "synonyms": "[Somali] Synonyms",
-  "@synonyms": {
-    "x-mt": true
-  },
-  "antonyms": "[Somali] Antonyms",
-  "@antonyms": {
-    "x-mt": true
-  },
-  "notifications": "[Somali] Notifications",
-  "@notifications": {
-    "x-mt": true
-  },
-  "notification": "[Somali] Notification",
-  "@notification": {
-    "x-mt": true
-  },
-  "notificationsUnavailable": "[Somali] Notifications unavailable",
-  "@notificationsUnavailable": {
-    "x-mt": true
-  },
-  "markAllRead": "[Somali] Mark all read",
-  "@markAllRead": {
-    "x-mt": true
-  },
   "all": "Dhammaan",
-  "read": "[Somali] Read",
-  "@read": {
-    "x-mt": true
-  },
-  "unreadCount": "[Somali] Unread ({count})",
-  "@unreadCount": {
-    "x-mt": true
-  },
   "noNotifications": "Wax ogeysiis ah ma jiro",
   "noUnreadNotifications": "Wax ogeysiis aan la akhiyin ma jiro",
   "noReadNotifications": "Wax ogeysiis la akhiyay ma jiro",
   "delete": "Tirtir",
-  "deleteNotification": "[Somali] Delete notification?",
-  "@deleteNotification": {
-    "x-mt": true
-  },
-  "deleteNotificationConfirmation": "[Somali] This notification will be removed from this device.",
-  "@deleteNotificationConfirmation": {
-    "x-mt": true
-  },
-  "taskNotification": "[Somali] Task",
-  "@taskNotification": {
-    "x-mt": true
-  },
   "chatNotification": "Sawir",
-  "replyNotification": "[Somali] New reply",
-  "@replyNotification": {
-    "x-mt": true
-  },
   "resourceNotification": "Vifijo",
-  "storageNotification": "[Somali] Storage warning",
-  "@storageNotification": {
-    "x-mt": true
-  },
   "joinRequestNotification": "Codsi ku biirid",
-  "teamNotification": "[Somali] Team update",
-  "@teamNotification": {
-    "x-mt": true
-  },
   "tasks": "Hawlgalaha",
   "notifGroupJoinRequests": "Codsiyada Ku-Biiritaanka",
   "notifGroupTeamUpdates": "Cusboonaysiinta Kooxda",
@@ -545,269 +113,29 @@
   "notifGroupVoiceReplies": "Jawaabaha Codka",
   "notificationGroupSystem": "Nidaam",
   "notificationGroupOther": "Kale",
-  "myLife": "[Somali] My life",
-  "@myLife": {
-    "x-mt": true
-  },
-  "myLifeUnavailable": "[Somali] My life is unavailable",
-  "@myLifeUnavailable": {
-    "x-mt": true
-  },
-  "noLifeItems": "[Somali] No My life items",
-  "@noLifeItems": {
-    "x-mt": true
-  },
-  "shownOnDashboard": "[Somali] Shown",
-  "@shownOnDashboard": {
-    "x-mt": true
-  },
-  "hiddenFromDashboard": "[Somali] Hidden",
-  "@hiddenFromDashboard": {
-    "x-mt": true
-  },
-  "hideItem": "[Somali] Hide {title}",
-  "@hideItem": {
-    "x-mt": true
-  },
-  "showItem": "[Somali] Show {title}",
-  "@showItem": {
-    "x-mt": true
-  },
-  "reorderItem": "[Somali] Reorder {title}",
-  "@reorderItem": {
-    "x-mt": true
-  },
-  "myHealth": "[Somali] My health",
-  "@myHealth": {
-    "x-mt": true
-  },
-  "achievements": "[Somali] Achievements",
-  "@achievements": {
-    "x-mt": true
-  },
-  "submissions": "[Somali] Submissions",
-  "@submissions": {
-    "x-mt": true
-  },
-  "submission": "[Somali] Submission",
-  "@submission": {
-    "x-mt": true
-  },
-  "submissionsUnavailable": "[Somali] Submissions are unavailable",
-  "@submissionsUnavailable": {
-    "x-mt": true
-  },
-  "noSubmissions": "[Somali] No submissions yet",
-  "@noSubmissions": {
-    "x-mt": true
-  },
-  "pending": "[Somali] Pending",
-  "@pending": {
-    "x-mt": true
-  },
-  "submissionGrade": "[Somali] Grade: {grade}",
-  "@submissionGrade": {
-    "x-mt": true
-  },
-  "refresh": "[Somali] Refresh",
-  "@refresh": {
-    "x-mt": true
-  },
   "complete": "Buuxi",
-  "noMatchingSubmissions": "[Somali] No submissions match this filter",
-  "@noMatchingSubmissions": {
-    "x-mt": true
-  },
   "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
   "@submissionsSynced": {
-    "x-mt": true
-  },
-  "submissionDetails": "[Somali] Submission details",
-  "@submissionDetails": {
-    "x-mt": true
-  },
-  "submissionNotFound": "[Somali] Submission not found",
-  "@submissionNotFound": {
-    "x-mt": true
-  },
-  "unknown": "[Somali] Unknown",
-  "@unknown": {
     "x-mt": true
   },
   "nA": "N/A",
   "otherDiagnosis": "Xeerka Kale",
   "add": "Ku dar",
   "status": "xaalad",
-  "lastUpdated": "[Somali] Last updated",
-  "@lastUpdated": {
-    "x-mt": true
-  },
-  "grade": "[Somali] Grade",
-  "@grade": {
-    "x-mt": true
-  },
   "submittedBy": "La Diyaariyay",
   "submissionType": "Nooca",
-  "uploadStatus": "[Somali] Upload status",
-  "@uploadStatus": {
-    "x-mt": true
-  },
-  "uploaded": "[Somali] Uploaded",
-  "@uploaded": {
-    "x-mt": true
-  },
-  "answers": "[Somali] Answers",
-  "@answers": {
-    "x-mt": true
-  },
-  "answersUnavailable": "[Somali] Answers are unavailable",
-  "@answersUnavailable": {
-    "x-mt": true
-  },
-  "noAnswers": "[Somali] No answers were saved with this submission",
-  "@noAnswers": {
-    "x-mt": true
-  },
-  "noAnswer": "[Somali] No answer",
-  "@noAnswer": {
-    "x-mt": true
-  },
-  "questionNumber": "[Somali] Question {number}",
-  "@questionNumber": {
-    "x-mt": true
-  },
-  "newSubmission": "[Somali] New submission",
-  "@newSubmission": {
-    "x-mt": true
-  },
   "answer": "Jawaab",
-  "availableChoices": "[Somali] Choices",
-  "@availableChoices": {
-    "x-mt": true
-  },
-  "exportPdf": "[Somali] Export PDF",
-  "@exportPdf": {
-    "x-mt": true
-  },
-  "pdfExportFailed": "[Somali] The PDF could not be created",
-  "@pdfExportFailed": {
-    "x-mt": true
-  },
-  "pdfSaved": "[Somali] PDF saved to {path}",
-  "@pdfSaved": {
-    "x-mt": true
-  },
-  "mySurveys": "[Somali] My surveys",
-  "@mySurveys": {
-    "x-mt": true
-  },
   "references": "Tixraacyo",
-  "myPersonals": "[Somali] My personals",
-  "@myPersonals": {
-    "x-mt": true
-  },
-  "featureComingSoon": "[Somali] This feature is not ported yet",
-  "@featureComingSoon": {
-    "x-mt": true
-  },
   "maps": "Maps",
   "englishDictionary": "Qaamuuska Af Ingiriiska",
-  "offlineMapsComingSoon": "[Somali] Offline maps are not ported yet",
-  "@offlineMapsComingSoon": {
-    "x-mt": true
-  },
-  "addPersonal": "[Somali] Add personal item",
-  "@addPersonal": {
-    "x-mt": true
-  },
-  "editPersonal": "[Somali] Edit personal item",
-  "@editPersonal": {
-    "x-mt": true
-  },
-  "deletePersonal": "[Somali] Delete personal item?",
-  "@deletePersonal": {
-    "x-mt": true
-  },
-  "deletePersonalConfirmation": "[Somali] Delete “{title}” from this device?",
-  "@deletePersonalConfirmation": {
-    "x-mt": true
-  },
-  "personalsUnavailable": "[Somali] Personal items are unavailable",
-  "@personalsUnavailable": {
-    "x-mt": true
-  },
-  "noPersonals": "[Somali] No personal items yet. Add a private note to get started.",
-  "@noPersonals": {
-    "x-mt": true
-  },
-  "duplicateTitle": "[Somali] A personal item with this title already exists",
-  "@duplicateTitle": {
-    "x-mt": true
-  },
-  "attachFile": "[Somali] Attach file",
-  "@attachFile": {
-    "x-mt": true
-  },
-  "attachedFile": "[Somali] Attached: {name}",
-  "@attachedFile": {
-    "x-mt": true
-  },
   "noFileSelected": "No file selected",
   "@noFileSelected": {
     "x-mt": true
   },
-  "removeFile": "[Somali] Remove file",
-  "@removeFile": {
-    "x-mt": true
-  },
-  "savedOffline": "[Somali] Saved offline — pending upload",
-  "@savedOffline": {
-    "x-mt": true
-  },
   "edit": "Tafatir",
   "title": "Cinwaanka",
-  "titleRequired": "[Somali] Enter a title",
-  "@titleRequired": {
-    "x-mt": true
-  },
-  "rateCourse": "[Somali] Rate course",
-  "@rateCourse": {
-    "x-mt": true
-  },
-  "rateTitle": "[Somali] Rate {title}",
-  "@rateTitle": {
-    "x-mt": true
-  },
-  "ratingsUnavailable": "[Somali] Ratings are unavailable",
-  "@ratingsUnavailable": {
-    "x-mt": true
-  },
   "ratingSummary": "{average} from {count, plural, =1{1 rating} other{{count} ratings}}",
   "@ratingSummary": {
-    "x-mt": true
-  },
-  "ratingCompact": "[Somali] {average} ({count})",
-  "@ratingCompact": {
-    "x-mt": true
-  },
-  "ratingOutOfFive": "[Somali] Rating: {rating} out of 5",
-  "@ratingOutOfFive": {
-    "x-mt": true
-  },
-  "setRating": "[Somali] Set rating to {rating}",
-  "@setRating": {
-    "x-mt": true
-  },
-  "ratingRequired": "[Somali] Choose a rating",
-  "@ratingRequired": {
-    "x-mt": true
-  },
-  "commentOptional": "[Somali] Comment (optional)",
-  "@commentOptional": {
-    "x-mt": true
-  },
-  "submitRating": "[Somali] Submit rating",
-  "@submitRating": {
     "x-mt": true
   },
   "skip": "Ka gudub",
@@ -818,405 +146,53 @@
   "openLearning": "Waxbarasho Fur",
   "unleashLearningPower": "Ku Xir Barashada Xoojinta",
   "onboardingWelcomeDescription": "Boggaaga ee Barashada aan dheeraad ahayn",
-  "onboardingOfflineDescription": "[Somali] Download resources for offline learning.\nAccess knowledge on the go.",
-  "@onboardingOfflineDescription": {
-    "x-mt": true
-  },
-  "onboardingOpenDescription": "[Somali] Choose your interests and dive into interactive content.\nCraft your unique learning journey.",
-  "@onboardingOpenDescription": {
-    "x-mt": true
-  },
-  "onboardingPowerDescription": "[Somali] Explore a world of knowledge at your fingertips.\n\n🌍 Offline Access: Learn without borders, anytime.\n🎯 Personalized: Tailor your learning path.\n📚 Interactive: Engage with videos, books, games.\n\nBegin your limitless learning journey with myPlanet!",
-  "@onboardingPowerDescription": {
-    "x-mt": true
-  },
   "onboardingServerPrepHint": "Ka hor inta aadan gelin, waxaad u baahan doontaa cinwaanka server-ka Planet iyo PIN-ka. Weydii maamulaha bulshadaada haddii aadan weli haysan.",
-  "pageProgress": "[Somali] Page {current} of {total}",
-  "@pageProgress": {
-    "x-mt": true
-  },
-  "meetups": "[Somali] Meetups",
-  "@meetups": {
-    "x-mt": true
-  },
-  "syncPendingMeetups": "[Somali] Sync pending meetups",
-  "@syncPendingMeetups": {
-    "x-mt": true
-  },
-  "meetupsUnavailable": "[Somali] Meetups are unavailable",
-  "@meetupsUnavailable": {
-    "x-mt": true
-  },
-  "noMeetups": "[Somali] No meetups yet",
-  "@noMeetups": {
-    "x-mt": true
-  },
-  "dateNotSet": "[Somali] Date not set",
-  "@dateNotSet": {
-    "x-mt": true
-  },
-  "untitledMeetup": "[Somali] Untitled meetup",
-  "@untitledMeetup": {
-    "x-mt": true
-  },
   "addMeetup": "Ku dar kulan",
-  "meetupDetails": "[Somali] Meetup details",
-  "@meetupDetails": {
-    "x-mt": true
-  },
-  "meetupNotFound": "[Somali] Meetup not found",
-  "@meetupNotFound": {
-    "x-mt": true
-  },
   "createdBy": "Lagu sameeyay",
-  "category": "[Somali] Category",
-  "@category": {
-    "x-mt": true
-  },
   "location": "Goobta",
   "link": "Xiriirka",
   "recurring": "Ku dhaqan",
   "description": "Sharaxaad",
-  "leaveMeetup": "[Somali] Leave meetup",
-  "@leaveMeetup": {
-    "x-mt": true
-  },
-  "joinMeetup": "[Somali] Join meetup",
-  "@joinMeetup": {
-    "x-mt": true
-  },
   "editMeetup": "Wax ka beddel kulanka",
   "startTime": "Bilowga Waqtiga",
   "endTime": "Dhamaadka Waqtiga",
   "none": "Midna",
   "daily": "Maalinle",
   "weekly": "Toddobaad",
-  "syncMeetups": "[Somali] Sync meetups",
-  "@syncMeetups": {
-    "x-mt": true
-  },
-  "searchMeetups": "[Somali] Search meetups",
-  "@searchMeetups": {
-    "x-mt": true
-  },
-  "sortMeetups": "[Somali] Sort meetups",
-  "@sortMeetups": {
-    "x-mt": true
-  },
-  "sortResources": "[Somali] Sort resources",
-  "@sortResources": {
-    "x-mt": true
-  },
-  "newestFirst": "[Somali] Newest first",
-  "@newestFirst": {
-    "x-mt": true
-  },
-  "oldestFirst": "[Somali] Oldest first",
-  "@oldestFirst": {
-    "x-mt": true
-  },
-  "titleAscending": "[Somali] Title A–Z",
-  "@titleAscending": {
-    "x-mt": true
-  },
-  "titleDescending": "[Somali] Title Z–A",
-  "@titleDescending": {
-    "x-mt": true
-  },
   "startDate": "Bilowga Dhibaatada",
   "endDate": "Dhamaadka Dhibaatada",
-  "timeNotSet": "[Somali] Time not set",
-  "@timeNotSet": {
-    "x-mt": true
-  },
-  "syncSurveys": "[Somali] Sync surveys",
-  "@syncSurveys": {
-    "x-mt": true
-  },
-  "searchSurveys": "[Somali] Search surveys",
-  "@searchSurveys": {
-    "x-mt": true
-  },
-  "sortSurveys": "[Somali] Sort surveys",
-  "@sortSurveys": {
-    "x-mt": true
-  },
-  "surveysUnavailable": "[Somali] Surveys are unavailable",
-  "@surveysUnavailable": {
-    "x-mt": true
-  },
-  "noSurveys": "[Somali] No surveys available",
-  "@noSurveys": {
-    "x-mt": true
-  },
-  "untitledSurvey": "[Somali] Untitled survey",
-  "@untitledSurvey": {
-    "x-mt": true
-  },
   "takeSurvey": "Ku Dar Survey",
-  "surveyLoadFailed": "[Somali] Survey could not be loaded",
-  "@surveyLoadFailed": {
-    "x-mt": true
-  },
-  "surveyHasNoQuestions": "[Somali] This survey has no questions",
-  "@surveyHasNoQuestions": {
-    "x-mt": true
-  },
-  "submitSurvey": "[Somali] Submit survey",
-  "@submitSurvey": {
-    "x-mt": true
-  },
-  "answerRequiredQuestions": "[Somali] Answer all required questions",
-  "@answerRequiredQuestions": {
-    "x-mt": true
-  },
-  "voices": "[Somali] Voices",
-  "@voices": {
-    "x-mt": true
-  },
-  "searchVoices": "[Somali] Search voices",
-  "@searchVoices": {
-    "x-mt": true
-  },
-  "syncVoices": "[Somali] Sync voices",
-  "@syncVoices": {
-    "x-mt": true
-  },
-  "noVoices": "[Somali] No voices yet",
-  "@noVoices": {
-    "x-mt": true
-  },
-  "voicesUnavailable": "[Somali] Voices are unavailable",
-  "@voicesUnavailable": {
-    "x-mt": true
-  },
-  "shareYourVoice": "[Somali] Share your voice",
-  "@shareYourVoice": {
-    "x-mt": true
-  },
-  "postVoice": "[Somali] Post",
-  "@postVoice": {
-    "x-mt": true
-  },
   "replyToVoice": "jawaab",
-  "writeAReply": "[Somali] Write a reply",
-  "@writeAReply": {
-    "x-mt": true
-  },
   "repliesCount": "{count, plural, =0{No replies} =1{1 reply} other{{count} replies}}",
   "@repliesCount": {
     "x-mt": true
   },
-  "edited": "[Somali] Edited",
-  "@edited": {
-    "x-mt": true
-  },
   "editVoice": "Tafatir",
   "deleteVoice": "Tirtir",
-  "deleteVoiceConfirm": "[Somali] Delete this post and all of its replies?",
-  "@deleteVoiceConfirm": {
-    "x-mt": true
-  },
-  "voiceDeleted": "[Somali] Post deleted",
-  "@voiceDeleted": {
-    "x-mt": true
-  },
-  "emptyMessageNotAllowed": "[Somali] Write something first",
-  "@emptyMessageNotAllowed": {
-    "x-mt": true
-  },
-  "thread": "[Somali] Thread",
-  "@thread": {
-    "x-mt": true
-  },
-  "surveySubmitFailed": "[Somali] Could not save your answers",
-  "@surveySubmitFailed": {
-    "x-mt": true
-  },
-  "sendSurveyTo": "[Somali] Select users to send survey to",
-  "@sendSurveyTo": {
-    "x-mt": true
-  },
   "sendSurvey": "Dir Survey",
   "surveySentToUsers": "Survey sent to selected users",
   "@surveySentToUsers": {
     "x-mt": true
   },
-  "noUsersAvailable": "[Somali] No users available",
-  "@noUsersAvailable": {
-    "x-mt": true
-  },
   "teams": "Kooxaha",
-  "syncTeams": "[Somali] Sync teams",
-  "@syncTeams": {
-    "x-mt": true
-  },
-  "searchTeams": "[Somali] Search teams",
-  "@searchTeams": {
-    "x-mt": true
-  },
-  "teamsUnavailable": "[Somali] Teams are unavailable",
-  "@teamsUnavailable": {
-    "x-mt": true
-  },
-  "noTeams": "[Somali] No teams available",
-  "@noTeams": {
-    "x-mt": true
-  },
-  "untitledTeam": "[Somali] Untitled team",
-  "@untitledTeam": {
-    "x-mt": true
-  },
-  "teamDetails": "[Somali] Team details",
-  "@teamDetails": {
-    "x-mt": true
-  },
-  "teamNotFound": "[Somali] Team not found",
-  "@teamNotFound": {
-    "x-mt": true
-  },
-  "publicTeam": "[Somali] Public team",
-  "@publicTeam": {
-    "x-mt": true
-  },
-  "privateTeam": "[Somali] Private team",
-  "@privateTeam": {
-    "x-mt": true
-  },
   "enterprises": "Shirkado",
-  "searchEnterprises": "[Somali] Search enterprises",
-  "@searchEnterprises": {
-    "x-mt": true
-  },
-  "leader": "[Somali] Leader",
-  "@leader": {
-    "x-mt": true
-  },
   "leave": "Ka Dib",
   "remove": "Ka saar",
   "makeLeader": "Gacan-siin",
   "leftTeam": "Kooxda iska saaray",
-  "memberRemoved": "[Somali] Member removed",
-  "@memberRemoved": {
-    "x-mt": true
-  },
-  "leaderUpdated": "[Somali] Leader updated",
-  "@leaderUpdated": {
-    "x-mt": true
-  },
-  "member": "[Somali] Member",
-  "@member": {
-    "x-mt": true
-  },
-  "teamLeader": "[Somali] You lead this team",
-  "@teamLeader": {
-    "x-mt": true
-  },
-  "teamMember": "[Somali] You are a member",
-  "@teamMember": {
-    "x-mt": true
-  },
   "services": "adeegyo",
-  "rules": "[Somali] Rules",
-  "@rules": {
-    "x-mt": true
-  },
-  "teamCourses": "[Somali] Team courses",
-  "@teamCourses": {
-    "x-mt": true
-  },
   "membersCount": "{count, plural, =0{No members} =1{1 member} other{{count} members}}",
   "@membersCount": {
     "x-mt": true
   },
   "teamTasks": "Hawlgalaha",
-  "tasksUnavailable": "[Somali] Tasks are unavailable",
-  "@tasksUnavailable": {
-    "x-mt": true
-  },
-  "noTeamTasks": "[Somali] No tasks yet",
-  "@noTeamTasks": {
-    "x-mt": true
-  },
-  "noDeadline": "[Somali] No deadline",
-  "@noDeadline": {
-    "x-mt": true
-  },
-  "untitledTask": "[Somali] Untitled task",
-  "@untitledTask": {
-    "x-mt": true
-  },
   "addTask": "Ku dar xog",
-  "editTask": "[Somali] Edit task",
-  "@editTask": {
-    "x-mt": true
-  },
-  "deleteTask": "[Somali] Delete task",
-  "@deleteTask": {
-    "x-mt": true
-  },
-  "taskTitle": "[Somali] Task title",
-  "@taskTitle": {
-    "x-mt": true
-  },
-  "assigneeId": "[Somali] Assignee ID",
-  "@assigneeId": {
-    "x-mt": true
-  },
-  "teamDiscussions": "[Somali] Discussions",
-  "@teamDiscussions": {
-    "x-mt": true
-  },
   "teamMembers": "Xubinayaasha",
   "members": "Xubinayaasha",
   "joinRequests": "Su'aasha xubinaha",
-  "noMembers": "[Somali] No members yet",
-  "@noMembers": {
-    "x-mt": true
-  },
-  "membersUnavailable": "[Somali] Members are unavailable",
-  "@membersUnavailable": {
-    "x-mt": true
-  },
-  "unknownMember": "[Somali] Unknown member",
-  "@unknownMember": {
-    "x-mt": true
-  },
-  "noJoinRequests": "[Somali] No pending requests",
-  "@noJoinRequests": {
-    "x-mt": true
-  },
   "accept": "Qabto",
-  "decline": "[Somali] Decline",
-  "@decline": {
-    "x-mt": true
-  },
   "joinTeam": "Codso Inaad Ku Dhaqmeyso",
-  "leaveTeam": "[Somali] Leave team",
-  "@leaveTeam": {
-    "x-mt": true
-  },
-  "requestPending": "[Somali] Request pending",
-  "@requestPending": {
-    "x-mt": true
-  },
   "teamResources": "Vifijo",
-  "resourcesUnavailable": "[Somali] Resources are unavailable",
-  "@resourcesUnavailable": {
-    "x-mt": true
-  },
-  "noTeamResources": "[Somali] No resources linked to this team",
-  "@noTeamResources": {
-    "x-mt": true
-  },
-  "untitledResource": "[Somali] Untitled resource",
-  "@untitledResource": {
-    "x-mt": true
-  },
-  "removeFromTeam": "[Somali] Remove from team",
-  "@removeFromTeam": {
-    "x-mt": true
-  },
   "addResource": "Kudar Ilaha",
   "editResource": "Wax ka beddel kheyraadka",
   "resourceUpdated": "Kheyraadka waa la cusboonaysiiyay",
@@ -1224,174 +200,30 @@
   "descriptionIsRequired": "Sharaxaadda waa loo baahan yahay",
   "levelIsRequired": "Heerka waa loo baahan yahay",
   "subjectIsRequired": "Mawduuca waa loo baahan yahay",
-  "selectFile": "[Somali] Select a file",
-  "@selectFile": {
-    "x-mt": true
-  },
   "fileSelected": "File selected",
   "@fileSelected": {
     "x-mt": true
   },
-  "privateResource": "[Somali] Private resource",
-  "@privateResource": {
-    "x-mt": true
-  },
   "saveChanges": "Kaydi isbedelada",
-  "selectOpenWith": "[Somali] Select open with",
-  "@selectOpenWith": {
-    "x-mt": true
-  },
-  "selectMedia": "[Somali] Select media",
-  "@selectMedia": {
-    "x-mt": true
-  },
-  "selectResourceType": "[Somali] Select resource type",
-  "@selectResourceType": {
-    "x-mt": true
-  },
   "linkToLicense": "Link to shatiga",
-  "noResourcesToAdd": "[Somali] All available resources are already linked",
-  "@noResourcesToAdd": {
-    "x-mt": true
-  },
-  "coursesUnavailable": "[Somali] Courses are unavailable",
-  "@coursesUnavailable": {
-    "x-mt": true
-  },
-  "noTeamCourses": "[Somali] No courses linked to this team",
-  "@noTeamCourses": {
-    "x-mt": true
-  },
   "untitledCourse": "Koorso Aan Magac Lahayn",
-  "addCourse": "[Somali] Add course",
-  "@addCourse": {
-    "x-mt": true
-  },
-  "noCoursesToAdd": "[Somali] All available courses are already linked",
-  "@noCoursesToAdd": {
-    "x-mt": true
-  },
-  "financialReports": "[Somali] Financial reports",
-  "@financialReports": {
-    "x-mt": true
-  },
-  "reportsUnavailable": "[Somali] Reports are unavailable",
-  "@reportsUnavailable": {
-    "x-mt": true
-  },
-  "noReports": "[Somali] No financial reports yet",
-  "@noReports": {
-    "x-mt": true
-  },
   "addReport": "Ku dar warbixin",
-  "editReport": "[Somali] Edit report",
-  "@editReport": {
-    "x-mt": true
-  },
   "archiveReport": "Arsiif",
   "beginningBalance": "Hadhsiga bilowga",
   "sales": "Iibka",
   "otherIncome": "Dakhliga kale",
-  "wages": "[Somali] Wages",
-  "@wages": {
-    "x-mt": true
-  },
-  "otherExpenses": "[Somali] Other expenses",
-  "@otherExpenses": {
-    "x-mt": true
-  },
   "totalIncome": "Dakhliga Guud",
   "totalExpenses": "Kharashaadka Guud",
-  "profitLoss": "[Somali] Profit / loss",
-  "@profitLoss": {
-    "x-mt": true
-  },
   "endingBalance": "Hadhsiga dhammaadka",
   "negativeBalance": "Xalinta hanaanka hadda waa ka baxa!",
-  "reportDateDetails": "[Somali] Report created on: {created} | Updated on: {updated}",
-  "@reportDateDetails": {
-    "x-mt": true
-  },
-  "chatHistory": "[Somali] Chat History",
-  "@chatHistory": {
-    "x-mt": true
-  },
   "chat": "Sawir",
   "newChat": "Wadahadal cusub",
-  "searchChats": "[Somali] Search chats",
-  "@searchChats": {
-    "x-mt": true
-  },
-  "noChats": "[Somali] No chats yet",
-  "@noChats": {
-    "x-mt": true
-  },
-  "noSearchResults": "[Somali] No matching chats",
-  "@noSearchResults": {
-    "x-mt": true
-  },
-  "untitledChat": "[Somali] Untitled chat",
-  "@untitledChat": {
-    "x-mt": true
-  },
   "fullConversationResponse": "Jawaabta wada hadalka oo dhameystiran",
   "response": "Jawaab",
-  "chatConversation": "[Somali] Conversation",
-  "@chatConversation": {
-    "x-mt": true
-  },
-  "newConversation": "[Somali] New conversation",
-  "@newConversation": {
-    "x-mt": true
-  },
-  "startConversation": "[Somali] Start a new conversation",
-  "@startConversation": {
-    "x-mt": true
-  },
-  "typeMessage": "[Somali] Type a message…",
-  "@typeMessage": {
-    "x-mt": true
-  },
-  "selectAiProvider": "[Somali] Select AI provider",
-  "@selectAiProvider": {
-    "x-mt": true
-  },
-  "aiProviders": "[Somali] AI providers",
-  "@aiProviders": {
-    "x-mt": true
-  },
-  "aiProviderAvailable": "[Somali] {name} (available)",
-  "@aiProviderAvailable": {
-    "x-mt": true
-  },
-  "aiProviderUnavailable": "[Somali] {name} (unavailable)",
-  "@aiProviderUnavailable": {
-    "x-mt": true
-  },
   "feedback": "Rajayn",
-  "feedbackNotFound": "[Somali] Feedback not found",
-  "@feedbackNotFound": {
-    "x-mt": true
-  },
   "feedbackSaved": "Warbixinta lagu kayd geliyay",
-  "isUrgent": "[Somali] Is this urgent?",
-  "@isUrgent": {
-    "x-mt": true
-  },
-  "feedbackType": "[Somali] Feedback type",
-  "@feedbackType": {
-    "x-mt": true
-  },
   "feedbackTypeRequired": "Please select a feedback type",
   "@feedbackTypeRequired": {
-    "x-mt": true
-  },
-  "yourFeedback": "[Somali] Your feedback",
-  "@yourFeedback": {
-    "x-mt": true
-  },
-  "pleaseEnterFeedback": "[Somali] Please enter your feedback",
-  "@pleaseEnterFeedback": {
     "x-mt": true
   },
   "question": "Su'aal",
@@ -1399,219 +231,43 @@
   "suggestion": "talo soo jeedin",
   "priority": "mudnaanta",
   "openDate": "Taariikhda Furan",
-  "replies": "[Somali] Replies",
-  "@replies": {
-    "x-mt": true
-  },
   "pleaseEnterReply": "Fadlan geli jawaab",
-  "untitledFeedback": "[Somali] Untitled feedback",
-  "@untitledFeedback": {
-    "x-mt": true
-  },
   "yes": "Haa",
   "no": "Maya",
   "submit": "Ku Dir",
-  "takeTest": "[Somali] Take test",
-  "@takeTest": {
-    "x-mt": true
-  },
   "recordSurvey": "Gali suuragal",
-  "react": "[Somali] React",
-  "@react": {
-    "x-mt": true
-  },
-  "pickReaction": "[Somali] Pick a reaction",
-  "@pickReaction": {
-    "x-mt": true
-  },
-  "comments": "[Somali] Comments",
-  "@comments": {
-    "x-mt": true
-  },
-  "addComment": "[Somali] Add a comment",
-  "@addComment": {
-    "x-mt": true
-  },
-  "commentsCount": "[Somali] {count} comments",
-  "@commentsCount": {
-    "x-mt": true
-  },
-  "noComments": "[Somali] No comments yet",
-  "@noComments": {
-    "x-mt": true
-  },
-  "leaderboard": "[Somali] Leaderboard",
-  "@leaderboard": {
-    "x-mt": true
-  },
-  "allTime": "[Somali] All time",
-  "@allTime": {
-    "x-mt": true
-  },
-  "thisMonth": "[Somali] This month",
-  "@thisMonth": {
-    "x-mt": true
-  },
-  "coursesCompleted": "[Somali] {completed}/{total} courses",
-  "@coursesCompleted": {
-    "x-mt": true
-  },
-  "surveysCompleted": "[Somali] {completed}/{total} surveys",
-  "@surveysCompleted": {
-    "x-mt": true
-  },
-  "error": "[Somali] Error",
-  "@error": {
-    "x-mt": true
-  },
   "close": "Xir",
   "filter": "Gaaji",
   "type": "Nooca",
-  "apply": "[Somali] Apply",
-  "@apply": {
-    "x-mt": true
-  },
-  "unavailable": "[Somali] unavailable",
-  "@unavailable": {
-    "x-mt": true
-  },
-  "chatsUnavailable": "[Somali] Chats could not be loaded",
-  "@chatsUnavailable": {
-    "x-mt": true
-  },
   "community": "Bulshada",
   "communityLeaders": "Hogaamiyayaasha bulshada",
   "nationLeaders": "Hoggaamiyeyaasha qaranka",
   "ourVoices": "Codadkeena",
   "finances": "Maaliyadda",
   "reports": "warbixino",
-  "transaction": "[Somali] Transaction",
-  "@transaction": {
-    "x-mt": true
-  },
-  "transactions": "[Somali] Transactions",
-  "@transactions": {
-    "x-mt": true
-  },
   "addTransaction": "Ku daray Hawlaha",
-  "noTransactions": "[Somali] No transactions yet",
-  "@noTransactions": {
-    "x-mt": true
-  },
   "debit": "Debit",
   "credit": "Credit",
   "balance": "Baaki",
   "amount": "Masaafad",
-  "note": "[Somali] Note",
-  "@note": {
-    "x-mt": true
-  },
   "date": "Taariikhda",
   "fromDate": "Ka bilaabata taariikhda",
   "toDate": "Ku egtahay taariikhda",
-  "reset": "[Somali] Reset",
-  "@reset": {
-    "x-mt": true
-  },
   "noteRequired": "Fariin waa loo baahan yahay",
-  "amountRequired": "[Somali] Amount must be greater than 0",
-  "@amountRequired": {
-    "x-mt": true
-  },
   "transactionAdded": "Hawlasha lagu daray",
-  "addReceipt": "[Somali] Add receipt",
-  "@addReceipt": {
-    "x-mt": true
-  },
   "receiptSelected": "Receipt selected",
   "@receiptSelected": {
     "x-mt": true
   },
-  "noReceipt": "[Somali] No receipt attached",
-  "@noReceipt": {
-    "x-mt": true
-  },
-  "receipt": "[Somali] Receipt",
-  "@receipt": {
-    "x-mt": true
-  },
-  "viewReceipt": "[Somali] View receipt",
-  "@viewReceipt": {
-    "x-mt": true
-  },
-  "noLeadersAvailable": "[Somali] No leaders available",
-  "@noLeadersAvailable": {
-    "x-mt": true
-  },
-  "noServicesAvailable": "[Somali] No services available",
-  "@noServicesAvailable": {
-    "x-mt": true
-  },
   "noDescriptionAvailable": "Sharaxaad lama heli karo",
-  "takeExam": "[Somali] Take exam",
-  "@takeExam": {
-    "x-mt": true
-  },
-  "examLoadFailed": "[Somali] Exam could not be loaded",
-  "@examLoadFailed": {
-    "x-mt": true
-  },
-  "examHasNoQuestions": "[Somali] This exam has no questions",
-  "@examHasNoQuestions": {
-    "x-mt": true
-  },
-  "examComplete": "[Somali] Exam Complete",
-  "@examComplete": {
-    "x-mt": true
-  },
-  "examUnavailable": "[Somali] Exam is unavailable",
-  "@examUnavailable": {
-    "x-mt": true
-  },
-  "submitExam": "[Somali] Submit exam",
-  "@submitExam": {
-    "x-mt": true
-  },
   "incorrectAnswer": "Jawaab aan sax ahayn, fadlan isku day",
-  "correctAnswers": "[Somali] Correct",
-  "@correctAnswers": {
-    "x-mt": true
-  },
   "yourAnswer": "Jawaabtaada",
   "previous": "Hore",
   "finish": "Dhammaad",
-  "exitExam": "[Somali] Exit exam?",
-  "@exitExam": {
-    "x-mt": true
-  },
-  "exitExamMessage": "[Somali] Your progress will be lost.",
-  "@exitExamMessage": {
-    "x-mt": true
-  },
   "exit": "Ka Bax",
   "download": "Download",
   "downloading": "Soo degsado.... \"",
   "downloadFailed": "Soo dejintu way fashilantay.",
-  "resourceNotDownloaded": "[Somali] This resource is not on your device yet.",
-  "@resourceNotDownloaded": {
-    "x-mt": true
-  },
-  "retry": "[Somali] Retry",
-  "@retry": {
-    "x-mt": true
-  },
-  "fieldRequired": "[Somali] Required",
-  "@fieldRequired": {
-    "x-mt": true
-  },
-  "examSubmitFailed": "[Somali] Could not save your exam. Please try again.",
-  "@examSubmitFailed": {
-    "x-mt": true
-  },
-  "yourInformation": "[Somali] Your information",
-  "@yourInformation": {
-    "x-mt": true
-  },
   "showAdditionalFields": "Muuji beeraha dheeraadka ah",
   "hideAdditionalFields": "Qari beeraha dheeraadka ah",
   "phoneNumber": "Telefoon Number",
@@ -1620,28 +276,8 @@
   "male": "Lab",
   "female": "Naag",
   "yearOfBirth": "Sannadka dhalashada",
-  "yearOfBirthRequired": "[Somali] Year of birth is required",
-  "@yearOfBirthRequired": {
-    "x-mt": true
-  },
-  "invalidYear": "[Somali] Please enter a valid year",
-  "@invalidYear": {
-    "x-mt": true
-  },
-  "yearBetween": "[Somali] Year must be between {min} and {max}",
-  "@yearBetween": {
-    "x-mt": true
-  },
   "thankYouForTakingSurvey": "Mahadsanid in aad iska soo qaatay suuragal",
-  "errorSavingProfile": "[Somali] Error saving profile",
-  "@errorSavingProfile": {
-    "x-mt": true
-  },
   "videoPlayer": "Qalabka fiidyowga",
-  "audioPlayer": "[Somali] Audio player",
-  "@audioPlayer": {
-    "x-mt": true
-  },
   "videoFileNotFound": "Faylka fiidyowga lama helin gudaha",
   "unableToLoadVideo": "Lama helin fiidyowga",
   "audioFileNotFound": "Faylka maqalka lama helin gudaha",
@@ -1657,190 +293,26 @@
   "errorOccurred": "Khalad: {error}",
   "openingResource": "Furaya: {title}",
   "loadingMedia": "Soo dejinta...",
-  "resourceUnavailable": "[Somali] This resource is not available for offline viewing",
-  "@resourceUnavailable": {
-    "x-mt": true
-  },
   "healthRecordNotAvailable": "Diiwaanada Caafimaadka ma helayo",
-  "updateHealth": "[Somali] Update health",
-  "@updateHealth": {
-    "x-mt": true
-  },
-  "addHealthRecord": "[Somali] Add health record",
-  "@addHealthRecord": {
-    "x-mt": true
-  },
-  "healthProfile": "[Somali] Health profile",
-  "@healthProfile": {
-    "x-mt": true
-  },
   "specialNeeds": "Dib-u-xuso",
   "otherNeeds": "Dib-u-heshiisi kale",
   "emergencyContact": "Xiriirka Degdegga ah",
-  "contactNumber": "[Somali] Contact number",
-  "@contactNumber": {
-    "x-mt": true
-  },
-  "vitalSigns": "[Somali] Vital signs",
-  "@vitalSigns": {
-    "x-mt": true
-  },
-  "temperature": "[Somali] Temperature",
-  "@temperature": {
-    "x-mt": true
-  },
-  "pulse": "[Somali] Pulse",
-  "@pulse": {
-    "x-mt": true
-  },
-  "height": "[Somali] Height",
-  "@height": {
-    "x-mt": true
-  },
-  "weight": "[Somali] Weight",
-  "@weight": {
-    "x-mt": true
-  },
-  "bloodPressure": "[Somali] Blood pressure",
-  "@bloodPressure": {
-    "x-mt": true
-  },
   "vision": "Ruuxa",
   "hearing": "Gurinaan",
-  "examinationHistory": "[Somali] Examination history",
-  "@examinationHistory": {
-    "x-mt": true
-  },
-  "personalInformation": "[Somali] Personal information",
-  "@personalInformation": {
-    "x-mt": true
-  },
   "birthPlace": "Meesha dhalashada",
-  "contactName": "[Somali] Contact name",
-  "@contactName": {
-    "x-mt": true
-  },
-  "contactType": "[Somali] Contact type",
-  "@contactType": {
-    "x-mt": true
-  },
-  "healthInformation": "[Somali] Health information",
-  "@healthInformation": {
-    "x-mt": true
-  },
-  "requiredField": "[Somali] This field is required",
-  "@requiredField": {
-    "x-mt": true
-  },
-  "healthSavedSuccessfully": "[Somali] Health data saved successfully",
-  "@healthSavedSuccessfully": {
-    "x-mt": true
-  },
-  "examinationDetails": "[Somali] Examination details",
-  "@examinationDetails": {
-    "x-mt": true
-  },
   "allergies": "Alargada",
   "diagnosis": "Baaris",
   "medications": "Daaweynaha",
   "immunizations": "Xallinta daryeelka",
   "treatments": "Dib u dhiska",
-  "observations": "[Somali] Observations",
-  "@observations": {
-    "x-mt": true
-  },
   "referrals": "Dabaqyo",
   "labTests": "Baarista labada",
   "xrays": "X-ray",
-  "conditions": "[Somali] Conditions",
-  "@conditions": {
-    "x-mt": true
-  },
-  "selfExamination": "[Somali] Self-examination",
-  "@selfExamination": {
-    "x-mt": true
-  },
-  "healthRecordAdded": "[Somali] Health record added successfully",
-  "@healthRecordAdded": {
-    "x-mt": true
-  },
   "selectHealthMember": "Dooro Xubin",
-  "newPatient": "[Somali] New patient",
-  "@newPatient": {
-    "x-mt": true
-  },
-  "sortJoinDateDesc": "[Somali] Newest first",
-  "@sortJoinDateDesc": {
-    "x-mt": true
-  },
-  "sortJoinDateAsc": "[Somali] Oldest first",
-  "@sortJoinDateAsc": {
-    "x-mt": true
-  },
-  "sortNameAsc": "[Somali] Name A–Z",
-  "@sortNameAsc": {
-    "x-mt": true
-  },
-  "sortNameDesc": "[Somali] Name Z–A",
-  "@sortNameDesc": {
-    "x-mt": true
-  },
-  "searchMembers": "[Somali] Search members",
-  "@searchMembers": {
-    "x-mt": true
-  },
   "dismiss": "saar",
   "addMember": "Ku Dar Xubin",
-  "invalidNumber": "[Somali] Invalid number",
-  "@invalidNumber": {
-    "x-mt": true
-  },
-  "tempRangeError": "[Somali] Temperature must be between 30 and 40",
-  "@tempRangeError": {
-    "x-mt": true
-  },
-  "pulseRangeError": "[Somali] Pulse must be between 40 and 120",
-  "@pulseRangeError": {
-    "x-mt": true
-  },
-  "heightRangeError": "[Somali] Height must be between 1 and 250",
-  "@heightRangeError": {
-    "x-mt": true
-  },
-  "weightRangeError": "[Somali] Weight must be between 1 and 150",
-  "@weightRangeError": {
-    "x-mt": true
-  },
   "bloodPressureFormatError": "Dhacdo dheecaanka waa in uu noocan yahay (systolic/diastolic)",
-  "bloodPressureRangeError": "[Somali] Blood pressure must be between 60/40 and 300/200",
-  "@bloodPressureRangeError": {
-    "x-mt": true
-  },
   "bloodPressureNotNumbers": "Dhacdo dheecaanka iyo dheecaanku waa in ay yihiin lambarka",
-  "temp": "[Somali] Temp",
-  "@temp": {
-    "x-mt": true
-  },
-  "bp": "[Somali] BP",
-  "@bp": {
-    "x-mt": true
-  },
-  "offlineMaps": "[Somali] Offline Maps",
-  "@offlineMaps": {
-    "x-mt": true
-  },
-  "centerOnDefault": "[Somali] Center on default location",
-  "@centerOnDefault": {
-    "x-mt": true
-  },
-  "storage": "[Somali] Storage",
-  "@storage": {
-    "x-mt": true
-  },
-  "storageManagement": "[Somali] Storage Management",
-  "@storageManagement": {
-    "x-mt": true
-  },
   "storageTotalDownloaded": "Wadarta la soo dejiyay",
   "storageVideos": "Fiidiyowyada",
   "storageAudio": "Codka",
@@ -1848,26 +320,14 @@
   "storageImages": "Sawirrada",
   "storageOther": "Kale",
   "fileCountOne": "1 fayl",
-  "fileCountMany": "[Somali] {count} files",
-  "@fileCountMany": {
-    "x-mt": true
-  },
   "storageUnknownResource": "Agabka Aan La Garanayn",
   "areYouSure": "Ma hubtaa?",
   "cancelAddingExamination": "Ma hubtaa inaad rabto inaad tirtirto ku-darka imtixaanka? Xogtu way lumin doontaa.",
   "yesIWantToExit": "Haa, waxaan rabaa inaan ka cabsado.",
   "inactiveMessage": "Isticmalahu ma hawlgelin, fadlan la xidhiidh maamulaha ama maareeyaha si aad u hawlgeliso akoonkaaga.",
   "submitFeedback": "Rajayn Qoraalka",
-  "failedToDelete": "[Somali] Failed to delete: {error}",
-  "@failedToDelete": {
-    "x-mt": true
-  },
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
   "@storageDeleteSelectedConfirm": {
-    "x-mt": true
-  },
-  "storageDeleteConfirm": "[Somali] Delete all {category} files?",
-  "@storageDeleteConfirm": {
     "x-mt": true
   },
   "storageSelectedCount": "{count} selected",
@@ -1882,82 +342,26 @@
   "leftCourses": "{count, plural, =1{1 koors oo laga saaray} other{{count} koors oo laga saaray}}",
   "coursesSelected": "{count, plural, =1{1 la doortay} other{{count} la doortay}}",
   "leaveCoursesConfirm": "{count, plural, =1{Ma hubtaa inaad ka saarayso koorsan?} other{Ma hubtaa inaad ka saaraysid koorsasyadaan?}}",
-  "noStorageUsed": "[Somali] No downloaded files found",
-  "@noStorageUsed": {
-    "x-mt": true
-  },
   "availableSpace": "Boos la heli karo",
-  "freeUpSpace": "[Somali] Free up space",
-  "@freeUpSpace": {
-    "x-mt": true
-  },
-  "freeUpSpaceConfirm": "[Somali] This will delete all downloaded resources to free up storage space. Continue?",
-  "@freeUpSpaceConfirm": {
-    "x-mt": true
-  },
   "storageFreedSummary": "Freed {bytes}. {count, plural, =0{No files removed} =1{1 file removed} other{{count} files removed}}.",
   "@storageFreedSummary": {
     "x-mt": true
   },
-  "freeUpSpaceFailed": "[Somali] Could not free up space: {error}",
-  "@freeUpSpaceFailed": {
-    "x-mt": true
-  },
   "enterUsername": "Geli Magaca isticmaalaha",
-  "enterPassword": "[Somali] Enter password",
-  "@enterPassword": {
-    "x-mt": true
-  },
-  "retypePassword": "[Somali] Retype password",
-  "@retypePassword": {
-    "x-mt": true
-  },
   "becomeMember": "noqo xubin",
   "toAccessThisFeatureBecomeAMember": "hadda waxaad tahay isticmaale marti ah. si aad u hesho helitaanka astaamahan, noqo xubin.",
   "creatingMember": "Abuuraya akoonka xubnaha...",
   "passwordsDoNotMatch": "Furayaasha sirta isma waafaqsana",
   "pleaseSelectGender": "Fadlan xulo jinsiga",
   "pleaseEnterPassword": "Fadlan geli ereyga sirta ah",
-  "usernameAlreadyExists": "[Somali] Username already exists",
-  "@usernameAlreadyExists": {
-    "x-mt": true
-  },
   "usernameCannotBeEmpty": "Magaca isticmaasha waa in lagu jiro waxaan kusoo haysano",
   "invalidUsername": "Magac isticmaalaha aan sax ahayn",
   "usernameMustStartWithLetterOrNumber": "Waa in la bilaabo lambarka ama tirada",
-  "usernameOnlyLettersNumbers": "[Somali] Only letters a-z, numbers and \"_\", \".\", \"-\" are allowed",
-  "@usernameOnlyLettersNumbers": {
-    "x-mt": true
-  },
   "usernameTaken": "Magaca isticmaalaha laga qaadsiyey",
-  "memberCreatedOffline": "[Somali] Member account created offline",
-  "@memberCreatedOffline": {
-    "x-mt": true
-  },
-  "memberCreatedOnline": "[Somali] Member account created successfully",
-  "@memberCreatedOnline": {
-    "x-mt": true
-  },
   "congratulations": "Hambalyo! Tartanka waa la dhameeyay",
   "dailyVoices": "5 Cod maalinle ah",
-  "voicesProgress": "[Somali] {count} of 5 Daily Voices",
-  "@voicesProgress": {
-    "x-mt": true
-  },
-  "progressLabel": "[Somali] Progress: {percent}%",
-  "@progressLabel": {
-    "x-mt": true
-  },
-  "courseNotStarted": "[Somali] Course: Not started",
-  "@courseNotStarted": {
-    "x-mt": true
-  },
   "syncCompletedChallenge": "Dib-u-hagreeska la kahadsanayaa",
   "rememberSync": "Xusuusnow inaad la socodsiiso codsiga mobilka.",
-  "challengeDialogTitle": "[Somali] Daily Challenge",
-  "@challengeDialogTitle": {
-    "x-mt": true
-  },
   "start": "Bilow",
   "continuation": "Sii wad",
   "plan": "Qorshe",
@@ -1968,56 +372,12 @@
   "entServices": "Xidhiidhka Beelahaada waxay bixisaa?",
   "entRules": "Qawaanada Beelahaada waa maxay?",
   "noMissionDefined": "Beelaha waa maxay & adeegyadooda ma jirto.",
-  "noPlanDefined": "[Somali] This team has no plan defined.",
-  "@noPlanDefined": {
-    "x-mt": true
-  },
   "noDescriptionDefined": "Kooxdani ma laha sharaxaad la cayimay.",
-  "enterpriseName": "[Somali] Enterprise name",
-  "@enterpriseName": {
-    "x-mt": true
-  },
-  "teamName": "[Somali] Team name",
-  "@teamName": {
-    "x-mt": true
-  },
-  "teamType": "[Somali] Team type",
-  "@teamType": {
-    "x-mt": true
-  },
-  "local": "[Somali] Local",
-  "@local": {
-    "x-mt": true
-  },
   "isPublic": "Ciidamo",
   "nameRequired": "Magacu waa loo baahan yahay",
   "nameIsRequired": "Fadlan geli magac",
   "createdOn": "Lagu sameeyey",
-  "courseDetails": "[Somali] Course Details",
-  "@courseDetails": {
-    "x-mt": true
-  },
-  "addedToCourse": "[Somali] Added to your courses",
-  "@addedToCourse": {
-    "x-mt": true
-  },
-  "removedFromCourse": "[Somali] Removed from your courses",
-  "@removedFromCourse": {
-    "x-mt": true
-  },
   "pleaseCompleteSurvey": "fadlan dhameystir sahanka si aad u dhameystirto koorsada",
-  "takeCourse": "[Somali] Take Course",
-  "@takeCourse": {
-    "x-mt": true
-  },
-  "teamCalendar": "[Somali] Team Calendar",
-  "@teamCalendar": {
-    "x-mt": true
-  },
-  "noMeetupsOnDate": "[Somali] No meetups on this date",
-  "@noMeetupsOnDate": {
-    "x-mt": true
-  },
   "myProgress": "Halistaaga",
   "progress": "Horumar",
   "orderByTitle": "Ku qoraalka Cinwaanka",
@@ -2026,115 +386,23 @@
   "progressFilterNotStarted": "Lama bilaaban",
   "progressFilterInProgress": "Socda",
   "progressFilterCompleted": "Dhammaystay",
-  "stepProgress": "[Somali] {current} of {max} steps",
-  "@stepProgress": {
-    "x-mt": true
-  },
-  "noEnrolledCourses": "[Somali] You are not enrolled in any courses",
-  "@noEnrolledCourses": {
-    "x-mt": true
-  },
   "mistakes": "Khalad",
   "step": "Tallaabo",
-  "untitledResourceTitle": "[Somali] Untitled Resource",
-  "@untitledResourceTitle": {
-    "x-mt": true
-  },
   "author": "Qoraaga",
   "publisher": "Daabace",
   "license": "Shatiga",
   "addedBy": "Waxaa ku daray",
-  "resourceInformation": "[Somali] Resource Information",
-  "@resourceInformation": {
-    "x-mt": true
-  },
-  "resourceFor": "[Somali] For",
-  "@resourceFor": {
-    "x-mt": true
-  },
-  "mediaType": "[Somali] Media Type",
-  "@mediaType": {
-    "x-mt": true
-  },
   "resourceType": "Nooca Kheyraadka",
-  "subject": "[Somali] Subject",
-  "@subject": {
-    "x-mt": true
-  },
   "year": "Sannad",
-  "timesRated": "[Somali] Times Rated",
-  "@timesRated": {
-    "x-mt": true
-  },
-  "addToMyLibrary": "[Somali] Add to My Library",
-  "@addToMyLibrary": {
-    "x-mt": true
-  },
-  "removeFromMyLibrary": "[Somali] Remove from My Library",
-  "@removeFromMyLibrary": {
-    "x-mt": true
-  },
-  "addedToMyLibrary": "[Somali] Added to My Library",
-  "@addedToMyLibrary": {
-    "x-mt": true
-  },
-  "removedFromMyLibrary": "[Somali] Removed from My Library",
-  "@removedFromMyLibrary": {
-    "x-mt": true
-  },
-  "myLibrary": "[Somali] My Library",
-  "@myLibrary": {
-    "x-mt": true
-  },
-  "allResources": "[Somali] All Resources",
-  "@allResources": {
-    "x-mt": true
-  },
-  "viewResource": "[Somali] View Resource",
-  "@viewResource": {
-    "x-mt": true
-  },
   "view": "Eeg",
   "linkNotAvailable": "Xogta lama helin",
-  "noRatings": "[Somali] No ratings yet",
-  "@noRatings": {
-    "x-mt": true
-  },
   "basedOnRatings": "based on {count, plural, =1{1 rating} other{{count} ratings}}",
   "@basedOnRatings": {
     "x-mt": true
   },
-  "rating": "[Somali] Rating",
-  "@rating": {
-    "x-mt": true
-  },
-  "operationFailed": "[Somali] Operation failed",
-  "@operationFailed": {
-    "x-mt": true
-  },
-  "filterResources": "[Somali] Filter Resources",
-  "@filterResources": {
-    "x-mt": true
-  },
   "teamSurveys": "Sahaminta kooxda",
-  "adoptableSurveys": "[Somali] Surveys available to adopt",
-  "@adoptableSurveys": {
-    "x-mt": true
-  },
-  "noAdoptableSurveys": "[Somali] No surveys available to adopt",
-  "@noAdoptableSurveys": {
-    "x-mt": true
-  },
   "adoptSurvey": "Sahaminta qaado",
-  "surveyAdopted": "[Somali] Survey adopted",
-  "@surveyAdopted": {
-    "x-mt": true
-  },
   "completedCourse": "koorso la dhammaaday",
-  "userNameWithLogins": "[Somali] {name} ({logins})",
-  "@userNameWithLogins": {
-    "x-mt": true
-  },
   "remindMeLater": "मलाई पछि सम्झाउनुहोस्",
   "remindLater": "पछि सम्झाउनुहोस्",
   "setReminder": "रिमाइन्डर सेट गर्नुहोस्",
@@ -2145,10 +413,6 @@
   "@reminderSurveysToComplete": {
     "x-mt": true
   },
-  "myActivities": "[Somali] My activities",
-  "@myActivities": {
-    "x-mt": true
-  },
   "chartLabel": "Tirada galitaanka",
   "selectLanguage": "Xulo luqadda",
   "english": "english",
@@ -2157,61 +421,25 @@
   "nepali": "नेपाली",
   "arabic": "عربى",
   "french": "français",
-  "activitySummary": "[Somali] Activity",
-  "@activitySummary": {
-    "x-mt": true
-  },
   "lastLogin": "Gelitaankii Ugu Dambeeyay",
-  "memberDetail": "[Somali] Member detail",
-  "@memberDetail": {
-    "x-mt": true
-  },
   "numberOfVisits": "Tirada booqashooyinka",
-  "noLogoutRecord": "[Somali] No logout record found",
-  "@noLogoutRecord": {
-    "x-mt": true
-  },
   "totalVisits": "Tirada Booqashooyinka",
   "mostOpenedResource": "Kheyraadka Ugu Badan ee La Furay",
   "numberOfResourcesOpened": "Tirada Kheyraadka La Furay",
-  "resourceOpenedTimes": "[Somali] {title} opened {count} times",
-  "@resourceOpenedTimes": {
-    "x-mt": true
-  },
   "resourcesOpenedTimes": "{count, plural, =1{Resource opened 1 time} other{Resource opened {count} times}}",
   "@resourcesOpenedTimes": {
-    "x-mt": true
-  },
-  "serverReachable": "[Somali] Server reachable",
-  "@serverReachable": {
-    "x-mt": true
-  },
-  "serverUnreachable": "[Somali] Server unreachable",
-  "@serverUnreachable": {
     "x-mt": true
   },
   "serverChecking": "Hubinta server-ka",
   "gridView": "Muuqaal shabag",
   "listView": "Muuqaal liis",
   "disclaimer": "soo Celinta",
-  "aboutContent": "[Somali] ### MyPlanet\n\nmyPlanet is a learning tool that is designed to work with Planet web application. It has been used to improve early education, secondary schools, village health, youth workforce development, and economic and community development.\n\nPlanet houses is a repository of free, open access and public domain resources to benefit all learners.\n\nmyPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable. It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.\n\nThis application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet. Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take. Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.\n\nThe dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.\n\nmyPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations, in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda.",
-  "@aboutContent": {
-    "x-mt": true
-  },
   "disclaimerContent": "# Disclaimer\n\nLast updated: January 10, 2020\n\n# Interpretation and Definitions\n\n## Interpretation\n\nThe words of which the initial letter is capitalized have meanings defined under the following conditions.\n\nThe following definitions shall have the same meaning regardless of whether they appear in singular or in plural.\n\n## Definitions\n\nFor the purposes of this Disclaimer:\n\n- **Company** (referred to as either \"the Company\", \"We\", \"Us\" or \"Our\" in this Cookies Policy) refers to myPlanet.\n- **You** means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.\n- **Application** means the software program provided by the Company downloaded by You on any electronic device named myPlanet.\n- **Service** refers to the Application.\n\n# Disclaimer\n\nThe information contained on the Service is for general information purposes only.\n\nThe Company assumes no responsibility for errors or omissions in the contents of the Service.\n\nIn no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.\n\nThe Company does not warrant that the Service is free of viruses or other harmful components.\n\n# Medical Information Disclaimer\n\nThe information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information, and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.\n\nInformation offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.\n\nIndividuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.\n\nThe Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.\n\nThe Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.\n\n# External Links Disclaimer\n\nThe Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.\n\nPlease note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.\n\n# Errors and Omissions Disclaimer\n\nThe information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.\n\nThe Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.\n\n# Fair Use Disclaimer\n\nThe Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.\n\nThe Company believes this constitutes a \"fair use\" of any such copyrighted material as provided for in section 107 of the United States Copyright law.\n\nIf You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.\n\n# Views Expressed Disclaimer\n\nThe Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.\n\nComments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.\n\n# No Responsibility Disclaimer\n\nThe information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.\n\nIn no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.\n\n# \"Use at Your Own Risk\" Disclaimer\n\nAll information in the Service is provided \"as is\", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.\n\nThe Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.\n\n## Contact Us\n\nIf you have any questions about this Disclaimer, You can contact Us:\n\n- By email: myplanet@ole.org\n- By visiting this page on our website: [https://ole.org/contact](https://ole.org/contact)",
   "@disclaimerContent": {
     "x-mt": true
   },
   "shareWithCommunity": "Waxbaridii Bulshada la Wadaag",
   "confirmShareCommunity": "Ma hubtaa inaad rabto inaad la wadaagto macluumaadkan bulshada?",
-  "voiceShared": "[Somali] Post shared with community",
-  "@voiceShared": {
-    "x-mt": true
-  },
-  "voiceUnshared": "[Somali] Removed from community",
-  "@voiceUnshared": {
-    "x-mt": true
-  },
   "exportCsv": "Dhoofinta CSV",
   "csvFileSavedSuccessfully": "faylka CSV si guul leh ayaa loo keydiyay.",
   "failedToSaveCsvFile": "Waa lagu guuldareystay in la badbaadiyo faylka CSV.",
@@ -2249,10 +477,6 @@
   "chooseFile": "Dooro faylka",
   "currentCv": "CV-ga hadda: {name}",
   "update": "Cusbooneysiin",
-  "fillRequiredFields": "[Somali] Please fill required fields: {fields}",
-  "@fillRequiredFields": {
-    "x-mt": true
-  },
   "@currentCv": {
     "placeholders": {
       "name": {
@@ -2267,14 +491,6 @@
   "textSizeLarge": "Weyn",
   "resetApp": "Isku day App-ka",
   "clearAllDataConfirm": "Ma hubtaa inaad diiwaangelisid dhammaan xogta?",
-  "dataCleared": "[Somali] All data cleared",
-  "@dataCleared": {
-    "x-mt": true
-  },
-  "dataManagement": "[Somali] Data management",
-  "@dataManagement": {
-    "x-mt": true
-  },
   "resourceTitleAlreadyExists": "Kheyraad leh cinwaankan hore ayuu u jiray",
   "failedToUpdateResource": "Cusbooneysiin kheyraadka waxay ku guuldareysatay",
   "unableToAddHealthRecord": "Lama helayno diiwaan caafimaad",

--- a/flutter/test/l10n/locale_coverage_test.dart
+++ b/flutter/test/l10n/locale_coverage_test.dart
@@ -142,8 +142,11 @@ void main() {
     );
 
     // `login` is derived; `appTitle` may not be. Either way both must render
-    // something — 532 of the 727 keys are English-only in Somali today, and
-    // that has to read as English rather than as an empty label.
+    // something — 455 of the 870 template keys have no Somali value at all
+    // today, and that has to read as English rather than as an empty label.
+    // Phase 118 raised that number on purpose: 446 of those keys used to hold
+    // `[Somali] ` plus the English, which displaced this fallback with the same
+    // words under a tag.
     expect(l10n.login, isNotEmpty);
     expect(l10n.appTitle, isNotEmpty);
   });

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -104,11 +104,17 @@ void main() {
   // ---------------------------------------------------------------------
   // Machine-translation marking (Phase 109).
   //
-  // ~560 keys per locale are Google-Translate output with no human review,
-  // sitting indistinguishably beside the ~250 Phase 47 strings derived from the
-  // Kotlin `values-*/strings.xml` — translations already shipping in the
-  // Android app. `"@<key>": {"x-mt": true}` in the locale file marks the
+  // 496–545 keys in Arabic, Spanish and French are Google-Translate output
+  // with no human review, sitting indistinguishably beside the strings derived
+  // from the Kotlin `values-*/strings.xml` — translations already shipping in
+  // the Android app. `"@<key>": {"x-mt": true}` in the locale file marks the
   // unreviewed ones, so a reviewer can list precisely what still needs a human.
+  //
+  // Nepali and Somali carry 26 each, and that is not because they were
+  // reviewed: the external pass never translated them at all. It emitted
+  // `[Nepali] `/`[Somali] ` plus the English for 899 keys, which Phase 118
+  // deleted (see the marker test above), leaving 26 whose machine output
+  // happened to equal the English.
   // ---------------------------------------------------------------------
 
   test('every locale marks its machine-translated strings', () {
@@ -202,6 +208,48 @@ void main() {
             'app/src/main/res/values${code == 'en' ? '' : '-$code'}/strings.xml',
       );
     }
+  });
+
+  test('no locale value is a language marker wearing a translation\'s clothes', () {
+    // The other half of the external pass's damage, and the larger half. Where
+    // the tokenisation defect broke 58 strings that tried to render data, this
+    // one filled 899 keys with the tool's own "nothing here" output: the value
+    // was `[Nepali] ` or `[Somali] ` followed by the English template verbatim,
+    // flagged `x-mt`, present in the file, and therefore *preferred over the
+    // English fallback*. A Somali user read `[Somali] Join requests` — not a
+    // translation, not even a clean untranslated string, but a bracketed tag
+    // that reads as a bug.
+    //
+    // Nothing could see it. The value is well-formed JSON with the right
+    // placeholders, `gen-l10n` compiles it, and every structural test passes:
+    // the key exists, is non-empty, and is honestly flagged unreviewed. Only
+    // reading the text finds it. Phase 114 named two instances; Phase 118
+    // counted the rest and deleted them, so those keys fall back to English —
+    // the same words, without the tag.
+    //
+    // The net is wider than the two markers that shipped, because the next tool
+    // will pick a different one: no legitimate value in any locale, the
+    // template included, opens with a bracketed word.
+    final defects = <String>[];
+    for (final code in locales) {
+      final arb = _readArb(code);
+      for (final key in _messageKeys(arb)) {
+        final value = arb[key] as String;
+        if (RegExp(r'^\s*\[[^\]]{1,20}\]').hasMatch(value)) {
+          defects.add('$code:$key opens with a marker — "$value"');
+        }
+      }
+    }
+
+    expect(
+      defects,
+      isEmpty,
+      reason:
+          'A value that only labels the language it was not translated into is '
+          'worse than no value at all: it displaces the English fallback with '
+          'the same English plus a tag. Delete the key (and its "@key" block) '
+          'so the fallback serves it, or translate it.\n${defects.join('\n')}',
+    );
   });
 
   test('the template declares no review state of its own', () {

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -221,11 +221,11 @@ void main() {
     // the map and say in the commit message who reviewed it. Adding an
     // unreviewed one means flagging it `x-mt`, which leaves them alone.
     const humanReviewed = {
-      'ar': 325,
-      'es': 321,
-      'fr': 314,
-      'ne': 384,
-      'so': 383,
+      'ar': 327,
+      'es': 323,
+      'fr': 316,
+      'ne': 389,
+      'so': 389,
     };
 
     for (final code in locales) {

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -46,7 +46,9 @@
 //
 // Machine-translation flags (Phase 109) survive a re-run too, and are kept
 // *honest* across one. `"@<key>": {"x-mt": true}` in a locale file marks a
-// string as unreviewed machine output; ~560 keys per locale carry it. The merge
+// string as unreviewed machine output; 496–545 keys carry it in ar/es/fr and
+// 26 in ne/so, where the external pass emitted a `[Nepali] `-style marker
+// instead of a translation and Phase 118 deleted those. The merge
 // carries those blocks over verbatim, and then reconciles them, because merely
 // preserving them is not enough:
 //
@@ -272,9 +274,9 @@ int _reconcileMachineTranslationFlags(
 
 /// Prints the strings still awaiting a human, per locale.
 ///
-/// This is the whole point of the marking: ~560 keys per locale are Google
-/// Translate output sitting indistinguishably beside translations derived from
-/// the Kotlin app. A reviewer needs to see exactly which.
+/// This is the whole point of the marking: several hundred keys per locale are
+/// Google Translate output sitting indistinguishably beside translations
+/// derived from the Kotlin app. A reviewer needs to see exactly which.
 void _reportUnreviewed(List<String> args) {
   for (final locale in args.isEmpty ? allLocales : args) {
     final file = File('lib/l10n/app_$locale.arb');


### PR DESCRIPTION
Lane C of the Phase 116–118 round. Files: `flutter/lib/l10n/*.arb`, `flutter/tool/arb_from_strings_xml.dart`, `flutter/test/l10n/`, `flutter/PHASE_118_NOTES.md`. The Kotlin `app/src/main/res/values*/strings.xml` are the source of truth and are not modified. `app_en.arb` is untouched, so no conflict with Lanes A/B.

Head: `c6c92ca`. Gate green: `dart format --set-exit-if-changed` clean, `flutter analyze` clean, **1897 tests pass** (1896 + 1 new guard).

## Summary

Phase 114 recovered 431 human translations from the Kotlin `strings.xml` and left a named residue. This lane finishes the half where a user is looking at English — and, while measuring it, found the same defect class at 450× the scale Phase 114 could report.

**Examined** 65 residue candidates (33 `no-unanimous`, 32 `keep-human`), 10 values `--adopt` had never seen, and a scan of all 4,257 locale values for anything that is English or a marker. **Applied 929 values. Left 42, each with a reason.**

| locale | values | x-mt | human | falls back to English |
|---|---|---|---|---|
| ar | 821 → 823 | 496 → 496 | 325 → **327** | 49 → 47 |
| es | 859 → 861 | 538 → 538 | 321 → **323** | 11 → 9 |
| fr | 859 → 861 | 545 → 545 | 314 → **316** | 11 → 9 |
| ne | 859 → **415** | 475 → **26** | 384 → **389** | 11 → **455** |
| so | 859 → **415** | 476 → **26** | 383 → **389** | 11 → **455** |

## Commit 1 — the named residue (30 values)

8 `no-unanimous` candidates were shipping the English itself or a `[Language] ` marker, so any of the disagreeing Kotlin translations is a repair rather than a coin toss:

| | before (what shipped) | after |
|---|---|---|
| `so:settings` | `Settings` | `Goobooyinka` |
| `so:joinRequests` | `[Somali] Join requests` | `Su'aasha xubinaha` |
| `so:addResource` | `[Somali] Add resource` | `Kudar Ilaha` |
| `so:descriptionIsRequired` | `[Somali] Description is required` | `Sharaxaadda waa loo baahan yahay` |
| `so:progressFilterCompleted` | `[Somali] Completed` | `Dhammaystay` |
| `ne:joinRequests` | `[Nepali] Join requests` | `सम्मिलित गर्न अनुरोधहरू` |
| `ne:addResource` | `[Nepali] Add resource` | `स्रोत थप्नुहोस्` |
| `ne:progressFilterCompleted` | `[Nepali] Completed` | `पूरा भयो` |

Tie-break: take the Kotlin name whose usage site matches the ARB key's, and never take a value that is itself English. `so:settings` is where that second half decided it — `values-so` renders `settings` as the literal "Settings", so only `action_settings` offers Somali (and it is what `SettingsActivity.kt:57` titles itself with). Full reasoning per string in the notes.

Plus 11 presentation-case fixes (`view`/`exportCancelled`/`failedToSaveCsvFile` in es/fr/so, `es:complete`, `es:serverPinLabel`), 1 camelCase artefact (`es:myCourses` = `misCursos` → `Mis cursos`), and 10 values `--adopt` had never seen (`teamDocuments`, `confirmLeaveTeam` — English keys added after Phase 114 ran).

## Commit 2 — the finding (899 values)

**449 Nepali and 450 Somali values were `[Nepali] `/`[Somali] ` plus the English template verbatim.** Verified: all 899 have the remainder byte-identical to `app_en.arb`, all 899 flagged `x-mt`, none carrying any translation content. **Nepali and Somali were never machine-translated at all** — the record's 475/476 "machine output" was 449/450 tags plus 26 real machine strings.

A marker is worse than no value: `gen-l10n` falls back to English for an omitted key, and a marker displaces that fallback with the same English under a bracket that reads as a bug. Nothing could catch it — valid JSON, correct placeholders, compiles, analyzes clean, and every structural test passes because the key exists, is non-empty, and is *honestly* flagged unreviewed.

Deleted, so those keys fall back to English. What makes that safe rather than merely tidy: after the deletion `--candidates` reports **zero** `apply` in all five locales — a deleted key is replaceable, so any of the 899 with an adoptable Kotlin translation would have surfaced. None did. New guard test uses a net wider than the two markers that shipped.

**Reviewers: this is deliberately its own commit and can be dropped alone** if you prefer the marker's one virtue — that it makes the hole visible in the file. That virtue is cheaper elsewhere: `flutter gen-l10n` now prints `"ne"/"so": 455 untranslated message(s)` on every build.

## Left for a human (42)

- **17 genuine disagreements** where both renderings are valid (`es:amount` Monto/Cantidad, `fr:unselectAll` "Tout désélectionner"/"Désélectionner tout", …). This is where the lane stops.
- **25 `no-unanimous`** that now all carry a real translation, so nothing is broken while they wait.
- **3 tool false positives** listed in the notes so the next pass skips them (`es:reports`, `es:myProgress`, `es:myCourses`).
- 127 `nameOnly`/`containment` per locale (needs `app_en.arb` edits) and 26–44 `x-mt` values per locale that are byte-identical to the English — both argued in the notes.

`flutter/PHASE_118_NOTES.md` carries the counts, the per-string reasoning, and replacement wording for `CLAUDE.md`'s **Current l10n state** passage, which was wrong about ne/so in the specific way this phase found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuChitWHdocX2fVkvYabWz