### PR TITLE
Phase 121 (Flutter port, Lane C): derive placeholder-carrying keys from the Kotlin locales

### DIFF
--- a/flutter/PHASE_117_NOTES.md
+++ b/flutter/PHASE_117_NOTES.md
@@ -258,6 +258,18 @@ so it will never derive them and Spanish will read English forever. One key,
 five files, all in Lane C's set. `stepsHeading` the tool will pick up by exact
 English match on `steps`, and `percentageValue` is `%s%%` in every locale.
 
+> **Corrected by Phase 121, which did the work.** `values-ne`'s `course_progress`
+> does **not** reorder its placeholders — `%1$s को %2$s प्रगति` keeps ascending
+> argument order, and only moves them relative to the words, which any
+> substitution handles. The conclusion drawn from it is right and the instance
+> is not: four other Kotlin strings really do reorder
+> (`ne/download_progress`, `ne/download_progress_with_errors`,
+> `ne/steps_done_of_total`, `ar/member_description`), and those are what pin the
+> conversion. `percentageValue` was *not* derived: `%s%%` carries no word, so
+> every locale's value would be the English template, and a skeleton with no
+> letter in it also matches any unrelated key of the same shape. See
+> `PHASE_121_NOTES.md`.
+
 ## Not a schema change
 
 No table, no converter, no index, no `schemaVersion` bump (still 45), so no

--- a/flutter/PHASE_121_NOTES.md
+++ b/flutter/PHASE_121_NOTES.md
@@ -1,8 +1,248 @@
-# Phase 121 — placeholder keys, the class the derivation tool could never reach
+# Phase 121 — the placeholder keys, a class the derivation tool could never reach
 
-*(in progress)*
+Phase 117 handed over one key. It is a class, and this phase measures it before
+changing anything, because the number is the deliverable.
 
