### PR TITLE
courses: smoother filter controlling (fixes #16634)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7020
-        versionName = "0.70.20"
+        versionCode = 7021
+        versionName = "0.70.21"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
@@ -110,7 +110,10 @@ class CourseFilterController(
     }
 
     private fun setupClearTagsButton() {
-        rootView.findViewById<View>(R.id.btn_clear_tags).setOnClickListener { clearAll() }
+        rootView.findViewById<View>(R.id.btn_clear_tags)?.setOnClickListener {
+            rootView.findViewById<View>(R.id.card_filter)?.visibility = View.GONE
+            clearAll()
+        }
     }
 
     fun addTag(tag: TagEntity) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -222,9 +222,12 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
         )
         filterController.setup()
 
+        val chipRow = view?.findViewById<LinearLayout>(R.id.chip_filter_row)
         var lastState: FilterState? = null
         var isFirstEmission = true
         collectLatestWhenStarted(filterController.filterState) { state ->
+            chipRow?.let { renderCourseChipSelection(it) }
+
             if (isFirstEmission) {
                 isFirstEmission = false
                 if (!state.isActive) {
@@ -327,9 +330,6 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
             bottomSheet.visibility = View.GONE
         }
         requireView().findViewById<View>(R.id.btn_collections)?.setOnClickListener {
-            bottomSheet.visibility = View.GONE
-        }
-        requireView().findViewById<View>(R.id.btn_clear_tags)?.setOnClickListener {
             bottomSheet.visibility = View.GONE
         }
         orderByDate = requireView().findViewById(R.id.order_by_date_button)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CourseFilterControllerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CourseFilterControllerTest.kt
@@ -1,0 +1,96 @@
+package org.ole.planet.myplanet.ui.courses
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Spinner
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.model.TagEntity
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CourseFilterControllerTest {
+
+    private lateinit var rootView: View
+
+    @Before
+    fun setUp() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val themedContext = ContextThemeWrapper(baseContext, com.google.android.material.R.style.Theme_MaterialComponents)
+        rootView = LayoutInflater.from(themedContext).inflate(R.layout.fragment_my_course, null, false)
+    }
+
+    @Test
+    fun testProgressFilterIsClearedOnClearAll() = runTest {
+        var scrolledToTop = false
+        val controller = CourseFilterController(
+            rootView = rootView,
+            coroutineScope = backgroundScope,
+            onScrollToTop = { scrolledToTop = true }
+        )
+        controller.setup()
+
+        controller.setProgressFilter("In Progress")
+        assertEquals("In Progress", controller.currentState().progressFilter)
+        assertTrue(controller.filterApplied())
+        assertEquals("In Progress", controller.filterState.value.progressFilter)
+
+        controller.clearAll()
+        assertEquals("", controller.currentState().progressFilter)
+        assertEquals("", controller.filterState.value.progressFilter)
+        assertFalse(controller.filterApplied())
+        assertTrue(scrolledToTop)
+    }
+
+    @Test
+    fun testClearButtonResetsAllFiltersAndHidesFilterCard() = runTest {
+        var scrolledToTop = false
+        val controller = CourseFilterController(
+            rootView = rootView,
+            coroutineScope = backgroundScope,
+            onScrollToTop = { scrolledToTop = true }
+        )
+        controller.setup()
+
+        val cardFilter = rootView.findViewById<View>(R.id.card_filter)
+        val btnClear = rootView.findViewById<Button>(R.id.btn_clear_tags)
+        val etSearch = rootView.findViewById<EditText>(R.id.et_search)
+        val spnGrade = rootView.findViewById<Spinner>(R.id.spn_grade)
+        val spnSubject = rootView.findViewById<Spinner>(R.id.spn_subject)
+
+        cardFilter.visibility = View.VISIBLE
+        etSearch.setText("Algebra")
+        spnGrade.setSelection(1)
+        spnSubject.setSelection(1)
+        controller.setProgressFilter("Completed")
+        controller.addTag(TagEntity().apply { name = "Math" })
+
+        assertTrue(controller.filterApplied())
+        assertEquals("Completed", controller.currentState().progressFilter)
+
+        btnClear.performClick()
+
+        assertEquals(View.GONE, cardFilter.visibility)
+        assertEquals("", etSearch.text.toString())
+        assertEquals(0, spnGrade.selectedItemPosition)
+        assertEquals(0, spnSubject.selectedItemPosition)
+        assertEquals("", controller.currentState().progressFilter)
+        assertEquals("", controller.filterState.value.progressFilter)
+        assertTrue(controller.searchTags.isEmpty())
+        assertFalse(controller.filterApplied())
+        assertTrue(scrolledToTop)
+    }
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/548469f2-07a0-4ecc-9a82-a0bea46aeae0

fixes #16634 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing course filters now resets all selections, including search text, grade, subject, progress, and tags.
  - The filter panel is hidden after filters are cleared.
  - Filter chips now stay synchronized with the current filter state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->