### PR TITLE
Phase 119 (Lane A): the five missing sync walks

### DIFF
--- a/flutter/PHASE_119_NOTES.md
+++ b/flutter/PHASE_119_NOTES.md
@@ -83,9 +83,18 @@ state) each had to stop being faithful to, and this phase makes the same call:
 - The `_rev` half is not incidental. Phase 116's D19 trap was that an
   achievement row carries no `_rev` until a walk supplies one, so its POST 409s
   and `OutboxDrainer` classifies 409 as permanent (`code < 500`) and abandons
-  the row with no snackbar and no log. Handing a pending row the `_rev` is what
-  turns its next attempt into a PUT. The same is true of ratings, whose
+  the row with no snackbar and no log. Handing the row the `_rev` is what makes
+  its **next enqueue** a PUT. The same is true of ratings, whose
   `markRatingUploaded` never records the server id at all.
+
+  **Not a retry, though — the next enqueue.** Every uploader serializes the row
+  at queue time and `OutboxDrainer` replays `row.payload` verbatim, so a `_rev`
+  stamped after a payload was queued never reaches that payload. It closes the
+  case the defect is actually about — a fresh device, where the walk runs before
+  the user has edited anything — and leaves the narrow one open: a row queued
+  offline, then synced, then drained still POSTs without its `_rev`. Closing
+  that means re-serializing at drain time or re-queueing after a sync, which is
+  the outbox's business rather than this phase's. Reported below.
 
 Mechanically, "takes only the identity columns" is an UPDATE
 (`recordServerIdentity` / `recordServerRev`), not a partial companion through
@@ -94,11 +103,16 @@ so one carrying only `id`/`couchId`/`rev` is rejected for the required columns i
 omits even though the row already exists. `OutboxDao.patch` already carries that
 warning in a comment; this is the second and third place it bites.
 
-`users` needed nothing new — `UserMapper.fromDoc` already returns
-`Value.absent()` for `key`, `iv`, `isUpdated`, `password` and an unchanged
-`userImage`, and `insertAllOnConflictUpdate` leaves absent columns out of the
-`DO UPDATE SET` list. Losing `key`/`iv` would make every health record already
-encrypted with them permanently unreadable.
+`users` needed nothing new **for the device-only columns**: `UserMapper.fromDoc`
+already returns `Value.absent()` for `key`, `iv`, `isUpdated`, `password` and an
+unchanged `userImage`, and `insertAllOnConflictUpdate` leaves absent columns out
+of the `DO UPDATE SET` list (verified against Drift, not assumed). Losing
+`key`/`iv` would make every health record already encrypted with them
+permanently unreadable.
+
+It is **not** true of the twelve guarded profile columns, and the difference is
+deliberate rather than overlooked — see *A pending profile edit does not win*
+below.
 
 ## The defects, each demonstrated failing first
 
@@ -114,10 +128,12 @@ key, so `TeamTask.fromJson` writes `status = ""`. Kotlin's own predicate is
 `status IS NULL OR status != 'archived'` (`TeamTaskDao.kt:11`, `:20`), which
 `""` satisfies. The port asked for `'active'`, which it does not.
 
-Reverting the predicate turns 2 of the 9 task tests red — *a task the server
-sent reaches the team list* and *an archived task is excluded* — while the other
-seven still pass, which is exactly what the defect looked like from outside: a
-sync reporting success over an empty list. The column is non-nullable here with
+Reverting the predicate turns 3 of the 9 task tests red — *a task the server
+sent reaches the team list*, *an archived task is excluded* and *a synced task
+the device already holds is updated, not duplicated*, the last of which also
+reads through `watchForTeam` on a `status = ''` row — while the other six still
+pass, which is exactly what the defect looked like from outside: a sync
+reporting success over an empty list. The column is non-nullable here with
 default `'active'`, so the Kotlin's `IS NULL` arm has nothing to match and is
 dropped; the walk writes the document's status verbatim, empty string included.
 
@@ -221,11 +237,39 @@ behaving differently and should not have to re-derive why.
    port's coercion tolerates it.
 7. **`ratings.user` and `ratings.createdOn` are dropped**, and **`team_tasks.sync`
    and `team_tasks.link` are dropped** — see *Reported, not fixed*.
-8. **The walks are foreground sync-centre areas.** Kotlin runs `ratings` in
+8. **A rating's rater is resolved to the local `users` row id**, the same rule
+   the shelf walk follows and for the same reason: the document names the rater
+   by CouchDB id, `submitRating` stores `session.user.id`, and for a member
+   registered on this device those differ.
+9. **A count response with no `total_rows` fails the area** rather than
+   reporting an empty success. `JsonUtils.getInt` reads a missing key and a real
+   zero alike, and a green tick over a walk that never issued a page request is
+   the worst possible outcome for this phase in particular. Kotlin has no count
+   query at all and would simply page. The port's other four count-first walks
+   still conflate the two.
+10. **The walks are foreground sync-centre areas.** Kotlin runs `ratings` in
    `HeavyTableSyncWorker` after the main sync, and the other four in phase 1 or
    3 of the sync itself. The port has no heavy-table worker; every pull is an
    area of the sync centre. The page sizes are Kotlin's (`ratings` 20, the rest
    its 1000 default reduced to an `AdaptiveBatchProcessor` seed).
+
+### A pending profile edit does not win, unlike the other three tables
+
+`applyJsonToUser`'s rule for `firstName`…`age` and `joinDate` is "a non-empty
+incoming value wins" (`UserRepositoryImpl.kt:205-256`), and the port's
+`UserMapper._keepingStored` is a faithful port of it. So the `tablet_users` walk
+reverts a profile edit made offline, where the ratings/tasks/achievements walks
+preserve theirs. Newly reachable, since before this phase the port never pulled
+`tablet_users` at all.
+
+Left faithful, for a reason that is about consequences rather than about
+fidelity alone: `UserMapper.fromDoc` leaves `isUpdated` absent, so the row stays
+dirty and the outbox entry `_queueUserUpload` made at edit time still carries
+the edited payload. The edit reaches the server; what the user sees locally is
+stale until the next pull after it lands. The other three had a strictly worse
+failure — the walk cleared the flag, so the edit was discarded *and* never
+uploaded. If a later phase decides the twelve columns should follow the same
+rule as the other three, this is the fourth instance, not a new question.
 
 ## Reported, not fixed
 
@@ -260,6 +304,22 @@ they are that walk's, not this phase's:
   the exact shape of the Phase 104 `SurveyMapper.choices` defect, and a value
   no team-id predicate can ever match.
 
+**A `_rev` stamped after a payload was queued never reaches it.** All three
+uploaders (`ratings_uploader.dart:44-60`, `achievements_uploader.dart:47-58`,
+`team_tasks_uploader.dart:21-34`) serialize at enqueue time and `OutboxDrainer`
+replays the stored body, and nothing re-queues after a sync. So a row queued
+offline and then synced still sends its original `_id`-less body, and CouchDB
+mints a second document. The fix is to re-serialize at drain time, or to sweep
+pending rows after a sync; both are outbox changes.
+
+**The shelf pull ignores `removed_log`.** `ShelfRepository.upload` subtracts it
+(`shelf_repository.dart:112-118`) — that subtraction is what makes "leave"
+stick — while the new pull re-stamps `userId` on a resource the user removed
+offline whose removal has not uploaded yet. Kotlin is identical, so this is not
+a regression; it is worth naming because `removed_log` is a preserved
+local-authority table whose stated purpose is exactly this, and only one of its
+two directions now honours it.
+
 **`TeamMapper.fromDoc` has none of `insertMyTeam`'s document rules** — no
 `status == "archived"` early return, no `membership`-supersedes-`request`
 delete, no already-a-member `request` skip (`TeamsRepositoryImpl.kt:1223-1237`).
@@ -282,9 +342,75 @@ repositories now take one; a shared `test/support/mock_planet_api.dart` holds
 the double. An unstubbed mocktail mock throws on any call, which is the right
 default: reaching the network from a local-only test should fail loudly.
 
+## A second audit, on the finished implementation
+
+Phases 110, 113 and 116 each had a second `parity-auditor` pass find real
+defects in their own green work. So did this one, and the first finding inverts
+the phase's own headline for one of the five walks. The suite was green (1978
+tests), format and analyze clean; that is not evidence.
+
+| # | defect | why the first pass missed it |
+|---|---|---|
+| 1 | **the achievements walk skipped the server ledger on any device where the screen had been opened** | the "pending edit" test used a real edit |
+| 2 | ratings: two documents for one item collapsed onto one row, dropping a rating from the average | no test sent two documents for one item |
+| 3 | ratings: the rater was matched by CouchDB id where the table stores the local row id | the shelf walk had this rule; ratings did not |
+| 4 | guest adoption carried 5 of 17 device-only columns | the guest test supplied the profile fields in the document |
+| 5 | `syncAchievements` used raw casts, so one non-string scalar lost the whole page | no test sent a malformed document |
+| 6 | a count response with no `total_rows` ticked green without a single page request | every walk test stubbed one page answering every `skip` |
+
+**Finding 1 is the one to learn from, and it is a rule this port already had.**
+`Achievements.uploaded` is the port's *inverted* name for Kotlin's `isUpdated`,
+and its column default is `false` — the wrong way round, since `Achievement()`
+starts `isUpdated = false`. `getOrInitialize` wrote no value, so a blank
+placeholder row read as "an edit the user has not uploaded". The walk then
+preserved that blank row *instead of* the server's ledger — permanently, because
+nothing ever clears the flag — and stamped it with a valid `_rev`, arming the
+next Save to PUT an empty ledger over the real one. Before this phase that PUT
+had no `_rev` and 409'd, which is what had been protecting the server copy.
+
+`achievementEntryProvider` calls `getOrInitialize` on watch, so **opening the
+achievements screen once was enough**. The preservation rule this phase adopted
+turned the exact defect it was meant to fix into a permanent one, and it did so
+by reading a column default as a user intention. *A flag whose default means
+"dirty" cannot distinguish a placeholder from an edit.*
+
+**The largest gap was in the tests, not the code.** Every `stubWalk` in the five
+new files returned the whole document set in one page and matched any `skip`, so
+nothing exercised the loop that feeds the writers: changing `skip += rows.length`
+to `skip += 1` still passed all 38. `test/core/sync/table_walk_test.dart` now
+drives the loop against a corpus that honours `limit`/`skip` — multi-page,
+short-page, `_design`-only page, error rows with no `doc`, a mid-walk failure,
+and the malformed count.
+
+The pass also corrected six factual claims in this file and in the new doc
+comments — the "`AdaptiveBatchProcessor` grows it" claim (`initialSize` is the
+ceiling, not the floor), the "no delete of any kind" claim (the guest re-key is
+a delete), a "1000 documents" figure where the page is 100, a past-tense claim
+that `CoursesRepository.sync`'s `shelfId` now has a caller (it still does not —
+the shelf walk calls `CourseMapper.fromDoc` directly), the `_rev`/retry claim
+above, and "2 of the 9 task tests" where it is 3. `UserDao.getByAnyIds` also
+gained the chunking every other id-list query in that file has; it binds each id
+twice, so it chunks at half the usual size.
+
+Two smaller behaviours changed with it: a failed shelf-probe chunk now skips that
+chunk and carries on, as `checkShelfBatchForDataOptimized` does, rather than
+failing the whole pass; and `DashboardSyncArea`'s two load-bearing orderings are
+now pinned by a test, because the existing one asserted
+`items.map(…) == DashboardSyncArea.values`, which is tautological with respect to
+order and would survive an alphabetising refactor that broke both.
+
+Things the pass checked and found sound, recorded so nobody re-derives them: the
+`teamIds`/`myTeamIds` verbatim copy, the meetups/teams arms genuinely taking no
+shelf id, the courses arm's exam/survey skip (the step→assessment join lives on
+`Exams.stepId`, not on `CourseSteps`, so the step prune cannot reach it), the
+`ratings` page size, Drift leaving `Value.absent()` columns out of
+`DO UPDATE SET`, no `deleteNotIn` reachable from any of the five, and that the
+shelf walk's sequential loop is *safer* than Kotlin's `Semaphore(6)`, which is a
+lost-update race on `my_library.userId`.
+
 ## The tests
 
-38 across five files, plus the nine constructor updates.
+51 across six files, plus the constructor updates in nine existing ones.
 
 Each document is built in the shape CouchDB actually stores — `_users` keyed
 `org.couchdb.user:<name>` with the photo as an `_attachments` entry, a task with

--- a/flutter/PHASE_119_NOTES.md
+++ b/flutter/PHASE_119_NOTES.md
@@ -1,6 +1,298 @@
 # Phase 119 — the five missing sync walks
 
-Work in progress. Phase 116 audited reachability and reported, without fixing,
-that five `TransactionSyncManager` walks Kotlin runs have no counterpart in the
-port: `shelf`, `tablet_users`, `ratings`, `tasks`, `achievements`. This phase
-closes them.
+Phase 116 audited data-path reachability across the port and reported, without
+fixing, that five walks Kotlin's `TransactionSyncManager`/`SyncManager` run have
+no counterpart here. It called them "one phase, not five", and they are: the
+walks share a shape, and four of the five had a Dart writer already sitting
+uncalled — plumbing laid for a pull nobody wrote.
+
+This is the same failure class Phase 113 found in the exam path, one level up.
+**The data never arrives at all**, so every screen reading that table is dead no
+matter how well it is written — and green tests cannot see it, because a
+repository test builds its own rows and a screen test builds its own screen.
+
+## The five, and what each one feeds
+
+| walk | Kotlin | what was dead | Phase 116 |
+|---|---|---|---|
+| `shelf` | `SyncManager.kt:441-540` → `processShelfParallel` | My Library, My Courses, course progress, both home cards, the completed-course stars | D1/D2 |
+| `tablet_users` | `TransactionSyncManager.kt:230-232` | member detail ("Unknown member" for everyone), the team leaderboard (one row), every team member's name (raw `org.couchdb.user:bob`) | D15 |
+| `ratings` | `:242-244`, via `HeavyTableSyncWorker` | every rating average was the single number this device had typed | D4 |
+| `tasks` | `:254-256` | a task made on Planet or by a teammate never arrived | D16 |
+| `achievements` | `:260-262` + `downloadCvAttachmentsFromBatch` | a second device showed a blank ledger, and saving there 409'd into the outbox's permanent-failure branch | D19 |
+
+Four of the five confirm Phase 116's "plumbing laid for a caller that does not
+exist": `AchievementsRepository.syncAchievements`, `CoursesRepository.sync`'s
+`shelfId` parameter, `TeamTaskDao.upsertAll` and `AchievementFiles.hasResume` —
+the last of which carried a doc comment naming itself *"the Kotlin's
+`!file.exists()` guard on the sync-in"* for a sync-in that did not exist.
+
+No schema bump. Every table and column the five need already exists at
+`schemaVersion` 45; the two gaps found are recorded under *Reported, not fixed*.
+
+## The prune decision: none of the five prunes, and it is not a shortcut
+
+The Kotlin issues **no delete of any kind** on any of these five paths — checked
+per walk, not assumed. The only prune in the whole Kotlin sync is
+`SyncManager.kt:396 → MyLibraryDao.deleteStalePublicNotIn`, which belongs to the
+*resources* walk (phase 2), not to the shelf pass that follows it.
+
+That matters more here than usual, because Phase 52 fixed exactly this shape for
+resources (a mid-walk batch failure must set a flag and skip the cleanup) and
+Phase 116 then found the resources walk clearing My Library on every sync
+anyway. So, per table:
+
+- **`users`** — also holds accounts registered offline that have never reached
+  the server, and the session is restored by looking the signed-in user up here.
+  A `deleteNotIn` would sign the user out. Kotlin's only delete is the guest
+  re-key.
+- **`team_tasks`, `achievements`** — preserved local-authority tables whose rows
+  are authored here and keyed by a locally-minted id (`task-<micros>`) or a
+  derived one (`<userId>@<planetCode>`). Neither appears in any `_all_docs` keep
+  set before it has been uploaded *and* pulled back.
+- **`rating`** — same: a rating submitted here is keyed by a locally-minted id.
+- **shelf** — the stamp is a union (`MyLibrary.setUserId`,
+  `MyCourse.setUserId`), so pulling one user's shelf must leave another user's
+  membership on the same row intact. A prune here would be a prune of the
+  *resources* and *courses* tables from a `keys` subset, which is categorically
+  wrong.
+
+`walkAllDocs` therefore takes no keep set at all, and says so at the top: a
+caller that needs `deleteNotIn` needs the keep set, and the keep set is only
+trustworthy when every page landed. The three walks that do prune (resources,
+courses, tags) keep their own loops with their own `hadBatchFailure` guards.
+
+## The local-authority decision: a pending edit wins
+
+Three of the five tables have a column the device writes and the server document
+knows nothing about. Kotlin overwrites all of them, because `fromJson` /
+`insertRatingsFromSync` build a **fresh entity per document** and upsert it. That
+is the shape Phase 56 (security data), Phase 74 (reactions) and Phase 98 (read
+state) each had to stop being faithful to, and this phase makes the same call:
+
+- **`team_tasks.isNotified`** — device-local, on neither the document nor
+  `TeamTask.serialize`, and the only thing making a deadline reminder
+  once-only. Kotlin resets it on every sync, so the same reminder fires again
+  after each sync. The port never writes the column from the walk, so the flag
+  survives.
+- **A row still flagged `isUpdated` / `uploaded = false`** (ratings, tasks,
+  achievements) takes **only the identity columns** — `_id` and `_rev`. Its
+  content is an edit the user made offline that has not reached the server;
+  adopting the server's older copy discards the edit *and*, by clearing the
+  flag, stops it ever uploading. Kotlin does both.
+- The `_rev` half is not incidental. Phase 116's D19 trap was that an
+  achievement row carries no `_rev` until a walk supplies one, so its POST 409s
+  and `OutboxDrainer` classifies 409 as permanent (`code < 500`) and abandons
+  the row with no snackbar and no log. Handing a pending row the `_rev` is what
+  turns its next attempt into a PUT. The same is true of ratings, whose
+  `markRatingUploaded` never records the server id at all.
+
+Mechanically, "takes only the identity columns" is an UPDATE
+(`recordServerIdentity` / `recordServerRev`), not a partial companion through
+the upsert: Drift validates an upsert's companion against the **insert** path,
+so one carrying only `id`/`couchId`/`rev` is rejected for the required columns it
+omits even though the row already exists. `OutboxDao.patch` already carries that
+warning in a comment; this is the second and third place it bites.
+
+`users` needed nothing new — `UserMapper.fromDoc` already returns
+`Value.absent()` for `key`, `iv`, `isUpdated`, `password` and an unchanged
+`userImage`, and `insertAllOnConflictUpdate` leaves absent columns out of the
+`DO UPDATE SET` list. Losing `key`/`iv` would make every health record already
+encrypted with them permanently unreadable.
+
+## The defects, each demonstrated failing first
+
+### 1. `TeamTaskDao.watchForTeam` required `status = 'active'`
+
+The trap Phase 116 predicted, and the reason this one is worth stating first:
+**the walk would have worked and the screen would have stayed empty.**
+
+`TeamTask.serialize` (`model/TeamTask.kt:56-72`) emits `_id`, `_rev`, `title`,
+`deadline`, `description`, `completed`, `completedTime`, `assignee`, `sync`,
+`link` — and **no `status`**. `JsonUtils.getString` returns `""` for a missing
+key, so `TeamTask.fromJson` writes `status = ""`. Kotlin's own predicate is
+`status IS NULL OR status != 'archived'` (`TeamTaskDao.kt:11`, `:20`), which
+`""` satisfies. The port asked for `'active'`, which it does not.
+
+Reverting the predicate turns 2 of the 9 task tests red — *a task the server
+sent reaches the team list* and *an archived task is excluded* — while the other
+seven still pass, which is exactly what the defect looked like from outside: a
+sync reporting success over an empty list. The column is non-nullable here with
+default `'active'`, so the Kotlin's `IS NULL` arm has nothing to match and is
+dropped; the walk writes the document's status verbatim, empty string included.
+
+### 2. The shelf stamp was keyed on the wrong id
+
+Found by the ground-truth audit before it shipped, and the sharpest thing in the
+phase. A shelf document is keyed by its owner's **CouchDB** id — that is what
+`shelf/_all_docs` returns — but every reader in this app scopes by
+`session.user.id`, the **local row** id: `MyLibraryDao.watchResources`,
+`CourseDao.watchCourses`, the home library and course cards, the
+completed-course stars.
+
+For an account that first appeared server-side the two are the same string. For
+a member **registered on this device** they are not: that row keeps its
+locally-minted `'<millis>'` id and gains a `couchId` only when the upload lands
+(the Phase 107 identity rule, `user_mapper.dart:26-35`). Stamping the raw shelf
+id for such a member writes a `userId` no reader can match — My Library stays
+empty and the sync reports success.
+
+`ShelfSyncRepository._localUserId` resolves it through `UserDao.getById`, which
+matches either column. Removing the resolution turns *a member registered on
+this device gets the stamp their screens read* red and leaves the other seven
+shelf tests green. This is also why the sync centre runs `tabletUsers` **before**
+`shelf`: the mapping has to exist.
+
+### 3. A rating came back as two rows
+
+`markRatingUploaded` only clears the dirty flag — it never records the
+server-assigned `_id` (`UploadConfigs.kt:294-304`) — so a rating submitted here
+keeps its locally-minted id for life. `insertRatingsFromSync` keys its row by
+the CouchDB `_id` (`Rating().apply { id = _id }`), so the user's own rating comes
+back as a *second* row and `getAggregate` counts both: rate a resource 5 stars,
+sync twice, and the summary reads "2 ratings, average 5".
+
+The port reconciles instead — a document whose `(type, item, userId)` matches a
+local row that has no CouchDB id yet updates that row. Keying by `_id` alone
+turns two ratings tests red. Same shape for tasks (`getByAnyIds` resolves through
+`docId` first); a locally created task otherwise appears twice under its team.
+
+### 4. Pending edits and the notification flag
+
+Covered above; each demonstrated by disabling its guard:
+
+| disabled | test that goes red |
+|---|---|
+| the ratings identity-only branch | *an unsent rating keeps its rate and stays queued* |
+| the tasks identity-only branch | *an edit made offline survives the pull that carries its old copy* |
+| writing `isNotified: false` from the walk | *a re-pull does not re-fire a deadline notification* |
+| the achievements pending branch | *an edit not yet uploaded survives the pull, and gains its rev* |
+
+### 5. The guest adoption dropped the guest's key
+
+Not shipped — caught between writing and committing, by the ground-truth pass.
+Kotlin's guest branch assigns `this.id = id; this._id = id` **before** calling
+`applyJsonToUser` (`UserRepositoryImpl.kt:1126-1131`), because `applyJsonToUser`
+only reassigns `id` when it is blank. The port's first cut passed the guest row
+to `UserMapper.fromDoc` as `existing`, which keys the companion on
+`existing.id` — still `guest_ada` — so the row was updated in situ under the
+guest key and the account stayed unresolvable by its CouchDB id.
+
+The fix carries the guest's device-only columns across by hand
+(`_adoptGuest`). That is needed because the port rebuilds the row rather than
+mutating it, as Kotlin does: written under a *new* key there is nothing for
+`Value.absent()` to preserve, so `key`, `iv`, `password` and `userImage` would
+each silently take their default.
+
+## Deliberate divergences from the Kotlin
+
+Recorded because each is a place where a later reader will find the two apps
+behaving differently and should not have to re-derive why.
+
+1. **The three reconciliations and preservations above.** Kotlin duplicates the
+   row and clobbers the edit in every one of these cases; the duplication is
+   observable (a rating counted twice, a task listed twice under its team).
+2. **The shelf walk covers `resources` and `courses` only.**
+   `Constants.shelfDataList` has four arms, but `batchInsertMeetups(docs)` and
+   `batchInsertMyTeams(docs)` take **no shelf id** — they record no membership,
+   and they re-insert documents the port's own `meetups` and `teams` walks pull
+   in full, from the same databases, in the same pass. There is nothing for them
+   to add. (Kotlin's meetups arm is in fact *destructive* here:
+   `Meetup.fromJson(doc, "", existing)` writes `userId = ""`, clearing
+   attendance. Not porting it avoids inheriting that.)
+3. **The courses arm writes the course and its steps, not the embedded exams and
+   surveys**, where `upsertRoomCoursesFromSync` writes all four. The `courses`
+   walk runs earlier in the same pass over the same documents and owns those
+   tables, including the step-join release whose churn Phase 113 had to fix.
+4. **No six-hour shelf cache.** Kotlin caches "which shelves have data" in
+   preferences for six hours (`SyncManager.kt:468-491`), so a shelf that gains
+   its first resource is invisible to sync for up to six hours. The port re-reads
+   every time — and, having just read the documents, does not re-fetch each shelf
+   individually the way `processShelfParallel` does.
+5. **`hasShelfData` keeps Kotlin's key set verbatim**, `teamIds` included, which
+   is a Kotlin bug: `Constants.shelfDataList` processes `myTeamIds` and the
+   string `teamIds` appears nowhere else in the Kotlin codebase, so a shelf whose
+   only non-empty array is `myTeamIds` is judged "no data" and skipped entirely.
+   Not "fixed" here because this walk processes neither team key; widening the
+   set would only spend two requests on a shelf with nothing in it for us.
+6. **`sendToNation: null` does not abort the page.** `Achievement.fromJson:120`
+   calls `.asString` on the raw element, which throws on a JSON null out of a
+   function with no per-document try/catch, taking the whole page with it. The
+   port's coercion tolerates it.
+7. **`ratings.user` and `ratings.createdOn` are dropped**, and **`team_tasks.sync`
+   and `team_tasks.link` are dropped** — see *Reported, not fixed*.
+8. **The walks are foreground sync-centre areas.** Kotlin runs `ratings` in
+   `HeavyTableSyncWorker` after the main sync, and the other four in phase 1 or
+   3 of the sync itself. The port has no heavy-table worker; every pull is an
+   area of the sync centre. The page sizes are Kotlin's (`ratings` 20, the rest
+   its 1000 default reduced to an `AdaptiveBatchProcessor` seed).
+
+## Reported, not fixed
+
+**Two missing columns, each needing a schema number I am not allowed to
+allocate.** Both are deferrable, and I have deferred them rather than working
+around them:
+
+- **`rating.user` and `rating.createdOn`.** `insertRatingsFromSync` writes both
+  and `Rating.serializeRating` re-emits them. `RatingsUploader._toDoc` already
+  rebuilds `user` from the `users` table and derives `createdOn` from
+  `parentCode`, and a sync-in row is `isUpdated = false` so it never re-enters
+  `pendingUploads` — the columns are write-only from the port's side today.
+  `Ratings` is not a preserved table, so adding them is a plain `createAll`.
+- **`team_tasks.sync` and `team_tasks.link`.** `TeamTask.fromJson` sets both and
+  `TeamTask.serialize` re-emits them verbatim; `TeamTasksRepository.serialize`
+  rebuilds them from `teamId` and the session's planet code, which is what
+  `upsertTask` does for a locally authored row. `team_tasks` **is** a preserved
+  table, so this one needs a hand-written `_addColumnIfMissing` step as well as a
+  version.
+
+**Two pre-existing defects in `MyLibraryMapper` that the shelf walk now
+inherits**, both in the `resources` walk already and both left alone because
+they are that walk's, not this phase's:
+
+- `my_library_mapper.dart:85` reads `'tag'` where `MyLibrary.kt:291` reads
+  `'tags'`. Phase 116 called this inert; it is inert only because nothing else
+  fills the column.
+- `my_library_mapper.dart:93` reads `privateFor` as a string, while Kotlin reads
+  the nested `privateFor.teams` (`MyLibrary.kt:294-298`). Dart's
+  `JsonUtils.getString` falls through to `toString()`, so a document carrying
+  `{"privateFor": {"teams": "abc"}}` stores the Dart literal `{teams: abc}` —
+  the exact shape of the Phase 104 `SurveyMapper.choices` defect, and a value
+  no team-id predicate can ever match.
+
+**`TeamMapper.fromDoc` has none of `insertMyTeam`'s document rules** — no
+`status == "archived"` early return, no `membership`-supersedes-`request`
+delete, no already-a-member `request` skip (`TeamsRepositoryImpl.kt:1223-1237`).
+Not reachable from this phase, since the shelf walk does not route teams, but it
+is the reason a future phase should not casually add that arm.
+
+## Files touched outside this lane's set
+
+None. Lane B owns `submissions_repository.dart` and
+`notifications_repository.dart` and their mappers and tests; neither is touched.
+Lane C owns `lib/l10n/`, `test/l10n/` and `tool/arb_from_strings_xml.dart`; the
+only file of theirs this phase touches is **`lib/l10n/app_en.arb`**, which the
+brief explicitly designates for new strings, with five keys appended at the end
+of the file to keep the hunk out of the way: `ratings`, `syncShelfDescription`,
+`syncMembersDescription`, `syncRatingsDescription`, `syncTasksDescription`,
+`syncAchievementsDescription`.
+
+Nine existing test files gained a `PlanetApi` argument, because three
+repositories now take one; a shared `test/support/mock_planet_api.dart` holds
+the double. An unstubbed mocktail mock throws on any call, which is the right
+default: reaching the network from a local-only test should fail loudly.
+
+## The tests
+
+38 across five files, plus the nine constructor updates.
+
+Each document is built in the shape CouchDB actually stores — `_users` keyed
+`org.couchdb.user:<name>` with the photo as an `_attachments` entry, a task with
+`link: {teams: …}` and no `status`, a rating with the rater embedded as a `user`
+object, a shelf with `resourceIds`/`courseIds` arrays — rather than flattened to
+the columns the row happens to have. **That is the whole point of the exercise**:
+the `status` defect was invisible to a fixture written from the row's columns,
+and would have stayed invisible to one.
+
+Every walk has a `never prunes` test that puts a locally-authored row in the
+table, runs a walk that does not list it, and asserts it survives.