-`tool/arb_from_strings_xml.dart` skips every template value carrying an ICU
-placeholder or a printf specifier. Kotlin ships human translations for those
-strings in all five locales. This phase measures that class and derives what
-can be derived unambiguously.
+## The size of the class
+
+| | |
+|---|---|
+| Kotlin strings in `values/strings.xml` | 1052 |
+| …carrying a format specifier (`%s`, `%1$s`, `%d`, `%.1f`) | **92** |
+| ARB template message keys | 873 |
+| …declaring an ICU placeholder | 76 |
+| …of which plural/select bodies | 23 |
+| …of which simple `{name}` messages | 53 |
+| simple messages whose skeleton matches a Kotlin format string | 11 |
+| …rejected because the skeleton carries no word | 3 |
+| **derived** | **8 keys × 5 locales = 40 values** |
+
+Every one of the 92 has a human translation shipping in all five locales of the
+Android app. `tool/arb_from_strings_xml.dart` skipped any template value
+containing `{`, so it could never read one of them.
+
+**Only 8 keys came back, and that is the honest answer, not a shortfall.** The
+class is 92 Kotlin strings wide but the port has minted its own English for most
+of what it renders: of the 53 simple placeholder messages in `app_en.arb`, 42
+have no Kotlin counterpart with the same words at all (`Syncing {completed} of
+{total} areas`, `Rate {title}`, `Year must be between {min} and {max}` — port
+screens Kotlin does not have, or port phrasing of screens it does). Those are a
+`nameOnly`/`containment` judgement about what a screen should say, which is
+Phase 114's line and still not a derivation. Recovering them means editing
+`app_en.arb` first.
+
+## The conversion, and why it is index-aware rather than positional
+
+Android numbers its arguments and lets a translator move them; ICU names them.
+The tool now reduces both notations to a `_FormatString` — literal segments plus
+the ordered ids of the holes between them — matches on the literal, zips the two
+English hole lists to get **argument index → placeholder name**, and applies
+that map to wherever the *translation's* holes fall.
+
+A left-to-right substitution reads correctly on every string whose translation
+keeps the English order, and silently prints the wrong value into a sentence on
+the ones that do not. Four Kotlin strings reorder:
+
+```
+ne/download_progress             %2$d मध्ये %1$d फाइलहरू डाउनलोड भएका छन्
+ne/download_progress_with_errors %2$d मध्ये %1$d फाइलहरू … (केही त्रुटिहरूसहित)
+ne/steps_done_of_total           %2$d मध्ये %1$d सम्पन्न
+ar/member_description            (‎%2$d زيارة) ‎%1$s
+```
+
+`format_derivation_test.dart` drives the first of these through the real XML:
+positional substitution yields `{completed} मध्ये {total}`, i.e. a device three
+files into eight reading "eight of three"; the index-aware conversion yields
+`{total} मध्ये {completed}`. A second test runs the Spanish of the same string,
+which keeps the English order, so the first cannot pass by reversing everything.
+
+**One correction to Phase 117.** Its note said `values-ne:1010`
+(`course_progress`) reorders its placeholders. It does not — `%1$s को %2$s प्रगति`
+keeps ascending index order; it moves the placeholders relative to the *words*,
+which any substitution handles. The claim that the conversion must be
+index-aware is right and the named instance is not the evidence for it. The four
+strings above are.
+
+### `courseProgressCount`, before and after
+
+| | before | after |
+|---|---|---|
+| ar | *absent → "Progress 3 of 8"* | `التقدم {current} من {max}` |
+| es | *absent → "Progress 3 of 8"* | `Progreso {current} de {max}` |
+| fr | *absent → "Progress 3 of 8"* | `Progression {current} sur {max}` |
+| ne | *absent → "Progress 3 of 8"* | `{current} को {max} प्रगति` |
+| so | *absent → "Progress 3 of 8"* | `Habka {current} ee {max}` |
+
+All eight derived keys were absent in every locale that got one, so the value
+each replaces is the English fallback — nothing was overwritten except values
+flagged `x-mt` or holding the English template verbatim.
+
+The eight: `appVersion`, `courseProgressCount`, `currentCv`, `errorOccurred`,
+`fileCountMany`, `fileNotFound`, `reportDateDetails`, `storageSelectedCount`.
+Plus `stepsHeading`, Phase 117's third key, which needed no format layer — it is
+plain text and the existing English-match rule picked it up once it was asked.
+
+## The guards, and the one that earned its place
+
+Four rules reject, in order. Three are obvious in hindsight; the third is not.
+
+* **Plurals and selects are out of scope.** A Kotlin `%d` string is one
+  sentence, `{count, plural, =0{…} =1{…} other{…}}` is three. Filling `other`
+  from the Kotlin and leaving `=0`/`=1` in English would put two languages
+  inside one rendered string — worse than the English fallback. 23 keys.
+* **An unsupported conversion rejects the whole string.** `%.1f` says "one
+  decimal place" and `{value}` does not. One Kotlin string (`float_placeholder`).
+* **A skeleton with no letter in it is not evidence.** This is the one that
+  matters. `%1$s (%2$s)` is punctuation: byte-identical in all five locales, so
+  deriving from it adds a value that says nothing — and it matches *any* key of
+  that shape. `ratingCompact` ("{average} ({count})") matched Kotlin's
+  `user_name`, which is a person's name beside their login count. Same
+  punctuation, different words, and no test in this tree could have caught the
+  swap because the rendered string is identical in English. Requiring a letter
+  throws the wrong match out along with the two useless ones
+  (`userNameWithLogins`, `percentageValue` — `%s%%` in every locale, which is
+  the template already).
+* **Every declared placeholder must survive**, which is
+  `placeholder_integrity_test.dart`'s rule applied at the source.
+
+Matching is **exact skeleton only** — no punctuation or casing tier. Those tiers
+strip a value's trailing punctuation and give the template's back, which is not
+safe next to a hole, and nothing in the corpus matches at them anyway.
+
+## Phase 118's residue: 42 → 26
+
+Two rules, both narrow, close 16 of the 42.
+
+**A namesake breaks a tie.** Where two Kotlin names share one English text and
+disagree in translation, the tool reported `no-unanimous` and stopped. But a
+candidate whose name camel-cases to the ARB key is the same string identified
+*twice* — by its words and by its name — and that is more evidence, not less.
+The `--adopt` header already said to "prefer the name whose usage site matches
+the ARB key's"; nothing implemented it. It settles 13 of the 25: `addResource`
+takes `add_resource` over `add_res`; `joinRequests` and `notifGroupJoinRequests`
+share both their candidates and each picks its own namesake. **4 remain**, all
+`progressFilterCompleted` — `completed` vs `status_completed`, genuinely no name
+to break the tie.
+
+**A locale entry that is still the English is not a translation.** Phase 118
+wrote that rule down as advice for a reader; the tool did not have it. With the
+namesake rule in, it stopped being advice: `values-so` renders `settings` as
+"Settings", and that string is the namesake of the ARB key `settings`, so it
+would have won the tie against the real Somali `Goobooyinka` the moment anyone
+flagged that key. Proposals byte-identical to the English template are now
+dropped before any tie-break runs.
+
+**Whitespace class is not a difference worth adopting.** `app_fr.arb` writes
+`Rapport créé le\u{a0}: {created}` where `values-fr` writes an ordinary space.
+French typography wants the no-break space; the words are identical. There is no
+translation to gain and a nicety to lose, so "same words, different space
+character" is now `already` rather than `apply`, and a test pins the French
+value.
+
+### What is left, and why
+
+* **22 `keep-human`** (es 17, so 3, fr 1, ne 1). Two valid renderings, e.g.
+  `es:amount` Monto/Cantidad, `fr:unselectAll` "Tout désélectionner"/
+  "Désélectionner tout". Needs a speaker. This is where the lane stops.
+* **4 `no-unanimous`**, all `progressFilterCompleted`.
+* **4 tool false positives, confirmed rather than re-derived.** Phase 118 named
+  three; there is a fourth of the same shape. `es:reports` (`Informes` vs
+  `informes`), `so:settings` (`Goobooyinka` vs `goobooyinka`) — both are the
+  case-aligned form already, reported only because `_alignInitialCase` runs in
+  the `casing` tier and these match at `exact`, where no transform runs.
+  `es:myProgress` and `es:myCourses` hold the good value against a camelCase
+  artefact in the Spanish XML, so they will be reported forever. That is the
+  correct state, not a to-do. Extending the case alignment to every tier would
+  fix the first two and has a blast radius across all 873 keys; it is a phase of
+  its own.
+* **132 `nameOnly` + `containment` per locale**, unchanged. Recovering one means
+  editing `app_en.arb`.
+
+## The finding this phase did not go looking for
+
+**259 values across ar/es/fr were flagged `x-mt` while being byte-identical to
+the translation shipping in the Android app** (ar 62, es 122, fr 75). The flag
+means "unreviewed machine output, a human still has to look at this". One has —
+whatever pipeline produced this particular copy of the words, they are the words
+a translator wrote for the Kotlin app. The tool's own reconcile rule already
+said a stale flag on a Kotlin-derived value should be dropped; it only ever
+fired on values it had just *adopted*, never on the ones that needed no
+adopting, which is an inconsistency rather than a new policy.
+
+Cleared. **Nothing a user sees changed** — this is marking only, and it is one
+line to revert (`_reconcileMachineTranslationFlags`' `already` branch) if the
+reading is rejected. It is called out here rather than buried because it moves
+the human-reviewed counts more than the 33 new translations do, and a count that
+moves for two different reasons in one phase is exactly the kind of thing that
+later reads as drift.
+
+Same shape as Phase 118's own generalisation: a report built to answer "what can
+I adopt?" cannot answer "what is already fine and mislabelled?", and this one
+was invisible because the `already` verdict is the one the report does not print.
+
+## Counts, before → after
+
+| locale | values | human (unflagged) | of which new this phase |
+|---|---|---|---|
+| ar | 823 → 829 | 327 → 395 | 6 derived + 62 flags cleared |
+| es | 861 → 864 | 323 → 448 | 3 derived + 122 flags cleared |
+| fr | 861 → 864 | 316 → 394 | 3 derived + 75 flags cleared |
+| ne | 415 → 421 | 389 → 396 | 7 derived |
+| so | 415 → 421 | 389 → 396 | 7 derived |
+
+`gen-l10n`'s untranslated report moves with them: ar 50 → 44, es/fr 12 → 9,
+ne/so 458 → 452.
+
+## Wording for `CLAUDE.md`
+
+Replace the **Current l10n state** passage (Phase 118's suggested text is now
+out of date on both the counts and the tool's reach):
+
+> **Current l10n state, and one open decision.** The template `app_en.arb` has
+> 873 keys. Arabic, Spanish and French carry 829–864 values each, of which
+> 394–448 are human translations and the rest machine output flagged `x-mt`.
+> Nepali and Somali carry 421 values, 396 human — and the other 452 keys fall
+> back to English on purpose. Nothing here is translated by hand: the human
+> share comes from reading the Kotlin `values-*/strings.xml`, which ships real
+> translations in all five languages, and preferring them wherever the port had
+> minted its own English for a string Kotlin already had. Phase 114 recovered
+> 431 that way, Phase 118 deleted 899 `[Nepali] `/`[Somali] ` markers that were
+> displacing the English fallback with the English plus a tag, and Phase 121
+> reached the class both were structurally blind to: **92 Kotlin strings carry a
+> `%s`/`%d` format specifier and the derivation tool skipped every message with
+> a placeholder in it**, so `courseProgressCount` read "Progress 3 of 8" to a
+> Spanish learner while "Progreso %1$s de %2$s" shipped in the Android app.
+> `tool/arb_from_strings_xml.dart` now converts Android's positional specifiers
+> to ICU named placeholders **by argument index, never by position** — four
+> Kotlin locale strings reorder their arguments, and a left-to-right
+> substitution renders "eight of three" on those. `--candidates` reports what is
+> left and `--adopt` applies the confident ones; **re-run `--adopt` whenever a
+> phase adds an English key**, because the Kotlin app may already ship the
+> translation. **Match on English text, never on the key name** — `achievements`
+> and Kotlin's `myAchievements` are the same concept and different strings —
+> except as a *tie-break* between two Kotlin names that share one English and
+> disagree, where the namesake is the same string identified twice. Never adopt
+> a value that is itself English (`values-so` renders `settings` as "Settings"),
+> and never derive from a skeleton with no word in it (`%1$s (%2$s)` matches any
+> key of that shape and carries no translation). What still needs a human is 22
+> two-valid-renderings disagreements, the 452 keys per locale Nepali and Somali
+> have never had, and a visual RTL review in Arabic; a confidently wrong
+> translation can mislead a learner where an English fallback merely
+> inconveniences them.
+
+For the Migration progress table's Localisation row: the honest figure is now
+**394–448 human of 873 in ar/es/fr, 396 of 873 in ne/so**. The score can move
+from ~30 to ~34 — the derived slice is small, and most of the count movement is
+truthfulness about strings that were already correct rather than new coverage.
+
+## What is not here
+
+* **No schema change.** No table, converter or index; `schemaVersion` stays 45.
+* **No `lib/` change at all.** `lib/l10n/*.arb` are data; the generated
+  `app_localizations*.dart` are gitignored build output.
+* **The three `app_en.arb` keys that write printf in their own English** —
+  `communityEarnings`, `perSurvey`, `yourEarnings` — are still skipped. They
+  declare ICU placeholders and write `%1$d`, so ICU never interpolates and the
+  getter drops its argument *in English too*. That is a defect in the template,
+  not in the derivation, and fixing it is a decision about what those screens
+  say.

--- a/flutter/PHASE_121_NOTES.md
+++ b/flutter/PHASE_121_NOTES.md
@@ -15,7 +15,8 @@ changing anything, because the number is the deliverable.
 | …of which simple `{name}` messages | 53 |
 | simple messages whose skeleton matches a Kotlin format string | 11 |
 | …rejected because the skeleton carries no word | 3 |
-| **derived** | **8 keys × 5 locales = 40 values** |
+| **derived** | **8 keys × 5 locales = 40 slots** |
+| …slots that needed writing (the rest already held the Kotlin translation) | **25** |
 
 Every one of the 92 has a human translation shipping in all five locales of the
 Android app. `tool/arb_from_strings_xml.dart` skipped any template value
@@ -73,14 +74,18 @@ strings above are.
 | ne | *absent → "Progress 3 of 8"* | `{current} को {max} प्रगति` |
 | so | *absent → "Progress 3 of 8"* | `Habka {current} ee {max}` |
 
-All eight derived keys were absent in every locale that got one, so the value
-each replaces is the English fallback — nothing was overwritten except values
-flagged `x-mt` or holding the English template verbatim.
+The eight keys are `appVersion`, `courseProgressCount`, `currentCv`,
+`errorOccurred`, `fileCountMany`, `fileNotFound`, `reportDateDetails`,
+`storageSelectedCount`. **25 of their 40 locale slots needed writing**; the
+other 15 already held the Kotlin translation byte for byte (`errorOccurred` in
+all five, and es/fr had picked several up by hand). 20 of the 25 were *absent*,
+so the value they replace is the English fallback; the other 5 held the English
+template verbatim, flagged `x-mt` — `storageSelectedCount` read "{count}
+selected" in all five locales. **Nothing was overwritten that was not flagged
+machine output or literally the English template.**
 
-The eight: `appVersion`, `courseProgressCount`, `currentCv`, `errorOccurred`,
-`fileCountMany`, `fileNotFound`, `reportDateDetails`, `storageSelectedCount`.
-Plus `stepsHeading`, Phase 117's third key, which needed no format layer — it is
-plain text and the existing English-match rule picked it up once it was asked.
+`stepsHeading`, Phase 117's third key, needed no format layer — it is plain
+text, and the existing English-match rule picked it up once it was asked.
 
 ## The guards, and the one that earned its place
 
@@ -160,8 +165,8 @@ value.
 
 ## The finding this phase did not go looking for
 
-**259 values across ar/es/fr were flagged `x-mt` while being byte-identical to
-the translation shipping in the Android app** (ar 62, es 122, fr 75). The flag
+**250 values across ar/es/fr were flagged `x-mt` while being byte-identical to
+the translation shipping in the Android app** (ar 60, es 118, fr 72). The flag
 means "unreviewed machine output, a human still has to look at this". One has —
 whatever pipeline produced this particular copy of the words, they are the words
 a translator wrote for the Kotlin app. The tool's own reconcile rule already
@@ -174,7 +179,8 @@ line to revert (`_reconcileMachineTranslationFlags`' `already` branch) if the
 reading is rejected. It is called out here rather than buried because it moves
 the human-reviewed counts more than the 33 new translations do, and a count that
 moves for two different reasons in one phase is exactly the kind of thing that
-later reads as drift.
+later reads as drift: 250 of the 261 cleared flags are this, and only 11 are
+strings the phase actually rewrote.
 
 Same shape as Phase 118's own generalisation: a report built to answer "what can
 I adopt?" cannot answer "what is already fine and mislabelled?", and this one
@@ -182,13 +188,22 @@ was invisible because the `already` verdict is the one the report does not print
 
 ## Counts, before → after
 
-| locale | values | human (unflagged) | of which new this phase |
-|---|---|---|---|
-| ar | 823 → 829 | 327 → 395 | 6 derived + 62 flags cleared |
-| es | 861 → 864 | 323 → 448 | 3 derived + 122 flags cleared |
-| fr | 861 → 864 | 316 → 394 | 3 derived + 75 flags cleared |
-| ne | 415 → 421 | 389 → 396 | 7 derived |
-| so | 415 → 421 | 389 → 396 | 7 derived |
+36 values written in all: **25 placeholder-key** (this phase's subject) and
+**11 plain-text**, from the two residue rules below. 24 of the 36 filled a key
+the locale did not have; 12 replaced a value that was flagged `x-mt` or was the
+English template.
+
+| locale | values | added | replaced | flags cleared | human (unflagged) |
+|---|---|---|---|---|---|
+| ar | 823 → 829 | 6 | 2 | 62 | 327 → 395 |
+| es | 861 → 864 | 3 | 4 | 122 | 323 → 448 |
+| fr | 861 → 864 | 3 | 4 | 75 | 316 → 394 |
+| ne | 415 → 421 | 6 | 1 | 1 | 389 → 396 |
+| so | 415 → 421 | 6 | 1 | 1 | 389 → 396 |
+
+261 flags cleared, of which **11 sit on a value this phase rewrote** and **250
+on a value that was already byte-identical to the Kotlin translation** — the
+finding below.
 
 `gen-l10n`'s untranslated report moves with them: ar 50 → 44, es/fr 12 → 9,
 ne/so 458 → 452.

--- a/flutter/PHASE_121_NOTES.md
+++ b/flutter/PHASE_121_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 121 — placeholder keys, the class the derivation tool could never reach
+
+*(in progress)*
+
+`tool/arb_from_strings_xml.dart` skips every template value carrying an ICU
+placeholder or a printf specifier. Kotlin ships human translations for those
+strings in all five locales. This phase measures that class and derives what
+can be derived unambiguously.

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -68,9 +68,6 @@
   "resources": "موارد",
   "search": "بحث",
   "sync": "مزامنة",
-  "@sync": {
-    "x-mt": true
-  },
   "cancel": "إلغاء",
   "settings": "الإعدادات",
   "backgroundSync": "مزامنة الخلفية",
@@ -143,9 +140,6 @@
   "appTheme": "سمة التطبيق",
   "aiChat": "AI Chat",
   "syncNow": "مزامنة الآن",
-  "@syncNow": {
-    "x-mt": true
-  },
   "syncCenter": "مركز المزامنة",
   "@syncCenter": {
     "x-mt": true
@@ -264,9 +258,6 @@
   },
   "courses": "الدورات",
   "myCourses": "دوراتي",
-  "@myCourses": {
-    "x-mt": true
-  },
   "allCourses": "جميع الدورات",
   "@allCourses": {
     "x-mt": true
@@ -280,9 +271,6 @@
     "x-mt": true
   },
   "gradeLevel": "مستوى الصف",
-  "@gradeLevel": {
-    "x-mt": true
-  },
   "subjectLevel": "موضوع",
   "@subjectLevel": {
     "x-mt": true
@@ -315,18 +303,12 @@
     "x-mt": true
   },
   "username": "اسم المستخدم",
-  "@username": {
-    "x-mt": true
-  },
   "email": "البريد الإلكتروني",
   "phone": "هاتف",
   "@phone": {
     "x-mt": true
   },
   "level": "مستوى",
-  "@level": {
-    "x-mt": true
-  },
   "levels": "المستويات",
   "@levels": {
     "x-mt": true
@@ -335,9 +317,6 @@
   "languages": "اللغات",
   "gender": "الجنس",
   "dateOfBirth": "تاريخ الميلاد",
-  "@dateOfBirth": {
-    "x-mt": true
-  },
   "planetCode": "كود الكوكب",
   "@planetCode": {
     "x-mt": true
@@ -351,9 +330,6 @@
     "x-mt": true
   },
   "editProfile": "تحرير الملف الشخصي",
-  "@editProfile": {
-    "x-mt": true
-  },
   "changePhoto": "تغيير الصورة الشخصية",
   "@changePhoto": {
     "x-mt": true
@@ -367,13 +343,7 @@
     "x-mt": true
   },
   "firstName": "الاسم الأول",
-  "@firstName": {
-    "x-mt": true
-  },
   "middleName": "الاسم الأوسط",
-  "@middleName": {
-    "x-mt": true
-  },
   "lastName": "الاسم الأخير",
   "save": "حفظ",
   "profileSaved": "تم حفظ الملف الشخصي على هذا الجهاز",
@@ -516,9 +486,6 @@
     "x-mt": true
   },
   "joinRequestNotification": "طلب الانضمام",
-  "@joinRequestNotification": {
-    "x-mt": true
-  },
   "teamNotification": "تحديث الفريق",
   "@teamNotification": {
     "x-mt": true
@@ -753,9 +720,6 @@
   },
   "skip": "تخطي",
   "next": "التالي",
-  "@next": {
-    "x-mt": true
-  },
   "getStarted": "البدء",
   "welcomeToMyPlanet": "مرحبًا بكم في myPlanet",
   "learnOffline": "تعلم بدون اتصال",
@@ -800,9 +764,6 @@
     "x-mt": true
   },
   "addMeetup": "إضافة لقاء",
-  "@addMeetup": {
-    "x-mt": true
-  },
   "meetupDetails": "تفاصيل اللقاء",
   "@meetupDetails": {
     "x-mt": true
@@ -830,13 +791,7 @@
   },
   "editMeetup": "تعديل الاجتماع",
   "startTime": "وقت البدء",
-  "@startTime": {
-    "x-mt": true
-  },
   "endTime": "وقت الانتهاء",
-  "@endTime": {
-    "x-mt": true
-  },
   "none": "لا شيء",
   "daily": "يوميًا",
   "weekly": "أسبوعيًا",
@@ -873,13 +828,7 @@
     "x-mt": true
   },
   "startDate": "تاريخ البدء",
-  "@startDate": {
-    "x-mt": true
-  },
   "endDate": "تاريخ الانتهاء",
-  "@endDate": {
-    "x-mt": true
-  },
   "timeNotSet": "لم يتم ضبط الوقت",
   "@timeNotSet": {
     "x-mt": true
@@ -1125,9 +1074,6 @@
   "teamMembers": "الأعضاء",
   "members": "الأعضاء",
   "joinRequests": "طلبات الانضمام",
-  "@joinRequests": {
-    "x-mt": true
-  },
   "noMembers": "لا يوجد أعضاء حتى الآن",
   "@noMembers": {
     "x-mt": true
@@ -1175,31 +1121,13 @@
   "@removeFromTeam": {
     "x-mt": true
   },
-  "addResource": "أضف موردًا",
-  "@addResource": {
-    "x-mt": true
-  },
+  "addResource": "إضافة مصدر",
   "editResource": "تعديل المورد",
   "resourceUpdated": "تم تحديث المورد",
-  "@resourceUpdated": {
-    "x-mt": true
-  },
   "resourceAddedToTeam": "تمت إضافة المورد إلى الفريق",
-  "@resourceAddedToTeam": {
-    "x-mt": true
-  },
   "descriptionIsRequired": "الوصف مطلوب",
-  "@descriptionIsRequired": {
-    "x-mt": true
-  },
   "levelIsRequired": "المستوى مطلوب",
-  "@levelIsRequired": {
-    "x-mt": true
-  },
   "subjectIsRequired": "الموضوع مطلوب",
-  "@subjectIsRequired": {
-    "x-mt": true
-  },
   "selectFile": "حدد ملفًا",
   "@selectFile": {
     "x-mt": true
@@ -1213,9 +1141,6 @@
     "x-mt": true
   },
   "saveChanges": "حفظ التغييرات",
-  "@saveChanges": {
-    "x-mt": true
-  },
   "selectOpenWith": "اختر فتح باستخدام",
   "@selectOpenWith": {
     "x-mt": true
@@ -1229,9 +1154,6 @@
     "x-mt": true
   },
   "linkToLicense": "رابط الترخيص",
-  "@linkToLicense": {
-    "x-mt": true
-  },
   "noResourcesToAdd": "جميع الموارد المتاحة مرتبطة بالفعل",
   "@noResourcesToAdd": {
     "x-mt": true
@@ -1245,9 +1167,6 @@
     "x-mt": true
   },
   "untitledCourse": "دورة بدون عنوان",
-  "@untitledCourse": {
-    "x-mt": true
-  },
   "addCourse": "إضافة دورة",
   "@addCourse": {
     "x-mt": true
@@ -1269,9 +1188,6 @@
     "x-mt": true
   },
   "addReport": "إضافة تقرير",
-  "@addReport": {
-    "x-mt": true
-  },
   "editReport": "تحرير التقرير",
   "@editReport": {
     "x-mt": true
@@ -1280,9 +1196,6 @@
   "beginningBalance": "الرصيد الافتتاحي",
   "sales": "المبيعات",
   "otherIncome": "دخل آخر",
-  "@otherIncome": {
-    "x-mt": true
-  },
   "wages": "أجور",
   "@wages": {
     "x-mt": true
@@ -1292,9 +1205,6 @@
     "x-mt": true
   },
   "totalIncome": "إجمالي الدخل",
-  "@totalIncome": {
-    "x-mt": true
-  },
   "totalExpenses": "إجمالي المصروفات",
   "profitLoss": "الربح / الخسارة",
   "@profitLoss": {
@@ -1356,9 +1266,6 @@
     "x-mt": true
   },
   "feedbackSaved": "تم حفظ التعليقات",
-  "@feedbackSaved": {
-    "x-mt": true
-  },
   "isUrgent": "هل هذا أمر عاجل؟",
   "@isUrgent": {
     "x-mt": true
@@ -1459,13 +1366,7 @@
   "community": "المجتمع",
   "communityLeaders": "قادة المجتمع",
   "nationLeaders": "قادة الأمة",
-  "@nationLeaders": {
-    "x-mt": true
-  },
   "ourVoices": "أصواتنا",
-  "@ourVoices": {
-    "x-mt": true
-  },
   "finances": "المالية",
   "reports": "التقارير",
   "transaction": "عملية",
@@ -1491,9 +1392,6 @@
   },
   "date": "التاريخ",
   "fromDate": "من تاريخ",
-  "@fromDate": {
-    "x-mt": true
-  },
   "toDate": "إلى تاريخ",
   "reset": "إعادة ضبط",
   "@reset": {
@@ -1564,9 +1462,6 @@
     "x-mt": true
   },
   "yourAnswer": "إجابتك",
-  "@yourAnswer": {
-    "x-mt": true
-  },
   "previous": "السابق",
   "finish": "إنهاء",
   "exitExam": "الخروج من الامتحان؟",
@@ -1580,13 +1475,7 @@
   "exit": "خروج",
   "download": "تحميل",
   "downloading": "جارٍ التنزيل…",
-  "@downloading": {
-    "x-mt": true
-  },
   "downloadFailed": "فشل التنزيل.",
-  "@downloadFailed": {
-    "x-mt": true
-  },
   "resourceNotDownloaded": "هذا المورد ليس على جهازك بعد.",
   "@resourceNotDownloaded": {
     "x-mt": true
@@ -1609,23 +1498,11 @@
   },
   "showAdditionalFields": "عرض الحقول الإضافية",
   "hideAdditionalFields": "إخفاء الحقول الإضافية",
-  "@hideAdditionalFields": {
-    "x-mt": true
-  },
   "phoneNumber": "رقم الهاتف",
   "birthDate": "تاريخ الميلاد",
-  "@birthDate": {
-    "x-mt": true
-  },
   "selectDate": "حدد التاريخ",
   "male": "ذكر",
-  "@male": {
-    "x-mt": true
-  },
   "female": "أنثى",
-  "@female": {
-    "x-mt": true
-  },
   "yearOfBirth": "سنة الميلاد",
   "yearOfBirthRequired": "سنة الميلاد مطلوبة",
   "@yearOfBirthRequired": {
@@ -1678,13 +1555,7 @@
     "x-mt": true
   },
   "specialNeeds": "احتياجات خاصة",
-  "@specialNeeds": {
-    "x-mt": true
-  },
   "otherNeeds": "احتياجات أخرى",
-  "@otherNeeds": {
-    "x-mt": true
-  },
   "emergencyContact": "جهة الاتصال في حالات الطوارئ",
   "contactNumber": "رقم الاتصال",
   "@contactNumber": {
@@ -1725,9 +1596,6 @@
     "x-mt": true
   },
   "birthPlace": "مكان الميلاد",
-  "@birthPlace": {
-    "x-mt": true
-  },
   "contactName": "اسم جهة الاتصال",
   "@contactName": {
     "x-mt": true
@@ -1756,9 +1624,6 @@
   "diagnosis": "التشخيص",
   "medications": "الأدوية",
   "immunizations": "التحصينات",
-  "@immunizations": {
-    "x-mt": true
-  },
   "treatments": "العلاجات",
   "observations": "الملاحظات",
   "@observations": {
@@ -1857,9 +1722,6 @@
     "x-mt": true
   },
   "storageTotalDownloaded": "إجمالي التنزيلات",
-  "@storageTotalDownloaded": {
-    "x-mt": true
-  },
   "storageVideos": "مقاطع الفيديو",
   "storageAudio": "الصوت",
   "storagePdfs": "ملفات PDF",
@@ -1867,9 +1729,6 @@
   "storageOther": "أخرى",
   "fileCountOne": "ملف واحد",
   "storageUnknownResource": "مورد غير معروف",
-  "@storageUnknownResource": {
-    "x-mt": true
-  },
   "areYouSure": "هل أنت متأكد؟",
   "cancelAddingExamination": "هل أنت متأكد من إلغاء إضافة الامتحان؟ سيتم فقدان البيانات",
   "yesIWantToExit": "نعم، أرغب في الخروج.",
@@ -1879,10 +1738,7 @@
   "@storageDeleteSelectedConfirm": {
     "x-mt": true
   },
-  "storageSelectedCount": "{count} selected",
-  "@storageSelectedCount": {
-    "x-mt": true
-  },
+  "storageSelectedCount": "{count} محدد",
   "deleteSelected": "حذف المحدد",
   "deleteAll": "حذف الكل",
   "selectAll": "تحديد الكل",
@@ -1896,9 +1752,6 @@
     "x-mt": true
   },
   "availableSpace": "المساحة المتوفرة",
-  "@availableSpace": {
-    "x-mt": true
-  },
   "freeUpSpace": "حرر مساحة",
   "@freeUpSpace": {
     "x-mt": true
@@ -1912,9 +1765,6 @@
     "x-mt": true
   },
   "enterUsername": "أدخل اسم المستخدم",
-  "@enterUsername": {
-    "x-mt": true
-  },
   "enterPassword": "أدخل كلمة المرور",
   "@enterPassword": {
     "x-mt": true
@@ -1956,9 +1806,6 @@
     "x-mt": true
   },
   "syncCompletedChallenge": "اكتملت المزامنة",
-  "@syncCompletedChallenge": {
-    "x-mt": true
-  },
   "rememberSync": "تذكر مزامنة التطبيق المحمول.",
   "challengeDialogTitle": "التحدي اليومي",
   "@challengeDialogTitle": {
@@ -1979,9 +1826,6 @@
     "x-mt": true
   },
   "noDescriptionDefined": "هذا الفريق ليس لديه وصف محدد.",
-  "@noDescriptionDefined": {
-    "x-mt": true
-  },
   "enterpriseName": "اسم المؤسسة",
   "@enterpriseName": {
     "x-mt": true
@@ -2048,9 +1892,6 @@
   },
   "mistakes": "الأخطاء",
   "step": "خطوة",
-  "@step": {
-    "x-mt": true
-  },
   "untitledResourceTitle": "مورد بلا عنوان",
   "@untitledResourceTitle": {
     "x-mt": true
@@ -2072,9 +1913,6 @@
     "x-mt": true
   },
   "resourceType": "نوع المورد",
-  "@resourceType": {
-    "x-mt": true
-  },
   "subject": "موضوع",
   "@subject": {
     "x-mt": true
@@ -2176,30 +2014,18 @@
     "x-mt": true
   },
   "lastLogin": "آخر تسجيل دخول",
-  "@lastLogin": {
-    "x-mt": true
-  },
   "memberDetail": "تفاصيل الأعضاء",
   "@memberDetail": {
     "x-mt": true
   },
   "numberOfVisits": "عدد الزيارات",
-  "@numberOfVisits": {
-    "x-mt": true
-  },
   "noLogoutRecord": "لم يتم العثور على سجل الخروج",
   "@noLogoutRecord": {
     "x-mt": true
   },
   "totalVisits": "إجمالي الزيارات",
-  "@totalVisits": {
-    "x-mt": true
-  },
   "mostOpenedResource": "أكثر مورد تم فتحه",
   "numberOfResourcesOpened": "عدد الموارد المفتوحة",
-  "@numberOfResourcesOpened": {
-    "x-mt": true
-  },
   "resourceOpenedTimes": "{title} تم الفتح {count} مرات",
   "@resourceOpenedTimes": {
     "x-mt": true
@@ -2283,23 +2109,11 @@
     }
   },
   "textSize": "حجم النص",
-  "@textSize": {
-    "x-mt": true
-  },
   "selectTextSize": "اختر حجم النص",
   "textSizeSmall": "صغير",
-  "@textSizeSmall": {
-    "x-mt": true
-  },
   "textSizeMedium": "متوسط",
   "textSizeLarge": "كبير",
-  "@textSizeLarge": {
-    "x-mt": true
-  },
   "resetApp": "إعادة تعيين التطبيق",
-  "@resetApp": {
-    "x-mt": true
-  },
   "clearAllDataConfirm": "هل أنت متأكد أنك تريد مسح جميع البيانات؟",
   "dataCleared": "تم مسح كافة البيانات",
   "@dataCleared": {
@@ -2317,5 +2131,11 @@
   "myPurposeDescription": "هدفي - ما هي طموحاتك التعليمية والمهنية؟",
   "pleaseAnswerToContinue": "يرجى تحديد / كتابة إجابتك للمتابعة",
   "teamDocuments": "الوثائق",
-  "confirmLeaveTeam": "هل أنت متأكد أنك تريد مغادرة هذا الفريق؟"
+  "confirmLeaveTeam": "هل أنت متأكد أنك تريد مغادرة هذا الفريق؟",
+  "appVersion": "{version} الإصدار",
+  "reportDateDetails": "تم إنشاء التقرير في: {created} | تم تحديثه في: {updated}",
+  "fileNotFound": "الملف غير موجود: {fileName}",
+  "fileCountMany": "{count} ملفات",
+  "stepsHeading": "خطوات",
+  "courseProgressCount": "التقدم {current} من {max}"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -154,9 +154,6 @@
     "x-mt": true
   },
   "syncing": "Sincronizando…",
-  "@syncing": {
-    "x-mt": true
-  },
   "waiting": "Espera",
   "@waiting": {
     "x-mt": true
@@ -343,9 +340,6 @@
   },
   "language": "Idioma",
   "languages": "Idiomas",
-  "@languages": {
-    "x-mt": true
-  },
   "gender": "Género",
   "dateOfBirth": "Fecha de nacimiento",
   "planetCode": "código de planeta",
@@ -532,33 +526,12 @@
     "x-mt": true
   },
   "tasks": "Tareas",
-  "@tasks": {
-    "x-mt": true
-  },
   "notifGroupJoinRequests": "Solicitudes de unión",
-  "@notifGroupJoinRequests": {
-    "x-mt": true
-  },
   "notifGroupTeamUpdates": "Actualizaciones del equipo",
-  "@notifGroupTeamUpdates": {
-    "x-mt": true
-  },
   "notifGroupNewVoices": "Nuevas voces",
-  "@notifGroupNewVoices": {
-    "x-mt": true
-  },
   "notifGroupVoiceReplies": "Respuestas de voz",
-  "@notifGroupVoiceReplies": {
-    "x-mt": true
-  },
   "notificationGroupSystem": "Sistema",
-  "@notificationGroupSystem": {
-    "x-mt": true
-  },
   "notificationGroupOther": "Otro",
-  "@notificationGroupOther": {
-    "x-mt": true
-  },
   "myLife": "miVida",
   "myLifeUnavailable": "mi vida no esta disponible",
   "@myLifeUnavailable": {
@@ -642,9 +615,6 @@
   "nA": "N/A",
   "otherDiagnosis": "Otros diagnósticos",
   "add": "Agregar",
-  "@add": {
-    "x-mt": true
-  },
   "status": "Estado",
   "lastUpdated": "Última actualización",
   "@lastUpdated": {
@@ -689,9 +659,6 @@
     "x-mt": true
   },
   "answer": "Respuesta",
-  "@answer": {
-    "x-mt": true
-  },
   "availableChoices": "Opciones",
   "@availableChoices": {
     "x-mt": true
@@ -859,9 +826,6 @@
     "x-mt": true
   },
   "addMeetup": "Agregar reunión",
-  "@addMeetup": {
-    "x-mt": true
-  },
   "meetupDetails": "Detalles de la reunión",
   "@meetupDetails": {
     "x-mt": true
@@ -871,21 +835,12 @@
     "x-mt": true
   },
   "createdBy": "Creado por",
-  "@createdBy": {
-    "x-mt": true
-  },
   "category": "Categoría",
   "@category": {
     "x-mt": true
   },
   "location": "Ubicación",
-  "@location": {
-    "x-mt": true
-  },
   "link": "Enlace",
-  "@link": {
-    "x-mt": true
-  },
   "recurring": "Recurrente",
   "description": "Descripción",
   "leaveMeetup": "Salir de la reunión",
@@ -897,21 +852,9 @@
     "x-mt": true
   },
   "editMeetup": "Editar reunión",
-  "@editMeetup": {
-    "x-mt": true
-  },
   "startTime": "Hora de inicio",
-  "@startTime": {
-    "x-mt": true
-  },
   "endTime": "Hora de finalización",
-  "@endTime": {
-    "x-mt": true
-  },
   "none": "Ninguno",
-  "@none": {
-    "x-mt": true
-  },
   "daily": "Diario",
   "weekly": "Semanal",
   "syncMeetups": "Sincronizar reuniones",
@@ -947,13 +890,7 @@
     "x-mt": true
   },
   "startDate": "Fecha de inicio",
-  "@startDate": {
-    "x-mt": true
-  },
   "endDate": "Fecha de finalización",
-  "@endDate": {
-    "x-mt": true
-  },
   "timeNotSet": "Hora no establecida",
   "@timeNotSet": {
     "x-mt": true
@@ -1028,9 +965,6 @@
     "x-mt": true
   },
   "replyToVoice": "Responder",
-  "@replyToVoice": {
-    "x-mt": true
-  },
   "writeAReply": "Escribe una respuesta",
   "@writeAReply": {
     "x-mt": true
@@ -1044,9 +978,6 @@
     "x-mt": true
   },
   "editVoice": "Editar",
-  "@editVoice": {
-    "x-mt": true
-  },
   "deleteVoice": "Eliminar",
   "deleteVoiceConfirm": "¿Eliminar esta publicación y todas sus respuestas?",
   "@deleteVoiceConfirm": {
@@ -1110,9 +1041,6 @@
     "x-mt": true
   },
   "enterprises": "Empresas",
-  "@enterprises": {
-    "x-mt": true
-  },
   "searchEnterprises": "Buscar empresas",
   "@searchEnterprises": {
     "x-mt": true
@@ -1123,9 +1051,6 @@
   },
   "leave": "Salir",
   "remove": "Eliminar",
-  "@remove": {
-    "x-mt": true
-  },
   "makeLeader": "Asignar como líder",
   "leftTeam": "Abandonó el equipo",
   "memberRemoved": "Miembro eliminado",
@@ -1149,9 +1074,6 @@
     "x-mt": true
   },
   "services": "Servicios",
-  "@services": {
-    "x-mt": true
-  },
   "rules": "Normas",
   "@rules": {
     "x-mt": true
@@ -1165,9 +1087,6 @@
     "x-mt": true
   },
   "teamTasks": "Tareas",
-  "@teamTasks": {
-    "x-mt": true
-  },
   "tasksUnavailable": "Las tareas no están disponibles",
   "@tasksUnavailable": {
     "x-mt": true
@@ -1185,9 +1104,6 @@
     "x-mt": true
   },
   "addTask": "Agregar tarea",
-  "@addTask": {
-    "x-mt": true
-  },
   "editTask": "Editar tarea",
   "@editTask": {
     "x-mt": true
@@ -1209,17 +1125,8 @@
     "x-mt": true
   },
   "teamMembers": "Miembros",
-  "@teamMembers": {
-    "x-mt": true
-  },
   "members": "Miembros",
-  "@members": {
-    "x-mt": true
-  },
   "joinRequests": "Solicitudes de unión",
-  "@joinRequests": {
-    "x-mt": true
-  },
   "noMembers": "Aún no hay miembros",
   "@noMembers": {
     "x-mt": true
@@ -1237,17 +1144,11 @@
     "x-mt": true
   },
   "accept": "Aceptar",
-  "@accept": {
-    "x-mt": true
-  },
   "decline": "Rechazar",
   "@decline": {
     "x-mt": true
   },
   "joinTeam": "Solicitar unirse",
-  "@joinTeam": {
-    "x-mt": true
-  },
   "leaveTeam": "dejar el equipo",
   "@leaveTeam": {
     "x-mt": true
@@ -1257,9 +1158,6 @@
     "x-mt": true
   },
   "teamResources": "Recursos",
-  "@teamResources": {
-    "x-mt": true
-  },
   "resourcesUnavailable": "Los recursos no están disponibles",
   "@resourcesUnavailable": {
     "x-mt": true
@@ -1277,26 +1175,11 @@
     "x-mt": true
   },
   "addResource": "Agregar recurso",
-  "@addResource": {
-    "x-mt": true
-  },
   "editResource": "Editar recurso",
-  "@editResource": {
-    "x-mt": true
-  },
   "resourceUpdated": "Recurso actualizado",
-  "@resourceUpdated": {
-    "x-mt": true
-  },
   "resourceAddedToTeam": "Recurso añadido al equipo",
-  "descriptionIsRequired": "Se requiere descripción",
-  "@descriptionIsRequired": {
-    "x-mt": true
-  },
+  "descriptionIsRequired": "Se requiere una descripción",
   "levelIsRequired": "Se requiere nivel",
-  "@levelIsRequired": {
-    "x-mt": true
-  },
   "subjectIsRequired": "Se requiere asignatura",
   "selectFile": "Seleccione un archivo",
   "@selectFile": {
@@ -1311,9 +1194,6 @@
     "x-mt": true
   },
   "saveChanges": "Guardar cambios",
-  "@saveChanges": {
-    "x-mt": true
-  },
   "selectOpenWith": "Seleccione abrir con",
   "@selectOpenWith": {
     "x-mt": true
@@ -1327,9 +1207,6 @@
     "x-mt": true
   },
   "linkToLicense": "Enlace a la licencia",
-  "@linkToLicense": {
-    "x-mt": true
-  },
   "noResourcesToAdd": "Todos los recursos disponibles ya están vinculados.",
   "@noResourcesToAdd": {
     "x-mt": true
@@ -1343,9 +1220,6 @@
     "x-mt": true
   },
   "untitledCourse": "Curso sin título",
-  "@untitledCourse": {
-    "x-mt": true
-  },
   "addCourse": "Agregar curso",
   "@addCourse": {
     "x-mt": true
@@ -1367,29 +1241,14 @@
     "x-mt": true
   },
   "addReport": "Agregar informe",
-  "@addReport": {
-    "x-mt": true
-  },
   "editReport": "Editar informe",
   "@editReport": {
     "x-mt": true
   },
   "archiveReport": "Archivo",
-  "@archiveReport": {
-    "x-mt": true
-  },
   "beginningBalance": "Saldo inicial",
-  "@beginningBalance": {
-    "x-mt": true
-  },
   "sales": "Ventas",
-  "@sales": {
-    "x-mt": true
-  },
   "otherIncome": "Otros ingresos",
-  "@otherIncome": {
-    "x-mt": true
-  },
   "wages": "Salarios",
   "@wages": {
     "x-mt": true
@@ -1399,38 +1258,20 @@
     "x-mt": true
   },
   "totalIncome": "Ingresos totales",
-  "@totalIncome": {
-    "x-mt": true
-  },
   "totalExpenses": "Gastos totales",
-  "@totalExpenses": {
-    "x-mt": true
-  },
   "profitLoss": "Ganancia/pérdida",
   "@profitLoss": {
     "x-mt": true
   },
   "endingBalance": "Saldo final",
-  "@endingBalance": {
-    "x-mt": true
-  },
   "negativeBalance": "¡El saldo actual es negativo!",
-  "@negativeBalance": {
-    "x-mt": true
-  },
   "reportDateDetails": "Informe creado el: {created} | Actualizado el: {updated}",
-  "@reportDateDetails": {
-    "x-mt": true
-  },
   "chatHistory": "Historial de chat",
   "@chatHistory": {
     "x-mt": true
   },
   "chat": "Chat",
   "newChat": "Nuevo chat",
-  "@newChat": {
-    "x-mt": true
-  },
   "searchChats": "Buscar chats",
   "@searchChats": {
     "x-mt": true
@@ -1449,9 +1290,6 @@
   },
   "fullConversationResponse": "Respuesta completa de la conversación",
   "response": "Respuesta",
-  "@response": {
-    "x-mt": true
-  },
   "chatConversation": "Conversación",
   "@chatConversation": {
     "x-mt": true
@@ -1484,10 +1322,7 @@
   "@aiProviderUnavailable": {
     "x-mt": true
   },
-  "feedback": "Comentario",
-  "@feedback": {
-    "x-mt": true
-  },
+  "feedback": "Comentarios",
   "feedbackNotFound": "Comentarios no encontrados",
   "@feedbackNotFound": {
     "x-mt": true
@@ -1514,18 +1349,9 @@
     "x-mt": true
   },
   "question": "Pregunta",
-  "@question": {
-    "x-mt": true
-  },
   "bug": "Error",
   "suggestion": "Sugerencia",
-  "@suggestion": {
-    "x-mt": true
-  },
   "priority": "Prioridad",
-  "@priority": {
-    "x-mt": true
-  },
   "openDate": "Fecha de apertura",
   "replies": "Respuestas",
   "@replies": {
@@ -1594,13 +1420,7 @@
   },
   "close": "Cerrar",
   "filter": "Filtrar",
-  "@filter": {
-    "x-mt": true
-  },
   "type": "Tipo",
-  "@type": {
-    "x-mt": true
-  },
   "apply": "Aplicar",
   "@apply": {
     "x-mt": true
@@ -1614,13 +1434,7 @@
     "x-mt": true
   },
   "community": "Comunidad",
-  "@community": {
-    "x-mt": true
-  },
   "communityLeaders": "Líderes comunitarios",
-  "@communityLeaders": {
-    "x-mt": true
-  },
   "nationLeaders": "Lideres de la nación",
   "ourVoices": "Nuestras voces",
   "finances": "Finanzas",
@@ -1649,9 +1463,6 @@
   "noLeadersAvailable": "No hay líderes disponibles",
   "noServicesAvailable": "No hay servicios disponibles",
   "noDescriptionAvailable": "No hay descripción disponible",
-  "@noDescriptionAvailable": {
-    "x-mt": true
-  },
   "takeExam": "tomar el examen",
   "@takeExam": {
     "x-mt": true
@@ -1682,17 +1493,8 @@
     "x-mt": true
   },
   "yourAnswer": "Tu respuesta",
-  "@yourAnswer": {
-    "x-mt": true
-  },
   "previous": "Anterior",
-  "@previous": {
-    "x-mt": true
-  },
   "finish": "Finalizar",
-  "@finish": {
-    "x-mt": true
-  },
   "exitExam": "¿Examen de salida?",
   "@exitExam": {
     "x-mt": true
@@ -1703,9 +1505,6 @@
   },
   "exit": "Salir",
   "download": "Descargar",
-  "@download": {
-    "x-mt": true
-  },
   "downloading": "Descargando....",
   "downloadFailed": "Descarga fallida.",
   "resourceNotDownloaded": "Este recurso aún no está en su dispositivo.",
@@ -1729,33 +1528,12 @@
     "x-mt": true
   },
   "showAdditionalFields": "Mostrar campos adicionales",
-  "@showAdditionalFields": {
-    "x-mt": true
-  },
   "hideAdditionalFields": "Ocultar campos adicionales",
-  "@hideAdditionalFields": {
-    "x-mt": true
-  },
   "phoneNumber": "Número de teléfono",
-  "@phoneNumber": {
-    "x-mt": true
-  },
   "birthDate": "Fecha de nacimiento",
-  "@birthDate": {
-    "x-mt": true
-  },
   "selectDate": "Seleccionar fecha",
-  "@selectDate": {
-    "x-mt": true
-  },
   "male": "Masculino",
-  "@male": {
-    "x-mt": true
-  },
   "female": "Femenino",
-  "@female": {
-    "x-mt": true
-  },
   "yearOfBirth": "Año de nacimiento",
   "yearOfBirthRequired": "Se requiere año de nacimiento",
   "@yearOfBirthRequired": {
@@ -1812,17 +1590,8 @@
     "x-mt": true
   },
   "specialNeeds": "Necesidades especiales",
-  "@specialNeeds": {
-    "x-mt": true
-  },
   "otherNeeds": "Otras necesidades",
-  "@otherNeeds": {
-    "x-mt": true
-  },
   "emergencyContact": "Contacto de emergencia",
-  "@emergencyContact": {
-    "x-mt": true
-  },
   "contactNumber": "Número de contacto",
   "@contactNumber": {
     "x-mt": true
@@ -1852,9 +1621,6 @@
     "x-mt": true
   },
   "vision": "Visión",
-  "@vision": {
-    "x-mt": true
-  },
   "hearing": "Audición",
   "examinationHistory": "historial de exámenes",
   "@examinationHistory": {
@@ -1890,17 +1656,8 @@
     "x-mt": true
   },
   "allergies": "Alergias",
-  "@allergies": {
-    "x-mt": true
-  },
   "diagnosis": "Diagnóstico",
-  "@diagnosis": {
-    "x-mt": true
-  },
   "medications": "Medicamentos",
-  "@medications": {
-    "x-mt": true
-  },
   "immunizations": "Inmunizaciones",
   "treatments": "Tratamientos",
   "observations": "Observaciones",
@@ -1908,9 +1665,6 @@
     "x-mt": true
   },
   "referrals": "Referencias",
-  "@referrals": {
-    "x-mt": true
-  },
   "labTests": "Pruebas de laboratorio",
   "xrays": "Radiografías",
   "conditions": "Condiciones",
@@ -1926,9 +1680,6 @@
     "x-mt": true
   },
   "selectHealthMember": "Seleccionar miembro",
-  "@selectHealthMember": {
-    "x-mt": true
-  },
   "newPatient": "Nuevo paciente",
   "@newPatient": {
     "x-mt": true
@@ -1955,9 +1706,6 @@
   },
   "dismiss": "Descartar",
   "addMember": "Agregar miembro",
-  "@addMember": {
-    "x-mt": true
-  },
   "invalidNumber": "Número no válido",
   "@invalidNumber": {
     "x-mt": true
@@ -2003,9 +1751,6 @@
     "x-mt": true
   },
   "storageTotalDownloaded": "Total descargado",
-  "@storageTotalDownloaded": {
-    "x-mt": true
-  },
   "storageVideos": "Videos",
   "storageAudio": "Audio",
   "@storageAudio": {
@@ -2013,21 +1758,9 @@
   },
   "storagePdfs": "PDFs",
   "storageImages": "Imágenes",
-  "@storageImages": {
-    "x-mt": true
-  },
   "storageOther": "Otro",