--- a/flutter/PHASE_119_NOTES.md
+++ b/flutter/PHASE_119_NOTES.md
@@ -1,0 +1,6 @@
+# Phase 119 — the five missing sync walks
+
+Work in progress. Phase 116 audited reachability and reported, without fixing,
+that five `TransactionSyncManager` walks Kotlin runs have no counterpart in the
+port: `shelf`, `tablet_users`, `ratings`, `tasks`, `achievements`. This phase
+closes them.

--- a/flutter/lib/core/sync/table_walk.dart
+++ b/flutter/lib/core/sync/table_walk.dart
@@ -44,6 +44,14 @@ Future<SyncResult> walkAllDocs({
     return SyncFailed(describeNetworkFailure(countResult));
   }
 
+  // A response with no `total_rows` at all is a malformed one, not an empty
+  // database. `JsonUtils.getInt` reads both as 0, and treating them alike would
+  // put a green tick on a walk that never issued a page request — the Kotlin
+  // has no count query and would simply page. `total_rows: 0` stays a
+  // legitimate empty answer.
+  if (!countResult.data.containsKey('total_rows')) {
+    return SyncFailed('$table/_all_docs returned no total_rows');
+  }
   final totalRows = JsonUtils.getInt('total_rows', countResult.data);
   if (totalRows == 0) {
     onProgress?.call(const SyncProgress(completed: 0, total: 0));

--- a/flutter/lib/core/sync/table_walk.dart
+++ b/flutter/lib/core/sync/table_walk.dart
@@ -1,0 +1,105 @@
+import '../config/server_config.dart';
+import '../network/network_result.dart';
+import '../utils/json_utils.dart';
+import '../utils/url_utils.dart';
+import '../../data/api/planet_api.dart';
+import 'adaptive_batch_processor.dart';
+import 'sync_result.dart';
+
+/// Shared `_all_docs` pagination for a CouchDB sync-in walk.
+///
+/// Port of the loop in `TransactionSyncManager.syncDb` (`services/sync/`),
+/// which every table pull in the Kotlin runs: fetch a page with
+/// `?include_docs=true&limit&skip`, hand its documents to the table's writer,
+/// and stop on a short page. The port adds the `?limit=0` count query its
+/// other walks already use, so the sync centre can show real progress rather
+/// than an indeterminate spinner.
+///
+/// The Kotlin's `_design` filter lives here rather than in each writer —
+/// `extractDocs` applies it to every table, and doing it once means a new walk
+/// cannot forget it.
+///
+/// **No pruning.** A caller that needs `deleteNotIn` needs the keep set, and
+/// the keep set is only trustworthy when every page landed; the walks that
+/// prune (resources, courses, tags) therefore keep their own loops with their
+/// own `hadBatchFailure` guards. Every walk built on this helper is one the
+/// Kotlin does not prune either — see `PHASE_119_NOTES.md` for the per-table
+/// reasoning.
+Future<SyncResult> walkAllDocs({
+  required PlanetApi api,
+  required ServerConfig config,
+  required String table,
+  required int initialBatchSize,
+  required Future<int> Function(List<Map<String, dynamic>> docs) insert,
+  void Function(SyncProgress)? onProgress,
+}) async {
+  final dbUrl = UrlUtils.dbUrl(config);
+  final authHeader = UrlUtils.authHeader(config);
+
+  final countResult = await api.getJsonObject(
+    '$dbUrl/$table/_all_docs?limit=0',
+    authHeader: authHeader,
+  );
+  if (countResult is! NetworkSuccess<Map<String, dynamic>>) {
+    return SyncFailed(describeNetworkFailure(countResult));
+  }
+
+  final totalRows = JsonUtils.getInt('total_rows', countResult.data);
+  if (totalRows == 0) {
+    onProgress?.call(const SyncProgress(completed: 0, total: 0));
+    return const SyncComplete(0);
+  }
+
+  final batchSizer = AdaptiveBatchProcessor(initialSize: initialBatchSize);
+  var skip = 0;
+  var saved = 0;
+
+  while (skip < totalRows) {
+    final size = batchSizer.currentSize;
+    final stopwatch = Stopwatch()..start();
+    final pageResult = await api.getJsonObject(
+      '$dbUrl/$table/_all_docs?include_docs=true&limit=$size&skip=$skip',
+      authHeader: authHeader,
+    );
+    stopwatch.stop();
+
+    if (pageResult is! NetworkSuccess<Map<String, dynamic>>) {
+      batchSizer.recordFailure();
+      return SyncFailed(describeNetworkFailure(pageResult));
+    }
+    batchSizer.recordSuccess(stopwatch.elapsedMilliseconds);
+
+    final rows = pageResult.data['rows'];
+    if (rows is! List || rows.isEmpty) break;
+
+    saved += await insert(extractDocs(rows));
+
+    skip += rows.length;
+    onProgress?.call(
+      SyncProgress(
+        completed: skip > totalRows ? totalRows : skip,
+        total: totalRows,
+      ),
+    );
+    if (rows.length < size) break;
+  }
+
+  return SyncComplete(saved);
+}
+
+/// Port of `TransactionSyncManager.extractDocs`: the `doc` of every row that
+/// has one, minus `_design/*` documents. A row with no `doc` (a deleted or
+/// missing key in a `keys` query) is dropped rather than passed on as an empty
+/// map, which is what the Kotlin's `getJsonObject` fallback would produce.
+List<Map<String, dynamic>> extractDocs(List<dynamic> rows) {
+  final docs = <Map<String, dynamic>>[];
+  for (final row in rows) {
+    if (row is! Map<String, dynamic>) continue;
+    final doc = JsonUtils.getObject('doc', row);
+    if (doc == null || doc.isEmpty) continue;
+    final id = JsonUtils.getString('_id', doc);
+    if (id.isEmpty || id.startsWith('_design')) continue;
+    docs.add(doc);
+  }
+  return docs;
+}

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -439,9 +439,22 @@ class TeamTaskDao extends DatabaseAccessor<AppDatabase>
     with _$TeamTaskDaoMixin {
   TeamTaskDao(super.db);
 
+  /// Port of `TeamTaskDao.getByTeamId`:
+  /// `WHERE teamId = :teamId AND (status IS NULL OR status != 'archived')`.
+  ///
+  /// **Not `status = 'active'`**, which is what this was. `TeamTask.serialize`
+  /// emits no `status` field at all, so `TeamTask.fromJson` reads the missing
+  /// key as `""` and every task the server sends arrives with an empty status.
+  /// Under the old predicate the `tasks` walk could land a full page of rows
+  /// and the screen would still be empty — the walk working and the list
+  /// blank. The column is non-nullable here (default `'active'`), so the
+  /// Kotlin's `IS NULL` arm has nothing to match and is dropped.
   Stream<List<TeamTaskRow>> watchForTeam(String teamId) =>
       (select(teamTasks)
-            ..where((t) => t.teamId.equals(teamId) & t.status.equals('active'))
+            ..where(
+              (t) =>
+                  t.teamId.equals(teamId) & t.status.equals('archived').not(),
+            )
             ..orderBy([
               (t) => OrderingTerm.asc(t.completed),
               (t) => OrderingTerm.asc(t.deadline),
@@ -455,6 +468,23 @@ class TeamTaskDao extends DatabaseAccessor<AppDatabase>
       batch((b) => b.insertAllOnConflictUpdate(teamTasks, rows));
   Future<List<TeamTaskRow>> pending() =>
       (select(teamTasks)..where((t) => t.isUpdated.equals(true))).get();
+
+  /// The local rows for a page of server documents, keyed by whichever column
+  /// carries the CouchDB id.
+  ///
+  /// A task created in this app keeps its locally-minted `task-<micros>` id
+  /// for life — `markUploaded` fills in `_id`/`_rev` and leaves `id` alone —
+  /// so a sync-in keyed on the document `_id` (which is what `TeamTask.fromJson`
+  /// does: `task.id = _id`) would insert a *second* row for a task the device
+  /// already has. Resolving through `_id` first lets the walk update the row
+  /// that exists.
+  Future<List<TeamTaskRow>> getByAnyIds(List<String> ids) async {
+    if (ids.isEmpty) return const [];
+    return (select(
+      teamTasks,
+    )..where((t) => t.id.isIn(ids) | t.docId.isIn(ids))).get();
+  }
+
   Future<void> markUploaded(String id, String docId, String rev) =>
       (update(teamTasks)..where((t) => t.id.equals(id))).write(
         TeamTasksCompanion(
@@ -462,6 +492,14 @@ class TeamTaskDao extends DatabaseAccessor<AppDatabase>
           rev: Value(rev),
           isUpdated: const Value(false),
         ),
+      );
+
+  /// Stamps the CouchDB id and rev onto a task the user has edited but not yet
+  /// uploaded, without disturbing the edit or the flag that carries it. An
+  /// UPDATE rather than an upsert, for the same reason [OutboxDao.patch] is.
+  Future<int> recordServerIdentity(String id, String docId, String? rev) =>
+      (update(teamTasks)..where((t) => t.id.equals(id))).write(
+        TeamTasksCompanion(docId: Value(docId), rev: Value(rev)),
       );
   Future<void> deleteById(String id) =>
       (delete(teamTasks)..where((t) => t.id.equals(id))).go();
@@ -872,6 +910,56 @@ class UserDao extends DatabaseAccessor<AppDatabase> with _$UserDaoMixin {
                 u.isUpdated.equals(true),
           ))
           .get();
+
+  /// Port of `UserDao.getUsersByAnyIds` — the batched form of [getById] the
+  /// `tablet_users` walk uses so a page of 1000 documents costs one read
+  /// rather than a thousand. Matches either identity column, as [getById]
+  /// does, because a member registered on this device keeps a locally-minted
+  /// `id` and carries the server's key in `couchId`.
+  Future<List<UserRow>> getByAnyIds(List<String> ids) async {
+    if (ids.isEmpty) return const [];
+    return (select(
+      users,
+    )..where((u) => u.id.isIn(ids) | u.couchId.isIn(ids))).get();
+  }
+
+  /// Port of `UserDao.getGuestUsersByNames` — the guest rows a
+  /// `tablet_users` page might be about to adopt. A guest is keyed
+  /// `guest_<username>` in `couchId` (`UserMapper.guestIdPrefix`), so the
+  /// prefix is what distinguishes one from a real account with the same name.
+  Future<List<UserRow>> getGuestUsersByNames(List<String> names) async {
+    if (names.isEmpty) return const [];
+    final matches = await (select(
+      users,
+    )..where((u) => u.name.isIn(names))).get();
+    // The prefix test is in Dart, not SQL: `LIKE 'guest_%'` would treat the
+    // underscore as a single-character wildcard and match `guestX…` too.
+    return [
+      for (final user in matches)
+        if (user.couchId?.startsWith('guest_') ?? false) user,
+    ];
+  }
+
+  /// Batched upsert for the `tablet_users` walk.
+  ///
+  /// Every companion comes from [UserMapper.fromDoc], which leaves the columns
+  /// a `_users` document does not carry — `key`, `iv`, `isUpdated`, and a
+  /// `userImage` holding a not-yet-uploaded local path — as `Value.absent()`.
+  /// Drift's `insertAllOnConflictUpdate` writes only the present columns, so
+  /// the walk cannot erase them. Losing `key`/`iv` would make every health
+  /// record already encrypted with them permanently unreadable.
+  Future<void> upsertAll(List<UsersCompanion> rows) async {
+    if (rows.isEmpty) return;
+    await batch((b) => b.insertAllOnConflictUpdate(users, rows));
+  }
+
+  /// Port of `UserDao.deleteByIds`, used only by the guest migration in the
+  /// `tablet_users` walk: a guest row is re-keyed to the account that has just
+  /// appeared server-side, and its old row has to go with it.
+  Future<void> deleteByIds(List<String> ids) async {
+    if (ids.isEmpty) return;
+    await (delete(users)..where((u) => u.id.isIn(ids))).go();
+  }
 
   /// Port of `UserRepositoryImpl.markUserUploaded` / `markUserRevUpdated` —
   /// records the server-assigned id/rev and clears the dirty flag so the row
@@ -1723,6 +1811,41 @@ class RatingDao extends DatabaseAccessor<AppDatabase> with _$RatingDaoMixin {
 
   Future<RatingRow?> findById(String id) =>
       (select(ratings)..where((row) => row.id.equals(id))).getSingleOrNull();
+
+  /// The local rows a page of `ratings` documents might already be about.
+  ///
+  /// Two lookups because a rating has two identities. A rating submitted on
+  /// this device is keyed by a locally-minted id and has no `_id` until a walk
+  /// supplies one, so the server's copy of it is found by `(type, item,
+  /// userId)`; a rating already synced once is found by its CouchDB id.
+  /// Without the first, the walk would insert a duplicate row alongside the
+  /// user's own and the average would count their rating twice.
+  Future<List<RatingRow>> getByCouchIds(List<String> ids) async {
+    if (ids.isEmpty) return const [];
+    return (select(
+      ratings,
+    )..where((row) => row.id.isIn(ids) | row.couchId.isIn(ids))).get();
+  }
+
+  /// Every rating this device authored that has not been given a CouchDB id
+  /// yet — the candidates for the `(type, item, userId)` match above.
+  Future<List<RatingRow>> unsyncedLocalRatings() => (select(
+    ratings,
+  )..where((row) => row.couchId.isNull() | row.couchId.equals(''))).get();
+
+  Future<void> upsertAll(List<RatingsCompanion> rows) async {
+    if (rows.isEmpty) return;
+    await batch((b) => b.insertAllOnConflictUpdate(ratings, rows));
+  }
+
+  /// Stamps the CouchDB id and rev onto a row without touching the rating the
+  /// user is still waiting to upload. An UPDATE rather than an upsert, because
+  /// `insertOnConflictUpdate` validates its companion against the insert path
+  /// and would reject one that carries only the identity columns.
+  Future<int> recordServerIdentity(String id, String couchId, String? rev) =>
+      (update(ratings)..where((row) => row.id.equals(id))).write(
+        RatingsCompanion(couchId: Value(couchId), rev: Value(rev)),
+      );
 }
 
 /// Port of `data/room/dao/RetryDao.kt`, backing [OutboxEntries].
@@ -3789,10 +3912,26 @@ class AchievementDao extends DatabaseAccessor<AppDatabase>
         ),
       );
 
+  /// The local rows a page of `achievements` documents is about, so the walk
+  /// can tell a ledger the user has edited but not yet uploaded from one it is
+  /// merely refreshing.
+  Future<List<AchievementRow>> getByIds(List<String> ids) async {
+    if (ids.isEmpty) return const [];
+    return (select(achievements)..where((a) => a.id.isIn(ids))).get();
+  }
+
   /// Port of the `bulkInsertAchievementsFromSync` upsert — a server document
   /// adopts its CouchDB id.
   Future<void> insertDocs(List<AchievementsCompanion> rows) =>
       batch((b) => b.insertAllOnConflictUpdate(achievements, rows));
+
+  /// Stamps the server `_rev` onto a ledger the user has edited but not
+  /// uploaded, leaving the edit and its pending flag alone. An UPDATE rather
+  /// than an upsert, for the same reason [OutboxDao.patch] is.
+  Future<int> recordServerRev(String id, String rev) =>
+      (update(achievements)..where((a) => a.id.equals(id))).write(
+        AchievementsCompanion(couchId: Value(id), rev: Value(rev)),
+      );
 }
 
 /// Port of `data/room/dao/UserChallengeActionsDao.kt`. One row per challenge

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -911,16 +911,25 @@ class UserDao extends DatabaseAccessor<AppDatabase> with _$UserDaoMixin {
           ))
           .get();
 
-  /// Port of `UserDao.getUsersByAnyIds` — the batched form of [getById] the
-  /// `tablet_users` walk uses so a page of 1000 documents costs one read
-  /// rather than a thousand. Matches either identity column, as [getById]
-  /// does, because a member registered on this device keeps a locally-minted
-  /// `id` and carries the server's key in `couchId`.
+  /// Port of `UserDao.getUsersByAnyIds` — the batched form of [getById], so a
+  /// page of documents costs a handful of reads rather than one per row.
+  /// Matches either identity column, as [getById] does, because a member
+  /// registered on this device keeps a locally-minted `id` and carries the
+  /// server's key in `couchId`.
+  ///
+  /// Chunked for the same reason as [MyLibraryDao.deleteNotIn], and at half the
+  /// usual size because each id is bound twice.
   Future<List<UserRow>> getByAnyIds(List<String> ids) async {
     if (ids.isEmpty) return const [];
-    return (select(
-      users,
-    )..where((u) => u.id.isIn(ids) | u.couchId.isIn(ids))).get();
+    final rows = <UserRow>[];
+    for (final chunk in _chunked(ids, _sqliteVariableChunk ~/ 2)) {
+      rows.addAll(
+        await (select(
+          users,
+        )..where((u) => u.id.isIn(chunk) | u.couchId.isIn(chunk))).get(),
+      );
+    }
+    return rows;
   }
 
   /// Port of `UserDao.getGuestUsersByNames` — the guest rows a

--- a/flutter/lib/data/local/my_library_mapper.dart
+++ b/flutter/lib/data/local/my_library_mapper.dart
@@ -16,6 +16,25 @@ class MyLibraryMapper {
   /// Mirrors the `titleNormal` computation. Used for accent-insensitive search.
   static String normalizeTitle(String title) => text.normalizeText(title);
 
+  /// Port of `MyLibrary.setUserId` — shelf membership is a union, so pulling a
+  /// second user's shelf does not evict the first, and a walk that knows
+  /// nothing about membership (`shelfId == null`) leaves the stored list
+  /// alone. Blank entries already persisted in the row are dropped on the way
+  /// through: `setUserId` returns early on a blank id, so `[""]` is a value the
+  /// Kotlin can never write, and it is the one value that fails the My Library
+  /// predicate *and* passes the catalog one.
+  ///
+  /// The same shape as `CourseMapper.mergeUserIds`; kept separate rather than
+  /// shared because the two mappers already carry their own copies of the
+  /// Kotlin's per-model merge and neither imports the other.
+  static List<String> mergeUserIds(List<String> existing, String? shelfId) {
+    final kept = existing.where((id) => id.isNotEmpty);
+    if (shelfId == null || shelfId.isEmpty) {
+      return {...kept}.toList(growable: false);
+    }
+    return {...kept, shelfId}.toList(growable: false);
+  }
+
   /// Returns `null` for an empty document or a `_design/*` doc, matching the
   /// filter in `ResourcesRepositoryImpl.batchInsertResources`.
   static MyLibraryTableCompanion? fromDoc(
@@ -27,6 +46,7 @@ class MyLibraryMapper {
     List<String> existingLevel = const [],
     List<String> existingTag = const [],
     List<String> existingLanguages = const [],
+    String? shelfId,
   }) {
     if (doc.isEmpty) return null;
 
@@ -69,7 +89,7 @@ class MyLibraryMapper {
       timesRated: Value(JsonUtils.getInt('timesRated', doc)),
       resourceRemoteAddress: Value(attachment?.remoteAddress),
       resourceLocalAddress: Value(attachment?.localAddress),
-      userId: Value(existingUserIds),
+      userId: Value(mergeUserIds(existingUserIds, shelfId)),
       resourceFor: Value(
         _mergedList(
           existingResourceFor,

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -1447,5 +1447,11 @@
   "resourceTitleAlreadyExists": "A resource with this title already exists",
   "failedToUpdateResource": "Failed to update resource",
   "thankYouForTakingExam": "Thank you for taking this exam! We wish you all the best.",
-  "pleaseAnswerToContinue": "Please select / write your answer to continue"
+  "pleaseAnswerToContinue": "Please select / write your answer to continue",
+  "ratings": "Ratings",
+  "syncShelfDescription": "Refresh which resources and courses are on each member's shelf",
+  "syncMembersDescription": "Refresh the member accounts registered on this planet",
+  "syncRatingsDescription": "Refresh community ratings for resources and courses",
+  "syncTasksDescription": "Refresh team tasks created on the server",
+  "syncAchievementsDescription": "Refresh achievement records and downloaded CVs"
 }

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -561,6 +561,7 @@ final ratingsRepositoryProvider = Provider<RatingsRepository>(
   (ref) => RatingsRepository(
     ref.watch(planetApiProvider),
     ref.watch(ratingDaoProvider),
+    ref.watch(userDaoProvider),
   ),
 );
 

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -44,6 +44,7 @@ import '../repository/life_repository.dart';
 import '../repository/resource_downloader.dart';
 import '../repository/resources_repository.dart';
 import '../repository/shelf_repository.dart';
+import '../repository/shelf_sync_repository.dart';
 import '../repository/myplanet_activities_uploader.dart';
 import '../repository/user_repository.dart';
 import '../repository/voices_repository.dart';
@@ -143,7 +144,10 @@ final teamTaskDaoProvider = Provider<TeamTaskDao>(
   (ref) => ref.watch(appDatabaseProvider).teamTaskDao,
 );
 final teamTasksRepositoryProvider = Provider<TeamTasksRepository>(
-  (ref) => TeamTasksRepository(ref.watch(teamTaskDaoProvider)),
+  (ref) => TeamTasksRepository(
+    ref.watch(planetApiProvider),
+    ref.watch(teamTaskDaoProvider),
+  ),
 );
 final teamTasksUploaderProvider = Provider<TeamTasksUploader>(
   (ref) => TeamTasksUploader(
@@ -205,7 +209,10 @@ final userChallengeActionDaoProvider = Provider<UserChallengeActionDao>(
 );
 
 final achievementsRepositoryProvider = Provider<AchievementsRepository>(
-  (ref) => AchievementsRepository(ref.watch(achievementDaoProvider)),
+  (ref) => AchievementsRepository(
+    ref.watch(planetApiProvider),
+    ref.watch(achievementDaoProvider),
+  ),
 );
 
 final achievementsUploaderProvider = Provider<AchievementsUploader>(
@@ -551,7 +558,10 @@ final personalsRepositoryProvider = Provider<PersonalsRepository>(
 );
 
 final ratingsRepositoryProvider = Provider<RatingsRepository>(
-  (ref) => RatingsRepository(ref.watch(ratingDaoProvider)),
+  (ref) => RatingsRepository(
+    ref.watch(planetApiProvider),
+    ref.watch(ratingDaoProvider),
+  ),
 );
 
 final coursesRepositoryProvider = Provider<CoursesRepository>(
@@ -647,6 +657,19 @@ final outboxDrainerProvider = Provider<OutboxDrainer>((ref) {
 /// Number of writes waiting to reach the server, for the UI to surface.
 final pendingUploadCountProvider = StreamProvider<int>(
   (ref) => ref.watch(outboxRepositoryProvider).watchPendingCount(),
+);
+
+/// The sync-in half of the shelf, added in Phase 119. Separate from
+/// [shelfRepositoryProvider] — and from `shelf_repository.dart` — because the
+/// pull needs the resource and course mappers, which import the shelf file for
+/// its `coursesType`/`resourcesType` constants.
+final shelfSyncRepositoryProvider = Provider<ShelfSyncRepository>(
+  (ref) => ShelfSyncRepository(
+    ref.watch(planetApiProvider),
+    ref.watch(myLibraryDaoProvider),
+    ref.watch(courseDaoProvider),
+    ref.watch(userDaoProvider),
+  ),
 );
 
 final shelfRepositoryProvider = Provider<ShelfRepository>(

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -12,9 +12,20 @@ import 'notifications_provider.dart';
 import 'resources_providers.dart';
 import 'surveys_provider.dart';
 import 'sync_state.dart';
+import 'sync_walk_providers.dart';
 import 'teams_provider.dart';
 import 'voices_provider.dart';
 
+/// The order is the order [DashboardSyncNotifier.syncAll] runs them in, and two
+/// positions are load-bearing, matching `SyncManager.startFullSync`:
+///
+/// * [tabletUsers] before [shelf], because a shelf document is keyed by its
+///   owner's CouchDB id and the stamp has to be resolved to the local `users`
+///   row that carries it.
+/// * [shelf] last, because it augments `my_library` and `courses` rows that
+///   [resources] and [courses] write — and prune — earlier in the same pass.
+///   Kotlin runs it as phase 3, after the whole parallel set and the resources
+///   pull, for the same reason.
 enum DashboardSyncArea {
   resources,
   courses,
@@ -27,6 +38,11 @@ enum DashboardSyncArea {
   health,
   activities,
   notifications,
+  tabletUsers,
+  ratings,
+  tasks,
+  achievements,
+  shelf,
 }
 
 enum DashboardSyncStatus { waiting, running, succeeded, failed }
@@ -254,6 +270,15 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
         ref.read(activitiesSyncProvider.notifier).sync(),
       DashboardSyncArea.notifications =>
         ref.read(notificationsSyncProvider.notifier).sync(),
+      DashboardSyncArea.tabletUsers =>
+        ref.read(tabletUsersSyncProvider.notifier).sync(),
+      DashboardSyncArea.ratings =>
+        ref.read(ratingsSyncProvider.notifier).sync(),
+      DashboardSyncArea.tasks =>
+        ref.read(teamTasksSyncProvider.notifier).sync(),
+      DashboardSyncArea.achievements =>
+        ref.read(achievementsSyncProvider.notifier).sync(),
+      DashboardSyncArea.shelf => ref.read(shelfSyncProvider.notifier).sync(),
     };
 
     final result = switch (area) {
@@ -268,6 +293,11 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
       DashboardSyncArea.health => ref.read(healthSyncProvider),
       DashboardSyncArea.activities => ref.read(activitiesSyncProvider),
       DashboardSyncArea.notifications => ref.read(notificationsSyncProvider),
+      DashboardSyncArea.tabletUsers => ref.read(tabletUsersSyncProvider),
+      DashboardSyncArea.ratings => ref.read(ratingsSyncProvider),
+      DashboardSyncArea.tasks => ref.read(teamTasksSyncProvider),
+      DashboardSyncArea.achievements => ref.read(achievementsSyncProvider),
+      DashboardSyncArea.shelf => ref.read(shelfSyncProvider),
     };
 
     _replace(

--- a/flutter/lib/providers/sync_walk_providers.dart
+++ b/flutter/lib/providers/sync_walk_providers.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/sync/sync_result.dart';
+import 'app_providers.dart';
+import 'sync_state.dart';
+
+/// The five sync-in walks Phase 116 found missing and Phase 119 added.
+///
+/// Each is an arm of `TransactionSyncManager.syncDb` or, for the shelf, phase 3
+/// of `services/sync/SyncManager.kt`. They live together rather than in their
+/// domain provider files because what they have in common — that the port ran
+/// without them, so every screen reading their tables was dead — is more useful
+/// to a reader than their individual domains.
+
+/// `TransactionSyncManager.syncDb("tablet_users")` — the planet's accounts.
+///
+/// Feeds member detail, the team leaderboard and every place a team member's
+/// name is rendered. Runs before [shelfSyncProvider] so a shelf keyed by a
+/// CouchDB id can be resolved to the local row that carries it.
+class TabletUsersSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncResult> runSync(config, void Function(SyncProgress) onProgress) =>
+      ref
+          .read(userRepositoryProvider)
+          .syncTabletUsers(config: config, onProgress: onProgress);
+}
+
+final tabletUsersSyncProvider =
+    NotifierProvider<TabletUsersSyncNotifier, SyncUiState>(
+      TabletUsersSyncNotifier.new,
+    );
+
+/// `TransactionSyncManager.syncDb("ratings")` — community ratings.
+class RatingsSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncResult> runSync(config, void Function(SyncProgress) onProgress) =>
+      ref
+          .read(ratingsRepositoryProvider)
+          .sync(config: config, onProgress: onProgress);
+}
+
+final ratingsSyncProvider = NotifierProvider<RatingsSyncNotifier, SyncUiState>(
+  RatingsSyncNotifier.new,
+);
+
+/// `TransactionSyncManager.syncDb("tasks")` — team tasks.
+class TeamTasksSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncResult> runSync(config, void Function(SyncProgress) onProgress) =>
+      ref
+          .read(teamTasksRepositoryProvider)
+          .sync(config: config, onProgress: onProgress);
+}
+
+final teamTasksSyncProvider =
+    NotifierProvider<TeamTasksSyncNotifier, SyncUiState>(
+      TeamTasksSyncNotifier.new,
+    );
+
+/// `TransactionSyncManager.syncDb("achievements")`, plus the CV attachments the
+/// same page downloads.
+class AchievementsSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncResult> runSync(config, void Function(SyncProgress) onProgress) =>
+      ref
+          .read(achievementsRepositoryProvider)
+          .sync(config: config, onProgress: onProgress);
+}
+
+final achievementsSyncProvider =
+    NotifierProvider<AchievementsSyncNotifier, SyncUiState>(
+      AchievementsSyncNotifier.new,
+    );
+
+/// Phase 3 of `SyncManager.startFullSync` — the shelf pass.
+///
+/// Runs last, as it does in the Kotlin: it augments the `my_library` and
+/// `courses` rows the resources and courses walks have already written, so
+/// running it first would stamp membership onto rows that a later
+/// `deleteNotIn` could still remove.
+class ShelfSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncResult> runSync(config, void Function(SyncProgress) onProgress) =>
+      ref
+          .read(shelfSyncRepositoryProvider)
+          .sync(config: config, onProgress: onProgress);
+}
+
+final shelfSyncProvider = NotifierProvider<ShelfSyncNotifier, SyncUiState>(
+  ShelfSyncNotifier.new,
+);

--- a/flutter/lib/repository/achievements_repository.dart
+++ b/flutter/lib/repository/achievements_repository.dart
@@ -7,6 +7,7 @@ import '../core/files/achievement_files.dart';
 import '../core/network/network_result.dart';
 import '../core/sync/sync_result.dart';
 import '../core/sync/table_walk.dart';
+import '../core/utils/json_utils.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
@@ -142,6 +143,16 @@ class AchievementsRepository {
         couchId: const Value(''),
         rev: const Value(''),
         resumeFileName: const Value(''),
+        // `Achievement()` starts `isUpdated = false`, and `uploaded` is the
+        // port's inverted name for it — so the placeholder must be `true`.
+        // The column's default is `false`, the wrong way round, and leaving it
+        // there made a blank row indistinguishable from an edit the user has
+        // not uploaded: the sync-in skipped the server's real ledger to
+        // "preserve" it, permanently (nothing ever sets `uploaded`), and then
+        // handed the blank row a `_rev` so the next save PUT it over the real
+        // one. Opening the achievements screen once was enough to trigger it,
+        // because `achievementEntryProvider` calls this on watch.
+        uploaded: const Value(true),
       ),
     );
     return _dao.getById(id);
@@ -182,7 +193,8 @@ class AchievementsRepository {
     if (docs.isEmpty) return 0;
     final ids = <String>[
       for (final doc in docs)
-        if (doc['_id'] case final String id when id.isNotEmpty) id,
+        if (JsonUtils.getString('_id', doc) case final id when id.isNotEmpty)
+          id,
     ];
     final pending = {
       for (final row in await _dao.getByIds(ids))
@@ -192,50 +204,59 @@ class AchievementsRepository {
     final rows = <AchievementsCompanion>[];
     final identityPatches = <(String, String)>[];
     for (final doc in docs) {
-      final id = doc['_id'];
-      if (id is! String || id.startsWith('_design')) continue;
+      final id = JsonUtils.getString('_id', doc);
+      if (id.isEmpty || id.startsWith('_design')) continue;
       // A ledger the user has edited but not yet uploaded takes only the
       // `_rev`. The Kotlin overwrites the whole row and clears `isUpdated`,
-      // which discards the edit *and* stops it uploading; and since the port's
-      // rows carry no `_rev` until a walk supplies one, the `_rev` is exactly
-      // what the pending upload needs to stop 409-ing into the outbox's
-      // permanent-failure branch. Same shape as the read state Phase 98 had to
-      // preserve.
+      // which discards the edit; and since the port's rows carry no `_rev`
+      // until a walk supplies one, the `_rev` is what a later save needs to be
+      // a PUT rather than a 409-ing POST. Same shape as the read state Phase 98
+      // had to preserve.
       if (pending.contains(id)) {
-        identityPatches.add((id, doc['_rev'] as String? ?? ''));
+        identityPatches.add((id, JsonUtils.getString('_rev', doc)));
         continue;
       }
       rows.add(
         AchievementsCompanion(
           id: Value(id),
           couchId: Value(id),
-          rev: Value(doc['_rev'] as String? ?? ''),
-          purpose: Value(doc['purpose'] as String? ?? ''),
-          goals: Value(doc['goals'] as String? ?? ''),
-          achievementsHeader: Value(doc['achievementsHeader'] as String? ?? ''),
-          sendToNation: Value(
-            doc['sendToNation'] is bool
-                ? doc['sendToNation'] as bool
-                : doc['sendToNation'] == 'true',
+          rev: Value(JsonUtils.getString('_rev', doc)),
+          purpose: Value(JsonUtils.getString('purpose', doc)),
+          goals: Value(JsonUtils.getString('goals', doc)),
+          achievementsHeader: Value(
+            JsonUtils.getString('achievementsHeader', doc),
           ),
-          dateSortOrder: Value(doc['dateSortOrder'] as String? ?? 'none'),
-          createdOn: Value(doc['createdOn'] as String? ?? ''),
-          username: Value(doc['username'] as String? ?? ''),
-          parentCode: Value(doc['parentCode'] as String? ?? ''),
+          sendToNation: Value(JsonUtils.getBool('sendToNation', doc)),
+          dateSortOrder: Value(_orDefault(doc, 'dateSortOrder', 'none')),
+          createdOn: Value(JsonUtils.getString('createdOn', doc)),
+          username: Value(JsonUtils.getString('username', doc)),
+          parentCode: Value(JsonUtils.getString('parentCode', doc)),
           achievementsJson: Value(jsonEncode(doc['achievements'] ?? [])),
           referencesJson: Value(jsonEncode(doc['references'] ?? [])),
           linksJson: Value(jsonEncode(doc['links'] ?? [])),
           otherInfoJson: Value(jsonEncode(doc['otherInfo'] ?? [])),
-          resumeFileName: Value(doc['resumeFileName'] as String? ?? ''),
+          resumeFileName: Value(JsonUtils.getString('resumeFileName', doc)),
           uploaded: const Value(true),
         ),
       );
     }
+
     await _dao.insertDocs(rows);
     for (final (id, rev) in identityPatches) {
       await _dao.recordServerRev(id, rev);
     }
     return rows.length + identityPatches.length;
+  }
+
+  /// `JsonUtils.getString` with a fallback for a key the document omits, where
+  /// the empty string is not the value the column should hold.
+  static String _orDefault(
+    Map<String, dynamic> doc,
+    String key,
+    String fallback,
+  ) {
+    final value = JsonUtils.getString(key, doc);
+    return value.isEmpty ? fallback : value;
   }
 
   /// Port of the `"achievements"` arm of `TransactionSyncManager.syncDb`
@@ -284,12 +305,10 @@ class AchievementsRepository {
   }) async {
     final started = <String>{};
     for (final doc in docs) {
-      final docId = doc['_id'];
-      if (docId is! String || docId.isEmpty || docId.startsWith('_design')) {
-        continue;
-      }
-      final resumeFileName = doc['resumeFileName'];
-      if (resumeFileName is! String || resumeFileName.isEmpty) continue;
+      final docId = JsonUtils.getString('_id', doc);
+      if (docId.isEmpty || docId.startsWith('_design')) continue;
+      final resumeFileName = JsonUtils.getString('resumeFileName', doc);
+      if (resumeFileName.isEmpty) continue;
       final attachments = doc['_attachments'];
       if (attachments is! Map || !attachments.containsKey('resume.pdf')) {
         continue;

--- a/flutter/lib/repository/achievements_repository.dart
+++ b/flutter/lib/repository/achievements_repository.dart
@@ -2,6 +2,13 @@ import 'dart:convert';
 
 import 'package:drift/drift.dart';
 
+import '../core/config/server_config.dart';
+import '../core/files/achievement_files.dart';
+import '../core/network/network_result.dart';
+import '../core/sync/sync_result.dart';
+import '../core/sync/table_walk.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 
 /// The editable state carried by one update of the achievements ledger.
@@ -42,8 +49,13 @@ class AchievementInput {
 /// JSON columns and the parsed lists is a plain helper here (the Kotlin puts
 /// it on `Achievement` and on Room's `Converters`).
 class AchievementsRepository {
-  AchievementsRepository(this._dao);
+  AchievementsRepository(this._api, this._dao);
 
+  /// `TransactionSyncManager.syncDb`'s default page size, which `achievements`
+  /// takes.
+  static const int initialBatchSize = 100;
+
+  final PlanetApi _api;
   final AchievementDao _dao;
 
   /// Port of the `"${user.id}@${user.planetCode}"` derivation both screens
@@ -167,10 +179,32 @@ class AchievementsRepository {
   /// and upserts the rest; the `isUpdated = false` reset matches the port's
   /// `uploaded = true` for sync-in rows.
   Future<int> syncAchievements(List<Map<String, dynamic>> docs) async {
+    if (docs.isEmpty) return 0;
+    final ids = <String>[
+      for (final doc in docs)
+        if (doc['_id'] case final String id when id.isNotEmpty) id,
+    ];
+    final pending = {
+      for (final row in await _dao.getByIds(ids))
+        if (!row.uploaded) row.id,
+    };
+
     final rows = <AchievementsCompanion>[];
+    final identityPatches = <(String, String)>[];
     for (final doc in docs) {
       final id = doc['_id'];
       if (id is! String || id.startsWith('_design')) continue;
+      // A ledger the user has edited but not yet uploaded takes only the
+      // `_rev`. The Kotlin overwrites the whole row and clears `isUpdated`,
+      // which discards the edit *and* stops it uploading; and since the port's
+      // rows carry no `_rev` until a walk supplies one, the `_rev` is exactly
+      // what the pending upload needs to stop 409-ing into the outbox's
+      // permanent-failure branch. Same shape as the read state Phase 98 had to
+      // preserve.
+      if (pending.contains(id)) {
+        identityPatches.add((id, doc['_rev'] as String? ?? ''));
+        continue;
+      }
       rows.add(
         AchievementsCompanion(
           id: Value(id),
@@ -198,7 +232,82 @@ class AchievementsRepository {
       );
     }
     await _dao.insertDocs(rows);
-    return rows.length;
+    for (final (id, rev) in identityPatches) {
+      await _dao.recordServerRev(id, rev);
+    }
+    return rows.length + identityPatches.length;
+  }
+
+  /// Port of the `"achievements"` arm of `TransactionSyncManager.syncDb`
+  /// (`:260-262`) together with `downloadCvAttachmentsFromBatch` (`:366-383`),
+  /// which the Kotlin runs immediately after each page.
+  ///
+  /// Phase 116 found [syncAchievements] written and never called: a second
+  /// device showed a blank ledger, and saving there POSTed a document with no
+  /// `_rev`, which CouchDB answers 409 — a status `OutboxDrainer` classifies as
+  /// permanent, so the row was abandoned with no snackbar and no log. Both ends
+  /// close together; adding only the upload would have made it worse.
+  ///
+  /// **Never prunes.** The Kotlin issues no delete, and `achievements` is a
+  /// preserved local-authority table whose rows are keyed by a derived
+  /// `"<userId>@<planetCode>"` that exists locally before it exists on the
+  /// server.
+  Future<SyncResult> sync({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) => walkAllDocs(
+    api: _api,
+    config: config,
+    table: 'achievements',
+    initialBatchSize: initialBatchSize,
+    onProgress: onProgress,
+    insert: (docs) async {
+      final saved = await syncAchievements(docs);
+      await downloadCvAttachments(docs, config: config);
+      return saved;
+    },
+  );
+
+  /// Port of `TransactionSyncManager.downloadCvAttachmentsFromBatch`.
+  ///
+  /// Downloads `achievements/<docId>/resume.pdf` for every document that both
+  /// names a `resumeFileName` and actually carries the attachment, skipping
+  /// anything already on disk (`!destFile.exists()`) and de-duplicating within
+  /// the page (`inProgress.add(resumeFileName)`) — two documents can name the
+  /// same file.
+  ///
+  /// Best-effort throughout, like the Kotlin's `catch (_: Exception) { }`: a CV
+  /// that fails to download must not fail the walk that carried the ledger.
+  Future<void> downloadCvAttachments(
+    List<Map<String, dynamic>> docs, {
+    required ServerConfig config,
+  }) async {
+    final started = <String>{};
+    for (final doc in docs) {
+      final docId = doc['_id'];
+      if (docId is! String || docId.isEmpty || docId.startsWith('_design')) {
+        continue;
+      }
+      final resumeFileName = doc['resumeFileName'];
+      if (resumeFileName is! String || resumeFileName.isEmpty) continue;
+      final attachments = doc['_attachments'];
+      if (attachments is! Map || !attachments.containsKey('resume.pdf')) {
+        continue;
+      }
+      if (!started.add(resumeFileName)) continue;
+      if (await AchievementFiles.hasResume(resumeFileName)) continue;
+
+      final result = await _api.getBytes(
+        '${UrlUtils.dbUrl(config)}/achievements/$docId/resume.pdf',
+        authHeader: UrlUtils.authHeader(config),
+      );
+      if (result is NetworkSuccess<List<int>> && result.data.isNotEmpty) {
+        await AchievementFiles.write(
+          resumeFileName: resumeFileName,
+          bytes: result.data,
+        );
+      }
+    }
   }
 
   /// Port of `UserRepositoryImpl.getAchievementsForUpload`.

--- a/flutter/lib/repository/ratings_repository.dart
+++ b/flutter/lib/repository/ratings_repository.dart
@@ -24,7 +24,8 @@ class RatingSummary {
 class RatingsRepository {
   RatingsRepository(
     this._api,
-    this._dao, {
+    this._dao,
+    this._userDao, {
     DateTime Function()? now,
     String Function()? createId,
   }) : _now = now ?? DateTime.now,
@@ -37,6 +38,11 @@ class RatingsRepository {
 
   final PlanetApi _api;
   final RatingDao _dao;
+
+  /// Only for the sync-in: a rating document names its rater by CouchDB id,
+  /// while every reader of this table passes `session.user.id`. See
+  /// [_localUserIds].
+  final UserDao _userDao;
   final DateTime Function() _now;
   final String Function() _createId;
 
@@ -183,6 +189,7 @@ class RatingsRepository {
       for (final row in await _dao.unsyncedLocalRatings())
         _ratingKey(row.type, row.item, row.userId): row,
     };
+    final localUserIds = await _localUserIds(docs);
 
     final companions = <RatingsCompanion>[];
     final identityPatches = <(String, String, String?)>[];
@@ -190,12 +197,18 @@ class RatingsRepository {
       final couchId = JsonUtils.getString('_id', doc);
       if (couchId.isEmpty) continue;
       final user = JsonUtils.getObject('user', doc) ?? const {};
-      final userId = JsonUtils.getString('_id', user);
+      final raterId = JsonUtils.getString('_id', user);
+      final userId = localUserIds[raterId] ?? raterId;
       final type = JsonUtils.getString('type', doc);
       final item = JsonUtils.getString('item', doc);
 
-      final existing =
-          byId[couchId] ?? unsyncedByRatingKey[_ratingKey(type, item, userId)];
+      final ratingKey = _ratingKey(type, item, userId);
+      final existing = byId[couchId] ?? unsyncedByRatingKey[ratingKey];
+      // Consumed, so a second document for the same (type, item, user) does
+      // not collapse onto the same row: it takes the CouchDB id as its key and
+      // both survive, which is what the Kotlin stores and what the average
+      // has to count.
+      if (byId[couchId] == null) unsyncedByRatingKey.remove(ratingKey);
       final rowId = existing?.id ?? couchId;
 
       if (existing != null && existing.isUpdated) {
@@ -235,6 +248,38 @@ class RatingsRepository {
       await _dao.recordServerIdentity(id, couchId, rev);
     }
     return companions.length + identityPatches.length;
+  }
+
+  /// Maps each rater's CouchDB id to the local `users` row id, for the raters
+  /// this page names.
+  ///
+  /// `insertRatingsFromSync` reads `userId` out of the embedded `user` object,
+  /// which is a CouchDB id; `submitRating` writes `user.id`, the local row id,
+  /// and every reader passes `session.user.id`. The two are the same string
+  /// for an account that first appeared server-side and **different** for a
+  /// member registered on this device, whose row keeps a locally-minted id
+  /// until its upload lands. Storing the raw id for such a member hides their
+  /// own rating from `userRating` and defeats the `(type, item, userId)` match
+  /// that stops the walk duplicating it — the same identity rule the shelf
+  /// walk follows.
+  Future<Map<String, String>> _localUserIds(
+    List<Map<String, dynamic>> docs,
+  ) async {
+    final raterIds = <String>{
+      for (final doc in docs)
+        if (JsonUtils.getObject('user', doc) case final user?)
+          if (JsonUtils.getString('_id', user) case final id when id.isNotEmpty)
+            id,
+    };
+    if (raterIds.isEmpty) return const {};
+    final rows = await _userDao.getByAnyIds(raterIds.toList(growable: false));
+    return {
+      for (final row in rows)
+        if (row.couchId case final couchId?)
+          if (raterIds.contains(couchId)) couchId: row.id,
+      for (final row in rows)
+        if (raterIds.contains(row.id)) row.id: row.id,
+    };
   }
 
   static String _ratingKey(String type, String item, String userId) =>

--- a/flutter/lib/repository/ratings_repository.dart
+++ b/flutter/lib/repository/ratings_repository.dart
@@ -1,5 +1,10 @@
 import 'package:drift/drift.dart';
 
+import '../core/config/server_config.dart';
+import '../core/sync/sync_result.dart';
+import '../core/sync/table_walk.dart';
+import '../core/utils/json_utils.dart';
+import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 
 class RatingSummary {
@@ -18,12 +23,19 @@ class RatingSummary {
 /// Offline-first portion of `repository/RatingsRepositoryImpl.kt`.
 class RatingsRepository {
   RatingsRepository(
+    this._api,
     this._dao, {
     DateTime Function()? now,
     String Function()? createId,
   }) : _now = now ?? DateTime.now,
        _createId = createId ?? _defaultId;
 
+  /// `TransactionSyncManager.syncDb` gives `ratings` a page size of 20 — the
+  /// smallest of any table, because a rating document embeds the rater's whole
+  /// `_users` document. The port keeps the number.
+  static const int initialBatchSize = 20;
+
+  final PlanetApi _api;
   final RatingDao _dao;
   final DateTime Function() _now;
   final String Function() _createId;
@@ -99,6 +111,134 @@ class RatingsRepository {
       ),
     );
   }
+
+  /// Port of the `"ratings"` arm of `TransactionSyncManager.syncDb`
+  /// (`:242-244`), which `HeavyTableSyncWorker` runs after a full sync
+  /// (`HeavyTableSyncWorker.ALL_HEAVY_TABLES`).
+  ///
+  /// The port has no background heavy-table worker, so this runs as an area of
+  /// the sync centre instead. Without it the only writer of the table is the
+  /// local [submit], whose one caller always passes the signed-in user — so
+  /// the read predicate (`type = ? AND item = ?`, deliberately unscoped by
+  /// user, because it computes a community average) could only ever see this
+  /// device's own rating, and every "average" was a single number the user had
+  /// typed themselves.
+  ///
+  /// **Never prunes.** The Kotlin's walk issues no delete, and a prune here
+  /// would destroy the user's own unsent ratings: a rating submitted on this
+  /// device is keyed by a locally-minted id that appears in no `_all_docs`
+  /// keep set until it has been uploaded *and* pulled back.
+  Future<SyncResult> sync({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) => walkAllDocs(
+    api: _api,
+    config: config,
+    table: 'ratings',
+    initialBatchSize: initialBatchSize,
+    onProgress: onProgress,
+    insert: insertRatingsFromSync,
+  );
+
+  /// Port of `RatingsRepositoryImpl.insertRatingsFromSync`
+  /// (`RatingsRepositoryImpl.kt:95-134`).
+  ///
+  /// Two divergences, both deliberate:
+  ///
+  /// * **A document is reconciled with the local row it is about**, rather than
+  ///   always keying the row by the CouchDB `_id` as `Rating().apply { id =
+  ///   _id }` does. A rating submitted here keeps its locally-minted id for
+  ///   life — `markRatingUploaded` only clears the dirty flag, it never
+  ///   records the server id — so the Kotlin ends up holding *two* rows for
+  ///   one rating as soon as the walk pulls it back, and `getRatingSummary`
+  ///   averages over both. Matching on `(type, item, userId)` for a row that
+  ///   has no CouchDB id yet keeps it to one row, and hands that row the
+  ///   `_rev` its next upload needs to be a PUT rather than a second POST.
+  /// * **A pending local edit wins.** When the matched row is still flagged
+  ///   `isUpdated`, only the identity columns are taken from the document; the
+  ///   rate, comment and timestamp the user has just entered stay, and so does
+  ///   the flag that makes them upload. The Kotlin overwrites them and clears
+  ///   the flag, which silently discards a rating made offline — the same
+  ///   shape as the read state Phase 98 had to preserve and the reactions
+  ///   Phase 74 did.
+  ///
+  /// The document's `createdOn` and its embedded `user` object are dropped:
+  /// neither has a column on this table, and neither is read by any port
+  /// screen or by `RatingsUploader`.
+  Future<int> insertRatingsFromSync(List<Map<String, dynamic>> docs) async {
+    if (docs.isEmpty) return 0;
+
+    final ids = <String>[
+      for (final doc in docs)
+        if (JsonUtils.getString('_id', doc) case final id when id.isNotEmpty)
+          id,
+    ];
+    final byId = <String, RatingRow>{};
+    for (final row in await _dao.getByCouchIds(ids)) {
+      byId[row.id] = row;
+      final couchId = row.couchId;
+      if (couchId != null && couchId.isNotEmpty) byId[couchId] = row;
+    }
+    final unsyncedByRatingKey = <String, RatingRow>{
+      for (final row in await _dao.unsyncedLocalRatings())
+        _ratingKey(row.type, row.item, row.userId): row,
+    };
+
+    final companions = <RatingsCompanion>[];
+    final identityPatches = <(String, String, String?)>[];
+    for (final doc in docs) {
+      final couchId = JsonUtils.getString('_id', doc);
+      if (couchId.isEmpty) continue;
+      final user = JsonUtils.getObject('user', doc) ?? const {};
+      final userId = JsonUtils.getString('_id', user);
+      final type = JsonUtils.getString('type', doc);
+      final item = JsonUtils.getString('item', doc);
+
+      final existing =
+          byId[couchId] ?? unsyncedByRatingKey[_ratingKey(type, item, userId)];
+      final rowId = existing?.id ?? couchId;
+
+      if (existing != null && existing.isUpdated) {
+        // An UPDATE, not a partial companion through the upsert: Drift
+        // validates an upsert's companion against the *insert* path, so one
+        // that omits the required columns is rejected even though the row
+        // already exists.
+        identityPatches.add((
+          rowId,
+          couchId,
+          JsonUtils.getStringOrNull('_rev', doc),
+        ));
+        continue;
+      }
+
+      companions.add(
+        RatingsCompanion(
+          id: Value(rowId),
+          couchId: Value(couchId),
+          rev: Value(JsonUtils.getStringOrNull('_rev', doc)),
+          time: Value(JsonUtils.getLong('time', doc)),
+          title: Value(JsonUtils.getStringOrNull('title', doc)),
+          type: Value(type),
+          item: Value(item),
+          rate: Value(JsonUtils.getInt('rate', doc)),
+          comment: Value(JsonUtils.getStringOrNull('comment', doc)),
+          userId: Value(userId),
+          parentCode: Value(JsonUtils.getStringOrNull('parentCode', doc)),
+          planetCode: Value(JsonUtils.getStringOrNull('planetCode', doc)),
+          isUpdated: const Value(false),
+        ),
+      );
+    }
+
+    await _dao.upsertAll(companions);
+    for (final (id, couchId, rev) in identityPatches) {
+      await _dao.recordServerIdentity(id, couchId, rev);
+    }
+    return companions.length + identityPatches.length;
+  }
+
+  static String _ratingKey(String type, String item, String userId) =>
+      '$type\u0000$item\u0000$userId';
 
   Future<List<RatingRow>> pendingUploads() => _dao.pendingUploads();
   Future<int> markUploaded(String id) => _dao.markUploaded(id);

--- a/flutter/lib/repository/shelf_sync_repository.dart
+++ b/flutter/lib/repository/shelf_sync_repository.dart
@@ -1,0 +1,326 @@
+import '../core/config/server_config.dart';
+import '../core/network/network_result.dart';
+import '../core/sync/sync_result.dart';
+import '../core/sync/table_walk.dart';
+import '../core/utils/json_utils.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
+import '../data/local/app_database.dart';
+import '../data/local/course_mapper.dart';
+import '../data/local/my_library_mapper.dart';
+
+/// Port of phase 3 of `services/sync/SyncManager.kt` — `myLibraryTransactionSync`
+/// → `getShelvesWithDataBatchOptimized` → `SyncRepositoryImpl.processShelfParallel`
+/// → `processShelfDataOptimizedSync`.
+///
+/// A `shelf` document is one user's library: `resourceIds`, `courseIds`,
+/// `meetupIds`, `myTeamIds`. The walk fetches every shelf, keeps the ones that
+/// list anything, and stamps the shelf's owner onto each listed resource and
+/// course — `my_library.userId` and `courses.userId`, which every "my" view in
+/// the app reads with `LIKE '%"<uid>"%'`.
+///
+/// **This is the walk whose absence made those views dead.** Phase 116's D1/D2:
+/// with no shelf pull, `my_library.userId` and `courses.userId` could only ever
+/// hold what a tap on this device had put there, so a shelf built on Planet web
+/// or on another handset never arrived, and `CoursesRepository.sync`'s
+/// `shelfId` parameter — threaded end to end — had no production caller.
+///
+/// **Two deliberate narrowings from the Kotlin**, both recorded in
+/// `PHASE_119_NOTES.md`:
+///
+/// * Only the `resources` and `courses` arms of `Constants.shelfDataList` are
+///   walked. The `meetups` and `teams` arms call `batchInsertMeetups(docs)` and
+///   `batchInsertMyTeams(docs)` — neither takes the shelf id, so neither
+///   records membership; they re-insert documents that the port's own `meetups`
+///   and `teams` walks have already pulled in full during the same pass, from
+///   the same databases. There is nothing for them to add.
+/// * The courses arm writes the course row and its steps but not the exams and
+///   surveys embedded in the same document, where `upsertRoomCoursesFromSync`
+///   writes all four. The `courses` walk runs earlier in the same pass over the
+///   same documents and owns those two tables, including the step-join release
+///   whose churn Phase 113 had to fix; a second writer of them adds nothing and
+///   risks that.
+///
+/// **Never prunes.** Kotlin's shelf pass issues no delete, and it must not: the
+/// stamp is a union (`MyLibrary.setUserId`, `MyCourse.setUserId`), so syncing
+/// one user's shelf leaves another's membership on the same row intact.
+class ShelfSyncRepository {
+  ShelfSyncRepository(
+    this._api,
+    this._libraryDao,
+    this._courseDao,
+    this._userDao,
+  );
+
+  /// `getShelvesWithDataBatchOptimized` checks shelves 25 at a time.
+  static const int shelfProbeBatchSize = 25;
+
+  /// `processShelfDataOptimizedSync` seeds its `AdaptiveBatchProcessor` at 50.
+  static const int itemBatchSize = 50;
+
+  final PlanetApi _api;
+  final MyLibraryDao _libraryDao;
+  final CourseDao _courseDao;
+  final UserDao _userDao;
+
+  Future<SyncResult> sync({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) async {
+    final dbUrl = UrlUtils.dbUrl(config);
+    final authHeader = UrlUtils.authHeader(config);
+
+    final listing = await _api.getJsonObject(
+      '$dbUrl/shelf/_all_docs',
+      authHeader: authHeader,
+    );
+    if (listing is! NetworkSuccess<Map<String, dynamic>>) {
+      return SyncFailed(describeNetworkFailure(listing));
+    }
+
+    final shelfIds = <String>[
+      for (final row in (listing.data['rows'] as List? ?? const []))
+        if (row is Map<String, dynamic>)
+          if (JsonUtils.getString('id', row) case final id
+              when id.isNotEmpty && !id.startsWith('_design'))
+            id,
+    ];
+    if (shelfIds.isEmpty) {
+      onProgress?.call(const SyncProgress(completed: 0, total: 0));
+      return const SyncComplete(0);
+    }
+
+    final shelvesWithData = <Map<String, dynamic>>[];
+    for (final chunk in _chunks(shelfIds, shelfProbeBatchSize)) {
+      final page = await _keysPage(
+        url: '$dbUrl/shelf/_all_docs?include_docs=true',
+        authHeader: authHeader,
+        keys: chunk,
+      );
+      if (page == null) {
+        return SyncFailed('Could not read the shelf listing from $dbUrl');
+      }
+      for (final doc in page) {
+        if (hasShelfData(doc)) shelvesWithData.add(doc);
+      }
+    }
+
+    if (shelvesWithData.isEmpty) {
+      onProgress?.call(const SyncProgress(completed: 0, total: 0));
+      return const SyncComplete(0);
+    }
+
+    // The Kotlin re-fetches each shelf document in `processShelfParallel`
+    // because its "which shelves have data" answer is cached in preferences for
+    // six hours and the ids in it may be stale by the time it is reused. This
+    // walk has no such cache, so the documents just read are the ones used.
+    var processed = 0;
+    var completed = 0;
+    for (final shelf in shelvesWithData) {
+      final shelfId = await _localUserId(JsonUtils.getString('_id', shelf));
+      processed += await _pullShelfResources(
+        config: config,
+        shelfId: shelfId,
+        ids: JsonUtils.getStringList('resourceIds', shelf),
+      );
+      processed += await _pullShelfCourses(
+        config: config,
+        shelfId: shelfId,
+        ids: JsonUtils.getStringList('courseIds', shelf),
+      );
+      completed++;
+      onProgress?.call(
+        SyncProgress(completed: completed, total: shelvesWithData.length),
+      );
+    }
+
+    return SyncComplete(processed);
+  }
+
+  /// The id the port's shelf readers actually scope by.
+  ///
+  /// A shelf document is keyed by the owner's **CouchDB** id
+  /// (`org.couchdb.user:<name>`) — that is what `shelf/_all_docs` returns — but
+  /// every reader in this app passes `session.user.id`, the local row id:
+  /// `MyLibraryDao.watchResources(shelfUserId:)`, `CourseDao.watchCourses`, the
+  /// home library and course cards, the completed-course stars. For an account
+  /// that first appeared server-side the two are the same string, because
+  /// `UserMapper.fromDoc` keys the row on the document id. For a **member
+  /// registered on this device** they are not: that row keeps its locally
+  /// minted `'<millis>'` id and only gains a `couchId` when the upload lands
+  /// (the identity rule at `user_mapper.dart:26-35`). Stamping the raw shelf id
+  /// for such a member would write a `userId` no reader can match, and My
+  /// Library would stay empty with the walk reporting success.
+  ///
+  /// [UserDao.getById] resolves either column, so the lookup covers both. An
+  /// account this device has never seen falls back to the document id — which
+  /// is what a later `tablet_users` pull will key its row on anyway. That is
+  /// also why the sync centre runs `tablet_users` **before** `shelf`.
+  Future<String> _localUserId(String shelfDocId) async {
+    if (shelfDocId.isEmpty) return shelfDocId;
+    final user = await _userDao.getById(shelfDocId);
+    return user?.id ?? shelfDocId;
+  }
+
+  /// Port of `UserRepositoryImpl.hasShelfDataUltraFast`, key set included.
+  ///
+  /// It reads `teamIds`, while `Constants.shelfDataList` — the list the shelf
+  /// is actually *processed* through — reads `myTeamIds`. The two disagree, and
+  /// the consequence in the Kotlin is that a shelf listing only teams, under
+  /// the key the processing loop uses, is judged to have no data and is skipped
+  /// entirely. The key set is kept verbatim rather than "fixed": this walk does
+  /// not process either team key (see the class comment), so the only effect of
+  /// widening it here would be to spend two requests on a shelf with nothing
+  /// for us in it.
+  static bool hasShelfData(Map<String, dynamic> shelf) {
+    const keys = ['resourceIds', 'courseIds', 'meetupIds', 'teamIds'];
+    for (final key in keys) {
+      final value = shelf[key];
+      if (value is List && value.isNotEmpty) return true;
+    }
+    return false;
+  }
+
+  /// Port of the `"resources"` arm of `processShelfDataOptimizedSync` →
+  /// `ResourcesRepositoryImpl.batchInsertMyLibrary`: the shelf's resource ids
+  /// are fetched 50 at a time with a `keys` POST and written through the same
+  /// mapper the `resources` walk uses, with the shelf's owner added to
+  /// `userId`.
+  ///
+  /// Every list column is passed back as its `existing…` argument. That is not
+  /// optional: [MyLibraryMapper.fromDoc] writes each of them unconditionally,
+  /// so omitting one replaces the stored list with `const []` — the Phase 116
+  /// D1 defect, which emptied My Library on every sync.
+  Future<int> _pullShelfResources({
+    required ServerConfig config,
+    required String shelfId,
+    required List<String> ids,
+  }) async {
+    if (ids.isEmpty) return 0;
+    final dbUrl = UrlUtils.dbUrl(config);
+    final authHeader = UrlUtils.authHeader(config);
+    var saved = 0;
+
+    for (final chunk in _chunks(ids, itemBatchSize)) {
+      final docs = await _keysPage(
+        url: '$dbUrl/resources/_all_docs?include_docs=true',
+        authHeader: authHeader,
+        keys: chunk,
+      );
+      // A failed batch is skipped, as `processShelfDataOptimizedSync` does
+      // (`if (response == null) { recordFailure(); continue }`). Nothing is
+      // pruned here, so a gap costs a missing stamp until the next sync rather
+      // than a deletion.
+      if (docs == null || docs.isEmpty) continue;
+
+      final existingById = {
+        for (final row in await _libraryDao.getByIds([
+          for (final doc in docs) JsonUtils.getString('_id', doc),
+        ]))
+          row.id: row,
+      };
+
+      final companions = <MyLibraryTableCompanion>[];
+      for (final doc in docs) {
+        final existing = existingById[JsonUtils.getString('_id', doc)];
+        final companion = MyLibraryMapper.fromDoc(
+          doc,
+          couchDbUrl: config.couchDbUrl,
+          existingUserIds: existing?.userId ?? const [],
+          existingResourceFor: existing?.resourceFor ?? const [],
+          existingSubject: existing?.subject ?? const [],
+          existingLevel: existing?.level ?? const [],
+          existingTag: existing?.tag ?? const [],
+          existingLanguages: existing?.languages ?? const [],
+          shelfId: shelfId,
+        );
+        if (companion == null) continue;
+        companions.add(companion);
+      }
+
+      if (companions.isNotEmpty) {
+        await _libraryDao.upsertAll(companions);
+        saved += companions.length;
+      }
+    }
+    return saved;
+  }
+
+  /// Port of the `"courses"` arm — `CoursesRepositoryImpl.batchInsertMyCourses`,
+  /// which is `upsertRoomCoursesFromSync(documents, shelfId)`.
+  ///
+  /// The course row and its steps are written exactly as the `courses` walk
+  /// writes them, with the shelf's owner added to `userId`. The embedded exams
+  /// and surveys are **not**: the `courses` walk runs earlier in the same pass
+  /// over the same documents and owns those tables, including the step-join
+  /// release whose churn Phase 113 had to fix, and a second writer of them adds
+  /// nothing.
+  Future<int> _pullShelfCourses({
+    required ServerConfig config,
+    required String shelfId,
+    required List<String> ids,
+  }) async {
+    if (ids.isEmpty) return 0;
+    final dbUrl = UrlUtils.dbUrl(config);
+    final authHeader = UrlUtils.authHeader(config);
+    var saved = 0;
+
+    for (final chunk in _chunks(ids, itemBatchSize)) {
+      final docs = await _keysPage(
+        url: '$dbUrl/courses/_all_docs?include_docs=true',
+        authHeader: authHeader,
+        keys: chunk,
+      );
+      if (docs == null || docs.isEmpty) continue;
+
+      final existingById = {
+        for (final row in await _courseDao.getByIds([
+          for (final doc in docs) JsonUtils.getString('_id', doc),
+        ]))
+          row.id: row,
+      };
+
+      final courseRows = <CoursesCompanion>[];
+      final stepRows = <CourseStepsCompanion>[];
+      for (final doc in docs) {
+        final existing = existingById[JsonUtils.getString('_id', doc)];
+        final parsed = CourseMapper.fromDoc(
+          doc,
+          existingUserIds: existing?.userId ?? const [],
+          shelfId: shelfId,
+        );
+        if (parsed == null) continue;
+        courseRows.add(parsed.course);
+        stepRows.addAll(parsed.steps);
+      }
+
+      if (courseRows.isNotEmpty) {
+        await _courseDao.upsertAll(courseRows, stepRows);
+        saved += courseRows.length;
+      }
+    }
+    return saved;
+  }
+
+  /// One `POST …/_all_docs?include_docs=true` with a `keys` body, returning the
+  /// documents it carried, or `null` when the request failed.
+  Future<List<Map<String, dynamic>>?> _keysPage({
+    required String url,
+    required String? authHeader,
+    required List<String> keys,
+  }) async {
+    final result = await _api.postJsonObject(url, {
+      'keys': keys,
+    }, authHeader: authHeader);
+    if (result is! NetworkSuccess<Map<String, dynamic>>) return null;
+    final rows = result.data['rows'];
+    if (rows is! List) return const [];
+    return extractDocs(rows);
+  }
+
+  static Iterable<List<String>> _chunks(List<String> ids, int size) sync* {
+    for (var i = 0; i < ids.length; i += size) {
+      yield ids.sublist(i, i + size > ids.length ? ids.length : i + size);
+    }
+  }
+}

--- a/flutter/lib/repository/shelf_sync_repository.dart
+++ b/flutter/lib/repository/shelf_sync_repository.dart
@@ -97,9 +97,11 @@ class ShelfSyncRepository {
         authHeader: authHeader,
         keys: chunk,
       );
-      if (page == null) {
-        return SyncFailed('Could not read the shelf listing from $dbUrl');
-      }
+      // A failed probe chunk is skipped, not fatal:
+      // `checkShelfBatchForDataOptimized` returns what it got and the caller
+      // carries on with the shelves that answered. Nothing is pruned here, so
+      // the cost is a shelf whose membership waits for the next sync.
+      if (page == null) continue;
       for (final doc in page) {
         if (hasShelfData(doc)) shelvesWithData.add(doc);
       }

--- a/flutter/lib/repository/team_tasks_repository.dart
+++ b/flutter/lib/repository/team_tasks_repository.dart
@@ -2,12 +2,18 @@ import 'dart:convert';
 
 import 'package:drift/drift.dart';
 
+import '../core/config/server_config.dart';
+import '../core/sync/sync_result.dart';
+import '../core/sync/table_walk.dart';
+import '../core/utils/json_utils.dart';
+import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 
 /// Port of the task CRUD portion of `TeamsRepositoryImpl.kt` and
 /// `TeamTask.serialize`.
 class TeamTasksRepository {
   TeamTasksRepository(
+    this._api,
     this._dao, {
     DateTime Function()? now,
     String Function()? createId,
@@ -15,6 +21,10 @@ class TeamTasksRepository {
        _createId =
            createId ?? (() => 'task-${DateTime.now().microsecondsSinceEpoch}');
 
+  /// `TransactionSyncManager.syncDb`'s default page size, which `tasks` takes.
+  static const int initialBatchSize = 100;
+
+  final PlanetApi _api;
   final TeamTaskDao _dao;
   final DateTime Function() _now;
   final String Function() _createId;
@@ -42,6 +52,120 @@ class TeamTasksRepository {
     final valid = taskIds.where((id) => id.trim().isNotEmpty).toSet().toList();
     if (valid.isEmpty) return;
     await _dao.markNotified(valid);
+  }
+
+  /// Port of the `"tasks"` arm of `TransactionSyncManager.syncDb` (`:254-256`),
+  /// run in phase 1 of every Kotlin sync.
+  ///
+  /// Without it a task created on Planet web, or by a teammate on another
+  /// handset, never arrives — the table only ever held tasks this device
+  /// authored, so the team tasks screen was a private list.
+  ///
+  /// **Never prunes.** The Kotlin issues no delete here, and `team_tasks` is a
+  /// preserved local-authority table: a task created offline lives only in this
+  /// table until the outbox drains, and it carries a locally-minted id that no
+  /// `_all_docs` keep set contains.
+  Future<SyncResult> sync({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) => walkAllDocs(
+    api: _api,
+    config: config,
+    table: 'tasks',
+    initialBatchSize: initialBatchSize,
+    onProgress: onProgress,
+    insert: insertTasksFromSync,
+  );
+
+  /// Port of `TeamsRepositoryImpl.bulkInsertTasksFromSync` + `TeamTask.fromJson`
+  /// (`model/TeamTask.kt:35-54`).
+  ///
+  /// `status` is stored exactly as the document carries it, **including the
+  /// empty string** `fromJson` produces for a document that has none —
+  /// `TeamTask.serialize` emits no `status` field, so that is what a task
+  /// authored by either app actually looks like on the server. The reader is
+  /// `TeamTaskDao.watchForTeam`, which after this phase excludes only
+  /// `'archived'`, matching `TeamTaskDao.getByTeamId`.
+  ///
+  /// `link` and `sync` are dropped: the port has no column for either, and
+  /// [serialize] rebuilds both from `teamId` and the session's planet code the
+  /// way `upsertTask` does for a locally authored row.
+  ///
+  /// Two preservation rules, both about columns the server document cannot
+  /// carry:
+  ///
+  /// * `isNotified` is never written, so a re-pull cannot make the deadline
+  ///   notifier fire a second time for a task the user has already been told
+  ///   about.
+  /// * A row still flagged `isUpdated` takes only the identity columns. Its
+  ///   title, deadline, assignee and completion state are an edit the user made
+  ///   offline that has not reached the server yet; overwriting them with the
+  ///   server's older copy — and clearing the flag, as the Kotlin does — would
+  ///   discard the edit and stop it ever uploading.
+  Future<int> insertTasksFromSync(List<Map<String, dynamic>> docs) async {
+    if (docs.isEmpty) return 0;
+
+    final ids = <String>[
+      for (final doc in docs)
+        if (JsonUtils.getString('_id', doc) case final id when id.isNotEmpty)
+          id,
+    ];
+    final byId = <String, TeamTaskRow>{};
+    for (final row in await _dao.getByAnyIds(ids)) {
+      byId[row.id] = row;
+      final docId = row.docId;
+      if (docId != null && docId.isNotEmpty) byId[docId] = row;
+    }
+
+    final companions = <TeamTasksCompanion>[];
+    final identityPatches = <(String, String, String?)>[];
+
+    for (final doc in docs) {
+      final docId = JsonUtils.getString('_id', doc);
+      if (docId.isEmpty) continue;
+      final existing = byId[docId];
+      final rowId = existing?.id ?? docId;
+
+      if (existing != null && existing.isUpdated) {
+        identityPatches.add((
+          rowId,
+          docId,
+          JsonUtils.getStringOrNull('_rev', doc),
+        ));
+        continue;
+      }
+
+      final link = JsonUtils.getObject('link', doc) ?? const {};
+      final assignee = JsonUtils.getObject('assignee', doc) ?? const {};
+
+      companions.add(
+        TeamTasksCompanion(
+          id: Value(rowId),
+          docId: Value(docId),
+          rev: Value(JsonUtils.getStringOrNull('_rev', doc)),
+          title: Value(JsonUtils.getStringOrNull('title', doc)),
+          description: Value(JsonUtils.getStringOrNull('description', doc)),
+          teamId: Value(JsonUtils.getString('teams', link)),
+          // `if (user.has("_id"))` — an `assignee` serialized as the empty
+          // string for an unassigned task leaves the column alone rather than
+          // writing `""`, which the deadline query would match on.
+          assignee: assignee.containsKey('_id')
+              ? Value(JsonUtils.getStringOrNull('_id', assignee))
+              : const Value.absent(),
+          deadline: Value(JsonUtils.getLong('deadline', doc)),
+          completedTime: Value(JsonUtils.getLong('completedTime', doc)),
+          status: Value(JsonUtils.getString('status', doc)),
+          completed: Value(JsonUtils.getBool('completed', doc)),
+          isUpdated: const Value(false),
+        ),
+      );
+    }
+
+    await _dao.upsertAll(companions);
+    for (final (id, docId, rev) in identityPatches) {
+      await _dao.recordServerIdentity(id, docId, rev);
+    }
+    return companions.length + identityPatches.length;
   }
 
   Future<String?> create({

--- a/flutter/lib/repository/user_repository.dart
+++ b/flutter/lib/repository/user_repository.dart
@@ -176,11 +176,14 @@ class UserRepository {
     return _userDao.getById(companion.id.value);
   }
 
-  /// Page size for the `tablet_users` walk. `TransactionSyncManager.syncDb`
-  /// uses its 1000-document default for this table; the port starts smaller and
-  /// lets `AdaptiveBatchProcessor` grow it, because a `_users` document can
-  /// carry a base64 profile photo in `_attachments` and a thousand of those in
-  /// one response is a large body on a weak link.
+  /// Page size for the `tablet_users` walk, and its ceiling —
+  /// `AdaptiveBatchProcessor` defaults `maxSize` to `initialSize`, so it can
+  /// only shrink from here and recover, never grow past it.
+  ///
+  /// `TransactionSyncManager.syncDb` uses its 1000-document default for this
+  /// table. The port asks for less because a `_users` document can carry a
+  /// base64 profile photo in `_attachments`, and a thousand of those in one
+  /// response is a large body on a weak link.
   static const int tabletUsersBatchSize = 100;
 
   /// Port of the `"tablet_users"` arm of `TransactionSyncManager.syncDb`
@@ -192,10 +195,13 @@ class UserRepository {
   /// team leaderboard silently drops every member it cannot resolve, and the
   /// team member list falls back to rendering `org.couchdb.user:bob`.
   ///
-  /// **Never prunes.** The Kotlin's walk issues no delete of any kind, and it
-  /// could not: this table also holds accounts registered offline that have
-  /// never reached the server, and the session itself is restored by looking
-  /// the signed-in user up here. A `deleteNotIn` would sign the user out.
+  /// **Never prunes.** Neither the Kotlin's walk nor this one deletes a row the
+  /// server no longer lists — the single delete on either path is the guest
+  /// re-key below, which removes a row it has just rewritten under a new key.
+  /// A prune could not be added: this table also holds accounts registered
+  /// offline that have never reached the server, and the session itself is
+  /// restored by looking the signed-in user up here, so a `deleteNotIn` would
+  /// sign the user out.
   Future<SyncResult> syncTabletUsers({
     required ServerConfig config,
     void Function(SyncProgress)? onProgress,
@@ -317,22 +323,61 @@ class UserRepository {
     UsersCompanion mapped,
     UserRow guest,
     String newId,
-  ) => mapped.copyWith(
-    // [UserMapper.fromDoc] keys the companion on `existing.id`, which here
-    // is still `guest_<name>`. The Kotlin assigns `this.id = id` *before*
-    // calling `applyJsonToUser` (`UserRepositoryImpl.kt:1126-1131`), so the
-    // adopted row is written under the server's id and the guest row is
-    // deleted. Leaving the guest key in place would update the guest in
-    // situ and leave the account still unresolvable by its CouchDB id.
-    id: Value(newId),
-    key: Value(guest.key),
-    iv: Value(guest.iv),
-    password: mapped.password.present ? mapped.password : Value(guest.password),
-    userImage: mapped.userImage.present
-        ? mapped.userImage
-        : Value(guest.userImage),
-    isUpdated: Value(guest.isUpdated),
-  );
+  ) {
+    // Start from the guest's own values — every column present — and overlay
+    // only the columns the document actually spoke to.
+    //
+    // [UserMapper.fromDoc] returns `Value.absent()` for a column the document
+    // omits, which means "keep what is stored" to an upsert. Here there is
+    // nothing stored to keep: the Kotlin mutates the guest entity in place
+    // (`UserRepositoryImpl.kt:1122-1128`), while the port writes a **new row
+    // under a new key**, so an absent column silently takes its default. That
+    // is why `key`/`iv` had to be carried by hand, and it is equally true of
+    // the twelve profile columns `_keepingStored` guards and of `joinDate`,
+    // `password`, `userImage` and `isUpdated`.
+    final base = guest.toCompanion(false);
+    Value<T> pick<T>(Value<T> incoming, Value<T> stored) =>
+        incoming.present ? incoming : stored;
+
+    return base.copyWith(
+      // [UserMapper.fromDoc] keys the companion on `existing.id`, which here is
+      // still `guest_<name>`. The Kotlin assigns `this.id = id` *before*
+      // calling `applyJsonToUser`, so the adopted row is written under the
+      // server's id and the guest row deleted.
+      id: Value(newId),
+      couchId: pick(mapped.couchId, base.couchId),
+      rev: pick(mapped.rev, base.rev),
+      name: pick(mapped.name, base.name),
+      rolesList: pick(mapped.rolesList, base.rolesList),
+      userAdmin: pick(mapped.userAdmin, base.userAdmin),
+      joinDate: pick(mapped.joinDate, base.joinDate),
+      firstName: pick(mapped.firstName, base.firstName),
+      lastName: pick(mapped.lastName, base.lastName),
+      middleName: pick(mapped.middleName, base.middleName),
+      email: pick(mapped.email, base.email),
+      planetCode: pick(mapped.planetCode, base.planetCode),
+      parentCode: pick(mapped.parentCode, base.parentCode),
+      phoneNumber: pick(mapped.phoneNumber, base.phoneNumber),
+      passwordScheme: pick(mapped.passwordScheme, base.passwordScheme),
+      iterations: pick(mapped.iterations, base.iterations),
+      derivedKey: pick(mapped.derivedKey, base.derivedKey),
+      salt: pick(mapped.salt, base.salt),
+      level: pick(mapped.level, base.level),
+      language: pick(mapped.language, base.language),
+      gender: pick(mapped.gender, base.gender),
+      dob: pick(mapped.dob, base.dob),
+      age: pick(mapped.age, base.age),
+      birthPlace: pick(mapped.birthPlace, base.birthPlace),
+      userImage: pick(mapped.userImage, base.userImage),
+      password: pick(mapped.password, base.password),
+      isArchived: pick(mapped.isArchived, base.isArchived),
+      // Never on a `_users` document, and losing `key`/`iv` would make every
+      // health record already encrypted with them unreadable.
+      isUpdated: base.isUpdated,
+      key: base.key,
+      iv: base.iv,
+    );
+  }
 
   /// Port of `UserRepositoryImpl.authenticateUser`.
   ///

--- a/flutter/lib/repository/user_repository.dart
+++ b/flutter/lib/repository/user_repository.dart
@@ -1,9 +1,12 @@
+import 'package:drift/drift.dart';
 import 'package:meta/meta.dart';
 
 import '../core/config/server_config.dart';
 import '../core/crypto/android_decrypter.dart';
 import '../core/crypto/health_cipher.dart';
 import '../core/network/network_result.dart';
+import '../core/sync/sync_result.dart';
+import '../core/sync/table_walk.dart';
 import '../core/utils/json_utils.dart';
 import '../core/utils/text_utils.dart';
 import '../core/utils/url_utils.dart';
@@ -172,6 +175,164 @@ class UserRepository {
     await _userDao.upsert(companion);
     return _userDao.getById(companion.id.value);
   }
+
+  /// Page size for the `tablet_users` walk. `TransactionSyncManager.syncDb`
+  /// uses its 1000-document default for this table; the port starts smaller and
+  /// lets `AdaptiveBatchProcessor` grow it, because a `_users` document can
+  /// carry a base64 profile photo in `_attachments` and a thousand of those in
+  /// one response is a large body on a weak link.
+  static const int tabletUsersBatchSize = 100;
+
+  /// Port of the `"tablet_users"` arm of `TransactionSyncManager.syncDb`
+  /// (`services/sync/TransactionSyncManager.kt:230-232`), which the Kotlin runs
+  /// in phase 1 of every full sync.
+  ///
+  /// Without it the `users` table holds only accounts that have signed in on
+  /// this device, so member detail says "Unknown member" for everyone else, the
+  /// team leaderboard silently drops every member it cannot resolve, and the
+  /// team member list falls back to rendering `org.couchdb.user:bob`.
+  ///
+  /// **Never prunes.** The Kotlin's walk issues no delete of any kind, and it
+  /// could not: this table also holds accounts registered offline that have
+  /// never reached the server, and the session itself is restored by looking
+  /// the signed-in user up here. A `deleteNotIn` would sign the user out.
+  Future<SyncResult> syncTabletUsers({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) => walkAllDocs(
+    api: _api,
+    config: config,
+    table: 'tablet_users',
+    initialBatchSize: tabletUsersBatchSize,
+    onProgress: onProgress,
+    insert: insertUsersFromSync,
+  );
+
+  /// Port of `UserRepositoryImpl.insertUsersFromSync`
+  /// (`UserRepositoryImpl.kt:1061-1147`).
+  ///
+  /// Two things beyond a plain upsert, both the Kotlin's:
+  ///
+  /// * **Existing rows are resolved by either identity column** before mapping,
+  ///   so a member registered on this device keeps their locally-minted `id`
+  ///   and their `key`/`iv` rather than gaining a second row keyed by the
+  ///   CouchDB `_id`. [UserMapper.fromDoc] does the rest — every column a
+  ///   `_users` document does not carry is left `Value.absent()`, so the walk
+  ///   cannot overwrite it.
+  /// * **A guest is adopted, not duplicated.** When a document keyed
+  ///   `org.couchdb.user:<name>` has no row of its own but a guest row carries
+  ///   that name, the Kotlin re-keys the guest to the new id and deletes the
+  ///   old row. The port has to rebuild the row rather than mutate it, so the
+  ///   device-only columns are carried across by hand — dropping `key`/`iv`
+  ///   here would make anything already encrypted with them unreadable.
+  Future<int> insertUsersFromSync(List<Map<String, dynamic>> docs) async {
+    if (docs.isEmpty) return 0;
+
+    final ids = <String>{};
+    final names = <String>{};
+    for (final doc in docs) {
+      final id = JsonUtils.getString('_id', doc);
+      if (id.isNotEmpty) ids.add(id);
+      final name = JsonUtils.getString('name', doc);
+      if (name.isNotEmpty) names.add(name);
+    }
+
+    final found = [
+      ...await _userDao.getByAnyIds(ids.toList(growable: false)),
+      ...await _userDao.getGuestUsersByNames(names.toList(growable: false)),
+    ];
+
+    // Kotlin's `distinctBy { it.id }` — the two reads above overlap for a guest
+    // whose name is also one of the ids.
+    final usersById = <String, UserRow>{};
+    final guestsByName = <String, UserRow>{};
+    final seen = <String>{};
+    for (final user in found) {
+      if (!seen.add(user.id)) continue;
+      usersById[user.id] = user;
+      final couchId = user.couchId;
+      if (couchId != null) usersById[couchId] = user;
+      if ((user.name ?? '').isNotEmpty && _isGuest(couchId)) {
+        guestsByName[user.name!] = user;
+      }
+    }
+
+    final toDelete = <String>{};
+    final toUpsert = <String, UsersCompanion>{};
+
+    for (final doc in docs) {
+      final couchId = JsonUtils.getString('_id', doc);
+      final name = JsonUtils.getString('name', doc);
+      final existing = usersById[couchId];
+      final guest =
+          (existing == null &&
+              couchId.startsWith('org.couchdb.user:') &&
+              name.isNotEmpty)
+          ? guestsByName[name]
+          : null;
+
+      // One call site, and `existing:` is always passed — the mapper-preservation
+      // guard (`test/data/local/mapper_preserves_local_columns_test.dart`) is
+      // right to insist: every column a `_users` document does not carry is
+      // `Value.absent()` only because `existing` reached the mapper.
+      var companion = UserMapper.fromDoc(doc, existing: existing ?? guest);
+
+      if (guest != null) {
+        // Re-key the guest onto the account that has just appeared
+        // server-side, exactly as `applyJsonToUser` does after
+        // `this.id = id; this._id = id`.
+        companion = _adoptGuest(companion, guest, couchId);
+        toDelete.add(guest.id);
+        if ((guest.name ?? '').isNotEmpty) guestsByName.remove(guest.name);
+        usersById.remove(guest.id);
+        final guestCouchId = guest.couchId;
+        if (guestCouchId != null) usersById.remove(guestCouchId);
+      }
+
+      final rowId = companion.id.value;
+      // A guest that has just been re-keyed must not be deleted again by a
+      // later document on the same page.
+      toDelete.remove(rowId);
+      toUpsert[rowId] = companion;
+    }
+
+    if (toDelete.isNotEmpty) {
+      await _userDao.deleteByIds(toDelete.toList(growable: false));
+    }
+    await _userDao.upsertAll(toUpsert.values.toList(growable: false));
+    return toUpsert.length;
+  }
+
+  static bool _isGuest(String? couchId) =>
+      couchId?.startsWith(UserMapper.guestIdPrefix) ?? false;
+
+  /// Carries a guest row's device-only columns onto the companion that will
+  /// replace it under the server's id.
+  ///
+  /// [UserMapper.fromDoc] leaves these `Value.absent()` because a `_users`
+  /// document does not carry them, and absent means "keep what is stored" —
+  /// but the adopted row is stored under a *different* key, so there is
+  /// nothing to keep and each column would silently take its default.
+  static UsersCompanion _adoptGuest(
+    UsersCompanion mapped,
+    UserRow guest,
+    String newId,
+  ) => mapped.copyWith(
+    // [UserMapper.fromDoc] keys the companion on `existing.id`, which here
+    // is still `guest_<name>`. The Kotlin assigns `this.id = id` *before*
+    // calling `applyJsonToUser` (`UserRepositoryImpl.kt:1126-1131`), so the
+    // adopted row is written under the server's id and the guest row is
+    // deleted. Leaving the guest key in place would update the guest in
+    // situ and leave the account still unresolvable by its CouchDB id.
+    id: Value(newId),
+    key: Value(guest.key),
+    iv: Value(guest.iv),
+    password: mapped.password.present ? mapped.password : Value(guest.password),
+    userImage: mapped.userImage.present
+        ? mapped.userImage
+        : Value(guest.userImage),
+    isUpdated: Value(guest.isUpdated),
+  );
 
   /// Port of `UserRepositoryImpl.authenticateUser`.
   ///

--- a/flutter/lib/ui/sync/sync_center_screen.dart
+++ b/flutter/lib/ui/sync/sync_center_screen.dart
@@ -227,4 +227,29 @@ class _SyncAreaTile extends StatelessWidget {
     description: l10n.syncNotificationsDescription,
     icon: Icons.notifications_outlined,
   ),
+  DashboardSyncArea.tabletUsers => (
+    label: l10n.members,
+    description: l10n.syncMembersDescription,
+    icon: Icons.people_outline,
+  ),
+  DashboardSyncArea.ratings => (
+    label: l10n.ratings,
+    description: l10n.syncRatingsDescription,
+    icon: Icons.star_outline,
+  ),
+  DashboardSyncArea.tasks => (
+    label: l10n.teamTasks,
+    description: l10n.syncTasksDescription,
+    icon: Icons.checklist_outlined,
+  ),
+  DashboardSyncArea.achievements => (
+    label: l10n.achievements,
+    description: l10n.syncAchievementsDescription,
+    icon: Icons.emoji_events_outlined,
+  ),
+  DashboardSyncArea.shelf => (
+    label: l10n.myLibrary,
+    description: l10n.syncShelfDescription,
+    icon: Icons.bookmark_outline,
+  ),
 };

--- a/flutter/test/core/notifications/task_deadline_notifier_test.dart
+++ b/flutter/test/core/notifications/task_deadline_notifier_test.dart
@@ -9,6 +9,7 @@ import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/notifications_repository.dart';
 import 'package:myplanet/repository/team_tasks_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../../support/mock_planet_api.dart';
 
 /// Port coverage for `TaskNotificationWorker.doWork`. The whole reason the
 /// policy is a plain Dart class is that the worker's contract — notify once,
@@ -28,7 +29,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     prefs = PlanetPrefs(await SharedPreferences.getInstance());
     db = AppDatabase.memory();
-    tasks = TeamTasksRepository(db.teamTaskDao);
+    tasks = TeamTasksRepository(MockPlanetApi(), db.teamTaskDao);
     notifications = NotificationsRepository(
       db.notificationDao,
       teamNotificationDao: db.teamNotificationDao,

--- a/flutter/test/core/sync/table_walk_test.dart
+++ b/flutter/test/core/sync/table_walk_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/core/sync/table_walk.dart';
+
+import '../../support/mock_planet_api.dart';
+
+/// The pagination shared by the five Phase 119 walks.
+///
+/// The per-walk tests all stub one page that answers every `skip`, which is
+/// enough to exercise a writer and no part at all of the loop that feeds it —
+/// the second audit's largest coverage finding. These drive the loop itself:
+/// change `skip += rows.length` to `skip += 1` and the first test hangs on
+/// duplicate ids rather than passing.
+void main() {
+  late MockPlanetApi api;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() => api = MockPlanetApi());
+
+  void stubCount(Map<String, dynamic> body) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/widgets/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((_) async => NetworkSuccess<Map<String, dynamic>>(body));
+  }
+
+  /// Serves `total` documents out of a real corpus, honouring `limit`/`skip`.
+  void stubCorpus(int total, {Set<int> failAtSkip = const {}}) {
+    stubCount({'total_rows': total});
+    when(
+      () => api.getJsonObject(
+        any(that: contains('widgets/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final url = invocation.positionalArguments[0] as String;
+      final query = Uri.parse(url).queryParameters;
+      final limit = int.parse(query['limit']!);
+      final skip = int.parse(query['skip']!);
+      if (failAtSkip.contains(skip)) {
+        return const NetworkError<Map<String, dynamic>>(503, 'upstream down');
+      }
+      final end = (skip + limit) > total ? total : skip + limit;
+      return NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (var i = skip; i < end; i++)
+            {
+              'id': 'doc-$i',
+              'doc': {'_id': 'doc-$i', '_rev': '1-x'},
+            },
+        ],
+      });
+    });
+  }
+
+  test('walks every page exactly once', () async {
+    stubCorpus(250);
+    final seen = <String>[];
+
+    final result = await walkAllDocs(
+      api: api,
+      config: config,
+      table: 'widgets',
+      initialBatchSize: 100,
+      insert: (docs) async {
+        seen.addAll(docs.map((d) => d['_id'] as String));
+        return docs.length;
+      },
+    );
+
+    expect(result, isA<SyncComplete>());
+    expect((result as SyncComplete).savedCount, 250);
+    expect(seen.length, 250);
+    expect(seen.toSet().length, 250);
+  });
+
+  test('reports progress that ends at the total', () async {
+    stubCorpus(250);
+    final progress = <int>[];
+
+    await walkAllDocs(
+      api: api,
+      config: config,
+      table: 'widgets',
+      initialBatchSize: 100,
+      insert: (docs) async => docs.length,
+      onProgress: (p) => progress.add(p.completed),
+    );
+
+    expect(progress.last, 250);
+    expect(progress.every((c) => c <= 250), isTrue);
+  });
+
+  test(
+    'a mid-walk failure fails the area rather than half-reporting',
+    () async {
+      stubCorpus(250, failAtSkip: {100});
+      var inserted = 0;
+
+      final result = await walkAllDocs(
+        api: api,
+        config: config,
+        table: 'widgets',
+        initialBatchSize: 100,
+        insert: (docs) async {
+          inserted += docs.length;
+          return docs.length;
+        },
+      );
+
+      // The first page is kept — nothing prunes, so a partial pull is a partial
+      // cache, not a loss — but the area reports failed so the user can retry.
+      expect(result, isA<SyncFailed>());
+      expect(inserted, 100);
+    },
+  );
+
+  test('_design documents are dropped without stalling the loop', () async {
+    // `total_rows` counts design documents, so a page that is entirely design
+    // docs still has to advance `skip` by the raw row count.
+    stubCount({'total_rows': 3});
+    when(
+      () => api.getJsonObject(
+        any(that: contains('widgets/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final skip = int.parse(
+        Uri.parse(
+          invocation.positionalArguments[0] as String,
+        ).queryParameters['skip']!,
+      );
+      if (skip > 0) {
+        return const NetworkSuccess<Map<String, dynamic>>({'rows': []});
+      }
+      return const NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {
+            'id': '_design/widgets',
+            'doc': {'_id': '_design/widgets'},
+          },
+          {
+            'id': 'doc-0',
+            'doc': {'_id': 'doc-0'},
+          },
+          {'key': 'missing', 'error': 'not_found'},
+        ],
+      });
+    });
+
+    var seen = <String>[];
+    final result = await walkAllDocs(
+      api: api,
+      config: config,
+      table: 'widgets',
+      initialBatchSize: 3,
+      insert: (docs) async {
+        seen = docs.map((d) => d['_id'] as String).toList();
+        return docs.length;
+      },
+    );
+
+    expect(seen, ['doc-0']);
+    expect((result as SyncComplete).savedCount, 1);
+  });
+
+  test('an empty database is a success with no page request', () async {
+    stubCount({'total_rows': 0});
+
+    final result = await walkAllDocs(
+      api: api,
+      config: config,
+      table: 'widgets',
+      initialBatchSize: 100,
+      insert: (docs) async => docs.length,
+    );
+
+    expect((result as SyncComplete).savedCount, 0);
+    verifyNever(
+      () => api.getJsonObject(
+        any(that: contains('include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    );
+  });
+
+  test(
+    'a count response with no total_rows fails rather than ticking',
+    () async {
+      // `JsonUtils.getInt` reads a missing key and a real zero alike, so without
+      // the containsKey guard a malformed count response put a green tick on a
+      // walk that never issued a page request.
+      stubCount({'offset': 0});
+
+      final result = await walkAllDocs(
+        api: api,
+        config: config,
+        table: 'widgets',
+        initialBatchSize: 100,
+        insert: (docs) async => docs.length,
+      );
+
+      expect(result, isA<SyncFailed>());
+    },
+  );
+}

--- a/flutter/test/providers/dashboard_sync_provider_test.dart
+++ b/flutter/test/providers/dashboard_sync_provider_test.dart
@@ -16,6 +16,38 @@ void main() {
       expect(state.progress, 0);
     });
 
+    test('the two load-bearing area orderings hold', () {
+      // `syncAll` iterates `DashboardSyncArea.values`, so declaration order is
+      // execution order, and two positions carry real behaviour:
+      //
+      // * `tabletUsers` before `shelf` — a shelf document is keyed by its
+      //   owner's CouchDB id, and `ShelfSyncRepository._localUserId` resolves
+      //   that to the local `users` row every reader scopes by. With no row
+      //   the stamp falls back to the raw id, which for a member registered on
+      //   this device matches nothing.
+      // * `shelf` after `resources` and `courses` — both of those prune with
+      //   `deleteNotIn`, so a stamp written before them can be deleted.
+      //
+      // The test above (`state.items.map(…) == DashboardSyncArea.values`) is
+      // tautological with respect to order: an alphabetising refactor would
+      // pass it and break both invariants silently.
+      int index(DashboardSyncArea area) =>
+          DashboardSyncArea.values.indexOf(area);
+
+      expect(
+        index(DashboardSyncArea.tabletUsers),
+        lessThan(index(DashboardSyncArea.shelf)),
+      );
+      expect(
+        index(DashboardSyncArea.resources),
+        lessThan(index(DashboardSyncArea.shelf)),
+      );
+      expect(
+        index(DashboardSyncArea.courses),
+        lessThan(index(DashboardSyncArea.shelf)),
+      );
+    });
+
     test('aggregate counts distinguish success and failure', () {
       final state = DashboardSyncState(
         items: const [

--- a/flutter/test/repository/achievements_repository_test.dart
+++ b/flutter/test/repository/achievements_repository_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/achievements_repository.dart';
+import '../support/mock_planet_api.dart';
 
 void main() {
   late AppDatabase database;
@@ -10,7 +11,10 @@ void main() {
 
   setUp(() {
     database = AppDatabase.memory();
-    repository = AchievementsRepository(database.achievementDao);
+    repository = AchievementsRepository(
+      MockPlanetApi(),
+      database.achievementDao,
+    );
   });
   tearDown(() => database.close());
 

--- a/flutter/test/repository/achievements_repository_test.dart
+++ b/flutter/test/repository/achievements_repository_test.dart
@@ -24,7 +24,13 @@ void main() {
       final row = await repository.getOrInitialize('ada@earth');
       expect(row?.id, 'ada@earth');
       expect(row?.achievementsJson, '[]');
-      expect(row?.uploaded, isFalse);
+      // `Achievement()` starts `isUpdated = false`, and `uploaded` is the
+      // port's inverted name for it, so a placeholder nobody has edited is
+      // `true`. This assertion used to pin the column's default, which is the
+      // wrong way round: it made a blank row indistinguishable from an unsent
+      // edit, and the `achievements` sync-in then skipped the server's real
+      // ledger to "preserve" it — permanently, since nothing clears the flag.
+      expect(row?.uploaded, isTrue);
     },
   );
 

--- a/flutter/test/repository/achievements_sync_test.dart
+++ b/flutter/test/repository/achievements_sync_test.dart
@@ -1,0 +1,232 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/files/achievement_files.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/achievements_repository.dart';
+
+import '../support/mock_planet_api.dart';
+
+/// The `achievements` walk — `TransactionSyncManager.syncDb("achievements")`
+/// plus `downloadCvAttachmentsFromBatch`.
+///
+/// Phase 116's D19: `AchievementsRepository.syncAchievements` was written and
+/// never called, and `AchievementFiles.hasResume` carried a doc comment naming
+/// itself "the Kotlin's `!file.exists()` guard on the sync-in" for a sync-in
+/// that did not exist. A second device showed a blank ledger, and saving there
+/// POSTed a document with no `_rev`, which CouchDB answers 409 — a status
+/// `OutboxDrainer` treats as permanent, so the row was abandoned with no
+/// snackbar and no log. Both ends close together.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late AchievementsRepository repository;
+  late Directory tempDir;
+  late Future<Directory> Function() savedBaseDirectory;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = AchievementsRepository(api, db.achievementDao);
+    tempDir = Directory.systemTemp.createTempSync('achievements_sync');
+    savedBaseDirectory = AchievementFiles.baseDirectory;
+    AchievementFiles.baseDirectory = () async => tempDir;
+  });
+
+  tearDown(() {
+    AchievementFiles.baseDirectory = savedBaseDirectory;
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    return db.close();
+  });
+
+  Map<String, dynamic> achievementDoc(
+    String id, {
+    String purpose = 'Run the community seed bank',
+    String? resumeFileName,
+    bool withAttachment = false,
+  }) => {
+    '_id': id,
+    '_rev': '4-abc',
+    'purpose': purpose,
+    'goals': 'Train two more growers',
+    'achievementsHeader': 'What I have done',
+    'sendToNation': false,
+    'dateSortOrder': 'none',
+    'createdOn': 'ole',
+    'username': 'ada',
+    'parentCode': 'ole',
+    'achievements': [
+      {'title': 'Seed bank opened', 'date': '2024-03-01', 'resources': []},
+    ],
+    'references': [
+      {'name': 'Bob', 'phone': '555-0100'},
+    ],
+    'links': <dynamic>[],
+    'otherInfo': <dynamic>[],
+    'resumeFileName': ?resumeFileName,
+    '_attachments': withAttachment
+        ? {
+            'resume.pdf': {'content_type': 'application/pdf', 'length': 9},
+          }
+        : null,
+  };
+
+  void stubWalk(List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/achievements/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('achievements/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  test('a ledger written on another device arrives here', () async {
+    stubWalk([achievementDoc('org.couchdb.user:ada@gua')]);
+
+    await repository.sync(config: config);
+
+    final row = await db.achievementDao.getById('org.couchdb.user:ada@gua');
+    expect(row, isNotNull);
+    expect(row!.purpose, 'Run the community seed bank');
+    expect(row.rev, '4-abc');
+    expect(row.uploaded, isTrue);
+    expect(
+      AchievementsRepository.achievementsArray(row.achievementsJson).single,
+      containsPair('title', 'Seed bank opened'),
+    );
+  });
+
+  test('skips _design documents', () async {
+    stubWalk([
+      {'_id': '_design/achievements'},
+      achievementDoc('org.couchdb.user:ada@gua'),
+    ]);
+
+    await repository.sync(config: config);
+
+    expect(await db.achievementDao.getById('_design/achievements'), isNull);
+  });
+
+  test('downloads the CV attachment named by the document', () async {
+    stubWalk([
+      achievementDoc(
+        'org.couchdb.user:ada@gua',
+        resumeFileName: 'ada-cv.pdf',
+        withAttachment: true,
+      ),
+    ]);
+    // The URL uses the literal attachment key `resume.pdf`, not the
+    // `resumeFileName` the local file is stored under
+    // (`TransactionSyncManager.kt:451` vs `:376`).
+    when(
+      () => api.getBytes(
+        '$dbUrl/achievements/org.couchdb.user:ada@gua/resume.pdf',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((_) async => NetworkSuccess<List<int>>(List.filled(9, 37)));
+
+    await repository.sync(config: config);
+
+    expect(await AchievementFiles.hasResume('ada-cv.pdf'), isTrue);
+  });
+
+  test('a document with no resume.pdf attachment fetches nothing', () async {
+    // `hasAttachment` is the Kotlin's guard: a `resumeFileName` alone is not
+    // enough, because the document may name a CV the server never stored.
+    stubWalk([
+      achievementDoc('org.couchdb.user:ada@gua', resumeFileName: 'ada-cv.pdf'),
+    ]);
+
+    await repository.sync(config: config);
+
+    verifyNever(
+      () => api.getBytes(any(), authHeader: any(named: 'authHeader')),
+    );
+    expect(await AchievementFiles.hasResume('ada-cv.pdf'), isFalse);
+  });
+
+  test('a CV already on disk is not fetched again', () async {
+    await AchievementFiles.write(
+      resumeFileName: 'ada-cv.pdf',
+      bytes: List.filled(9, 1),
+    );
+    stubWalk([
+      achievementDoc(
+        'org.couchdb.user:ada@gua',
+        resumeFileName: 'ada-cv.pdf',
+        withAttachment: true,
+      ),
+    ]);
+
+    await repository.sync(config: config);
+
+    verifyNever(
+      () => api.getBytes(any(), authHeader: any(named: 'authHeader')),
+    );
+  });
+
+  test(
+    'an edit not yet uploaded survives the pull, and gains its rev',
+    () async {
+      // The row is authored locally under `"<userId>@<planetCode>"` and carries
+      // no `_rev` until a walk supplies one. Overwriting it — which the Kotlin
+      // does, `isUpdated = false` and all — discards the edit *and* stops it
+      // uploading; and the missing `_rev` is exactly what makes its POST 409.
+      await repository.update(
+        'org.couchdb.user:ada@gua',
+        const AchievementInput(
+          purpose: 'Run the community seed bank and the tool library',
+          username: 'ada',
+          parentCode: 'ole',
+        ),
+      );
+
+      stubWalk([achievementDoc('org.couchdb.user:ada@gua')]);
+      await repository.sync(config: config);
+
+      final row = await db.achievementDao.getById('org.couchdb.user:ada@gua');
+      expect(row!.purpose, 'Run the community seed bank and the tool library');
+      expect(row.uploaded, isFalse);
+      expect(row.rev, '4-abc');
+      expect(row.couchId, 'org.couchdb.user:ada@gua');
+      expect(await repository.pendingUploads(), hasLength(1));
+    },
+  );
+
+  test('never prunes: a ledger the walk did not list survives', () async {
+    await repository.getOrInitialize('org.couchdb.user:bob@gua');
+
+    stubWalk([achievementDoc('org.couchdb.user:ada@gua')]);
+    await repository.sync(config: config);
+
+    expect(
+      await db.achievementDao.getById('org.couchdb.user:bob@gua'),
+      isNotNull,
+    );
+  });
+}

--- a/flutter/test/repository/achievements_sync_test.dart
+++ b/flutter/test/repository/achievements_sync_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/core/files/achievement_files.dart';
 import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/achievements_repository.dart';
 
@@ -217,6 +218,61 @@ void main() {
       expect(await repository.pendingUploads(), hasLength(1));
     },
   );
+
+  test(
+    'opening the screen first does not make the walk skip the server ledger',
+    () async {
+      // `achievementEntryProvider` calls `getOrInitialize` on watch, so simply
+      // opening the achievements screen inserts a blank row. `uploaded`
+      // defaults to `false` — the inverse of Kotlin's `isUpdated = false` — so
+      // that blank row read as "an edit the user has not uploaded", the walk
+      // preserved it *instead of* the server's ledger, and nothing ever
+      // cleared the flag, so the screen stayed blank forever. Worse, the walk
+      // then handed the blank row a valid `_rev`, arming the next save to PUT
+      // an empty ledger over the real one.
+      await repository.getOrInitialize('org.couchdb.user:ada@gua');
+
+      stubWalk([achievementDoc('org.couchdb.user:ada@gua')]);
+      await repository.sync(config: config);
+
+      final row = await db.achievementDao.getById('org.couchdb.user:ada@gua');
+      expect(row!.purpose, 'Run the community seed bank');
+      expect(row.uploaded, isTrue);
+      expect(await repository.pendingUploads(), isEmpty);
+    },
+  );
+
+  test('a placeholder row is not queued for upload', () async {
+    // The same defect from the other side: a blank ledger nobody has edited
+    // must not reach `pendingUploads`, or Save would push it to the server.
+    await repository.getOrInitialize('org.couchdb.user:ada@gua');
+
+    expect(await repository.pendingUploads(), isEmpty);
+  });
+
+  test('one non-string scalar does not take the whole page down', () async {
+    // Kotlin's `JsonUtils.getString` coerces through `toString()`, and so does
+    // the port's — but this walk was reading `doc['parentCode'] as String?`
+    // directly, so a numeric `parentCode` threw out of the mapper, `insertDocs`
+    // never ran, the good document on the page was lost with it, and the whole
+    // achievements area reported failed.
+    stubWalk([
+      achievementDoc('org.couchdb.user:ada@gua'),
+      {...achievementDoc('org.couchdb.user:bob@gua'), 'parentCode': 123},
+    ]);
+
+    final result = await repository.sync(config: config);
+
+    expect(result, isA<SyncComplete>());
+    expect(
+      await db.achievementDao.getById('org.couchdb.user:ada@gua'),
+      isNotNull,
+    );
+    expect(
+      (await db.achievementDao.getById('org.couchdb.user:bob@gua'))!.parentCode,
+      '123',
+    );
+  });
 
   test('never prunes: a ledger the walk did not list survives', () async {
     await repository.getOrInitialize('org.couchdb.user:bob@gua');

--- a/flutter/test/repository/achievements_uploader_test.dart
+++ b/flutter/test/repository/achievements_uploader_test.dart
@@ -31,7 +31,7 @@ void main() {
   setUp(() {
     database = AppDatabase.memory();
     api = MockPlanetApi();
-    repository = AchievementsRepository(database.achievementDao);
+    repository = AchievementsRepository(api, database.achievementDao);
     outbox = OutboxRepository(database.outboxDao);
     uploader = AchievementsUploader(
       api,

--- a/flutter/test/repository/ratings_repository_test.dart
+++ b/flutter/test/repository/ratings_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/ratings_repository.dart';
+import '../support/mock_planet_api.dart';
 
 void main() {
   late AppDatabase database;
@@ -11,6 +12,7 @@ void main() {
     database = AppDatabase.memory();
     id = 0;
     repository = RatingsRepository(
+      MockPlanetApi(),
       database.ratingDao,
       now: () => DateTime.fromMillisecondsSinceEpoch(1234),
       createId: () => 'rating-${id++}',

--- a/flutter/test/repository/ratings_repository_test.dart
+++ b/flutter/test/repository/ratings_repository_test.dart
@@ -14,6 +14,7 @@ void main() {
     repository = RatingsRepository(
       MockPlanetApi(),
       database.ratingDao,
+      database.userDao,
       now: () => DateTime.fromMillisecondsSinceEpoch(1234),
       createId: () => 'rating-${id++}',
     );

--- a/flutter/test/repository/ratings_sync_test.dart
+++ b/flutter/test/repository/ratings_sync_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/core/network/network_result.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/ratings_repository.dart';
 
@@ -33,7 +34,7 @@ void main() {
   setUp(() {
     db = AppDatabase.memory();
     api = MockPlanetApi();
-    repository = RatingsRepository(api, db.ratingDao);
+    repository = RatingsRepository(api, db.ratingDao, db.userDao);
   });
 
   tearDown(() => db.close());
@@ -209,6 +210,74 @@ void main() {
     expect(pending.single.couchId, 'rating-1');
     expect(pending.single.rev, '1-abc');
   });
+
+  test('two server ratings for one item are both counted', () async {
+    // Both documents match the same unsynced local row on
+    // `(type, item, userId)`, so keying both companions on that row collapsed
+    // them: the batch's last write won and one person's rating vanished from
+    // the average. The match is consumed by the first document; the second
+    // takes its CouchDB id as its key, which is what the Kotlin stores.
+    await repository.submit(
+      type: 'resource',
+      itemId: 'resource-1',
+      title: 'Water pump manual',
+      userId: 'org.couchdb.user:ada',
+      rate: 5,
+    );
+    await repository.markUploaded(
+      (await repository.pendingUploads()).single.id,
+    );
+
+    stubWalk([
+      ratingDoc('rating-1', userId: 'org.couchdb.user:ada', rate: 5),
+      ratingDoc('rating-2', userId: 'org.couchdb.user:ada', rate: 1),
+    ]);
+    await repository.sync(config: config);
+
+    final summary = await repository.summary('resource', 'resource-1', null);
+    expect(summary.total, 2);
+    expect(summary.average, 3);
+  });
+
+  test(
+    'a member registered on this device sees their own rating as theirs',
+    () async {
+      // A rating document names its rater by CouchDB id; `submit` stores
+      // `session.user.id`, and for a member registered offline those differ.
+      // Storing the raw id hides the rating from `userRating` *and* defeats the
+      // `(type, item, userId)` match, so the walk duplicates it.
+      await db.userDao.upsert(
+        UsersCompanion.insert(
+          id: '1756900000000',
+          couchId: const Value('org.couchdb.user:ada'),
+          name: const Value('ada'),
+        ),
+      );
+      await repository.submit(
+        type: 'resource',
+        itemId: 'resource-1',
+        title: 'Water pump manual',
+        userId: '1756900000000',
+        rate: 5,
+      );
+      await repository.markUploaded(
+        (await repository.pendingUploads()).single.id,
+      );
+
+      stubWalk([
+        ratingDoc('rating-1', userId: 'org.couchdb.user:ada', rate: 5),
+      ]);
+      await repository.sync(config: config);
+
+      final summary = await repository.summary(
+        'resource',
+        'resource-1',
+        '1756900000000',
+      );
+      expect(summary.total, 1);
+      expect(summary.userRating, 5);
+    },
+  );
 
   test('never prunes: a rating the walk did not list survives', () async {
     await repository.submit(

--- a/flutter/test/repository/ratings_sync_test.dart
+++ b/flutter/test/repository/ratings_sync_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/ratings_repository.dart';
+
+import '../support/mock_planet_api.dart';
+
+/// The `ratings` walk — `TransactionSyncManager.syncDb("ratings")` plus
+/// `RatingsRepositoryImpl.insertRatingsFromSync`.
+///
+/// Phase 116's D4: the only writer of the table was the local `submit()`, whose
+/// one caller always passes the signed-in user. So the read predicate —
+/// `type = ? AND item = ?`, deliberately unscoped by user because it computes a
+/// community average — could only ever see this device's own rating, and every
+/// "average" was a single number the user had typed themselves.
+///
+/// The documents carry the rater as an embedded `user` object, which is where
+/// the Kotlin reads `userId` from and where a base64 profile photo would sit.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late RatingsRepository repository;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = RatingsRepository(api, db.ratingDao);
+  });
+
+  tearDown(() => db.close());
+
+  Map<String, dynamic> ratingDoc(
+    String id, {
+    required String userId,
+    String type = 'resource',
+    String item = 'resource-1',
+    int rate = 4,
+    String? comment,
+  }) => {
+    '_id': id,
+    '_rev': '1-abc',
+    'time': 1750000000000,
+    'title': 'Water pump manual',
+    'type': type,
+    'item': item,
+    'rate': rate,
+    'comment': ?comment,
+    'parentCode': 'ole',
+    'planetCode': 'gua',
+    'createdOn': 'ole',
+    'user': {
+      '_id': userId,
+      'name': userId.split(':').last,
+      'planetCode': 'gua',
+      '_attachments': {
+        'img': {'content_type': 'image/png', 'length': 4000, 'stub': true},
+      },
+    },
+  };
+
+  void stubWalk(List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/ratings/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('ratings/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  test(
+    'the average is other people\'s ratings, not only this device\'s',
+    () async {
+      stubWalk([
+        ratingDoc('rating-1', userId: 'org.couchdb.user:ada', rate: 5),
+        ratingDoc('rating-2', userId: 'org.couchdb.user:bob', rate: 3),
+        ratingDoc('rating-3', userId: 'org.couchdb.user:cy', rate: 4),
+      ]);
+
+      await repository.sync(config: config);
+
+      final summary = await repository.summary('resource', 'resource-1', null);
+      expect(summary.total, 3);
+      expect(summary.average, 4);
+    },
+  );
+
+  test('reads userId out of the embedded user object', () async {
+    stubWalk([ratingDoc('rating-1', userId: 'org.couchdb.user:ada', rate: 5)]);
+
+    await repository.sync(config: config);
+
+    final summary = await repository.summary(
+      'resource',
+      'resource-1',
+      'org.couchdb.user:ada',
+    );
+    expect(summary.userRating, 5);
+  });
+
+  test('a synced rating is not queued for upload', () async {
+    // `Ratings.isUpdated` defaults to **true**, so a companion that omitted it
+    // would push the whole ratings database straight back to the server as new
+    // documents. `insertRatingsFromSync:112` sets it false explicitly.
+    stubWalk([ratingDoc('rating-1', userId: 'org.couchdb.user:ada')]);
+
+    await repository.sync(config: config);
+
+    expect(await repository.pendingUploads(), isEmpty);
+  });
+
+  test('skips _design documents', () async {
+    stubWalk([
+      {'_id': '_design/ratings'},
+      ratingDoc('rating-1', userId: 'org.couchdb.user:ada'),
+    ]);
+
+    await repository.sync(config: config);
+
+    expect(await db.ratingDao.findById('_design/ratings'), isNull);
+  });
+
+  test(
+    'the rating the user just left is not counted twice when it comes back',
+    () async {
+      // A rating submitted here keeps its locally-minted id for life —
+      // `markRatingUploaded` only clears the dirty flag, it never records the
+      // server id. Keying the pulled document on `_id`, as `Rating().apply { id
+      // = _id }` does, leaves two rows for one rating and `getAggregate` counts
+      // both: a 5-star rating reads as "2 ratings, average 5".
+      await repository.submit(
+        type: 'resource',
+        itemId: 'resource-1',
+        title: 'Water pump manual',
+        userId: 'org.couchdb.user:ada',
+        rate: 5,
+      );
+      await repository.markUploaded(
+        (await repository.pendingUploads()).single.id,
+      );
+
+      stubWalk([
+        ratingDoc('rating-1', userId: 'org.couchdb.user:ada', rate: 5),
+      ]);
+      await repository.sync(config: config);
+
+      final summary = await repository.summary(
+        'resource',
+        'resource-1',
+        'org.couchdb.user:ada',
+      );
+      expect(summary.total, 1);
+      expect(summary.userRating, 5);
+    },
+  );
+
+  test('an unsent rating keeps its rate and stays queued', () async {
+    // The user re-rated offline; the server still holds the old value. Taking
+    // the document's rate and clearing `isUpdated` — which the Kotlin does —
+    // discards the new rating and stops it ever uploading.
+    await repository.submit(
+      type: 'resource',
+      itemId: 'resource-1',
+      title: 'Water pump manual',
+      userId: 'org.couchdb.user:ada',
+      rate: 2,
+      comment: 'The diagram on page 4 is wrong',
+    );
+
+    stubWalk([
+      ratingDoc(
+        'rating-1',
+        userId: 'org.couchdb.user:ada',
+        rate: 5,
+        comment: 'Great',
+      ),
+    ]);
+    await repository.sync(config: config);
+
+    final pending = await repository.pendingUploads();
+    expect(pending.length, 1);
+    expect(pending.single.rate, 2);
+    expect(pending.single.comment, 'The diagram on page 4 is wrong');
+    // …and it now carries the rev, so the upload is a PUT rather than a second
+    // POST of the same rating.
+    expect(pending.single.couchId, 'rating-1');
+    expect(pending.single.rev, '1-abc');
+  });
+
+  test('never prunes: a rating the walk did not list survives', () async {
+    await repository.submit(
+      type: 'resource',
+      itemId: 'resource-9',
+      title: 'Seed catalogue',
+      userId: 'org.couchdb.user:ada',
+      rate: 3,
+    );
+
+    stubWalk([ratingDoc('rating-1', userId: 'org.couchdb.user:bob')]);
+    await repository.sync(config: config);
+
+    expect((await repository.summary('resource', 'resource-9', null)).total, 1);
+  });
+}

--- a/flutter/test/repository/ratings_uploader_test.dart
+++ b/flutter/test/repository/ratings_uploader_test.dart
@@ -32,7 +32,7 @@ void main() {
     registerFallbackValue(<String, dynamic>{});
     registerFallbackValue(config);
     outbox = OutboxRepository(database.outboxDao);
-    repository = RatingsRepository(api, database.ratingDao);
+    repository = RatingsRepository(api, database.ratingDao, database.userDao);
     uploader = RatingsUploader(
       api,
       repository,

--- a/flutter/test/repository/ratings_uploader_test.dart
+++ b/flutter/test/repository/ratings_uploader_test.dart
@@ -32,7 +32,7 @@ void main() {
     registerFallbackValue(<String, dynamic>{});
     registerFallbackValue(config);
     outbox = OutboxRepository(database.outboxDao);
-    repository = RatingsRepository(database.ratingDao);
+    repository = RatingsRepository(api, database.ratingDao);
     uploader = RatingsUploader(
       api,
       repository,

--- a/flutter/test/repository/shelf_sync_test.dart
+++ b/flutter/test/repository/shelf_sync_test.dart
@@ -1,0 +1,385 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/my_library_mapper.dart';
+import 'package:myplanet/repository/courses_repository.dart';
+import 'package:myplanet/repository/resources_repository.dart';
+import 'package:myplanet/repository/shelf_sync_repository.dart';
+
+import '../support/mock_planet_api.dart';
+
+/// The shelf walk — phase 3 of `SyncManager.startFullSync`.
+///
+/// Phase 116's D1/D2, and the reason the whole "my" half of the app was dead:
+/// `my_library.userId` and `courses.userId` are shelf membership, every "my"
+/// view reads them with `LIKE '%"<uid>"%'`, and with no shelf pull the only
+/// writer was a tap on this device. A shelf built on Planet web or on another
+/// handset never arrived, and `CoursesRepository.sync`'s `shelfId` parameter —
+/// threaded end to end — had no production caller at all.
+///
+/// The shelf documents here are shaped as CouchDB stores them: keyed by the
+/// owner's `org.couchdb.user:<name>` id, with `resourceIds`/`courseIds` arrays
+/// and the `myTeamIds` key the probe list does *not* look at.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late ShelfSyncRepository repository;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = ShelfSyncRepository(
+      api,
+      db.myLibraryDao,
+      db.courseDao,
+      db.userDao,
+    );
+  });
+
+  tearDown(() => db.close());
+
+  Map<String, dynamic> resourceDoc(String id, {String title = 'Water pump'}) =>
+      {
+        '_id': id,
+        '_rev': '2-abc',
+        'title': title,
+        'description': 'How to service the hand pump',
+        'isPrivate': false,
+        'languages': <String>['English'],
+        'subject': <String>['Practical skills'],
+        'level': <String>['Beginner'],
+        'resourceFor': <String>['Learner'],
+      };
+
+  Map<String, dynamic> courseDoc(String id, {String title = 'Well repair'}) => {
+    '_id': id,
+    '_rev': '2-abc',
+    'courseTitle': title,
+    'description': 'Five steps',
+    'steps': <dynamic>[],
+  };
+
+  /// `GET shelf/_all_docs`, then the `keys` POSTs the walk makes.
+  void stubShelves(Map<String, Map<String, dynamic>> shelvesById) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/shelf/_all_docs',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final id in shelvesById.keys) {'id': id, 'key': id},
+        ],
+      }),
+    );
+    when(
+      () => api.postJsonObject(
+        '$dbUrl/shelf/_all_docs?include_docs=true',
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final keys =
+          (invocation.positionalArguments[1] as Map<String, dynamic>)['keys']
+              as List;
+      return NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final key in keys)
+            if (shelvesById[key] case final doc?) {'id': key, 'doc': doc},
+        ],
+      });
+    });
+  }
+
+  void stubDocs(String table, Map<String, Map<String, dynamic>> docsById) {
+    when(
+      () => api.postJsonObject(
+        '$dbUrl/$table/_all_docs?include_docs=true',
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final keys =
+          (invocation.positionalArguments[1] as Map<String, dynamic>)['keys']
+              as List;
+      return NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final key in keys)
+            if (docsById[key] case final doc?)
+              {'id': key, 'doc': doc}
+            else
+              // CouchDB answers a missing key with an `error` row and no `doc`.
+              {'key': key, 'error': 'not_found'},
+        ],
+      });
+    });
+  }
+
+  test(
+    'a shelf built elsewhere puts the resource in that user\'s My Library',
+    () async {
+      await db.userDao.upsert(
+        UsersCompanion.insert(
+          id: 'org.couchdb.user:ada',
+          couchId: const Value('org.couchdb.user:ada'),
+          name: const Value('ada'),
+        ),
+      );
+      stubShelves({
+        'org.couchdb.user:ada': {
+          '_id': 'org.couchdb.user:ada',
+          '_rev': '5-abc',
+          'resourceIds': <String>['resource-1'],
+          'courseIds': <String>['course-1'],
+          'meetupIds': <String>[],
+        },
+      });
+      stubDocs('resources', {'resource-1': resourceDoc('resource-1')});
+      stubDocs('courses', {'course-1': courseDoc('course-1')});
+
+      final result = await repository.sync(config: config);
+      expect(result, isA<SyncComplete>());
+
+      final library = await db.myLibraryDao
+          .watchResources(shelfUserId: 'org.couchdb.user:ada', myLibrary: true)
+          .first;
+      expect(library.map((r) => r.id), ['resource-1']);
+
+      final courses = await db.courseDao
+          .watchCourses(shelfUserId: 'org.couchdb.user:ada')
+          .first;
+      expect(courses.map((c) => c.id), ['course-1']);
+    },
+  );
+
+  test(
+    'a member registered on this device gets the stamp their screens read',
+    () async {
+      // The shelf document is keyed by the CouchDB id; every reader passes
+      // `session.user.id`. For a member registered offline those differ — the
+      // row keeps its locally-minted id and gains a `couchId` when the upload
+      // lands — so stamping the raw shelf id writes a `userId` no reader can
+      // match, and My Library stays empty with the walk reporting success.
+      await db.userDao.upsert(
+        UsersCompanion.insert(
+          id: '1756900000000',
+          couchId: const Value('org.couchdb.user:ada'),
+          name: const Value('ada'),
+        ),
+      );
+      stubShelves({
+        'org.couchdb.user:ada': {
+          '_id': 'org.couchdb.user:ada',
+          'resourceIds': <String>['resource-1'],
+        },
+      });
+      stubDocs('resources', {'resource-1': resourceDoc('resource-1')});
+      stubDocs('courses', const {});
+
+      await repository.sync(config: config);
+
+      final library = await db.myLibraryDao
+          .watchResources(shelfUserId: '1756900000000', myLibrary: true)
+          .first;
+      expect(library.map((r) => r.id), ['resource-1']);
+    },
+  );
+
+  test('membership is a union across shelves, never a replacement', () async {
+    stubShelves({
+      'org.couchdb.user:ada': {
+        '_id': 'org.couchdb.user:ada',
+        'resourceIds': <String>['resource-1'],
+      },
+      'org.couchdb.user:bob': {
+        '_id': 'org.couchdb.user:bob',
+        'resourceIds': <String>['resource-1'],
+      },
+    });
+    stubDocs('resources', {'resource-1': resourceDoc('resource-1')});
+    stubDocs('courses', const {});
+
+    await repository.sync(config: config);
+
+    final row = await db.myLibraryDao.getById('resource-1');
+    expect(
+      row!.userId,
+      containsAll(<String>['org.couchdb.user:ada', 'org.couchdb.user:bob']),
+    );
+  });
+
+  test('a shelf that lists nothing is never fetched', () async {
+    // `hasShelfDataUltraFast`. An empty shelf costs one probe, not two more
+    // requests per data type.
+    stubShelves({
+      'org.couchdb.user:ada': {
+        '_id': 'org.couchdb.user:ada',
+        'resourceIds': <String>[],
+        'courseIds': <String>[],
+        'meetupIds': <String>[],
+      },
+    });
+
+    final result = await repository.sync(config: config);
+
+    expect((result as SyncComplete).savedCount, 0);
+    verifyNever(
+      () => api.postJsonObject(
+        any(that: contains('/resources/')),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    );
+  });
+
+  test('a shelf id that resolves to no document stamps nothing', () async {
+    stubShelves({
+      'org.couchdb.user:ada': {
+        '_id': 'org.couchdb.user:ada',
+        'resourceIds': <String>['resource-gone'],
+      },
+    });
+    stubDocs('resources', const {});
+    stubDocs('courses', const {});
+
+    final result = await repository.sync(config: config);
+
+    expect((result as SyncComplete).savedCount, 0);
+    expect(await db.myLibraryDao.getById('resource-gone'), isNull);
+  });
+
+  test('the walk does not retract what the resources walk stored', () async {
+    // `MyLibraryMapper.fromDoc` writes every list column unconditionally, so a
+    // caller that omits one replaces the stored list with `const []` — the D1
+    // defect, which emptied My Library on every sync. The shelf pass runs the
+    // same mapper, so it inherits the same requirement.
+    final resourcesRepository = ResourcesRepository(
+      api,
+      db.myLibraryDao,
+      db.removedLogDao,
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/resources/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 1}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('resources/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {'id': 'resource-1', 'doc': resourceDoc('resource-1')},
+        ],
+      }),
+    );
+    await resourcesRepository.sync(config: config);
+    // The user also added it by hand on this device.
+    await resourcesRepository.setShelfMembership(
+      'resource-1',
+      'local-user',
+      joined: true,
+    );
+
+    stubShelves({
+      'org.couchdb.user:ada': {
+        '_id': 'org.couchdb.user:ada',
+        'resourceIds': <String>['resource-1'],
+      },
+    });
+    stubDocs('resources', {'resource-1': resourceDoc('resource-1')});
+    stubDocs('courses', const {});
+    await repository.sync(config: config);
+
+    final row = await db.myLibraryDao.getById('resource-1');
+    expect(
+      row!.userId,
+      containsAll(<String>['local-user', 'org.couchdb.user:ada']),
+    );
+    expect(row.languages, ['English']);
+    expect(row.subject, ['Practical skills']);
+    expect(row.level, ['Beginner']);
+    expect(row.resourceFor, ['Learner']);
+  });
+
+  test('a course keeps its steps and gains the shelf owner', () async {
+    final coursesRepository = CoursesRepository(
+      api,
+      db.courseDao,
+      db.removedLogDao,
+      db.examDao,
+      db.surveyDao,
+    );
+    final withSteps = {
+      ...courseDoc('course-1'),
+      'steps': [
+        {'stepTitle': 'Turn off the water', 'description': 'At the valve'},
+        {'stepTitle': 'Remove the seal', 'description': 'Two bolts'},
+      ],
+    };
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 1}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('courses/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {'id': 'course-1', 'doc': withSteps},
+        ],
+      }),
+    );
+    await coursesRepository.sync(config: config);
+
+    stubShelves({
+      'org.couchdb.user:ada': {
+        '_id': 'org.couchdb.user:ada',
+        'courseIds': <String>['course-1'],
+      },
+    });
+    stubDocs('resources', const {});
+    stubDocs('courses', {'course-1': withSteps});
+    await repository.sync(config: config);
+
+    expect(await db.courseDao.getSteps('course-1'), hasLength(2));
+    expect(
+      (await db.courseDao.getById('course-1'))!.userId,
+      contains('org.couchdb.user:ada'),
+    );
+  });
+
+  test('mergeUserIds drops blanks and never duplicates', () {
+    // `MyLibrary.setUserId` returns early on a blank id, so `[""]` is a value
+    // the Kotlin cannot write — and it is the one value that fails the My
+    // Library predicate and passes the catalog one.
+    expect(MyLibraryMapper.mergeUserIds(const ['', 'a'], 'b'), ['a', 'b']);
+    expect(MyLibraryMapper.mergeUserIds(const ['a'], 'a'), ['a']);
+    expect(MyLibraryMapper.mergeUserIds(const ['a'], null), ['a']);
+    expect(MyLibraryMapper.mergeUserIds(const [''], ''), isEmpty);
+  });
+}

--- a/flutter/test/repository/tablet_users_sync_test.dart
+++ b/flutter/test/repository/tablet_users_sync_test.dart
@@ -213,6 +213,51 @@ void main() {
     expect(rows.single.iv, 'guest-iv');
   });
 
+  test('an adopted guest keeps every column, not only the health key', () async {
+    // The adopted row is an INSERT under a new key, so every column
+    // `UserMapper.fromDoc` leaves `Value.absent()` — which is what a document
+    // that omits a profile field produces — silently takes its default. Kotlin
+    // mutates the guest entity in place, so `applyJsonToUser`'s keep-stored
+    // guard preserves all of them; the port has to carry them by hand.
+    await db.userDao.upsert(
+      UsersCompanion.insert(
+        id: 'guest_ada',
+        couchId: const Value('guest_ada'),
+        name: const Value('ada'),
+        firstName: const Value('Ada'),
+        level: const Value('Intermediate'),
+        language: const Value('fr'),
+        phoneNumber: const Value('555-0100'),
+        joinDate: const Value(1699999999999),
+        userImage: const Value('/tmp/pending-upload.jpg'),
+        key: const Value('guest-key'),
+        iv: const Value('guest-iv'),
+      ),
+    );
+
+    // A minimal document, as `_users` documents for a fresh account are.
+    stubWalk([
+      {
+        '_id': 'org.couchdb.user:ada',
+        '_rev': '1-abc',
+        'name': 'ada',
+        'roles': <String>['learner'],
+      },
+    ]);
+    await repository.syncTabletUsers(config: config);
+
+    final rows = await db.userDao.getAllUsers();
+    expect(rows.single.id, 'org.couchdb.user:ada');
+    expect(rows.single.firstName, 'Ada');
+    expect(rows.single.level, 'Intermediate');
+    expect(rows.single.language, 'fr');
+    expect(rows.single.phoneNumber, '555-0100');
+    expect(rows.single.joinDate, 1699999999999);
+    expect(rows.single.userImage, '/tmp/pending-upload.jpg');
+    expect(rows.single.key, 'guest-key');
+    expect(rows.single.iv, 'guest-iv');
+  });
+
   test('never prunes: an account the walk did not list survives', () async {
     // Kotlin's walk issues no delete, and it could not — this table also holds
     // accounts registered offline, and the session is restored by looking the

--- a/flutter/test/repository/tablet_users_sync_test.dart
+++ b/flutter/test/repository/tablet_users_sync_test.dart
@@ -1,0 +1,233 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/user_repository.dart';
+
+import '../support/mock_planet_api.dart';
+
+/// The `tablet_users` walk — `TransactionSyncManager.syncDb("tablet_users")`
+/// plus `UserRepositoryImpl.insertUsersFromSync`.
+///
+/// Phase 116's D15: the port had no walk at all, so `users` only ever held
+/// accounts that had signed in on this device. Member detail said "Unknown
+/// member" for everyone else, the leaderboard silently dropped every member it
+/// could not resolve, and the team member list rendered the raw
+/// `org.couchdb.user:bob`.
+///
+/// The documents below are shaped like real `_users` documents, not like
+/// fixtures: `_id` is `org.couchdb.user:<name>`, the profile photo is an
+/// `_attachments` entry rather than a `userImage` field, and the credentials
+/// are the PBKDF2 quartet CouchDB actually stores.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late UserRepository repository;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = UserRepository(api, db.userDao);
+  });
+
+  tearDown(() => db.close());
+
+  Map<String, dynamic> userDoc(
+    String name, {
+    String? firstName,
+    String? lastName,
+    Map<String, dynamic>? attachments,
+  }) => {
+    '_id': 'org.couchdb.user:$name',
+    '_rev': '3-abc',
+    'name': name,
+    'type': 'user',
+    'roles': <String>['learner'],
+    'isUserAdmin': false,
+    'joinDate': 1700000000000,
+    'firstName': ?firstName,
+    'lastName': ?lastName,
+    'planetCode': 'gua',
+    'parentCode': 'ole',
+    'password_scheme': 'pbkdf2',
+    'iterations': '10',
+    'derived_key': 'deadbeef',
+    'salt': 'cafe',
+    '_attachments': ?attachments,
+  };
+
+  void stubWalk(List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/tablet_users/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('tablet_users/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  test('pulls the planet accounts a device has never signed in as', () async {
+    stubWalk([
+      userDoc('ada', firstName: 'Ada', lastName: 'Lovelace'),
+      userDoc('bob', firstName: 'Bob'),
+    ]);
+
+    final result = await repository.syncTabletUsers(config: config);
+
+    expect(result, isA<SyncComplete>());
+    final ada = await db.userDao.getById('org.couchdb.user:ada');
+    expect(ada, isNotNull);
+    expect(ada!.firstName, 'Ada');
+    expect(ada.lastName, 'Lovelace');
+    expect(ada.rolesList, ['learner']);
+    expect(ada.derivedKey, 'deadbeef');
+    expect(await db.userDao.count(), 2);
+  });
+
+  test('skips _design documents', () async {
+    stubWalk([
+      {'_id': '_design/users', 'name': 'design'},
+      userDoc('ada'),
+    ]);
+
+    await repository.syncTabletUsers(config: config);
+
+    expect(await db.userDao.count(), 1);
+    expect(await db.userDao.getById('_design/users'), isNull);
+  });
+
+  test('stores the profile photo as its attachment name', () async {
+    stubWalk([
+      userDoc(
+        'ada',
+        attachments: {
+          'img': {'content_type': 'image/png', 'length': 12, 'stub': true},
+        },
+      ),
+    ]);
+
+    await repository.syncTabletUsers(config: config);
+
+    expect(
+      (await db.userDao.getById('org.couchdb.user:ada'))!.userImage,
+      'img',
+    );
+  });
+
+  test('a member registered on this device keeps their row, their local id and '
+      'their health key', () async {
+    // The Phase 107 identity rule: an offline registration keeps a
+    // locally-minted id and gains a `couchId` when the upload lands. Keying
+    // the pulled document on `_id` would give them a second row carrying no
+    // `key`/`iv`, and `UserDao.getById` matches either — which makes their
+    // encrypted health records unreadable.
+    await db.userDao.upsert(
+      UsersCompanion.insert(
+        id: '1756900000000',
+        couchId: const Value('org.couchdb.user:ada'),
+        name: const Value('ada'),
+        key: const Value('local-aes-key'),
+        iv: const Value('local-iv'),
+      ),
+    );
+
+    stubWalk([userDoc('ada', firstName: 'Ada')]);
+    await repository.syncTabletUsers(config: config);
+
+    expect(await db.userDao.count(), 1);
+    final row = await db.userDao.getById('org.couchdb.user:ada');
+    expect(row!.id, '1756900000000');
+    expect(row.firstName, 'Ada');
+    expect(row.key, 'local-aes-key');
+    expect(row.iv, 'local-iv');
+  });
+
+  test('a document that omits a profile field keeps the stored one', () async {
+    await db.userDao.upsert(
+      UsersCompanion.insert(
+        id: 'org.couchdb.user:ada',
+        couchId: const Value('org.couchdb.user:ada'),
+        name: const Value('ada'),
+        phoneNumber: const Value('555-0100'),
+      ),
+    );
+
+    // `applyJsonToUser`'s `if (new.isNotEmpty() || old.isNullOrEmpty())`.
+    stubWalk([userDoc('ada', firstName: 'Ada')]);
+    await repository.syncTabletUsers(config: config);
+
+    expect(
+      (await db.userDao.getById('org.couchdb.user:ada'))!.phoneNumber,
+      '555-0100',
+    );
+  });
+
+  test('adopts a guest row rather than duplicating the account', () async {
+    // `UserRepositoryImpl.kt:1114-1128`: the guest is re-keyed to the server id
+    // and its old row deleted, so the person keeps one row across the
+    // transition from guest to member.
+    await db.userDao.upsert(
+      UsersCompanion.insert(
+        id: 'guest_ada',
+        couchId: const Value('guest_ada'),
+        name: const Value('ada'),
+        key: const Value('guest-key'),
+        iv: const Value('guest-iv'),
+      ),
+    );
+
+    stubWalk([userDoc('ada', firstName: 'Ada')]);
+    await repository.syncTabletUsers(config: config);
+
+    expect(await db.userDao.count(), 1);
+    final rows = await db.userDao.getAllUsers();
+    expect(rows.single.id, 'org.couchdb.user:ada');
+    expect(rows.single.firstName, 'Ada');
+    // The device-only columns survive the re-key: the row is rebuilt under a
+    // new key, so anything `Value.absent()` would silently take its default.
+    expect(rows.single.key, 'guest-key');
+    expect(rows.single.iv, 'guest-iv');
+  });
+
+  test('never prunes: an account the walk did not list survives', () async {
+    // Kotlin's walk issues no delete, and it could not — this table also holds
+    // accounts registered offline, and the session is restored by looking the
+    // signed-in user up here.
+    await db.userDao.upsert(
+      UsersCompanion.insert(
+        id: '1756900000000',
+        name: const Value('offline-only'),
+      ),
+    );
+
+    stubWalk([userDoc('ada')]);
+    await repository.syncTabletUsers(config: config);
+
+    expect(await db.userDao.getById('1756900000000'), isNotNull);
+    expect(await db.userDao.count(), 2);
+  });
+}

--- a/flutter/test/repository/team_tasks_repository_test.dart
+++ b/flutter/test/repository/team_tasks_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/team_tasks_repository.dart';
+import '../support/mock_planet_api.dart';
 
 void main() {
   late AppDatabase database;
@@ -8,6 +9,7 @@ void main() {
   setUp(() {
     database = AppDatabase.memory();
     repository = TeamTasksRepository(
+      MockPlanetApi(),
       database.teamTaskDao,
       now: () => DateTime.fromMillisecondsSinceEpoch(500),
       createId: () => 'local-task',

--- a/flutter/test/repository/team_tasks_sync_test.dart
+++ b/flutter/test/repository/team_tasks_sync_test.dart
@@ -1,0 +1,239 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/team_tasks_repository.dart';
+
+import '../support/mock_planet_api.dart';
+
+/// The `tasks` walk — `TransactionSyncManager.syncDb("tasks")` plus
+/// `TeamsRepositoryImpl.bulkInsertTasksFromSync` / `TeamTask.fromJson`.
+///
+/// Phase 116's D16 came with a trap attached, and it is the first test here:
+/// the walk can land a full page of rows and the screen still shows nothing,
+/// because `TeamTask.serialize` emits **no `status` field** while the port's
+/// `watchForTeam` required `status = 'active'`.
+///
+/// The documents are shaped the way `TeamTask.serialize` actually writes them —
+/// `link: {teams: …}`, `assignee` as an object or the empty string, no
+/// `status` — rather than flattened to the columns the row happens to have.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late TeamTasksRepository repository;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = TeamTasksRepository(api, db.teamTaskDao);
+  });
+
+  tearDown(() => db.close());
+
+  /// A document in the shape `TeamTask.serialize` produces.
+  Map<String, dynamic> taskDoc(
+    String id, {
+    String teamId = 'team-1',
+    String title = 'Fix the well pump',
+    Object? assignee = '',
+    bool completed = false,
+    int deadline = 1800000000000,
+    String? status,
+  }) => {
+    '_id': id,
+    '_rev': '2-abc',
+    'title': title,
+    'deadline': deadline,
+    'description': 'Ordered the seal, arriving Tuesday',
+    'completed': completed,
+    'completedTime': 0,
+    'assignee': assignee,
+    'sync': {'type': 'local', 'planetCode': 'gua'},
+    'link': {'teams': teamId},
+    'status': ?status,
+  };
+
+  void stubWalk(List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/tasks/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('tasks/_all_docs?include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  test('a task the server sent reaches the team list, though its document '
+      'carries no status', () async {
+    // The defect: `TeamTask.serialize` emits no `status`, `fromJson` reads
+    // the missing key as `""`, and the port asked for `status = 'active'`.
+    // Reverting `TeamTaskDao.watchForTeam` to that predicate fails this test
+    // while everything else here still passes — the walk works and the
+    // screen is empty.
+    stubWalk([taskDoc('task-server-1')]);
+
+    await repository.sync(config: config);
+
+    final rows = await repository.watchForTeam('team-1').first;
+    expect(rows.single.id, 'task-server-1');
+    expect(rows.single.status, '');
+    expect(rows.single.title, 'Fix the well pump');
+  });
+
+  test(
+    'an archived task is excluded, matching TeamTaskDao.getByTeamId',
+    () async {
+      stubWalk([taskDoc('task-live'), taskDoc('task-old', status: 'archived')]);
+
+      await repository.sync(config: config);
+
+      final rows = await repository.watchForTeam('team-1').first;
+      expect(rows.map((r) => r.id), ['task-live']);
+      // Excluded from the list, not deleted — the walk prunes nothing.
+      expect(await db.teamTaskDao.getById('task-old'), isNotNull);
+    },
+  );
+
+  test(
+    'reads teamId out of link.teams and assignee out of assignee._id',
+    () async {
+      stubWalk([
+        taskDoc('task-1', teamId: 'team-9', assignee: {'_id': 'user-7'}),
+      ]);
+
+      await repository.sync(config: config);
+
+      final row = await db.teamTaskDao.getById('task-1');
+      expect(row!.teamId, 'team-9');
+      expect(row.assignee, 'user-7');
+    },
+  );
+
+  test('an empty-string assignee leaves the column null', () async {
+    // `if (user.has("_id"))`. Writing `""` would make the row match
+    // `pendingDeadlineTasks` for a user whose id is empty.
+    stubWalk([taskDoc('task-1')]);
+
+    await repository.sync(config: config);
+
+    expect((await db.teamTaskDao.getById('task-1'))!.assignee, isNull);
+  });
+
+  test('skips _design documents', () async {
+    stubWalk([
+      {'_id': '_design/tasks'},
+      taskDoc('task-1'),
+    ]);
+
+    await repository.sync(config: config);
+
+    expect(await db.teamTaskDao.getById('_design/tasks'), isNull);
+  });
+
+  test('a re-pull does not re-fire a deadline notification', () async {
+    // `isNotified` is device-local — it is on neither the document nor
+    // `TeamTask.serialize` — and it is the only thing making the reminder
+    // once-only. Kotlin's `fromJson` builds a fresh entity and resets it.
+    stubWalk([
+      taskDoc('task-1', assignee: {'_id': 'user-7'}),
+    ]);
+    await repository.sync(config: config);
+    await repository.markNotified(['task-1']);
+
+    await repository.sync(config: config);
+
+    expect((await db.teamTaskDao.getById('task-1'))!.isNotified, isTrue);
+  });
+
+  test(
+    'an edit made offline survives the pull that carries its old copy',
+    () async {
+      // The row was created here, uploaded, and edited again before the next
+      // sync. The server's copy is the pre-edit one; adopting it would discard
+      // the edit *and* clear the flag that makes it upload.
+      await db.teamTaskDao.upsert(
+        TeamTasksCompanion.insert(
+          id: 'task-local-1',
+          teamId: 'team-1',
+          docId: const Value('task-server-1'),
+          rev: const Value('1-old'),
+          title: const Value('Fix the well pump today'),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      stubWalk([taskDoc('task-server-1', title: 'Fix the well pump')]);
+      await repository.sync(config: config);
+
+      // One row, not two: resolving through `_id` finds the local row rather
+      // than inserting a second under the CouchDB id.
+      expect((await db.teamTaskDao.getByAnyIds(['task-server-1'])).length, 1);
+      final row = await db.teamTaskDao.getById('task-local-1');
+      expect(row!.title, 'Fix the well pump today');
+      expect(row.isUpdated, isTrue);
+      // …and it gains the rev its next upload needs.
+      expect(row.rev, '2-abc');
+    },
+  );
+
+  test(
+    'a synced task the device already holds is updated, not duplicated',
+    () async {
+      await db.teamTaskDao.upsert(
+        TeamTasksCompanion.insert(
+          id: 'task-local-1',
+          teamId: 'team-1',
+          docId: const Value('task-server-1'),
+          title: const Value('Fix the well pump'),
+          isUpdated: const Value(false),
+        ),
+      );
+
+      stubWalk([taskDoc('task-server-1', title: 'Fix the well pump (urgent)')]);
+      await repository.sync(config: config);
+
+      final rows = await repository.watchForTeam('team-1').first;
+      expect(rows.length, 1);
+      expect(rows.single.id, 'task-local-1');
+      expect(rows.single.title, 'Fix the well pump (urgent)');
+    },
+  );
+
+  test('never prunes: a task created offline survives the walk', () async {
+    await repository.create(
+      teamId: 'team-1',
+      title: 'Draft the budget',
+      description: '',
+      deadline: 1800000000000,
+    );
+
+    stubWalk([taskDoc('task-server-1')]);
+    await repository.sync(config: config);
+
+    final rows = await repository.watchForTeam('team-1').first;
+    expect(rows.map((r) => r.title), containsAll(<String>['Draft the budget']));
+  });
+}

--- a/flutter/test/support/mock_planet_api.dart
+++ b/flutter/test/support/mock_planet_api.dart
@@ -1,0 +1,10 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+
+/// A [PlanetApi] double for tests that construct a repository but never sync.
+///
+/// Phase 119 gave `RatingsRepository`, `TeamTasksRepository` and
+/// `AchievementsRepository` their missing sync-in walks, so each now takes an
+/// api. An unstubbed mocktail double throws on any call, which is what these
+/// tests want: reaching the network from a local-only test should fail loudly.
+class MockPlanetApi extends Mock implements PlanetApi {}

--- a/flutter/test/ui/achievements/achievements_screen_test.dart
+++ b/flutter/test/ui/achievements/achievements_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:myplanet/repository/achievements_repository.dart';
 import 'package:myplanet/ui/achievements/achievements_screen.dart';
 
 import '../../support/widget_harness.dart';
+import '../../support/mock_planet_api.dart';
 
 Widget harness(AchievementRow? row) {
   return wrapScreen(
@@ -32,7 +33,10 @@ void main() {
 
   testWidgets('renders goals, purpose, entries and references', (tester) async {
     final database = AppDatabase.memory();
-    final repository = AchievementsRepository(database.achievementDao);
+    final repository = AchievementsRepository(
+      MockPlanetApi(),
+      database.achievementDao,
+    );
     await repository.update(
       'ada@earth',
       const AchievementInput(

--- a/flutter/test/ui/achievements/edit_achievement_screen_test.dart
+++ b/flutter/test/ui/achievements/edit_achievement_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/ui/achievements/edit_achievement_screen.dart';
 
 import '../../support/widget_harness.dart';
+import '../../support/mock_planet_api.dart';
 
 /// The screen's own localisations, so a test never has to repeat a string the
 /// `.arb` owns.
@@ -142,7 +143,7 @@ void main() {
   });
 
   AchievementsRepository repository() =>
-      AchievementsRepository(db.achievementDao);
+      AchievementsRepository(MockPlanetApi(), db.achievementDao);
 
   Future<AchievementRow?> ledger() => db.achievementDao.getById(achievementId);
 

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -180,7 +180,7 @@ void main() {
     );
 
     // Seed an existing course rating for the signed-in user.
-    await RatingsRepository(MockPlanetApi(), db.ratingDao).submit(
+    await RatingsRepository(MockPlanetApi(), db.ratingDao, db.userDao).submit(
       type: 'course',
       itemId: 'course-1',
       title: 'Algebra',

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:myplanet/repository/ratings_repository.dart';
 import 'package:myplanet/ui/courses/take_course_screen.dart';
 
 import '../../support/widget_harness.dart';
+import '../../support/mock_planet_api.dart';
 
 /// Mirrors the test-session notifier in `session_provider_test.dart`: returns a
 /// fixed user (or none) without touching the database or prefs, so the
@@ -179,7 +180,7 @@ void main() {
     );
 
     // Seed an existing course rating for the signed-in user.
-    await RatingsRepository(db.ratingDao).submit(
+    await RatingsRepository(MockPlanetApi(), db.ratingDao).submit(
       type: 'course',
       itemId: 'course-1',
       title: 'Algebra',


### PR DESCRIPTION
Lane A of the Phase 119 parallel round. Full write-up in `flutter/PHASE_119_NOTES.md`.

Phase 116 audited data-path reachability and reported, without fixing, five sync-in walks Kotlin runs that the port never had. This is the same failure class Phase 113 found in the exam path, one level up: **the data never arrives at all**, so every screen reading that table is dead however well it is written — and green tests cannot see it, because a repository test builds its own rows and a screen test builds its own screen.

| walk | what was dead | Phase 116 |
|---|---|---|
| `shelf` | My Library, My Courses, course progress, both home cards, the completed-course stars | D1/D2 |
| `tablet_users` | member detail, the team leaderboard, every team member's name | D15 |
| `ratings` | every rating average was the one number this device had typed | D4 |
| `tasks` | a task made on Planet or by a teammate never arrived | D16 |
| `achievements` | a second device showed blank, and saving there 409'd into the outbox's permanent-failure branch | D19 |

**No schema bump** — every table and column already exists at `schemaVersion` 45.

### The two decisions the brief asked for

**Pruning: none of the five prunes.** Kotlin issues no delete on any of these paths (checked per walk); the one prune in its whole sync belongs to the *resources* walk, not the shelf pass that follows it. And four of the tables hold locally-authored rows keyed by ids no `_all_docs` keep set contains until they have been uploaded *and* pulled back. `walkAllDocs` therefore takes no keep set at all.

**Local authority: a pending edit wins.** `isNotified` is never written by the walk, so a re-pull cannot re-fire a deadline reminder; and a row still flagged `isUpdated`/`uploaded = false` takes only `_id`/`_rev`, which preserves the unsent edit and hands it the `_rev` its next enqueue needs to be a PUT rather than a 409-ing POST. Kotlin discards both.

### Defects, each demonstrated failing on pre-fix code

First pass — the headline is that `TeamTaskDao.watchForTeam` required `status = 'active'` while `TeamTask.serialize` emits no `status` at all, so **the walk would have worked and the screen would have stayed empty**. Plus: the shelf stamp keyed on the CouchDB id where every reader scopes by the local row id (empty My Library for a member registered offline, sync reporting success); a rating counted twice; pending edits and the notification flag clobbered.

Second `parity-auditor` pass, aimed at the finished green diff, found six more. The one worth reading is finding 1: `Achievements.uploaded` is the inverted name for Kotlin's `isUpdated` and its column default is the wrong way round, so `getOrInitialize`'s blank placeholder read as an unsent edit — and `achievementEntryProvider` calls it on watch. **Opening the achievements screen once made the walk preserve that blank row instead of the server's ledger, permanently, and arm the next Save to overwrite the real one.** The preservation rule turned the exact defect it was meant to fix into a worse one.

### Reported, not fixed

Two missing columns needing a version number the integrator allocates (`rating.user`/`createdOn`, `team_tasks.sync`/`link` — both write-only from the port's side today); a `_rev` stamped after a payload is queued never reaches that payload (an outbox change); two pre-existing `MyLibraryMapper` defects belonging to the `resources` walk, one storing a Dart map literal in `privateFor`; and the `tablet_users` walk reverting an offline profile edit, which is faithful to Kotlin but inconsistent with the other three tables.

### Gate

Format clean, analyze clean, **1991 tests** (baseline 1940). 51 new tests across six files, each built from a document in the shape CouchDB actually stores rather than from a fixture matching the row's columns — which is how the `status` defect stayed invisible.

Files outside this lane's set: none. The only Lane C file touched is `lib/l10n/app_en.arb`, which the brief designates for new strings; six keys appended at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5YJMJNzToREUm1eMhVZr4