-  "@storageOther": {
-    "x-mt": true
-  },
   "fileCountOne": "1 archivo",
-  "@fileCountOne": {
-    "x-mt": true
-  },
   "fileCountMany": "{count} archivos",
-  "@fileCountMany": {
-    "x-mt": true
-  },
   "storageUnknownResource": "Recurso desconocido",
   "areYouSure": "¿Estás seguro?",
   "cancelAddingExamination": "¿Está seguro de que desea cancelar la adición del examen? Se perderán los datos.",
@@ -2046,19 +1779,10 @@
   "@storageDeleteConfirm": {
     "x-mt": true
   },
-  "storageSelectedCount": "{count} selected",
-  "@storageSelectedCount": {
-    "x-mt": true
-  },
+  "storageSelectedCount": "{count} seleccionado(s)",
   "deleteSelected": "Eliminar seleccionados",
   "deleteAll": "Eliminar todo",
-  "@deleteAll": {
-    "x-mt": true
-  },
   "selectAll": "Seleccionar todo",
-  "@selectAll": {
-    "x-mt": true
-  },
   "unselectAll": "Deseleccionar todo",
   "addedToMyCourses": "{count, plural, =1{1 course added} other{{count} courses added}}",
   "@addedToMyCourses": {
@@ -2097,13 +1821,7 @@
   "becomeMember": "convertirse en miembro",
   "toAccessThisFeatureBecomeAMember": "Actualmente eres un usuario invitado. Para acceder a esta función, hazte miembro.",
   "creatingMember": "Creando cuenta de miembro...",
-  "@creatingMember": {
-    "x-mt": true
-  },
   "passwordsDoNotMatch": "Las contraseñas no coinciden",
-  "@passwordsDoNotMatch": {
-    "x-mt": true
-  },
   "pleaseSelectGender": "Por favor selecciona el género",
   "pleaseEnterPassword": "Por favor ingresa una contraseña",
   "usernameAlreadyExists": "El nombre de usuario ya existe",
@@ -2138,9 +1856,6 @@
     "x-mt": true
   },
   "syncCompletedChallenge": "Sincronización completada",
-  "@syncCompletedChallenge": {
-    "x-mt": true
-  },
   "rememberSync": "Recuerda sincronizar la aplicación móvil.",
   "challengeDialogTitle": "Desafío diario",
   "@challengeDialogTitle": {
@@ -2148,9 +1863,6 @@
   },
   "start": "Iniciar",
   "continuation": "Continuar",
-  "@continuation": {
-    "x-mt": true
-  },
   "plan": "Plan",
   "mission": "Misión y Servicios",
   "editPlan": "Editar Plan",
@@ -2203,17 +1915,8 @@
     "x-mt": true
   },
   "author": "Autor",
-  "@author": {
-    "x-mt": true
-  },
   "publisher": "Editor",
-  "@publisher": {
-    "x-mt": true
-  },
   "license": "Licencia",
-  "@license": {
-    "x-mt": true
-  },
   "addedBy": "Agregado por",
   "resourceInformation": "Información de recursos",
   "@resourceInformation": {
@@ -2228,17 +1931,11 @@
     "x-mt": true
   },
   "resourceType": "Tipo de recurso",
-  "@resourceType": {
-    "x-mt": true
-  },
   "subject": "Sujeto",
   "@subject": {
     "x-mt": true
   },
   "year": "Año",
-  "@year": {
-    "x-mt": true
-  },
   "timesRated": "Veces clasificados",
   "@timesRated": {
     "x-mt": true
@@ -2338,9 +2035,6 @@
     "x-mt": true
   },
   "numberOfVisits": "Número de visitas",
-  "@numberOfVisits": {
-    "x-mt": true
-  },
   "noLogoutRecord": "No se encontró ningún registro de cierre de sesión",
   "@noLogoutRecord": {
     "x-mt": true
@@ -2366,13 +2060,7 @@
   },
   "serverChecking": "Verificando el servidor",
   "gridView": "Vista de cuadrícula",
-  "@gridView": {
-    "x-mt": true
-  },
   "listView": "Vista de lista",
-  "@listView": {
-    "x-mt": true
-  },
   "disclaimer": "Descargo de responsabilidad",
   "aboutContent": "### MyPlanet\n\nmyPlanet es una herramienta de aprendizaje diseñada para funcionar con la aplicación web de Planet. Se ha utilizado para mejorar la educación temprana, las escuelas secundarias, la salud en las aldeas, el desarrollo de la fuerza laboral juvenil, y el desarrollo económico y comunitario.\n\nPlanet alberga un repositorio de recursos gratuitos, de acceso abierto y de dominio público para beneficiar a todos los estudiantes.\n\nmyPlanet está diseñado para estar disponible para todos, en todas partes, todo el tiempo. Es portátil, asequible, escalable y sostenible. Se ejecuta en cualquier dispositivo Android, como tabletas y teléfonos móviles. Funciona tanto en línea como sin conexión a Internet.\n\nEsta aplicación permite a las escuelas y comunidades tener una biblioteca multimedia completa y un sistema de aprendizaje que se conecta periódicamente con Planet. Los dispositivos configurados pueden contener el panel personal de los estudiantes. Esto garantiza que los estudiantes puedan leer libros en su estante y tomar cursos sin conexión, es decir, sin conexión a un servidor central. Se anima a los estudiantes a calificar con una a cinco estrellas los recursos que utilizan y los cursos que toman. Periódicamente, los estudiantes pueden sincronizarse con un servidor. Los datos de actividad se cargan y se descargan nuevos recursos en cuestión de minutos en myPlanet para su uso sin conexión.\n\nEl panel también contiene un registro de logros, un calendario de eventos y un sistema de chat interno para comunicarse con otros miembros.\n\nmyPlanet ha demostrado ser altamente efectivo para mejorar las oportunidades de aprendizaje de más de cincuenta mil estudiantes en más de 100 ubicaciones, en escuelas de Nepal, Ghana, Kenya y Rwanda, con refugiados Syrian en Jordan, refugiados Somali en Kenya y trabajadores de salud en aldeas de Uganda.",
   "disclaimerContent": "# Renuncia de responsabilidad\n\nÚltima actualización: 10 de enero de 2020\n\n# Interpretación y definiciones\n\n## Interpretación\n\nLas palabras cuya inicial está en mayúscula tienen significados definidos bajo las siguientes condiciones.\n\nLas siguientes definiciones tendrán el mismo significado independientemente de si aparecen en singular o en plural.\n\n## Definiciones\n\nA los efectos de este descargo de responsabilidad:\n\n- **Compañía** (referida como \"la Compañía\", \"Nosotros\", \"Nuestro\" en esta Política de cookies) se refiere a myPlanet.\n- **Tú** significa la persona que accede al Servicio, o la empresa u otra entidad legal en nombre de la cual esa persona accede o utiliza el Servicio, según corresponda.\n- **Aplicación** significa el programa de software proporcionado por la Compañía que tú descargas en cualquier dispositivo electrónico llamado myPlanet.\n- **Servicio** se refiere a la Aplicación.\n\n# Descargo de responsabilidad\n\nLa información contenida en el Servicio se suministra únicamente con fines informativos generales.\n\nLa Compañía no asume ninguna responsabilidad por errores u omisiones en el contenido del Servicio.\n\nEn ningún caso la Compañía será responsable por daños especiales, directos, indirectos, consecuentes o incidentales o cualquier otro tipo de daños, ya sea en una acción contractual, negligencia u otro agravio, que surjan o estén relacionados con el uso del Servicio o el contenido del Servicio. La Compañía se reserva el derecho de hacer adiciones, eliminaciones o modificaciones al contenido del Servicio en cualquier momento y sin previo aviso.\n\nLa Compañía no garantiza que el Servicio esté libre de virus u otros componentes dañinos.\n\n# Descargo de responsabilidad de información médica\n\nLa información sobre salud proporcionada por el Servicio no tiene la intención de diagnosticar, tratar, curar o prevenir enfermedades. Los productos, servicios, información y otros contenidos proporcionados por el Servicio, incluida la información que enlace a sitios web de terceros, se proporcionan únicamente con fines informativos.\n\nLa información ofrecida por el Servicio no es exhaustiva y no abarca todas las enfermedades, dolencias, condiciones físicas o su tratamiento.\n\nLas personas son diferentes y pueden reaccionar de manera diferente a diferentes productos. Los comentarios realizados en el Servicio por empleados u otros usuarios son estrictamente sus propias opiniones personales expresadas en su capacidad personal y no son afirmaciones hechas por la Compañía ni representan la posición o la visión de la Compañía.\n\nLa Compañía no se hace responsable de ninguna información proporcionada por el Servicio con respecto a recomendaciones sobre suplementos para cualquier propósito de salud.\n\nLa Compañía no garantiza ni ofrece garantías con respecto a ningún producto o servicio vendido. La Compañía no es responsable de ningún daño causado por información o servicios proporcionados, incluso si se ha informado de la posibilidad de tales daños.\n\n# Descargo de responsabilidad de enlaces externos\n\nEl Servicio puede contener enlaces a sitios web externos que no son proporcionados ni mantenidos por la Compañía de ninguna manera.\n\nTen en cuenta que la Compañía no garantiza la exactitud, pertinencia, puntualidad o integridad de ninguna información en estos sitios web externos.\n\n# Descargo de responsabilidad por errores y omisiones\n\nLa información proporcionada por el Servicio es solo una guía general sobre temas de interés. Aunque la Compañía toma todas las precauciones para garantizar que el contenido del Servicio sea actual y preciso, pueden producirse errores. Además, debido a la naturaleza cambiante de las leyes, normas y regulaciones, puede haber demoras, omisiones o inexactitudes en la información contenida en el Servicio.\n\nLa Compañía no se hace responsable de ningún error u omisión, ni de los resultados obtenidos del uso de esta información.\n\n# Descargo de responsabilidad de uso justo\n\nLa Compañía puede utilizar material protegido por derechos de autor que no siempre ha sido autorizado específicamente por el propietario de los derechos de autor. La Compañía pone a disposición dicho material para crítica, comentario, informes de noticias, enseñanza, becas o investigación.\n\nLa Compañía cree que esto constituye un \"uso justo\" de cualquier material protegido por derechos de autor según lo establecido en la sección 107 de la ley de derechos de autor de Estados Unidos.\n\nSi deseas utilizar material protegido por derechos de autor del Servicio para tus propios fines que vayan más allá del uso justo, debes obtener permiso del titular de los derechos de autor.\n\n# Descargo de responsabilidad de opiniones expresadas\n\nEl Servicio puede contener opiniones y puntos de vista que son de los autores y no reflejan necesariamente la política oficial o la posición de cualquier otro autor, agencia, organización, empleador o empresa, incluida la Compañía.\n\nLos comentarios publicados por los usuarios son su única responsabilidad y los usuarios asumirán la responsabilidad total, la responsabilidad y la culpa por cualquier difamación o litigio que resulte de algo escrito en un comentario o como resultado directo de algo escrito en un comentario. La Compañía no se hace responsable de ningún comentario publicado por los usuarios y se reserva el derecho de eliminar cualquier comentario por cualquier motivo que sea.\n\n# Descargo de responsabilidad sin responsabilidad\n\nLa información del Servicio se proporciona con el entendimiento de que la Compañía no se dedica aquí a prestar asesoramiento y servicios legales, contables, fiscales u otros servicios profesionales. Como tal, no debe utilizarse como sustituto de la consulta con asesores profesionales de contabilidad, fiscalidad, legal u otros competentes.\n\nEn ningún caso, la Compañía o sus proveedores serán responsables de ningún daño especial, incidental, indirecto o consecuente que surja de o en relación con tu acceso o uso o incapacidad para acceder o usar el Servicio.\n\n# Descargo de responsabilidad de \"Uso bajo tu propio riesgo\"\n\nToda la información en el Servicio se proporciona \"tal cual\", sin garantía de integridad, exactitud, puntualidad o de los resultados obtenidos del uso de esta información, y sin garantía de ningún tipo, expresa o implícita, incluidas, entre otras, las garantías de rendimiento, comerciabilidad y idoneidad para un propósito particular.\n\nLa Compañía no será responsable ante ti ni ante ninguna otra persona por cualquier decisión tomada o acción realizada en confianza en la información proporcionada por el Servicio o por cualquier daño consecuente, especial o similar, incluso si se informa de la posibilidad de tales daños.\n\n## Contáctanos\n\nSi tienes alguna pregunta sobre este descargo de responsabilidad, puedes contactarnos:\n\n- Por correo electrónico: myplanet@ole.org\n- Visitando esta página en nuestro sitio web: [https://ole.org/contact](https://ole.org/contact)",
@@ -2390,97 +2078,43 @@
   "selected": "Seleccionado: ",
   "myAchievements": "misLogros",
   "editAchievement": "Editar logros",
-  "@editAchievement": {
-    "x-mt": true
-  },
   "addAchievement": "Agregar logro",
-  "@addAchievement": {
-    "x-mt": true
-  },
   "addAnAchievement": "Agregar un logro",
-  "@addAnAchievement": {
-    "x-mt": true
-  },
   "addReference": "Agregar referencia",
-  "@addReference": {
-    "x-mt": true
-  },
   "addAReference": "Agregar una referencia",
-  "@addAReference": {
-    "x-mt": true
-  },
   "selectResources": "Seleccionar recursos: ",
   "myGoals": "Mis Metas",
   "myPurpose": "Mi Propósito",
   "noGoalAdded": "Aún no se han establecido objetivos",
   "noPurposeAdded": "No se agregó propósito",
   "noAchievementAdded": "Resumen de logros",
-  "@noAchievementAdded": {
-    "x-mt": true
-  },
   "noReferencesAdded": "No se agregaron referencias",
-  "@noReferencesAdded": {
-    "x-mt": true
-  },
   "sendToNation": "Permite que tus logros se compartan con la nación",
   "saving": "Guardando…",
   "achievementSaved": "Logro actualizado",
-  "@achievementSaved": {
-    "x-mt": true
-  },
   "titleIsRequired": "Se requiere un título.",
   "selectPdfOnly": "Por favor selecciona un archivo PDF",
   "viewCv": "Ver CV/Currículum",
   "deleteCv": "Eliminar CV",
-  "@deleteCv": {
-    "x-mt": true
-  },
   "uploadCvLabel": "Sube tu CV/currículum a continuación (solo PDF)",
   "addMaterials": "Agrega cualquier material que demuestre tus logros a continuación",
   "labelAddReferences": "Añada referencias abajo",
   "cvResume": "CV / Currículum",
-  "@cvResume": {
-    "x-mt": true
-  },
   "relationship": "Relación",
-  "@relationship": {
-    "x-mt": true
-  },
   "noFileChosen": "Ningún archivo seleccionado",
   "chooseFile": "Elegir archivo",
-  "currentCv": "CV/Currículum vitae actual: {name}",
-  "@currentCv": {
-    "x-mt": true
-  },
+  "currentCv": "CV/Currículum actual: {name}",
   "update": "Actualizar",
-  "@update": {
-    "x-mt": true
-  },
   "fillRequiredFields": "Por favor complete los campos obligatorios: {fields}",
   "@fillRequiredFields": {
     "x-mt": true
   },
   "textSize": "Tamaño del texto",
-  "@textSize": {
-    "x-mt": true
-  },
   "selectTextSize": "Seleccionar tamaño de texto",
-  "@selectTextSize": {
-    "x-mt": true
-  },
   "textSizeSmall": "Pequeño",
-  "@textSizeSmall": {
-    "x-mt": true
-  },
   "textSizeMedium": "Mediano",
   "textSizeLarge": "Grande",
-  "@textSizeLarge": {
-    "x-mt": true
-  },
   "resetApp": "Restablecer aplicación",
-  "@resetApp": {
-    "x-mt": true
-  },
   "clearAllDataConfirm": "¿Estás seguro de que deseas borrar todos los datos?",
   "dataCleared": "Todos los datos borrados",
   "@dataCleared": {
@@ -2498,5 +2132,8 @@
   "myPurposeDescription": "Mi Propósito - ¿Cuáles son tus ambiciones educativas y profesionales?",
   "pleaseAnswerToContinue": "Por favor, selecciona/escribe tu respuesta para continuar",
   "teamDocuments": "Documentos",
-  "confirmLeaveTeam": "¿Estás seguro/a de que quieres abandonar este equipo?"
+  "confirmLeaveTeam": "¿Estás seguro/a de que quieres abandonar este equipo?",
+  "fileNotFound": "Archivo no encontrado: {fileName}",
+  "stepsHeading": "Pasos",
+  "courseProgressCount": "Progreso {current} de {max}"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -72,9 +72,6 @@
   "resources": "Ressources",
   "search": "Rechercher",
   "sync": "Synchroniser",
-  "@sync": {
-    "x-mt": true
-  },
   "cancel": "Annuler",
   "settings": "Paramètres",
   "backgroundSync": "Synchronisation en arrière-plan",
@@ -149,9 +146,6 @@
     "x-mt": true
   },
   "appTheme": "Thème de l'application",
-  "@appTheme": {
-    "x-mt": true
-  },
   "aiChat": "AI Chat",
   "syncNow": "Synchroniser maintenant",
   "syncCenter": "Centre de synchronisation",
@@ -296,9 +290,6 @@
   },
   "courses": "Cours",
   "myCourses": "Mes cours",
-  "@myCourses": {
-    "x-mt": true
-  },
   "allCourses": "Tous les cours",
   "@allCourses": {
     "x-mt": true
@@ -316,9 +307,6 @@
     "x-mt": true
   },
   "gradeLevel": "Niveau scolaire",
-  "@gradeLevel": {
-    "x-mt": true
-  },
   "subjectLevel": "Sujet",
   "@subjectLevel": {
     "x-mt": true
@@ -351,18 +339,12 @@
     "x-mt": true
   },
   "username": "Nom d'utilisateur",
-  "@username": {
-    "x-mt": true
-  },
   "email": "E-mail",
   "phone": "Téléphone",
   "@phone": {
     "x-mt": true
   },
   "level": "Niveau",
-  "@level": {
-    "x-mt": true
-  },
   "levels": "Niveaux",
   "@levels": {
     "x-mt": true
@@ -371,9 +353,6 @@
   "languages": "Langues",
   "gender": "Sexe",
   "dateOfBirth": "Date de naissance",
-  "@dateOfBirth": {
-    "x-mt": true
-  },
   "planetCode": "Code de la planète",
   "@planetCode": {
     "x-mt": true
@@ -391,9 +370,6 @@
     "x-mt": true
   },
   "editProfile": "Modifier le profil",
-  "@editProfile": {
-    "x-mt": true
-  },
   "changePhoto": "Changer la photo de profil",
   "@changePhoto": {
     "x-mt": true
@@ -407,17 +383,8 @@
     "x-mt": true
   },
   "firstName": "Prénom",
-  "@firstName": {
-    "x-mt": true
-  },
   "middleName": "Deuxième prénom",
-  "@middleName": {
-    "x-mt": true
-  },
   "lastName": "Nom de famille",
-  "@lastName": {
-    "x-mt": true
-  },
   "save": "Enregistrer",
   "profileSaved": "Profil enregistré sur cet appareil",
   "@profileSaved": {
@@ -567,9 +534,6 @@
     "x-mt": true
   },
   "joinRequestNotification": "Demande d'adhésion",
-  "@joinRequestNotification": {
-    "x-mt": true
-  },
   "teamNotification": "Mise à jour de l'équipe",
   "@teamNotification": {
     "x-mt": true
@@ -673,9 +637,6 @@
   "nA": "N/A",
   "otherDiagnosis": "Autres diagnostics",
   "add": "Ajouter",
-  "@add": {
-    "x-mt": true
-  },
   "status": "Statut",
   "lastUpdated": "Dernière mise à jour",
   "@lastUpdated": {
@@ -851,9 +812,6 @@
   },
   "skip": "Passer",
   "next": "Suivant",
-  "@next": {
-    "x-mt": true
-  },
   "getStarted": "COMMENCER",
   "welcomeToMyPlanet": "Bienvenue sur myPlanet",
   "learnOffline": "Apprendre hors ligne",
@@ -902,9 +860,6 @@
     "x-mt": true
   },
   "addMeetup": "Ajouter une rencontre",
-  "@addMeetup": {
-    "x-mt": true
-  },
   "meetupDetails": "Détails du Meetup",
   "@meetupDetails": {
     "x-mt": true
@@ -914,9 +869,6 @@
     "x-mt": true
   },
   "createdBy": "Créé par",
-  "@createdBy": {
-    "x-mt": true
-  },
   "category": "Catégorie",
   "@category": {
     "x-mt": true
@@ -924,9 +876,6 @@
   "location": "Emplacement",
   "link": "Lien",
   "recurring": "Récurrent",
-  "@recurring": {
-    "x-mt": true
-  },
   "description": "Description",
   "@description": {
     "x-mt": true
@@ -941,13 +890,7 @@
   },
   "editMeetup": "Modifier la réunion",
   "startTime": "Heure de début",
-  "@startTime": {
-    "x-mt": true
-  },
   "endTime": "Heure de fin",
-  "@endTime": {
-    "x-mt": true
-  },
   "none": "Aucun",
   "daily": "Quotidien",
   "weekly": "Hebdomadaire",
@@ -984,13 +927,7 @@
     "x-mt": true
   },
   "startDate": "Date de début",
-  "@startDate": {
-    "x-mt": true
-  },
   "endDate": "Date de fin",
-  "@endDate": {
-    "x-mt": true
-  },
   "timeNotSet": "Heure non réglée",
   "@timeNotSet": {
     "x-mt": true
@@ -1020,9 +957,6 @@
     "x-mt": true
   },
   "takeSurvey": "Répondre à l'enquête",
-  "@takeSurvey": {
-    "x-mt": true
-  },
   "surveyLoadFailed": "L'enquête n'a pas pu être chargée",
   "@surveyLoadFailed": {
     "x-mt": true
@@ -1216,9 +1150,6 @@
     "x-mt": true
   },
   "addTask": "Ajouter une tâche",
-  "@addTask": {
-    "x-mt": true
-  },
   "editTask": "Modifier la tâche",
   "@editTask": {
     "x-mt": true
@@ -1241,10 +1172,7 @@
   },
   "teamMembers": "Membres",
   "members": "Membres",
-  "joinRequests": "Demandes d'adhésion",
-  "@joinRequests": {
-    "x-mt": true
-  },
+  "joinRequests": "Demandes de participation",
   "noMembers": "Pas encore de membres",
   "@noMembers": {
     "x-mt": true
@@ -1293,29 +1221,11 @@
     "x-mt": true
   },
   "addResource": "Ajouter une ressource",
-  "@addResource": {
-    "x-mt": true
-  },
   "editResource": "Modifier la ressource",
-  "@editResource": {
-    "x-mt": true
-  },
   "resourceUpdated": "Ressource mise à jour",
-  "@resourceUpdated": {
-    "x-mt": true
-  },
   "resourceAddedToTeam": "Ressource ajoutée à l'équipe",
-  "@resourceAddedToTeam": {
-    "x-mt": true
-  },
-  "descriptionIsRequired": "Une description est requise",
-  "@descriptionIsRequired": {
-    "x-mt": true
-  },
+  "descriptionIsRequired": "La description est requise",
   "levelIsRequired": "Le niveau est requis",
-  "@levelIsRequired": {
-    "x-mt": true
-  },
   "subjectIsRequired": "Le sujet est requis",
   "selectFile": "Sélectionnez un fichier",
   "@selectFile": {
@@ -1330,9 +1240,6 @@
     "x-mt": true
   },
   "saveChanges": "Enregistrer les modifications",
-  "@saveChanges": {
-    "x-mt": true
-  },
   "selectOpenWith": "Sélectionnez ouvrir avec",
   "@selectOpenWith": {
     "x-mt": true
@@ -1346,9 +1253,6 @@
     "x-mt": true
   },
   "linkToLicense": "Lien vers la licence",
-  "@linkToLicense": {
-    "x-mt": true
-  },
   "noResourcesToAdd": "Toutes les ressources disponibles sont déjà liées",
   "@noResourcesToAdd": {
     "x-mt": true
@@ -1362,9 +1266,6 @@
     "x-mt": true
   },
   "untitledCourse": "Cours sans titre",
-  "@untitledCourse": {
-    "x-mt": true
-  },
   "addCourse": "Ajouter un cours",
   "@addCourse": {
     "x-mt": true
@@ -1386,9 +1287,6 @@
     "x-mt": true
   },
   "addReport": "Ajouter un rapport",
-  "@addReport": {
-    "x-mt": true
-  },
   "editReport": "Modifier le rapport",
   "@editReport": {
     "x-mt": true
@@ -1397,9 +1295,6 @@
   "beginningBalance": "Solde de départ",
   "sales": "Ventes",
   "otherIncome": "Autres revenus",
-  "@otherIncome": {
-    "x-mt": true
-  },
   "wages": "Salaires",
   "@wages": {
     "x-mt": true
@@ -1409,29 +1304,14 @@
     "x-mt": true
   },
   "totalIncome": "Revenu total",
-  "@totalIncome": {
-    "x-mt": true
-  },
   "totalExpenses": "Dépenses totales",
-  "@totalExpenses": {
-    "x-mt": true
-  },
   "profitLoss": "Bénéfice/perte",
   "@profitLoss": {
     "x-mt": true
   },
   "endingBalance": "Solde final",
-  "@endingBalance": {
-    "x-mt": true
-  },
   "negativeBalance": "Le solde actuel est négatif !",
-  "@negativeBalance": {
-    "x-mt": true
-  },
   "reportDateDetails": "Rapport créé le : {created} | Mis à jour le : {updated}",
-  "@reportDateDetails": {
-    "x-mt": true
-  },
   "chatHistory": "Historique des discussions",
   "@chatHistory": {
     "x-mt": true
@@ -1456,9 +1336,6 @@
   },
   "fullConversationResponse": "Réponse complète de la conversation",
   "response": "Réponse",
-  "@response": {
-    "x-mt": true
-  },
   "chatConversation": "Conversation",
   "@chatConversation": {
     "x-mt": true
@@ -1522,9 +1399,6 @@
   "suggestion": "Suggestion",
   "priority": "Priorité",
   "openDate": "Date d'ouverture",
-  "@openDate": {
-    "x-mt": true
-  },
   "replies": "Réponses",
   "@replies": {
     "x-mt": true
@@ -1608,13 +1482,7 @@
   "community": "Communauté",
   "communityLeaders": "Dirigeants de communauté",
   "nationLeaders": "Dirigeants nationaux",
-  "@nationLeaders": {
-    "x-mt": true
-  },
   "ourVoices": "Nos voix",
-  "@ourVoices": {
-    "x-mt": true
-  },
   "finances": "Finances",
   "reports": "rapports",
   "transaction": "Transaction",
@@ -1745,21 +1613,9 @@
     "x-mt": true
   },
   "showAdditionalFields": "Afficher les champs supplémentaires",
-  "@showAdditionalFields": {
-    "x-mt": true
-  },
   "hideAdditionalFields": "Masquer les champs supplémentaires",
-  "@hideAdditionalFields": {
-    "x-mt": true
-  },
   "phoneNumber": "Numéro de téléphone",
-  "@phoneNumber": {
-    "x-mt": true
-  },
   "birthDate": "Date de naissance",
-  "@birthDate": {
-    "x-mt": true
-  },
   "selectDate": "Sélectionner une date",
   "male": "Homme",
   "female": "Femme",
@@ -1782,9 +1638,6 @@
     "x-mt": true
   },
   "videoPlayer": "Lecteur vidéo",
-  "@videoPlayer": {
-    "x-mt": true
-  },
   "audioPlayer": "Lecteur audio",
   "@audioPlayer": {
     "x-mt": true
@@ -1804,9 +1657,6 @@
   "errorOccurred": "Erreur : {error}",
   "openingResource": "Ouverture : {title}",
   "loadingMedia": "Chargement...",
-  "@loadingMedia": {
-    "x-mt": true
-  },
   "resourceUnavailable": "Cette ressource n'est pas disponible pour une visualisation hors ligne",
   "@resourceUnavailable": {
     "x-mt": true
@@ -1825,13 +1675,7 @@
     "x-mt": true
   },
   "specialNeeds": "Besoins spéciaux",
-  "@specialNeeds": {
-    "x-mt": true
-  },
   "otherNeeds": "Autres besoins",
-  "@otherNeeds": {
-    "x-mt": true
-  },
   "emergencyContact": "Contact d'urgence",
   "contactNumber": "Numéro de contact",
   "@contactNumber": {
@@ -1872,9 +1716,6 @@
     "x-mt": true
   },
   "birthPlace": "Lieu de naissance",
-  "@birthPlace": {
-    "x-mt": true
-  },
   "contactName": "Nom du contact",
   "@contactName": {
     "x-mt": true
@@ -1924,9 +1765,6 @@
     "x-mt": true
   },
   "selectHealthMember": "Sélectionner un membre",
-  "@selectHealthMember": {
-    "x-mt": true
-  },
   "newPatient": "Nouveau patient",
   "@newPatient": {
     "x-mt": true
@@ -1974,9 +1812,6 @@
     "x-mt": true
   },
   "bloodPressureFormatError": "La tension artérielle doit être systolique/diastolique",
-  "@bloodPressureFormatError": {
-    "x-mt": true
-  },
   "bloodPressureRangeError": "La tension artérielle doit être comprise entre 60/40 et 300/200",
   "@bloodPressureRangeError": {
     "x-mt": true
@@ -2007,23 +1842,14 @@
     "x-mt": true
   },
   "storageTotalDownloaded": "Total téléchargé",
-  "@storageTotalDownloaded": {
-    "x-mt": true
-  },
   "storageVideos": "Vidéos",
   "storageAudio": "Audio",
-  "storagePdfs": "PDFs",
+  "storagePdfs": "PDF",
   "storageImages": "Images",
   "storageOther": "Autre",
   "fileCountOne": "1 fichier",
   "fileCountMany": "{count} fichiers",
-  "@fileCountMany": {
-    "x-mt": true
-  },
   "storageUnknownResource": "Ressource inconnue",
-  "@storageUnknownResource": {
-    "x-mt": true
-  },
   "areYouSure": "Êtes-vous sûr ?",
   "cancelAddingExamination": "Voulez-vous vraiment annuler l'ajout de l'examen? Les données seront perdues.",
   "yesIWantToExit": "Oui, je veux quitter.",
@@ -2041,10 +1867,7 @@
   "@storageDeleteConfirm": {
     "x-mt": true
   },
-  "storageSelectedCount": "{count} selected",
-  "@storageSelectedCount": {
-    "x-mt": true
-  },
+  "storageSelectedCount": "{count} sélectionné(s)",
   "deleteSelected": "Supprimer la sélection",
   "deleteAll": "Tout supprimer",
   "selectAll": "Sélectionner tout",
@@ -2058,9 +1881,6 @@
     "x-mt": true
   },
   "availableSpace": "Espace disponible",
-  "@availableSpace": {
-    "x-mt": true
-  },
   "freeUpSpace": "Libérer de l'espace",
   "@freeUpSpace": {
     "x-mt": true
@@ -2127,9 +1947,6 @@
     "x-mt": true
   },
   "syncCompletedChallenge": "Synchronisation terminée",
-  "@syncCompletedChallenge": {
-    "x-mt": true
-  },
   "rememberSync": "N'oubliez pas de synchroniser l'application mobile.",
   "challengeDialogTitle": "Défi quotidien",
   "@challengeDialogTitle": {
@@ -2137,9 +1954,6 @@
   },
   "start": "Démarrer",
   "continuation": "Continuer",
-  "@continuation": {
-    "x-mt": true
-  },
   "plan": "Plan",
   "mission": "Mission et Services",
   "editPlan": "Modifier le plan",
@@ -2173,9 +1987,6 @@
   "nameRequired": "Le nom est requis",
   "nameIsRequired": "Veuillez entrer un nom",
   "createdOn": "Créé le",
-  "@createdOn": {
-    "x-mt": true
-  },
   "courseDetails": "Détails du cours",
   "@courseDetails": {
     "x-mt": true
@@ -2219,26 +2030,14 @@
   },
   "mistakes": "Erreurs",
   "step": "Étape",
-  "@step": {
-    "x-mt": true
-  },
   "untitledResourceTitle": "Ressource sans titre",
   "@untitledResourceTitle": {
     "x-mt": true
   },
   "author": "Auteur",
-  "@author": {
-    "x-mt": true
-  },
   "publisher": "Éditeur",
   "license": "Licence",
-  "@license": {
-    "x-mt": true
-  },
   "addedBy": "Ajouté par",
-  "@addedBy": {
-    "x-mt": true
-  },
   "resourceInformation": "Informations sur les ressources",
   "@resourceInformation": {
     "x-mt": true
@@ -2252,9 +2051,6 @@
     "x-mt": true
   },
   "resourceType": "Type de ressource",
-  "@resourceType": {
-    "x-mt": true
-  },
   "subject": "Sujet",
   "@subject": {
     "x-mt": true
@@ -2365,9 +2161,6 @@
     "x-mt": true
   },
   "numberOfVisits": "Nombre de visites",
-  "@numberOfVisits": {
-    "x-mt": true
-  },
   "noLogoutRecord": "Aucun enregistrement de déconnexion trouvé",
   "@noLogoutRecord": {
     "x-mt": true
@@ -2392,9 +2185,6 @@
     "x-mt": true
   },
   "serverChecking": "Vérification du serveur",
-  "@serverChecking": {
-    "x-mt": true
-  },
   "gridView": "Vue en grille",
   "listView": "Vue en liste",
   "disclaimer": "Avis de non-responsabilité",
@@ -2465,26 +2255,11 @@
     }
   },
   "textSize": "Taille du texte",
-  "@textSize": {
-    "x-mt": true
-  },
   "selectTextSize": "Sélectionner la taille du texte",
   "textSizeSmall": "Petit",
-  "@textSizeSmall": {
-    "x-mt": true
-  },
   "textSizeMedium": "Moyen",
-  "@textSizeMedium": {
-    "x-mt": true
-  },
   "textSizeLarge": "Grand",
-  "@textSizeLarge": {
-    "x-mt": true
-  },
   "resetApp": "Réinitialiser l'application",
-  "@resetApp": {
-    "x-mt": true
-  },
   "clearAllDataConfirm": "Êtes-vous sûr de vouloir effacer toutes les données ?",
   "dataCleared": "Toutes les données effacées",
   "@dataCleared": {
@@ -2502,5 +2277,8 @@
   "myPurposeDescription": "Mon But - Quelles sont vos ambitions éducatives et professionnelles ?",
   "pleaseAnswerToContinue": "Veuillez sélectionner/écrire votre réponse pour continuer",
   "teamDocuments": "Documents",
-  "confirmLeaveTeam": "Êtes-vous sûr de vouloir quitter cette équipe ?"
+  "confirmLeaveTeam": "Êtes-vous sûr de vouloir quitter cette équipe ?",
+  "fileNotFound": "Fichier introuvable : {fileName}",
+  "stepsHeading": "Étapes",
+  "courseProgressCount": "Progression {current} sur {max}"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -330,10 +330,7 @@
   "@storageDeleteSelectedConfirm": {
     "x-mt": true
   },
-  "storageSelectedCount": "{count} selected",
-  "@storageSelectedCount": {
-    "x-mt": true
-  },
+  "storageSelectedCount": "{count} छानिएको",
   "deleteSelected": "छानिएका मेटाउनुहोस्",
   "deleteAll": "सबै मेटाउनुहोस्",
   "selectAll": "सबै चयन गर्नुहोस्",
@@ -499,5 +496,11 @@
   "myPurposeDescription": "मेरो उद्देश्य - तपाईका शैक्षिक र व्यावसायिक महत्वाकांक्षा के हुन्?",
   "pleaseAnswerToContinue": "कृपया जारी राख्नका लागि आफ्नो उत्तर चयन गर्नुहोस् / लेख्नुहोस्",
   "teamDocuments": "कागजातहरू",
-  "confirmLeaveTeam": "के तपाईं यस टिमबाट बाहिर निस्कन चाहानुहुन्छ?"
+  "confirmLeaveTeam": "के तपाईं यस टिमबाट बाहिर निस्कन चाहानुहुन्छ?",
+  "appVersion": "संस्करण {version}",
+  "reportDateDetails": "{created} मा बनाइएको रिपोर्ट | {updated} मा अद्यावधिक गरिएको",
+  "fileNotFound": "फाइल फेला परेन: {fileName}",
+  "fileCountMany": "{count} फाइलहरू",
+  "stepsHeading": "चरणहरू",
+  "courseProgressCount": "{current} को {max} प्रगति"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -330,10 +330,7 @@
   "@storageDeleteSelectedConfirm": {
     "x-mt": true
   },
-  "storageSelectedCount": "{count} selected",
-  "@storageSelectedCount": {
-    "x-mt": true
-  },
+  "storageSelectedCount": "{count} la doortay",
   "deleteSelected": "Tirtir Kuwa La Doortay",
   "deleteAll": "Tirtir Dhammaan",
   "selectAll": "Dhammaad Dhammaadee",
@@ -499,5 +496,11 @@
   "myPurposeDescription": "Ujeedadayda - Waa maxay himilooyinkaaga waxbarasho iyo kuwa xirfadeed?",
   "pleaseAnswerToContinue": "Fadlan dooro / qor jawaabtaada si aad u sii wadato",
   "teamDocuments": "Documents",
-  "confirmLeaveTeam": "Ma hubtaa inaad ka tashato kooxan?"
+  "confirmLeaveTeam": "Ma hubtaa inaad ka tashato kooxan?",
+  "appVersion": "Nooca {version}",
+  "reportDateDetails": "Warbixin lagu sameeyay: {created} | La cusbooneysiiyay: {updated}",
+  "fileNotFound": "Faylka lama helin: {fileName}",
+  "fileCountMany": "{count} fayl",
+  "stepsHeading": "Agoonta",
+  "courseProgressCount": "Habka {current} ee {max}"
 }

--- a/flutter/test/l10n/format_derivation_test.dart
+++ b/flutter/test/l10n/format_derivation_test.dart
@@ -1,0 +1,287 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xml/xml.dart';
+
+import '../../tool/arb_from_strings_xml.dart';
+
+/// Guards the placeholder-key derivation (Phase 121).
+///
+/// `tool/arb_from_strings_xml.dart` used to skip every message carrying an ICU
+/// placeholder, which cost the port a whole class of translations: 91 of the
+/// Kotlin app's 1052 strings carry a `%s`/`%d` specifier, and every one of them
+/// has a human translation shipping in all five locales.
+///
+/// The conversion those keys now go through is the part that has to be right
+/// rather than merely plausible. Android numbers its arguments and a translator
+/// may reorder them; ICU names them. A left-to-right substitution reads
+/// correctly on every string where the order happens to match, and silently
+/// prints the wrong value into a sentence on the ones where it does not — a
+/// defect no other test in this tree could catch and no user could diagnose.
+void main() {
+  group('argument order', () {
+    test('a reordered translation keeps each argument with its meaning', () {
+      // `values-ne` writes `download_progress` with argument **2 first**, which
+      // is the case that separates an index-aware conversion from a positional
+      // one. A left-to-right substitution yields
+      // `{completed} मध्ये {total} …` — the two numbers swapped, so a device
+      // three files into eight reads "eight of three".
+      expect(
+        convertAndroidFormat(
+          templateValue: '{completed} of {total} files downloaded',
+          kotlinEnglish: r'%1$d of %2$d files downloaded',
+          translation: _kotlin('ne', 'download_progress'),
+        ),
+        '{total} मध्ये {completed} फाइलहरू डाउनलोड भएका छन्',
+      );
+    });
+
+    test('the same conversion is not merely a fixed swap', () {
+      // The counterpart, so the test above cannot pass by reversing everything:
+      // `values-es` keeps the English order and must come back unreordered.
+      expect(
+        convertAndroidFormat(
+          templateValue: '{completed} of {total} files downloaded',
+          kotlinEnglish: r'%1$d of %2$d files downloaded',
+          translation: r'%1$d de %2$d archivos descargados',
+        ),
+        '{completed} de {total} archivos descargados',
+      );
+    });
+
+    test('a repeated argument maps to one name', () {
+      expect(
+        convertAndroidFormat(
+          templateValue: '{name} said hello to {name}',
+          kotlinEnglish: r'%1$s said hello to %1$s',
+          translation: r'%1$s a dit bonjour à %1$s',
+        ),
+        '{name} a dit bonjour à {name}',
+      );
+    });
+
+    test('an argument the English never named is refused', () {
+      // A locale string carrying more arguments than the English it translates
+      // has no mapping for the extra one, and guessing would put a name on a
+      // value nobody promised.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Progress {current} of {max}',
+          kotlinEnglish: r'Progress %1$s of %2$s',
+          translation: r'Progreso %1$s de %2$s (%3$s)',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('guards', () {
+    test('an unsupported conversion refuses the whole string', () {
+      // `%.1f` says "one decimal place" and `{value}` does not, so converting
+      // it would quietly change what the number reads as.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Rating {value}',
+          kotlinEnglish: 'Rating %.1f',
+          translation: 'Note %.1f',
+        ),
+        isNull,
+      );
+    });
+
+    test('a literal with no word in it is not evidence of anything', () {
+      // `%1$s (%2$s)` is punctuation. It is byte-identical in all five locales,
+      // so there is nothing to derive — and it matches *any* key of that shape.
+      // `ratingCompact` is "{average} ({count})" and Kotlin's `user_name` is
+      // a name beside a login count: same punctuation, different words.
+      expect(
+        convertAndroidFormat(
+          templateValue: '{average} ({count})',
+          kotlinEnglish: r'%1$s (%2$s)',
+          translation: _kotlin('ne', 'user_name'),
+        ),
+        isNull,
+      );
+    });
+
+    test('a translation that drops a placeholder is refused', () {
+      // The failure `placeholder_integrity_test.dart` exists for: the getter
+      // still takes the argument, and renders a sentence with its data missing.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Progress {current} of {max}',
+          kotlinEnglish: r'Progress %1$s of %2$s',
+          translation: r'Progreso %1$s',
+        ),
+        isNull,
+      );
+    });
+
+    test('a plural template is out of scope', () {
+      // A Kotlin `%d` string is one sentence; an ICU plural is three. Filling
+      // the `other` branch and leaving `=0`/`=1` in English would put two
+      // languages inside one rendered string.
+      expect(
+        convertAndroidFormat(
+          templateValue: '{count, plural, =1{1 file} other{{count} files}}',
+          kotlinEnglish: r'%1$d files',
+          translation: r'%1$d fichiers',
+        ),
+        isNull,
+      );
+    });
+
+    test('a brace in the translation is refused', () {
+      // It would be ICU syntax the moment it is written into an `.arb`.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Progress {current} of {max}',
+          kotlinEnglish: r'Progress %1$s of %2$s',
+          translation: r'Progreso %1$s de {%2$s}',
+        ),
+        isNull,
+      );
+    });
+
+    test('a Kotlin string saying something else is refused', () {
+      // The literal is the evidence, and it has to match. This is the guard
+      // that stops a name collision attaching a translation of other words.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Progress {current} of {max}',
+          kotlinEnglish: r'Step %1$s of %2$s',
+          translation: r'Paso %1$s de %2$s',
+        ),
+        isNull,
+      );
+    });
+
+    test('a mix of numbered and bare specifiers is refused', () {
+      // Android itself throws on this; there is no order to be faithful to.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Progress {current} of {max}',
+          kotlinEnglish: r'Progress %1$s of %s',
+          translation: r'Progreso %1$s de %s',
+        ),
+        isNull,
+      );
+    });
+
+    test('a literal percent survives the round trip', () {
+      expect(
+        convertAndroidFormat(
+          templateValue: '{value}% done',
+          kotlinEnglish: '%s%% done',
+          translation: '%s%% terminé',
+        ),
+        '{value}% terminé',
+      );
+    });
+  });
+
+  group('what shipped', () {
+    // The derived values, pinned against the Kotlin XML rather than copied
+    // here: the claim is that the `.arb` tracks the Android app's translations,
+    // and a hardcoded expectation would pass just as happily against a stale
+    // value. Every one of these was absent — the whole key, in every locale —
+    // before this phase, so the alternative each replaces is English.
+    const derived = {
+      'courseProgressCount': ('course_progress', ['current', 'max']),
+      'fileNotFound': ('file_not_found', ['fileName']),
+      'appVersion': ('version', ['version']),
+      'fileCountMany': ('file_count_many', ['count']),
+      'reportDateDetails': ('report_date_details', ['created', 'updated']),
+      'storageSelectedCount': ('storage_selected_count', ['count']),
+      'currentCv': ('current_cv', ['name']),
+    };
+
+    final english = _readArb('en');
+
+    for (final entry in derived.entries) {
+      final (kotlinName, names) = entry.value;
+      test('${entry.key} is the Kotlin ${entry.value.$1}, everywhere', () {
+        for (final locale in const ['ar', 'es', 'fr', 'ne', 'so']) {
+          final value = _readArb(locale)[entry.key];
+          if (value == null) continue; // reported in the phase notes
+          final expected = convertAndroidFormat(
+            templateValue: english[entry.key]! as String,
+            kotlinEnglish: _kotlin('en', kotlinName),
+            translation: _kotlin(locale, kotlinName),
+          );
+          // Compared with the space characters normalised, because one
+          // derived value deliberately differs from the XML by exactly that:
+          // `app_fr.arb` writes a no-break space before the colon where
+          // `values-fr` writes an ordinary one, and French typography wants
+          // the former. The words are what this pins.
+          expect(
+            _spacing(value as String),
+            _spacing(expected!),
+            reason:
+                'app_$locale.arb has drifted from `$kotlinName` in the Kotlin '
+                'app, or the conversion changed',
+          );
+          for (final name in names) {
+            expect(
+              value,
+              contains('{$name}'),
+              reason: '$locale:${entry.key} lost the "$name" placeholder',
+            );
+          }
+        }
+      });
+    }
+
+    test('French keeps its no-break space before a colon', () {
+      // The one place a derived value is deliberately not byte-identical to the
+      // Kotlin XML. `--adopt` treats "same words, different space character" as
+      // nothing to adopt: there is no translation to gain and a typographic
+      // nicety to lose.
+      expect(
+        _readArb('fr')['reportDateDetails'],
+        'Rapport créé le\u{a0}: {created} | Mis à jour le\u{a0}: {updated}',
+      );
+    });
+
+    test('the Spanish course-progress header is Spanish', () {
+      // The instance Phase 117 handed over, spelled out because it is the one
+      // a reader can check without reading the tool: Kotlin has shipped
+      // "Progreso %1$s de %2$s" all along, and the port rendered "Progress 3
+      // of 8" to a Spanish learner because the derivation skipped the key.
+      expect(
+        _readArb('es')['courseProgressCount'],
+        'Progreso {current} de {max}',
+      );
+      expect(
+        _readArb('ne')['courseProgressCount'],
+        '{current} को {max} प्रगति',
+      );
+    });
+  });
+}
+
+/// Every run of whitespace as one ordinary space — see the caller.
+String _spacing(String value) =>
+    value.trim().replaceAll(RegExp(r'[\s\u00a0\u202f\u2009]+'), ' ');
+
+Map<String, Object?> _readArb(String locale) =>
+    jsonDecode(File('lib/l10n/app_$locale.arb').readAsStringSync())
+        as Map<String, Object?>;
+
+/// One string out of a `values*` directory, with Android's quoting undone —
+/// the same reading `tool/arb_from_strings_xml.dart` does.
+String _kotlin(String locale, String name) {
+  final dir = locale == 'en' ? 'values' : 'values-$locale';
+  final document = XmlDocument.parse(
+    File('../app/src/main/res/$dir/strings.xml').readAsStringSync(),
+  );
+  for (final element in document.findAllElements('string')) {
+    if (element.getAttribute('name') != name) continue;
+    final raw = element.innerText;
+    return raw.length > 1 && raw.startsWith('"') && raw.endsWith('"')
+        ? raw.substring(1, raw.length - 1)
+        : raw;
+  }
+  throw StateError('no <string name="$name"> in $dir');
+}

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -268,12 +268,23 @@ void main() {
     // Adding a *reviewed* translation is meant to move these numbers: update
     // the map and say in the commit message who reviewed it. Adding an
     // unreviewed one means flagging it `x-mt`, which leaves them alone.
+    //
+    // Phase 121 moved all five, in two ways worth separating. 33 values across
+    // the five locales are *new* human translations, derived from the Kotlin
+    // XML for keys carrying an ICU placeholder — a class the derivation tool
+    // used to skip outright. The other 259 (ar 62, es 122, fr 75) are values
+    // that were already byte-identical to the translation shipping in the
+    // Android app and were nonetheless flagged unreviewed machine output. The
+    // flag means "a human still has to look at this", and one has; nothing a
+    // user sees changed when they were cleared. If that reading is ever
+    // rejected, `_reconcileMachineTranslationFlags`' `already` branch is the
+    // one line to revert.
     const humanReviewed = {
-      'ar': 327,
-      'es': 323,
-      'fr': 316,
-      'ne': 389,
-      'so': 389,
+      'ar': 395,
+      'es': 448,
+      'fr': 394,
+      'ne': 396,
+      'so': 396,
     };
 
     for (final code in locales) {

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -269,12 +269,13 @@ void main() {
     // the map and say in the commit message who reviewed it. Adding an
     // unreviewed one means flagging it `x-mt`, which leaves them alone.
     //
-    // Phase 121 moved all five, in two ways worth separating. 33 values across
-    // the five locales are *new* human translations, derived from the Kotlin
-    // XML for keys carrying an ICU placeholder — a class the derivation tool
-    // used to skip outright. The other 259 (ar 62, es 122, fr 75) are values
-    // that were already byte-identical to the translation shipping in the
-    // Android app and were nonetheless flagged unreviewed machine output. The
+    // Phase 121 moved all five, in two ways worth separating. 36 values across
+    // the five locales are human translations newly written from the Kotlin
+    // XML, 25 of them for keys carrying an ICU placeholder — a class the
+    // derivation tool used to skip outright. The other 250 (ar 60, es 118,
+    // fr 72) are values that were *already* byte-identical to the translation
+    // shipping in the Android app and were nonetheless flagged unreviewed
+    // machine output. The
     // flag means "a human still has to look at this", and one has; nothing a
     // user sees changed when they were cleared. If that reading is ever
     // rejected, `_reconcileMachineTranslationFlags`' `already` branch is the

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -120,6 +120,15 @@ void main(List<String> args) {
   for (final entry in english.entries) {
     byEnglishText.putIfAbsent(entry.value.trim(), () => []).add(entry.key);
   }
+  // The same index for format strings, keyed on the literal with the holes
+  // taken out: `Progress %1$s of %2$s` and `Progress {current} of {max}` are
+  // the same message written twice, and only the literal says so.
+  final byEnglishFormat = <String, List<String>>{};
+  for (final entry in english.entries) {
+    final format = _parseAndroidFormat(entry.value.trim());
+    if (format == null || format.holes.isEmpty) continue;
+    byEnglishFormat.putIfAbsent(format.literal.trim(), () => []).add(entry.key);
+  }
 
   for (final locale in locales) {
     final path = '${resDir.path}/values-$locale/strings.xml';
@@ -135,16 +144,62 @@ void main(List<String> args) {
     for (final key in keys) {
       final templateValue = template[key];
       if (templateValue is! String) continue;
-      // ICU syntax of any kind is out of scope — see the header.
-      if (templateValue.contains('{')) continue;
-      // So is Kotlin's printf syntax. Three template keys — `communityEarnings`,
-      // `perSurvey`, `yourEarnings` — declare ICU placeholders but write their
-      // English with `%1$d`/`%1$s`, which ICU never interpolates: the generated
-      // getter takes the argument and drops it, in every language including
-      // English. Deriving a translation would spread that defect into the
-      // locale files, where the placeholder guard then fails on it. Leave them
-      // absent until `app_en.arb` is corrected to `{amount}`/`{status}`.
+      // Kotlin's printf syntax in the *template*. Three keys —
+      // `communityEarnings`, `perSurvey`, `yourEarnings` — declare ICU
+      // placeholders but write their English with `%1$d`/`%1$s`, which ICU
+      // never interpolates: the generated getter takes the argument and drops
+      // it, in every language including English. Deriving a translation would
+      // spread that defect into the locale files, where the placeholder guard
+      // then fails on it. Leave them absent until `app_en.arb` is corrected to
+      // `{amount}`/`{status}`.
       if (_printfSpecifier.hasMatch(templateValue)) continue;
+
+      // A message with ICU placeholders is derived through the format layer at
+      // the foot of this file, which lines the two notations up by argument
+      // index. Everything else is plain text and matches on the text itself.
+      if (templateValue.contains('{')) {
+        final format = _parseIcuFormat(templateValue);
+        if (format == null || format.holes.isEmpty || !format.hasWords) {
+          continue;
+        }
+        final named = byCamelCase[key] ?? const [];
+        String? fromName;
+        for (final name in named) {
+          final source = english[name];
+          final value = translated[name];
+          if (source == null || value == null) continue;
+          fromName = convertAndroidFormat(
+            templateValue: templateValue,
+            kotlinEnglish: source,
+            translation: value,
+          );
+          if (fromName != null) break;
+        }
+        if (fromName != null) {
+          derived[key] = fromName;
+          byName++;
+          continue;
+        }
+        // No name match: fall back to every Kotlin string whose English says
+        // the same thing, and require them to agree — the same unanimity rule
+        // the plain-text path uses, for the same reason.
+        final proposals = <String>{};
+        for (final name in byEnglishFormat[format.literal.trim()] ?? const []) {
+          final value = translated[name];
+          if (value == null) continue;
+          final converted = convertAndroidFormat(
+            templateValue: templateValue,
+            kotlinEnglish: english[name]!,
+            translation: value,
+          );
+          if (converted != null) proposals.add(converted);
+        }
+        if (proposals.length == 1) {
+          derived[key] = proposals.single;
+          byText++;
+        }
+        continue;
+      }
       final wanted = templateValue.trim();
 
       final named = byCamelCase[key] ?? const [];
@@ -385,6 +440,7 @@ class _Candidate {
     required this.current,
     required this.proposed,
     required this.verdict,
+    this.nameResolved = false,
   });
 
   final String key;
@@ -394,6 +450,10 @@ class _Candidate {
 
   /// `apply`, `already`, `keep-human`, `report`, or `no-unanimous`.
   final String verdict;
+
+  /// Whether the tier's candidates disagreed and the Kotlin name that
+  /// camel-cases to [key] broke the tie.
+  final bool nameResolved;
 }
 
 void _recover(List<String> args, {required bool apply}) {
@@ -426,10 +486,24 @@ void _recover(List<String> args, {required bool apply}) {
       final templateValue = template[key];
       if (templateValue is! String) continue;
       final current = arb[key] is String ? arb[key] as String : null;
-      final proposals = <String>{};
+      // Keyed by Kotlin name, because when two names disagree the name itself
+      // is the tiebreak — see below.
+      final byKotlinName = <String, String>{};
+      final isFormat = templateValue.contains('{');
       for (final name in entry.value.names) {
         final value = translated[name];
         if (value == null || value.trim().isEmpty) continue;
+        if (isFormat) {
+          // The format layer does its own guarding, and a null from it means
+          // "not unambiguous" — the candidate simply drops out.
+          final converted = convertAndroidFormat(
+            templateValue: templateValue,
+            kotlinEnglish: english[name] ?? '',
+            translation: value,
+          );
+          if (converted != null) byKotlinName[name] = converted;
+          continue;
+        }
         final proposal = _proposal(entry.value.tier, value, templateValue);
         // The template is placeholder-free by the time it gets here, but a
         // translation is a separate string and could carry syntax of its own.
@@ -441,7 +515,36 @@ void _recover(List<String> args, {required bool apply}) {
             _printfSpecifier.hasMatch(proposal)) {
           continue;
         }
-        proposals.add(proposal);
+        byKotlinName[name] = proposal;
+      }
+      // A locale entry that is still the English is an untranslated string, not
+      // a translation, and adopting one *replaces* a translation with English.
+      // `values-so` renders `settings` as "Settings"; with the namesake rule
+      // below that string would otherwise have won the tie against the real
+      // Somali `Goobooyinka` the moment anybody flagged that key.
+      byKotlinName.removeWhere(
+        (_, proposal) => proposal.trim() == templateValue.trim(),
+      );
+      var proposals = byKotlinName.values.toSet();
+      // Two Kotlin names sharing one English, translated differently. The
+      // English alone cannot choose between them — but a name that *also*
+      // camel-cases to this very ARB key is the same string identified twice,
+      // and that is more evidence, not less. `addResource` has `add_resource`
+      // and `add_res`; `joinRequests` and `notifGroupJoinRequests` share both
+      // their candidates and each picks its own namesake. Phase 118 left 25
+      // such keys unresolved for want of this rule; it settles 13 of them and
+      // leaves the rest — `progressFilterCompleted` really is a choice between
+      // `completed` and `status_completed`, with no name to break the tie.
+      var nameResolved = false;
+      if (proposals.length > 1) {
+        final namesake = {
+          for (final row in byKotlinName.entries)
+            if (_camelCase(row.key) == key) row.value,
+        };
+        if (namesake.length == 1) {
+          proposals = namesake;
+          nameResolved = true;
+        }
       }
       String verdict;
       if (!entry.value.tier.isAdoptable) {
@@ -456,6 +559,14 @@ void _recover(List<String> args, {required bool apply}) {
       } else if (proposals.length != 1) {
         verdict = 'no-unanimous';
       } else if (current == proposals.single) {
+        verdict = 'already';
+      } else if (current != null &&
+          _sameButForSpacing(current, proposals.single)) {
+        // Identical words, different space character. `app_fr.arb` writes
+        // `Rapport créé le\u{a0}: {created}` where `values-fr` writes an
+        // ordinary space — French typography puts a no-break space before a
+        // colon and the Kotlin XML does not. There is no translation to gain
+        // and a typographic nicety to lose, so this is not a candidate.
         verdict = 'already';
       } else if (current != null && current.trim() == proposals.single.trim()) {
         // Same translation, different surrounding whitespace. `selectResources`
@@ -475,6 +586,7 @@ void _recover(List<String> args, {required bool apply}) {
           current: current,
           proposed: proposals.isEmpty ? null : proposals.join(' | '),
           verdict: verdict,
+          nameResolved: nameResolved,
         ),
       );
     }
@@ -520,8 +632,30 @@ Map<String, _Match> _matchTemplateToKotlin(
   for (final key in template.keys) {
     final value = template[key];
     if (key.startsWith('@') || value is! String) continue;
-    // ICU and Kotlin's printf syntax are both out of scope — see the header.
-    if (value.contains('{') || _printfSpecifier.hasMatch(value)) continue;
+    // Kotlin's printf syntax in the template is out of scope — see the header.
+    if (_printfSpecifier.hasMatch(value)) continue;
+    // A placeholder message matches on its literal, and only exactly. The
+    // punctuation and casing tiers below reshape a value's ends, which is not
+    // safe next to a hole; nothing in the corpus needs them here.
+    if (value.contains('{')) {
+      final format = _parseIcuFormat(value);
+      if (format == null || format.holes.isEmpty || !format.hasWords) continue;
+      final literal = format.literal.trim();
+      final sameLiteral = <String>[];
+      for (final entry in english.entries) {
+        final other = _parseAndroidFormat(entry.value.trim());
+        if (other == null || other.holes.length != format.holes.length) {
+          continue;
+        }
+        if (other.literal.trim() == literal) sameLiteral.add(entry.key);
+      }
+      if (sameLiteral.isNotEmpty) {
+        matches[key] = _Match(MatchTier.exact, sameLiteral);
+      } else if (byCamelCase.containsKey(key)) {
+        matches[key] = _Match(MatchTier.nameOnly, byCamelCase[key]!);
+      }
+      continue;
+    }
 
     final exact = <String>[];
     final punctuation = <String>[];
@@ -601,6 +735,14 @@ bool _replaceable(String? current, String templateEnglish, bool isMachine) {
 }
 
 final _untranslatedMarker = RegExp(r'^\[[A-Z][A-Za-z]+\]\s');
+
+/// Whether two values are the same words differing only in which space
+/// characters they use. See the caller for why that is not worth adopting.
+bool _sameButForSpacing(String a, String b) =>
+    _ordinarySpaces(a) == _ordinarySpaces(b);
+
+String _ordinarySpaces(String value) =>
+    value.trim().replaceAll(RegExp(r'[\s\u00a0\u202f\u2009]+'), ' ');
 
 /// A trailing run of label punctuation, with the space Android puts around it.
 final _trailingLabelPunctuation = RegExp('[\\s ]*[:.…!]+[\\s ]*\$');
@@ -705,7 +847,16 @@ _AdoptCounts _adopt(
 
   final flags = _reconcileMachineTranslationFlags(merged, {
     for (final candidate in candidates)
-      if (candidate.verdict == 'apply') candidate.key,
+      // `already` counts as well as `apply`. The flag means "unreviewed machine
+      // output, a human still has to look at this", and a value byte-identical
+      // to the translation shipping in the Android app has had one — whatever
+      // pipeline produced this copy of it. 96 values across ar/es/fr were
+      // flagged that way, and the rule dropping a stale flag on an adopted
+      // value already said so; it simply never fired on the values that needed
+      // no adopting. Nothing a user sees changes: this is marking only.
+      if (candidate.verdict == 'apply' ||
+          (candidate.verdict == 'already' && candidate.match.tier.isAdoptable))
+        candidate.key,
   });
   file.writeAsStringSync('${_encodeArb(merged)}\n');
   return _AdoptCounts(values, escapes, flags);
@@ -733,7 +884,8 @@ void _printCandidates(
       // Every field on one line. A value with a newline in it would otherwise
       // split its own row in half, and this report is meant to be greppable.
       stdout.writeln(
-        '${row.key}\t${row.match.tier.name}\n'
+        '${row.key}\t${row.match.tier.name}'
+        '${row.nameResolved ? ' (name-resolved)' : ''}\n'
         '  en   ${_oneLine(template[row.key] as String?)}\n'
         '  xml  $names\n'
         '  was  ${_oneLine(row.current)}\n'
@@ -867,4 +1019,224 @@ String _escape(String value) {
   }
   buffer.write('"');
   return buffer.toString();
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder keys (Phase 121).
+//
+// Everything above deliberately skipped a template value carrying an ICU
+// placeholder. That skip was never about the placeholders being untranslatable
+// — it was about not having a safe way to line two different notations up. It
+// cost a whole class: **91 of the Kotlin app's 1052 strings carry a `%s`/`%d`
+// format specifier**, and each one has a human translation shipping in all five
+// locales that the port could not read.
+//
+// The two notations differ in a way a left-to-right substitution gets wrong.
+// Android numbers its arguments (`%1$s`, `%2$s`) and a translator may reorder
+// them: `values-ne` writes `download_progress` as
+// `%2$d मध्ये %1$d फाइलहरू डाउनलोड भएका छन्` — argument 2 first. ICU names its
+// arguments instead, so the conversion has to carry each *argument index* to
+// the name that argument means, never to the name sitting in the same position.
+// [_FormatString] is that: literal segments plus the ordered ids of the holes
+// between them. Two strings describe the same message when their literals are
+// identical; zipping their hole lists gives the index → name map, which is then
+// applied to the translation wherever *its* holes fall.
+//
+// The guards, in the order they reject:
+//
+//   * **ICU plurals and selects are out of scope.** A Kotlin `%d` string is one
+//     sentence; `{count, plural, =0{…} =1{…} other{…}}` is three. Filling the
+//     `other` branch from the Kotlin and leaving `=0`/`=1` in English would put
+//     two languages inside one rendered string, which is worse than the English
+//     fallback. 23 of the template's 76 placeholder keys are plurals; they are
+//     reported and never derived.
+//   * **An unsupported conversion rejects the whole string.** `%.1f` formats a
+//     number to one decimal place and `{name}` does not, so dropping the
+//     precision would change what the number says.
+//   * **A literal with no letter in it is not evidence.** `%1$s (%2$s)` is
+//     punctuation; it is byte-identical in all five locales, so deriving from
+//     it adds a value that says nothing. Worse, it matches *any* key of that
+//     shape — `ratingCompact` ("{average} ({count})") matches Kotlin's
+//     `user_name` ("name (logins)") on it, which is a translation of different
+//     words. Requiring a letter throws the wrong match out with the useless
+//     ones.
+//   * **Every declared placeholder must survive.** A translation that drops one
+//     renders a sentence with its data missing, which is what
+//     `test/l10n/placeholder_integrity_test.dart` exists to stop.
+//
+// Matching is **exact literal only** — no punctuation or casing tier. Those
+// tiers strip trailing punctuation and give the template's back, and a hole
+// adjacent to the punctuation makes the result ambiguous for no gain: nothing
+// in the corpus matches at those tiers anyway.
+
+/// A format string reduced to its literal segments and the holes between them.
+///
+/// There is always one more segment than hole, so [parts] and [holes]
+/// interleave: `parts[0] holes[0] parts[1] holes[1] … parts[n]`.
+///
+/// For a Kotlin string a hole id is the argument index as written (`%2$s` →
+/// `'2'`, a bare `%s` → its ordinal). For an ARB message it is the placeholder
+/// name.
+class _FormatString {
+  const _FormatString(this.parts, this.holes);
+
+  final List<String> parts;
+  final List<String> holes;
+
+  /// The text with every hole removed, which is what makes the two notations
+  /// comparable.
+  String get literal => parts.join();
+
+  /// Whether the literal carries a word at all — see the header.
+  bool get hasWords => _anyLetter.hasMatch(literal);
+
+  /// The string back again, with each hole id mapped through [names] and
+  /// written in ICU form. Null when a hole has no mapping.
+  String? renderIcu(Map<String, String> names) {
+    final buffer = StringBuffer(parts.first);
+    for (var i = 0; i < holes.length; i++) {
+      final name = names[holes[i]];
+      if (name == null) return null;
+      buffer.write('{$name}');
+      buffer.write(parts[i + 1]);
+    }
+    return buffer.toString();
+  }
+}
+
+final _anyLetter = RegExp(r'\p{L}', unicode: true);
+
+/// Every printf conversion Android permits, so an unsupported one is *seen*
+/// rather than read as literal text.
+final _anySpecifier = RegExp(
+  r'%(?:(\d+)\$)?([-#+ 0,(]*\d*(?:\.\d+)?)([a-zA-Z])',
+);
+
+/// Parses an Android format string, or returns null when it is not convertible.
+///
+/// Null means "do not derive from this", never "this has no holes": a string
+/// with no specifier parses to an empty [_FormatString.holes].
+_FormatString? _parseAndroidFormat(String value) {
+  // A brace in the literal would become ICU syntax the moment the value is
+  // written into an `.arb`.
+  if (value.contains('{') || value.contains('}')) return null;
+
+  final parts = <String>[];
+  final holes = <String>[];
+  final segment = StringBuffer();
+  var explicit = false;
+  var implicit = 0;
+  var index = 0;
+  while (index < value.length) {
+    final at = value.indexOf('%', index);
+    if (at < 0) {
+      segment.write(value.substring(index));
+      break;
+    }
+    segment.write(value.substring(index, at));
+    if (value.startsWith('%%', at)) {
+      segment.write('%');
+      index = at + 2;
+      continue;
+    }
+    final match = _anySpecifier.matchAsPrefix(value, at);
+    // A lone `%`, or a conversion carrying flags/width/precision this cannot
+    // reproduce: `%.1f` says "one decimal place" and `{value}` does not.
+    if (match == null ||
+        match.group(2)!.isNotEmpty ||
+        !const ['s', 'd'].contains(match.group(3))) {
+      return null;
+    }
+    if (match.group(1) != null) {
+      explicit = true;
+      holes.add(match.group(1)!);
+    } else {
+      holes.add('${++implicit}');
+    }
+    // Android itself throws on a string that mixes the two forms.
+    if (explicit && implicit > 0) return null;
+    parts.add(segment.toString());
+    segment.clear();
+    index = match.end;
+  }
+  parts.add(segment.toString());
+  return _FormatString(parts, holes);
+}
+
+/// `{name}` occurrences in an ARB message, or null for anything more elaborate.
+///
+/// A plural or select body is rejected here rather than downstream: its braces
+/// are structure, not holes, and reducing it to a literal would compare a
+/// three-sentence message against a one-sentence Kotlin string.
+_FormatString? _parseIcuFormat(String value) {
+  final parts = <String>[];
+  final holes = <String>[];
+  var index = 0;
+  while (index < value.length) {
+    final at = value.indexOf('{', index);
+    if (at < 0) {
+      parts.add(value.substring(index));
+      index = value.length;
+      break;
+    }
+    parts.add(value.substring(index, at));
+    final close = value.indexOf('}', at);
+    if (close < 0) return null;
+    final name = value.substring(at + 1, close);
+    // `{count, plural, …}`, `{choice, select, …}`, or a nested body.
+    if (!_placeholderName.hasMatch(name)) return null;
+    holes.add(name);
+    index = close + 1;
+  }
+  if (index >= value.length && parts.length == holes.length) parts.add('');
+  if (parts.any((part) => part.contains('}'))) return null;
+  return _FormatString(parts, holes);
+}
+
+final _placeholderName = RegExp(r'^\w+$');
+
+/// The ICU form of [translation], or null when the conversion is not
+/// unambiguous.
+///
+/// [templateValue] is `app_en.arb`'s message and [kotlinEnglish] the
+/// `values/strings.xml` string it was matched to; between them they fix which
+/// argument index means which placeholder name. [translation] is that Kotlin
+/// string in some locale, free to put those arguments anywhere.
+String? convertAndroidFormat({
+  required String templateValue,
+  required String kotlinEnglish,
+  required String translation,
+}) {
+  final template = _parseIcuFormat(templateValue);
+  if (template == null || template.holes.isEmpty || !template.hasWords) {
+    return null;
+  }
+  final english = _parseAndroidFormat(kotlinEnglish.trim());
+  if (english == null) return null;
+  if (english.literal.trim() != template.literal.trim()) return null;
+  if (english.holes.length != template.holes.length) return null;
+
+  // Argument index → placeholder name, read off the two English forms. A repeat
+  // must agree with itself, and two indices may not claim one name: either
+  // would mean the literals line up by accident rather than by meaning.
+  final names = <String, String>{};
+  for (var i = 0; i < english.holes.length; i++) {
+    final existing = names[english.holes[i]];
+    if (existing != null && existing != template.holes[i]) return null;
+    if (existing == null && names.containsValue(template.holes[i])) return null;
+    names[english.holes[i]] = template.holes[i];
+  }
+
+  final localised = _parseAndroidFormat(translation.trim());
+  if (localised == null) return null;
+  final rendered = localised.renderIcu(names);
+  if (rendered == null) return null;
+
+  // Nothing may be lost: the generated getter still takes every declared
+  // argument, so a value that drops one discards it silently at render time.
+  for (final name in template.holes.toSet()) {
+    if (!rendered.contains('{$name}')) return null;
+  }
+  if (_printfSpecifier.hasMatch(rendered)) return null;
+  return rendered;
 }


### PR DESCRIPTION
Lane C of the Phase 119–121 round. **Complete.** Gate green locally (format clean, analyze clean, **1961 tests**, three independent full runs) and all five checks green on `e469df3`.

`tool/arb_from_strings_xml.dart` skipped every template value containing an ICU placeholder, so a whole class of translations the Android app already ships was unreachable.

## The class, measured

| | |
|---|---|
| Kotlin strings in `values/strings.xml` | 1052 |
| …carrying a format specifier | **92** |
| ARB template message keys | 873 |
| …declaring an ICU placeholder | 76 |
| …plural/select bodies (out of scope) | 23 |
| …simple `{name}` messages | 53 |
| …whose skeleton matches a Kotlin format string | 11 |
| …rejected: skeleton carries no word | 3 |
| **derived** | **8 keys, 40 locale slots, 25 needing a write** |

**36 values written** in all — 25 placeholder-key, 11 plain-text from the residue rules. 24 filled an absent key; 12 replaced a value flagged `x-mt` or holding the English template verbatim. Nothing else was overwritten.

Only 8 keys came back because 42 of the 53 simple placeholder messages have no Kotlin counterpart with the same words — port-minted English for port screens. Recovering those means editing `app_en.arb`, which is Phase 114's line, not a derivation.

## Index-aware, not positional

Android numbers its arguments and a translator may reorder them; ICU names them. The tool reduces both notations to a literal skeleton plus ordered hole ids, matches on the skeleton, and maps **argument index → placeholder name**. Four Kotlin strings reorder (`ne/download_progress` + two siblings, `ar/member_description`); a test drives the first through the real XML — positional substitution yields `{completed} मध्ये {total}`, i.e. three files into eight reading "eight of three". A second test runs the Spanish of the same string, which keeps the English order, so the first cannot pass by reversing everything.

`courseProgressCount` was absent in all five locales → `التقدم {current} من {max}` · `Progreso {current} de {max}` · `Progression {current} sur {max}` · `{current} को {max} प्रगति` · `Habka {current} ee {max}`.

**Correction to Phase 117:** `values-ne`'s `course_progress` does *not* reorder its placeholders — it keeps ascending argument order. The conclusion it drew is right; the instance cited for it is not. Recorded in both phase notes.

## Guards (each rejects rather than guesses)

- plural/select bodies — one Kotlin sentence is not three ICU branches;
- an unsupported conversion refuses the whole string (`%.1f` says "one decimal place", `{value}` does not);
- **a skeleton with no letter in it is not evidence** — `%1$s (%2$s)` is identical in five locales *and* matched `ratingCompact` to Kotlin's `user_name`, a translation of different words that no test here could have caught;
- a translation dropping a declared placeholder is refused.

## Phase 118 residue: 42 → 26

A namesake tie-break settles 13 of the 25 `no-unanimous` (a Kotlin name that camel-cases to the ARB key is the same string identified twice — the `--adopt` header already advised this and nothing implemented it). A proposal byte-identical to the English template is now dropped before any tie-break, so `values-so`'s "Settings" can never displace the real Somali. And "same words, different space character" is no longer a candidate, keeping French its no-break space before a colon.

Left: 22 `keep-human` needing a speaker, 4 `no-unanimous` (`progressFilterCompleted`, genuinely no tie-break), and 4 confirmed tool false positives — Phase 118's three plus `so:settings`, same casing-tier shape.

## One finding, recorded rather than buried

**250 values across ar/es/fr were flagged `x-mt` while byte-identical to the translation shipping in the Android app.** The flag means a human still has to look at the string; one has. Cleared — marking only, nothing rendered changes — and one line to revert. It moves the pinned human-reviewed counts more than the 36 new translations do, so it is called out rather than folded in.

## Notes for the integrator

- No schema change (`schemaVersion` stays 45), no `lib/` code change — `lib/l10n/*.arb` are data.
- New file `flutter/test/l10n/format_derivation_test.dart` (21 tests). The pinned human-reviewed count map in `placeholder_integrity_test.dart` is updated, with the reasoning at the constant.
- One boundary crossed deliberately: an appended correction paragraph in `flutter/PHASE_117_NOTES.md` (a merged lane's notes, no live owner), so the wrong reordering claim is corrected where a reader meets it.
- Wording for `CLAUDE.md`'s l10n passage is in `flutter/PHASE_121_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG8vGXkwmJ9kA1ostKSm4M