### PR TITLE
[Flutter port] Phase 124 — port `formatNotification` so a bell row stops reading `7`

### DIFF
--- a/flutter/PHASE_124_NOTES.md
+++ b/flutter/PHASE_124_NOTES.md
@@ -1,3 +1,283 @@
-# Phase 124 — `formatNotification`: the bell row that reads `7`
+# Phase 124 — `formatNotification`, and the bell row that read `7`
 
-Work in progress. See the PR description for the current state.
+Phase 120's third deferred item. `NotificationsViewModel.formatNotification`
+(`NotificationsViewModel.kt:354-425`) rewrites every notification's text per
+**resolved** type and hands the result to `Html.fromHtml`, which fills the row's
+single TextView (`NotificationsAdapter.kt:116-127`, `row_notifications.xml`).
+The port had none of that: it drew a type label as the row's title and the
+stored `message` verbatim underneath. Since `updateResourceNotification` stores
+*only the count*, the port's own resource notification rendered as the single
+character `7` — a row no learner can interpret and none would report.
+
+Two `parity-auditor` passes at `effort: max`: one on the Kotlin before writing
+any Dart, one on the finished diff. The first overturned the central design
+decision of this phase (see *The rendering decision*), and is the reason this
+lane ships a small HTML parser it had argued against.
+
+---
+
+## What each type formats to, and which part is the title
+
+There is **one** part. `row_notifications.xml` holds a `title` TextView and a
+`timestamp` TextView and nothing else — no per-row icon (`iconResFor` is called
+from `HeaderViewHolder`, once per *group*), no subtitle. So Kotlin's whole
+notification text is the row's primary line, and the port's "type label above
+the raw message" was an invention twice over: `AppNotification.title`, which the
+port's row preferred when set, is a column **nothing in either app ever
+writes** — `parseNotification` never assigns it and `model/Notification.kt` has
+no field for it.
+
+| resolved type | text | markup |
+|---|---|---|
+| `resource` | `You have 7 resources not downloaded` (`resource_notification`) — a non-numeric message is passed through | none |
+| `storage` | `Storage running low: 8%` — `<= 10` and `<= 40` produce the *same* string, `> 40` is `Storage available: N%`, a non-percentage is passed through with its `%` | none |
+| `task` | `Read chapter 3 is due in Thu 12, August 2027` (`task_notification`), prefixed `<b>Reading Club</b>: ` when the team resolves | bold team name, colon **outside** |
+| `join_request` | `<b>Join Request:</b> Jane has requested to join My Team` — only when the row's **raw** type is `join_request`; otherwise the server's message, verbatim | bold prefix, colon **inside** |
+| `chat`, `team_join`, `voice_reply`, unresolved | the message, verbatim | whatever the server sent |
+
+Ported to `lib/ui/notifications/notification_format.dart` as two halves:
+`notificationHtml` composes exactly what Kotlin composes, quirks intact, and
+`renderNotificationHtml` (`notification_html.dart`) turns it into spans. Keeping
+them apart is what lets the composition stay literally faithful — including the
+double space below — while the renderer accounts for what a user never sees.
+
+Consistency with Phase 49's navigation holds by construction: the formatter and
+`NotificationDestinationResolver` switch on the same `resolvedNotificationType`,
+so a row that reads as a task opens a task list and a row that reads as a join
+request opens the requests tab.
+
+---
+
+## The rendering decision, and why the obvious answer was wrong
+
+The brief asked for structured title/subtitle emphasis over an HTML renderer,
+"if it reproduces what a user sees" — and I wrote it that way first, with a
+comment claiming the only markup in play was the port's own `<b>` and that
+"Planet's notification messages are plain sentences". **The ground-truth audit
+killed that with the repo's own fixtures.** `NotificationsRepositoryImplTest.kt`
+shows what the server actually sends:
+
+```
+:168  "<b>Jane</b> has requested to join <b>\"My Team\"</b> team."   type team
+:192  "You have been added to <b>\"My Team\"</b> team."               type team
+:214  "<b>Jane</b> replied to your message."                          type replyMessage
+```
+
+Those three are precisely the arms `formatNotification` passes through
+unchanged — so **the arms that carry markup in production are the arms that do
+no formatting**, and a span list built only from the port's own emphasis would
+have drawn `<b>` on screen for the most common notifications in the app. The
+first design was worse than the defect it replaced.
+
+So: spans **and** a parser. `notification_html.dart` is ~140 lines and
+deliberately narrow, because the input is a closed set:
+
+* `<b>`/`<strong>`, `<i>`/`<em>` → emphasis flags;
+* an unknown tag is dropped and its text kept, as TagSoup does — so a task
+  titled `Read <chapter 3>` renders identically in both apps;
+* a small HTML4 entity table plus numeric references, and an unrecognised
+  `&foo;` is left alone;
+* runs of spaces and newlines collapse; leading whitespace is dropped; a tab is
+  not collapsed (AOSP collapses `' '` and `'\n'` only).
+
+No dependency: the alternative is a full HTML widget package for four tags, and
+`Text.rich` draws these spans exactly as the `Spanned` renders. What is **not**
+reproduced is block layout — `<p>`/`<div>` become one newline where AOSP emits
+paragraph breaks, and lists lose their bullets. Nothing in the corpus has one.
+
+That collapsing rule is not decoration. `storage_running_low` is
+`"Storage running low: "` — Android-quoted so AAPT keeps the trailing space —
+and `formatStorageNotification` composes `"$prefix ${it}%"`, adding a second.
+The Kotlin's own string carries a double space that only `Html.fromHtml` hides.
+The port composes the same two spaces and collapses them at render, so the
+composition can be diffed against the Kotlin line by line. It also means the
+French translation, whose XML is *unquoted* and so has no trailing space,
+renders with the same single space it does in the Android app.
+
+---
+
+## Did the Kotlin translations come across? Six of eight, yes
+
+Keys were named so the derivation tool could match them, and
+`dart tool/arb_from_strings_xml.dart` picked up **all six that have a Kotlin
+counterpart, in all five locales** — human translations already shipping in the
+Android app, at no cost:
+
+| ARB key | from | derived |
+|---|---|---|
+| `resourceNotificationMessage` | `resource_notification` | ar es fr ne so |
+| `taskNotificationMessage` | `task_notification` | ar es fr ne so |
+| `storageRunningLow` | `storage_running_low` | ar es fr ne so |
+| `storageAvailable` | `storage_available` | ar es fr ne so |
+| `joinRequestPrefix` | `join_request_prefix` | ar es fr ne so |
+| `userRequestedToJoinTeam` | `user_requested_to_join_team` | ar es fr ne so |
+| `unknownUser` | — | English fallback |
+| `unknownTeam` | — | English fallback |
+
+Two of them are Phase 121's placeholder path doing its job:
+`taskNotificationMessage` came across as Nepali's `{title} {date} मा समाप्त
+हुन्छ`, argument order rewritten, which is the whole reason that path exists.
+
+`resourceNotification` / `taskNotification` / `storageNotification` /
+`joinRequestNotification` — the names Phase 120 predicted this work would want
+— are the *type labels* the old row drew, and they still hold their own
+translations, so the new keys took `…Message`-style names instead. The type
+labels are now unused by the row (the group header names the type, as in
+Kotlin); the keys are left in place rather than deleted, because their five
+locale files carry real translations and a future caller may want them.
+
+`unknownUser`/`unknownTeam` have no Kotlin string to derive from: Kotlin
+hardcodes the English literals `"Unknown User"` / `"Unknown Team"` in
+`NotificationsRepositoryImpl` (`:184,188,229,242,248`). The port's repository
+leaves those fields **null** and the formatter fills them from the ARB, so the
+fallback is translatable — the same correction Phase 95 made to `MyHealthScreen`'s
+hardcoded `'Unknown'`. Rendered English is identical.
+
+`test/l10n/placeholder_integrity_test.dart`'s pinned human-reviewed counts move
+by exactly 6 per locale.
+
+---
+
+## Which types can actually reach this code
+
+Worth writing down, because it decides what the tests can honestly claim.
+
+`AppNotification` is constructed in exactly three places, all in
+`NotificationsRepositoryImpl`: the `resource` row (`:68`), the `storage` row
+(`:99`), and `parseNotification` (`:370`), which stores the server document's
+type verbatim. `refresh()` is `= Unit`; `insert(doc)` has no production caller;
+`utils/NotificationUtils.kt` only builds Android tray notifications and touches
+no DAO. So:
+
+* **reachable and reformatted**: `resource` (the port's own `"7"`), `storage`
+  (the port's own `"8%"`, and only ever `<= 10` — the writer *deletes* the row
+  above that, so the `<= 40` and `> 40` arms are dead);
+* **reachable and verbatim**: the server's `team`, `newTask`, `newResource`,
+  `replyMessage` documents;
+* **unreachable**: the join-request lookup, which needs a row whose *raw* type
+  is `join_request`. Nothing writes one. It is ported for fidelity, and the
+  tests that exercise it drive the pure function directly rather than implying
+  the feature works. Worth knowing why it would be *bad* if it fired:
+  `extractRelatedId` returns null for every raw type but `team`/`replyMessage`/
+  `newTask`, so such a row would carry no `relatedId`, hit the `''` fallback and
+  read "Join Request: Unknown User has requested to join Unknown Team" — worse
+  than the server's own sentence.
+
+The `newTask` hole Phase 120 recorded as item 4 is confirmed and preserved:
+`loadNotifications` partitions on the **stored raw** type before resolution
+(`:79-83`), so a server task notification gets no team-name lookup and renders
+without its `<b>Team</b>:` prefix even though it groups and routes as a task.
+Resolving before partitioning would be an improvement, not a port.
+
+---
+
+## Two Kotlin-vs-Dart primitives that do not match
+
+Both are the same shape as Phase 78's `normalizeText` duplicate: a stdlib
+function that looks equivalent and is not.
+
+**`int.tryParse` is not `toIntOrNull`.** It accepts surrounding whitespace and
+has no 32-bit ceiling. `" 7"` is null in Kotlin (so the message shows raw) and
+`7` in Dart; `"2147483648"` is null in Kotlin and a number in Dart, so the port
+would have announced 2,147,483,648 undownloaded resources where the Kotlin shows
+the raw string. `kotlinToIntOrNull` is the ASCII-and-range version, used by both
+the resource and storage arms. One divergence is left in place and documented:
+Kotlin's parser accepts any Unicode decimal digit (`"٧"` is 7); no writer in
+either app produces one.
+
+**Dart's `\s` is wider than Java's.** The task-date pattern is spelled
+`[ \t\n\x0B\f\r]` rather than `\s`, because Dart's also matches U+00A0 — a
+message with a non-breaking space would parse here and not there. `\b`, `\w` and
+`\d` do agree, and `\w` really is `[A-Za-z0-9_]`, so the pattern's month
+position matches any word, not a month name; the weekday tokens are
+case-sensitive. All three are pinned.
+
+---
+
+## Failing-first evidence
+
+Ten reverts, each demonstrated red against the finished tests.
+
+| revert | red |
+|---|---|
+| the row draws `notification.message` again | 4 screen tests, `a resource notification reads as a sentence, not a bare digit` among them |
+| `kotlinToIntOrNull` → `int.tryParse` | 2 |
+| `renderNotificationHtml` → a plain passthrough | 13 across the format and screen suites |
+| storage composes one space instead of Kotlin's two | 3 |
+| the task-date pattern uses Dart's `\s` | 1 |
+| the join-request arm stops testing the raw type | 2 (the server sentence is replaced by an all-Unknown one) |
+| the context partitions on the resolved type | 1 (`newTask` would gain a prefix Kotlin does not give it) |
+| whitespace before a tag moves into the next run | 2 |
+| a read row is un-bolded instead of dimmed | 1 |
+| the id no longer wins over the title for the team prefix | 1 |
+
+The starting point was the one the brief asked for: a screen test asserting the
+bell renders `"7"` today.
+
+```
+Expected: exactly one matching candidate
+  Actual: _TextWidgetFinder:<Found 0 widgets with text
+          "You have 7 resources not downloaded": []>
+```
+
+The whitespace-before-a-tag revert is not hypothetical — it was a **real bug in
+the first cut of the parser**, found by its own tests: the space in
+`<b>very <i>late</i></b>` was held over and emitted into the *next* span, so
+`"You have been added to "` lost its trailing space to the bold run. A run that
+ends at a tag owns the whitespace before it.
+
+The Kotlin's own unit tests are mirrored case for case where they exist —
+`NotificationsViewModelTest.kt:45-107` (`parseTaskDate`, the three storage arms,
+the join-request prefix) and `NotificationsAdapterTest.kt:86-99` (the
+`<b>Initial</b> text` render) — so a divergence in either app shows up as two
+suites disagreeing.
+
+---
+
+## Files touched outside this lane's set
+
+| file | why |
+|---|---|
+| `lib/data/local/app_database.dart` | **one added method**, `TeamTaskDao.getByTitles` — the port of `TeamTaskDao.kt:44-45`, which the team-name-by-title lookup needs and the port had no equivalent for. It sits in the team-task section Lane A owns; it is additive and adjacent to `getByAnyIds`, and **no column, table or `schemaVersion` change** (still 45). |
+| `lib/providers/app_providers.dart` | +2 lines: the two DAOs the repository's new lookups need. |
+| `lib/providers/notifications_provider.dart` | `notificationFormatContextProvider`, the ViewModel-equivalent that runs the lookups. |
+| `lib/l10n/app_{en,ar,es,fr,ne,so}.arb` | 8 new keys in the template; 6 derived into each locale by the tool. |
+| `test/l10n/placeholder_integrity_test.dart` | the pinned human-reviewed counts, +6 per locale. |
+| `test/ui/notifications_screen_test.dart` | one existing test asserted the type label the row no longer draws; rewritten around the group label and the message, keeping its point (readers use the *resolved* type). |
+| `test/repository/notifications_repository_test.dart`, `test/repository/notification_type_round_trip_test.dart`, `test/core/notifications/task_deadline_notifier_test.dart` | the repository constructor gained two required DAOs. Required, not optional-nullable: a silently-absent DAO returning no team names is exactly the class of defect this port keeps paying for. |
+
+---
+
+## Reported, not fixed
+
+1. **The row's timestamp is still absolute.** `NotificationsAdapter`
+   (`:152-163`) shows "just now / N minutes ago / yesterday / N days ago"; the
+   port shows `DateFormat.yMMMd().add_jm()`. Same row, same adapter, and the
+   ARB already has `justNow`/`minutesAgo`/`hoursAgo`/`yesterday`/`daysAgo`. Left
+   out to keep this diff to the text; it is a small, self-contained follow-up.
+2. **Selection mode is unported.** The Kotlin row carries a checkbox and an
+   explicit *Mark as read* button, entered by long-press
+   (`NotificationsAdapter.bind`'s `isSelectionMode` branch, `_selectedIds` in
+   the ViewModel, and `markSelectedAsRead`/`deleteSelected`). The port has
+   swipe-to-delete and tap-to-read instead. Pre-existing, not touched here.
+3. **A tool defect in the ARB derivation, one line.** The plain-text by-name
+   path writes `translated[exactNamed]?.trim()`
+   (`tool/arb_from_strings_xml.dart:211`) and never calls
+   `_mirrorTrailingSpace`, which exists precisely to keep a deliberate trailing
+   space (its own comment cites `selected` → `"Selected: "`). So
+   `storageRunningLow` derived into five locales **without** the trailing space
+   the template carries. Harmless here — the composer adds a space and the
+   renderer collapses doubles, so all six locales render one space — but any
+   future label-prefix key derived through that path loses its gap. The fix is
+   to wrap that assignment the way `_proposal` does. Not made: `tool/` is
+   another lane's file and this is not this lane's defect.
+4. **Kotlin formats the resource count through `String.format`** with the
+   configuration locale, so on an Arabic device it renders Arabic-Indic digits;
+   the port's ARB placeholder is a plain `int` and always renders ASCII. Kotlin
+   is internally inconsistent about this already — `formatStorageNotification`
+   uses a Kotlin template, so its percentage is ASCII in both apps.
+5. **`getTaskTeamNamesByTaskTitles` is called unconditionally** where Kotlin
+   guards it with `if (taskTitles.isNotEmpty())` (`:107-111`). Behaviourally
+   identical — both the Kotlin impl and the port early-return on an empty list —
+   but a Kotlin test pins the *call count* (`NotificationsRepositoryImplTest.kt:666`),
+   so the two suites assert different things about the same code.

--- a/flutter/PHASE_124_NOTES.md
+++ b/flutter/PHASE_124_NOTES.md
@@ -18,14 +18,22 @@ lane ships a small HTML parser it had argued against.
 
 ## What each type formats to, and which part is the title
 
-There is **one** part. `row_notifications.xml` holds a `title` TextView and a
-`timestamp` TextView and nothing else — no per-row icon (`iconResFor` is called
-from `HeaderViewHolder`, once per *group*), no subtitle. So Kotlin's whole
+There is **one** part for the message. `row_notifications.xml` holds a `title`
+TextView and a `timestamp` TextView — plus a `CheckBox` and a *Mark as read*
+`Button`, which are affordances rather than text — and **no icon**: `iconResFor`
+is called once per *group*, from `HeaderViewHolder`. So Kotlin's whole
 notification text is the row's primary line, and the port's "type label above
 the raw message" was an invention twice over: `AppNotification.title`, which the
 port's row preferred when set, is a column **nothing in either app ever
 writes** — `parseNotification` never assigns it and `model/Notification.kt` has
 no field for it.
+
+The port keeps its per-row **icon**, which by that same citation Kotlin does not
+have. That is a deliberate addition — it makes a long list scannable — and it is
+why the type *label* was the thing removed instead: the label duplicated the
+group header outright, where the icon does not. Said plainly here because the
+first draft of these notes used the layout to justify deleting the label while
+the code two lines away kept the icon.
 
 | resolved type | text | markup |
 |---|---|---|
@@ -96,10 +104,10 @@ renders with the same single space it does in the Android app.
 
 ---
 
-## Did the Kotlin translations come across? Six of eight, yes
+## Did the Kotlin translations come across? Seven of nine, yes
 
 Keys were named so the derivation tool could match them, and
-`dart tool/arb_from_strings_xml.dart` picked up **all six that have a Kotlin
+`dart tool/arb_from_strings_xml.dart` picked up **all seven that have a Kotlin
 counterpart, in all five locales** — human translations already shipping in the
 Android app, at no cost:
 
@@ -111,6 +119,7 @@ Android app, at no cost:
 | `storageAvailable` | `storage_available` | ar es fr ne so |
 | `joinRequestPrefix` | `join_request_prefix` | ar es fr ne so |
 | `userRequestedToJoinTeam` | `user_requested_to_join_team` | ar es fr ne so |
+| `markAsRead` | `mark_as_read` | ar es fr ne so |
 | `unknownUser` | — | English fallback |
 | `unknownTeam` | — | English fallback |
 
@@ -134,7 +143,7 @@ fallback is translatable — the same correction Phase 95 made to `MyHealthScree
 hardcoded `'Unknown'`. Rendered English is identical.
 
 `test/l10n/placeholder_integrity_test.dart`'s pinned human-reviewed counts move
-by exactly 6 per locale.
+by exactly 7 per locale (`markAsRead` arrived with the second pass below).
 
 ---
 
@@ -151,11 +160,18 @@ no DAO. So:
 
 * **reachable and reformatted**: `resource` (the port's own `"7"`), `storage`
   (the port's own `"8%"`, and only ever `<= 10` — the writer *deletes* the row
-  above that, so the `<= 40` and `> 40` arms are dead);
+  above that, so the `<= 40` and `> 40` arms are dead for every message either
+  app authors);
 * **reachable and verbatim**: the server's `team`, `newTask`, `newResource`,
   `replyMessage` documents;
-* **unreachable**: the join-request lookup, which needs a row whose *raw* type
-  is `join_request`. Nothing writes one. It is ported for fidelity, and the
+* **not reachable through any writer**: the join-request lookup needs a row
+  whose *raw* type is `join_request`. Neither app authors one — `AppNotification`
+  is built in exactly the three places above, and the Dart writers are the same
+  three — but `parseNotification` stores the server's `type` verbatim and
+  `join_request` is in `KNOWN_TYPES`, so a Planet document literally typed that
+  way *would* land here. None is evidenced anywhere in the tree; the same caveat
+  applies to the storage arms above, which are dead as far as the local writer
+  goes. It is ported for fidelity, and the
   tests that exercise it drive the pure function directly rather than implying
   the feature works. Worth knowing why it would be *bad* if it fired:
   `extractRelatedId` returns null for every raw type but `team`/`replyMessage`/
@@ -211,6 +227,14 @@ Ten reverts, each demonstrated red against the finished tests.
 | a read row is un-bolded instead of dimmed | 1 |
 | the id no longer wins over the title for the team prefix | 1 |
 
+Fourteen more from the second pass, each also confirmed red: the tag-start
+guard, the numeric-entity range guard, the closing-tag underflow clamp, the
+self-closing-tag split, `flush()`'s leading-whitespace guard, `'\r'` in the
+collapsing set, the format-context provider's body, the merge order (against a
+colliding stub), the empty-`relatedId` batch filter, the unread row's opacity,
+the per-row *Mark as read* button, the *Mark all read* tab gate, the swipe
+handler, and the tile receiving an empty context instead of the watched one.
+
 The starting point was the one the brief asked for: a screen test asserting the
 bell renders `"7"` today.
 
@@ -241,8 +265,8 @@ suites disagreeing.
 | `lib/data/local/app_database.dart` | **one added method**, `TeamTaskDao.getByTitles` — the port of `TeamTaskDao.kt:44-45`, which the team-name-by-title lookup needs and the port had no equivalent for. It sits in the team-task section Lane A owns; it is additive and adjacent to `getByAnyIds`, and **no column, table or `schemaVersion` change** (still 45). |
 | `lib/providers/app_providers.dart` | +2 lines: the two DAOs the repository's new lookups need. |
 | `lib/providers/notifications_provider.dart` | `notificationFormatContextProvider`, the ViewModel-equivalent that runs the lookups. |
-| `lib/l10n/app_{en,ar,es,fr,ne,so}.arb` | 8 new keys in the template; 6 derived into each locale by the tool. |
-| `test/l10n/placeholder_integrity_test.dart` | the pinned human-reviewed counts, +6 per locale. |
+| `lib/l10n/app_{en,ar,es,fr,ne,so}.arb` | 9 new keys in the template; 7 derived into each locale by the tool. |
+| `test/l10n/placeholder_integrity_test.dart` | the pinned human-reviewed counts, +7 per locale. |
 | `test/ui/notifications_screen_test.dart` | one existing test asserted the type label the row no longer draws; rewritten around the group label and the message, keeping its point (readers use the *resolved* type). |
 | `test/repository/notifications_repository_test.dart`, `test/repository/notification_type_round_trip_test.dart`, `test/core/notifications/task_deadline_notifier_test.dart` | the repository constructor gained two required DAOs. Required, not optional-nullable: a silently-absent DAO returning no team names is exactly the class of defect this port keeps paying for. |
 
@@ -251,15 +275,31 @@ suites disagreeing.
 ## Reported, not fixed
 
 1. **The row's timestamp is still absolute.** `NotificationsAdapter`
-   (`:152-163`) shows "just now / N minutes ago / yesterday / N days ago"; the
-   port shows `DateFormat.yMMMd().add_jm()`. Same row, same adapter, and the
-   ARB already has `justNow`/`minutesAgo`/`hoursAgo`/`yesterday`/`daysAgo`. Left
-   out to keep this diff to the text; it is a small, self-contained follow-up.
-2. **Selection mode is unported.** The Kotlin row carries a checkbox and an
-   explicit *Mark as read* button, entered by long-press
+   (`:152-163`) shows "just now / N minutes ago / Yesterday / N days ago", then
+   `MMM d, yyyy` beyond a week (pinned at `NotificationsAdapterTest.kt:80-84`);
+   the port shows `DateFormat.yMMMd().add_jm()`. It is the same *class* of
+   defect as the bare `7` — a stored value drawn where Kotlin transforms it —
+   and it sits inside the very line range this fix cites, so the honest reason
+   it is not here is scope, not principle. Its impact is far smaller: legible
+   but wrong, rather than uninterpretable. Three things the follow-up needs that
+   are easy to underestimate: the ARB has `justNow`/`minutesAgo`/`hoursAgo`/
+   `daysAgo` but **no `yesterday`** (the Kotlin has it, `strings.xml:1352`,
+   translated in all five locales, so a new key plus a derivation run);
+   `relativeTimeLabel` in `ui/components/relative_time.dart` is **not** a
+   drop-in, because it ports a different Kotlin function (`TimeUtils.getRelativeTime`,
+   four buckets, no Yesterday and no absolute arm); and the >7-day format drops
+   the time of day. Note also that `markAsRead` stamps `createdAt = now`
+   (faithfully, `app_database.dart`), so a row reads "Just now" the moment it is
+   read — a quirk that only becomes visible once this lands.
+2. **Selection mode is unported.** Long-press entry, the checkbox, the bulk bar
+   and `markSelectedAsRead`/`deleteSelected`
    (`NotificationsAdapter.bind`'s `isSelectionMode` branch, `_selectedIds` in
-   the ViewModel, and `markSelectedAsRead`/`deleteSelected`). The port has
-   swipe-to-delete and tap-to-read instead. Pre-existing, not touched here.
+   the ViewModel, `NotificationsFragment.kt:84-86`). The port has
+   swipe-to-delete — its own invention; Kotlin deletes only through the bulk bar
+   — and now the per-row *Mark as read* button, which is **not** part of
+   selection mode: it lives in the non-selection branch on every unread row, and
+   the second audit was right that folding it into this item hid a real gap. It
+   is ported (see below); the rest of selection mode is not.
 3. **A tool defect in the ARB derivation, one line.** The plain-text by-name
    path writes `translated[exactNamed]?.trim()`
    (`tool/arb_from_strings_xml.dart:211`) and never calls
@@ -277,7 +317,89 @@ suites disagreeing.
    is internally inconsistent about this already — `formatStorageNotification`
    uses a Kotlin template, so its percentage is ASCII in both apps.
 5. **`getTaskTeamNamesByTaskTitles` is called unconditionally** where Kotlin
-   guards it with `if (taskTitles.isNotEmpty())` (`:107-111`). Behaviourally
-   identical — both the Kotlin impl and the port early-return on an empty list —
-   but a Kotlin test pins the *call count* (`NotificationsRepositoryImplTest.kt:666`),
-   so the two suites assert different things about the same code.
+   guards it with `if (taskTitles.isNotEmpty())` (`:107-111`). A genuine no-op:
+   both the Kotlin impl (`:256`) and the port (`notifications_repository.dart`'s
+   `if (keys.isEmpty) return const {};`) early-return, and no DAO query runs
+   either way. An earlier draft of this file cited
+   `NotificationsRepositoryImplTest.kt:666` as pinning the call count and
+   concluded the two suites disagree — that citation is about the **DAO**, in a
+   test of the repository method, and the port satisfies it too; there is no
+   `exactly = 0` assertion over the ViewModel at all. The claim is withdrawn
+   rather than quietly deleted, because "a citation is not a reading" is exactly
+   how Phase 106's regression got in.
+
+
+---
+
+## A second audit, on the finished implementation
+
+Green is not evidence. The diff was format-clean, analyze-clean and 2107 tests
+green when a second `parity-auditor` pass at `effort: max` was aimed at it — and
+it found one live defect, nine behaviours the suite could not see, and five
+claims in this file or the code comments that were wrong. Its method is the one
+that keeps working: replay every revert the fix claims to guard (all ten red),
+then **inject new defects into the finished code and watch the suite stay
+green**.
+
+### The live defect: a `<` is not always a tag
+
+```
+'Compare 3 < 5 > 1 today'  →  'Compare 3 1 today'         // ' 5 ' deleted
+'is 3 < b > 2?'            →  'is 3  2?', with ' 2?' BOLD  // '< b >' read as <b>
+```
+
+The parser scanned from `<` to the next `>` unconditionally, and trimmed the
+result before reading the tag name. An ordinary sentence with a comparison in
+it — server-authored text, the kind these arms pass through — lost its middle.
+Now a `<` opens a tag only when a tag name can follow it (a letter, or `/` and a
+letter), which is what HTML tokenization does, and the trim is gone.
+
+### Two parity gaps the fix cited and did not close
+
+Both are in `NotificationsAdapter.bind`, the function this phase ports one line
+of:
+
+* **the per-row *Mark as read* button** (`:137-141`, `row_notifications.xml:44-55`),
+  visible on every unread row outside selection mode. Without it the port's only
+  single-row read path was `onTap`, which also navigates away — so a learner
+  could not clear one notification and keep reading the list. Ported, with
+  `markAsRead` derived from the Kotlin `mark_as_read` in all five locales;
+* **Mark all read is hidden on the Read tab** — Kotlin gates it on
+  `count > 0 && currentFilter != "read"` (`NotificationsFragment.kt:101-102`)
+  where the port gated on the count alone, offering an action with nothing to
+  act on.
+
+### The nine unpinned behaviours
+
+Each could be reverted with all 2107 tests green. Now each is red.
+
+| unguarded | why it matters |
+|---|---|
+| the numeric-entity range guard | `String.fromCharCode` throws above U+10FFFF, out of `build` — the whole bell screen, the Phase 95 shape |
+| the `</b>`/`</i>` underflow clamp | a stray closing tag drove the counter negative and **every later emphasis in the row was lost** |
+| the tag name splitting on `/` | `<br/>`, the conventional spelling, silently vanished instead of breaking the line |
+| `flush()`'s leading-whitespace guard | a leading space before a tag survived into the row |
+| `'\r'` in the collapsing set | the code and its own comment disagreed about which characters collapse |
+| `notificationFormatContextProvider` | **no test at all** — the repository lookups, the context builder and the tile were each covered and nothing joined them. Phase 74's shape exactly. A screen test now drives provider → repository → DAO → row with nothing overridden between |
+| the by-title/by-id merge order | the recording stub returned disjoint keys, so no collision existed to observe; a colliding stub now pins that an id wins |
+| the empty-string `relatedId` paths | the documented `mapNotNull`-vs-`isNullOrEmpty` asymmetry had no test, and a documented quirk with no test is what a later cleanup deletes |
+| four row behaviours | the unread row's opacity, the tap, the swipe, and *Mark all read* firing |
+
+### The claims that were wrong
+
+Corrected in place above, and worth listing because each was written
+confidently: `yesterday` is **not** in the ARB (it is in the Kotlin, and the
+timestamp follow-up needs a new key); the `exactly = 0` citation was about a DAO
+in a different test at a different layer and the port already satisfies it; the
+row layout does carry a checkbox and a button, so "a title and a timestamp and
+nothing else" was wrong in a section that four pages later says the opposite;
+the port draws a per-row icon that the citation used against the type label
+rules out just as firmly; and "nothing writes a raw `join_request` row" is true
+of the writers, not of the corpus.
+
+One divergence the audit surfaced is now a *documented decision* rather than an
+accident: Kotlin's `getTeamNamesByIds` substitutes the literal `"Unknown Team"`
+for a cached team row with a null name (`TeamsRepositoryImpl.kt:433`), so it
+renders a bold **Unknown Team:** prefix; the port drops the entry and renders
+the sentence unprefixed. Saying less beats saying something wrong, and the
+comment at the lookup now says so.

--- a/flutter/PHASE_124_NOTES.md
+++ b/flutter/PHASE_124_NOTES.md
@@ -1,0 +1,3 @@
+# Phase 124 — `formatNotification`: the bell row that reads `7`
+
+Work in progress. See the PR description for the current state.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -485,6 +485,23 @@ class TeamTaskDao extends DatabaseAccessor<AppDatabase>
     )..where((t) => t.id.isIn(ids) | t.docId.isIn(ids))).get();
   }
 
+  /// Port of `TeamTaskDao.getByTitles` (`TeamTaskDao.kt:44-45`):
+  /// `SELECT * FROM team_tasks WHERE title IN (:titles)`.
+  ///
+  /// Added for the notification list's team-name prefix, which resolves a task
+  /// by its title when the notification carries no task id
+  /// (`NotificationsViewModel.formatTaskNotification`).
+  Future<List<TeamTaskRow>> getByTitles(List<String> titles) async {
+    if (titles.isEmpty) return const [];
+    final rows = <TeamTaskRow>[];
+    for (final chunk in _chunked(titles, _sqliteVariableChunk)) {
+      rows.addAll(
+        await (select(teamTasks)..where((t) => t.title.isIn(chunk))).get(),
+      );
+    }
+    return rows;
+  }
+
   Future<void> markUploaded(String id, String docId, String rev) =>
       (update(teamTasks)..where((t) => t.id.equals(id))).write(
         TeamTasksCompanion(

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -2143,5 +2143,6 @@
   "storageRunningLow": "التخزين قليل:",
   "storageAvailable": "التخزين المتاح:",
   "joinRequestPrefix": "طلب الانضمام:",
-  "userRequestedToJoinTeam": "{user} قد طلب الانضمام إلى {team}"
+  "userRequestedToJoinTeam": "{user} قد طلب الانضمام إلى {team}",
+  "markAsRead": "وضع علامة كمقروء"
 }

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -2137,5 +2137,11 @@
   "fileNotFound": "الملف غير موجود: {fileName}",
   "fileCountMany": "{count} ملفات",
   "stepsHeading": "خطوات",
-  "courseProgressCount": "التقدم {current} من {max}"
+  "courseProgressCount": "التقدم {current} من {max}",
+  "resourceNotificationMessage": "لديك {count} موارد لم يتم تنزيلها",
+  "taskNotificationMessage": "{title} مستحق في {date}",
+  "storageRunningLow": "التخزين قليل:",
+  "storageAvailable": "التخزين المتاح:",
+  "joinRequestPrefix": "طلب الانضمام:",
+  "userRequestedToJoinTeam": "{user} قد طلب الانضمام إلى {team}"
 }

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -364,6 +364,59 @@
   "storageNotification": "Storage warning",
   "joinRequestNotification": "Join request",
   "teamNotification": "Team update",
+  "resourceNotificationMessage": "You have {count} resources not downloaded",
+  "@resourceNotificationMessage": {
+    "description": "The notification list's text for the offline-resource count. Port of the Kotlin `resource_notification`; the row's stored message is the bare count.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "taskNotificationMessage": "{title} is due in {date}",
+  "@taskNotificationMessage": {
+    "description": "The notification list's text for a task deadline. Port of the Kotlin `task_notification`; the date is the substring parsed out of the stored message, not a formatted DateTime.",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      },
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "storageRunningLow": "Storage running low: ",
+  "@storageRunningLow": {
+    "description": "Prefix of the low-storage notification, immediately followed by the percentage. The trailing space is deliberate and matches the Kotlin `storage_running_low`, which is Android-quoted for exactly that reason."
+  },
+  "storageAvailable": "Storage available: ",
+  "@storageAvailable": {
+    "description": "Prefix of the storage-available notification, immediately followed by the percentage. The trailing space is deliberate — see storageRunningLow."
+  },
+  "joinRequestPrefix": "Join Request:",
+  "@joinRequestPrefix": {
+    "description": "Bold prefix of a join-request notification, followed by the request sentence."
+  },
+  "userRequestedToJoinTeam": "{user} has requested to join {team}",
+  "@userRequestedToJoinTeam": {
+    "description": "Body of a join-request notification.",
+    "placeholders": {
+      "user": {
+        "type": "String"
+      },
+      "team": {
+        "type": "String"
+      }
+    }
+  },
+  "unknownUser": "Unknown User",
+  "@unknownUser": {
+    "description": "Stand-in for a join request whose requester has no cached user document."
+  },
+  "unknownTeam": "Unknown Team",
+  "@unknownTeam": {
+    "description": "Stand-in for a join request whose team has no cached document."
+  },
   "tasks": "Tasks",
   "notifGroupJoinRequests": "Join Requests",
   "notifGroupTeamUpdates": "Team Updates",

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -341,6 +341,10 @@
   "notification": "Notification",
   "notificationsUnavailable": "Notifications unavailable",
   "markAllRead": "Mark all read",
+  "markAsRead": "Mark as read",
+  "@markAsRead": {
+    "description": "The per-row action on an unread notification, porting the Kotlin row's btn_mark_as_read."
+  },
   "all": "All",
   "read": "Read",
   "unreadCount": "Unread ({count})",

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -2141,5 +2141,6 @@
   "storageRunningLow": "Almacenamiento bajo:",
   "storageAvailable": "Almacenamiento disponible:",
   "joinRequestPrefix": "Solicitud de Unión:",
-  "userRequestedToJoinTeam": "{user} ha solicitado unirse a {team}"
+  "userRequestedToJoinTeam": "{user} ha solicitado unirse a {team}",
+  "markAsRead": "Marcar como leído"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -2135,5 +2135,11 @@
   "confirmLeaveTeam": "¿Estás seguro/a de que quieres abandonar este equipo?",
   "fileNotFound": "Archivo no encontrado: {fileName}",
   "stepsHeading": "Pasos",
-  "courseProgressCount": "Progreso {current} de {max}"
+  "courseProgressCount": "Progreso {current} de {max}",
+  "resourceNotificationMessage": "Tienes {count} recursos no descargados",
+  "taskNotificationMessage": "{title} vence en {date}",
+  "storageRunningLow": "Almacenamiento bajo:",
+  "storageAvailable": "Almacenamiento disponible:",
+  "joinRequestPrefix": "Solicitud de Unión:",
+  "userRequestedToJoinTeam": "{user} ha solicitado unirse a {team}"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -2280,5 +2280,11 @@
   "confirmLeaveTeam": "Êtes-vous sûr de vouloir quitter cette équipe ?",
   "fileNotFound": "Fichier introuvable : {fileName}",
   "stepsHeading": "Étapes",
-  "courseProgressCount": "Progression {current} sur {max}"
+  "courseProgressCount": "Progression {current} sur {max}",
+  "resourceNotificationMessage": "Vous avez {count} ressources non téléchargées",
+  "taskNotificationMessage": "{title} est dû le {date}",
+  "storageRunningLow": "Espace de stockage presque plein:",
+  "storageAvailable": "Espace de stockage disponible:",
+  "joinRequestPrefix": "Demande d'adhésion :",
+  "userRequestedToJoinTeam": "{user} a demandé à rejoindre {team}"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -2286,5 +2286,6 @@
   "storageRunningLow": "Espace de stockage presque plein:",
   "storageAvailable": "Espace de stockage disponible:",
   "joinRequestPrefix": "Demande d'adhésion :",
-  "userRequestedToJoinTeam": "{user} a demandé à rejoindre {team}"
+  "userRequestedToJoinTeam": "{user} a demandé à rejoindre {team}",
+  "markAsRead": "Marquer comme lu"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -502,5 +502,11 @@
   "fileNotFound": "फाइल फेला परेन: {fileName}",
   "fileCountMany": "{count} फाइलहरू",
   "stepsHeading": "चरणहरू",
-  "courseProgressCount": "{current} को {max} प्रगति"
+  "courseProgressCount": "{current} को {max} प्रगति",
+  "resourceNotificationMessage": "तपाईंसँग {count} स्रोतहरू डाउनलोड गरिएको छैन",
+  "taskNotificationMessage": "{title} {date} मा समाप्त हुन्छ",
+  "storageRunningLow": "स्टोरेज गम्भीर रूपमा कम:",
+  "storageAvailable": "स्टोरेज उपलब्ध:",
+  "joinRequestPrefix": "सामेल हुने अनुरोध:",
+  "userRequestedToJoinTeam": "{user} ले {team} मा सामेल हुन अनुरोध गरेको छ"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -508,5 +508,6 @@
   "storageRunningLow": "स्टोरेज गम्भीर रूपमा कम:",
   "storageAvailable": "स्टोरेज उपलब्ध:",
   "joinRequestPrefix": "सामेल हुने अनुरोध:",
-  "userRequestedToJoinTeam": "{user} ले {team} मा सामेल हुन अनुरोध गरेको छ"
+  "userRequestedToJoinTeam": "{user} ले {team} मा सामेल हुन अनुरोध गरेको छ",
+  "markAsRead": "पढिएको रूपमा चिन्ह लगाउनुहोस्"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -502,5 +502,11 @@
   "fileNotFound": "Faylka lama helin: {fileName}",
   "fileCountMany": "{count} fayl",
   "stepsHeading": "Agoonta",
-  "courseProgressCount": "Habka {current} ee {max}"
+  "courseProgressCount": "Habka {current} ee {max}",
+  "resourceNotificationMessage": "Waxaad haysataa {count} agab aan la soo dejisan",
+  "taskNotificationMessage": "{title} waa inuu dhamaadaa {date}",
+  "storageRunningLow": "Xaddida maaliyadeed waa tagaa:",
+  "storageAvailable": "Xaddida maaliyadeed waa heli kara:",
+  "joinRequestPrefix": "Codsi ku biirid:",
+  "userRequestedToJoinTeam": "{user} ayaa codsaday ku biirista {team}"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -508,5 +508,6 @@
   "storageRunningLow": "Xaddida maaliyadeed waa tagaa:",
   "storageAvailable": "Xaddida maaliyadeed waa heli kara:",
   "joinRequestPrefix": "Codsi ku biirid:",
-  "userRequestedToJoinTeam": "{user} ayaa codsaday ku biirista {team}"
+  "userRequestedToJoinTeam": "{user} ayaa codsaday ku biirista {team}",
+  "markAsRead": "Calaamadee sidii la aqriyay"
 }

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -525,6 +525,8 @@ final notificationsRepositoryProvider = Provider<NotificationsRepository>(
     teamNotificationDao: ref.watch(teamNotificationDaoProvider),
     newsDao: ref.watch(newsDaoProvider),
     teamTaskDao: ref.watch(teamTaskDaoProvider),
+    teamDao: ref.watch(teamDaoProvider),
+    userDao: ref.watch(userDaoProvider),
     api: ref.watch(planetApiProvider),
   ),
 );

--- a/flutter/lib/providers/notifications_provider.dart
+++ b/flutter/lib/providers/notifications_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/sync/sync_result.dart';
 import '../data/local/app_database.dart';
+import '../ui/notifications/notification_format.dart';
 import '../ui/notifications/notification_grouping.dart';
 import 'app_providers.dart';
 import 'session_provider.dart';
@@ -137,3 +138,17 @@ final notificationsSyncProvider =
     NotifierProvider<NotificationsSyncNotifier, SyncUiState>(
       NotificationsSyncNotifier.new,
     );
+
+/// The team names and join-request details the notification list formats with
+/// — port of the lookup half of `NotificationsViewModel.loadNotifications`.
+///
+/// Rebuilt whenever the list changes, like the Kotlin, which re-runs the whole
+/// lookup on every `loadNotifications` call.
+final notificationFormatContextProvider =
+    FutureProvider<NotificationFormatContext>((ref) async {
+      final rows = await ref.watch(notificationsProvider.future);
+      return buildNotificationFormatContext(
+        rows,
+        ref.watch(notificationsRepositoryProvider),
+      );
+    });

--- a/flutter/lib/repository/notifications_repository.dart
+++ b/flutter/lib/repository/notifications_repository.dart
@@ -16,11 +16,15 @@ class NotificationsRepository {
     required TeamNotificationDao teamNotificationDao,
     required NewsDao newsDao,
     required TeamTaskDao teamTaskDao,
+    required TeamDao teamDao,
+    required UserDao userDao,
     DateTime Function()? now,
     PlanetApi? api,
   }) : _teamNotificationDao = teamNotificationDao,
        _newsDao = newsDao,
        _teamTaskDao = teamTaskDao,
+       _teamDao = teamDao,
+       _userDao = userDao,
        _now = now ?? DateTime.now,
        _api = api;
 
@@ -33,6 +37,8 @@ class NotificationsRepository {
   final TeamNotificationDao _teamNotificationDao;
   final NewsDao _newsDao;
   final TeamTaskDao _teamTaskDao;
+  final TeamDao _teamDao;
+  final UserDao _userDao;
   final DateTime Function() _now;
   final PlanetApi? _api;
 
@@ -292,6 +298,116 @@ class NotificationsRepository {
     );
   }
 
+  /// Port of `NotificationsRepositoryImpl.getTaskTeamNamesByTaskIds`
+  /// (`:191-213`) — task id → the name of the team that task belongs to, for
+  /// the `<b>Team</b>:` prefix the task notification carries.
+  ///
+  /// A task whose team has no cached document is simply absent from the map,
+  /// as in the Kotlin (`teamMap[teamId]?.let { … }`), which is what makes the
+  /// prefix optional rather than showing an empty bold run.
+  Future<Map<String, String>> taskTeamNamesByTaskIds(List<String> taskIds) =>
+      _taskTeamNames(taskIds, keyOf: (task) => task.id);
+
+  /// Port of `getTaskTeamNamesByTaskTitles` (`:255-280`) — the same map keyed
+  /// by title, for a notification that carries no task id and can only be
+  /// matched on the title parsed out of its message.
+  Future<Map<String, String>> taskTeamNamesByTaskTitles(
+    List<String> taskTitles,
+  ) => _taskTeamNames(taskTitles, byTitle: true, keyOf: (task) => task.title);
+
+  Future<Map<String, String>> _taskTeamNames(
+    List<String> keys, {
+    bool byTitle = false,
+    required String? Function(TeamTaskRow task) keyOf,
+  }) async {
+    if (keys.isEmpty) return const {};
+    final tasks = byTitle
+        ? await _teamTaskDao.getByTitles(keys)
+        : await _teamTaskDao.getByAnyIds(keys);
+    // `teamId` is non-nullable in this schema (Kotlin's is `String?`), so the
+    // Kotlin's null test is an emptiness test here.
+    final teamIds = <String>{
+      for (final task in tasks)
+        if (task.teamId.isNotEmpty) task.teamId,
+    };
+    if (teamIds.isEmpty) return const {};
+    final teams = await _teamDao.byIds(teamIds.toList());
+    final names = <String, String>{};
+    for (final task in tasks) {
+      final key = keyOf(task);
+      final teamId = task.teamId;
+      if (key == null || key.isEmpty || teamId.isEmpty) {
+        continue;
+      }
+      final name = teams[teamId]?.name;
+      if (name != null && name.isNotEmpty) names[key] = name;
+    }
+    return names;
+  }
+
+  /// Port of `NotificationsRepositoryImpl.getJoinRequestDetailsBatch`
+  /// (`:215-253`) — request document id → (requester, team).
+  ///
+  /// The Kotlin substitutes the literal English `"Unknown User"` /
+  /// `"Unknown Team"` here; the port leaves the field null and lets the
+  /// formatter fill it from `l10n`, so the fallback is translated rather than
+  /// hardcoded (the same correction Phase 95 made to `MyHealthScreen`'s
+  /// `'Unknown'`). Nothing else reads these fields.
+  Future<Map<String, JoinRequestDetail>> joinRequestDetailsBatch(
+    List<String> relatedIds,
+  ) async {
+    if (relatedIds.isEmpty) return const {};
+    final requests = await _teamDao.byIds(relatedIds);
+    if (requests.isEmpty) return const {};
+    final teamIds = <String>{
+      for (final request in requests.values)
+        if (request.teamId != null && request.teamId!.isNotEmpty)
+          request.teamId!,
+    };
+    final teams = teamIds.isEmpty
+        ? const <String, TeamRow>{}
+        : await _teamDao.byIds(teamIds.toList());
+
+    final details = <String, JoinRequestDetail>{};
+    for (final request in requests.values) {
+      final userId = request.userId;
+      // `getUsersByIds` in one call there, `getById` per requester here: this
+      // map is at most as large as the join requests on screen, and adding a
+      // batch method to `UserDao` would reach into another lane's section of
+      // `app_database.dart` for no measurable gain.
+      final user = (userId == null || userId.isEmpty)
+          ? null
+          : await _userDao.getById(userId);
+      details[request.id] = JoinRequestDetail(
+        requester: user?.name,
+        team: teams[request.teamId]?.name,
+      );
+    }
+    return details;
+  }
+
+  /// Port of `NotificationsRepositoryImpl.getJoinRequestDetails` (`:180-189`) —
+  /// the single-row lookup `loadNotifications` uses for join requests that
+  /// carry no `relatedId` at all. Kotlin passes the null straight through to
+  /// `getJoinRequestInfo`, which returns null for a null or empty id, so the
+  /// result is the unknown pair; the same holds here.
+  Future<JoinRequestDetail> joinRequestDetails(String? relatedId) async {
+    if (relatedId == null || relatedId.isEmpty) {
+      return const JoinRequestDetail();
+    }
+    final request = await _teamDao.getById(relatedId);
+    if (request == null) return const JoinRequestDetail();
+    final userId = request.userId;
+    final user = (userId == null || userId.isEmpty)
+        ? null
+        : await _userDao.getById(userId);
+    final teamId = request.teamId;
+    final team = (teamId == null || teamId.isEmpty)
+        ? null
+        : await _teamDao.getById(teamId);
+    return JoinRequestDetail(requester: user?.name, team: team?.name);
+  }
+
   /// Port of `NotificationsRepositoryImpl.getTeamNotifications` — the chat and
   /// task alert dots the dashboard draws on each team tile.
   ///
@@ -369,6 +485,27 @@ class NotificationsRepository {
       ),
     );
   }
+}
+
+/// The `Pair<String, String>` `getJoinRequestDetails` returns — the requester's
+/// name and the team they asked to join.
+///
+/// Both are nullable where the Kotlin writes `"Unknown User"` / `"Unknown
+/// Team"`, so the fallback can be localised at the point of display.
+class JoinRequestDetail {
+  const JoinRequestDetail({this.requester, this.team});
+
+  final String? requester;
+  final String? team;
+
+  @override
+  bool operator ==(Object other) =>
+      other is JoinRequestDetail &&
+      other.requester == requester &&
+      other.team == team;
+
+  @override
+  int get hashCode => Object.hash(requester, team);
 }
 
 /// Port of `model/TeamNotificationInfo.kt`.

--- a/flutter/lib/repository/notifications_repository.dart
+++ b/flutter/lib/repository/notifications_repository.dart
@@ -305,6 +305,14 @@ class NotificationsRepository {
   /// A task whose team has no cached document is simply absent from the map,
   /// as in the Kotlin (`teamMap[teamId]?.let { … }`), which is what makes the
   /// prefix optional rather than showing an empty bold run.
+  ///
+  /// **One deliberate divergence.** Kotlin's map comes from
+  /// `getTeamNamesByIds`, whose `associateBy` substitutes the literal
+  /// `"Unknown Team"` for a null name (`TeamsRepositoryImpl.kt:433`), so a
+  /// cached team row with no name still produces a prefix — a bold
+  /// "Unknown Team:" ahead of the sentence. This drops the entry instead and
+  /// renders the sentence unprefixed, which says less rather than something
+  /// wrong. Pinned by a test, so the choice is visible rather than accidental.
   Future<Map<String, String>> taskTeamNamesByTaskIds(List<String> taskIds) =>
       _taskTeamNames(taskIds, keyOf: (task) => task.id);
 

--- a/flutter/lib/ui/notifications/notification_format.dart
+++ b/flutter/lib/ui/notifications/notification_format.dart
@@ -1,0 +1,346 @@
+/// Port of `NotificationsViewModel.formatNotification`
+/// (`NotificationsViewModel.kt:354-425`).
+///
+/// The stored `message` is **not** what the Kotlin app shows. Each row's text
+/// is rewritten per *resolved* type, and the adapter renders the result through
+/// `Html.fromHtml` into the row's single TextView
+/// (`NotificationsAdapter.kt:116-127`, `row_notifications.xml` — no second line
+/// and no per-row icon). The port had none of that and drew `message` verbatim,
+/// so its own resource notification — whose stored message is the bare count,
+/// written by [NotificationsRepository.updateResourceNotification] — rendered
+/// as `7`.
+///
+/// ## The two halves
+///
+/// [notificationHtml] composes exactly the string Kotlin composes, markup and
+/// spacing quirks included; [renderNotificationHtml] is the `Html.fromHtml`
+/// stand-in that turns it into spans. Keeping them apart is what lets the
+/// composition stay literally faithful — the double space in the storage arm,
+/// the `<b>` in the join-request prefix — while the renderer accounts for
+/// everything a user does not see.
+///
+/// The renderer is a small parser rather than a package, and it is **not**
+/// optional: three of the four arms pass the server's message through
+/// unchanged, and those messages carry `<b>` around the names they mention
+/// (`NotificationsRepositoryImplTest.kt:168,192,214`). A span list built only
+/// from the port's own emphasis would have drawn those tags literally.
+library;
+
+import '../../data/local/app_database.dart';
+import '../../l10n/app_localizations.dart';
+import '../../repository/notifications_repository.dart';
+import 'notification_html.dart';
+
+/// The text the notification list draws for [row], as spans.
+FormattedNotification formatNotification(
+  NotificationRow row, {
+  required AppLocalizations l10n,
+  NotificationFormatContext context = const NotificationFormatContext.empty(),
+}) =>
+    renderNotificationHtml(notificationHtml(row, l10n: l10n, context: context));
+
+/// Kotlin's `formattedText` for [row] — the HTML string, before rendering.
+///
+/// [context] carries the team names and join-request details
+/// `loadNotifications` gathers before formatting
+/// (`NotificationsViewModel.kt:71-143`); an empty context is the state before
+/// those lookups resolve and degrades exactly as an uncached row does in the
+/// Kotlin — the sentence renders without its `<b>Team</b>:` prefix.
+String notificationHtml(
+  NotificationRow row, {
+  required AppLocalizations l10n,
+  NotificationFormatContext context = const NotificationFormatContext.empty(),
+}) {
+  final message = row.message;
+  switch (resolvedNotificationType(row)) {
+    case 'task':
+      final parsed = parseTaskDate(message);
+      if (parsed == null) return message;
+      return _taskNotificationHtml(
+        l10n,
+        title: parsed.title,
+        date: parsed.date,
+        relatedId: row.relatedId,
+        taskTeamNames: context.taskTeamNames,
+      );
+    case 'resource':
+      final count = kotlinToIntOrNull(message);
+      return count == null ? message : l10n.resourceNotificationMessage(count);
+    case 'storage':
+      return formatStorageNotification(
+        message,
+        runningLow: l10n.storageRunningLow,
+        available: l10n.storageAvailable,
+      );
+    case 'join_request':
+      // Only a row whose *raw* type is `join_request` gets the lookup. A server
+      // notification resolved onto `join_request` from a raw `team` type
+      // carries a message Planet already wrote as a sentence — with its own
+      // `<b>` around the names — and Kotlin uses it verbatim (`:382-384`,
+      // "Server notification with pre-formatted message"). In practice that is
+      // the only path that reaches this arm: nothing in either app stores a row
+      // whose raw type is `join_request`, so the lookup below is ported for
+      // fidelity rather than because it fires. See `PHASE_124_NOTES.md`.
+      if (row.type.toLowerCase() != 'join_request') return message;
+      final relatedId = row.relatedId;
+      // Kotlin keys the fallback lookup on `""` — the entry
+      // `loadNotifications` stores for the rows that carry no `relatedId`.
+      final key = (relatedId == null || relatedId.isEmpty) ? '' : relatedId;
+      final details = context.joinRequestDetails[key];
+      // Kotlin's `?: Pair("Unknown User", "Unknown Team")`, and the same two
+      // literals inside `getJoinRequestDetailsBatch`, localised: the repository
+      // leaves the fields null so the fallback comes from the ARB rather than
+      // being hardcoded English (the correction Phase 95 made to
+      // `MyHealthScreen`'s `'Unknown'`).
+      return formatJoinRequestNotification(
+        l10n.joinRequestPrefix,
+        l10n.userRequestedToJoinTeam(
+          details?.requester ?? l10n.unknownUser,
+          details?.team ?? l10n.unknownTeam,
+        ),
+      );
+    default:
+      return message;
+  }
+}
+
+/// Port of `formatTaskNotification` (`NotificationsViewModel.kt:414-425`).
+///
+/// The team name is looked up by the task's id first and its title second, and
+/// only a row that carries a `relatedId` tries the id — Kotlin's
+/// `if (!relatedId.isNullOrEmpty())` branch, not a collapsed `??` chain. The
+/// colon sits *outside* the `<b>`, unlike the join-request prefix.
+String _taskNotificationHtml(
+  AppLocalizations l10n, {
+  required String title,
+  required String date,
+  required String? relatedId,
+  required Map<String, String> taskTeamNames,
+}) {
+  final sentence = l10n.taskNotificationMessage(title, date);
+  final teamName = (relatedId != null && relatedId.isNotEmpty)
+      ? (taskTeamNames[relatedId] ?? taskTeamNames[title])
+      : taskTeamNames[title];
+  return teamName == null ? sentence : '<b>$teamName</b>: $sentence';
+}
+
+/// Port of `formatJoinRequestNotification` (`:346-351`) —
+/// `"<b>$prefix</b> $body"`.
+String formatJoinRequestNotification(String prefix, String body) =>
+    '<b>$prefix</b> $body';
+
+/// Port of `formatStorageNotification` (`:335-344`).
+///
+/// Kotlin's `<= 10` and `<= 40` arms produce the same string; only `> 40`
+/// differs, so the two are one condition here — `NotificationsViewModelTest`
+/// pins all three (`:60-88`). A message that is not a percentage falls back to
+/// itself **including its `%`**, not to the stripped form.
+///
+/// [runningLow] and [available] are the `storage_running_low` /
+/// `storage_available` resources, which are Android-quoted and therefore carry
+/// a trailing space; Kotlin's template adds a second one. The double space is
+/// preserved here and collapsed by [renderNotificationHtml], which is where
+/// Kotlin loses it too.
+///
+/// Only the `<= 10` arm is reachable in production: the local writer deletes
+/// the row above 10% and never stores a higher number
+/// (`NotificationsRepositoryImpl.kt:88,108-110`).
+String formatStorageNotification(
+  String message, {
+  required String runningLow,
+  required String available,
+}) {
+  final percent = kotlinToIntOrNull(message.replaceAll('%', ''));
+  if (percent == null) return message;
+  return percent <= 40 ? '$runningLow $percent%' : '$available $percent%';
+}
+
+/// Port of `NotificationsViewModel.parseTaskDate` (`:322-333`).
+///
+/// Splits `"Read chapter 3 Thu 12, August 2027"` into its title and the date
+/// tail. The tail runs from the match start to the **end of the message**, not
+/// to the end of the match, so anything trailing the date rides along with it —
+/// Kotlin's `message.substring(matcher.start())`.
+({String title, String date})? parseTaskDate(String message) {
+  final match = _taskDatePattern.firstMatch(message);
+  if (match == null) return null;
+  return (
+    title: message.substring(0, match.start).trim(),
+    date: message.substring(match.start).trim(),
+  );
+}
+
+/// `NotificationsViewModel.TASK_DATE_PATTERN` (`:322`).
+///
+/// `\s` is spelled out as Java's ASCII class rather than written `\s`: Dart's
+/// `\s` also matches U+00A0 and the other Unicode spaces, so a message using a
+/// non-breaking space would match here and not in the Kotlin. `\b`, `\w` and
+/// `\d` agree between the two — and `\w` is genuinely `[A-Za-z0-9_]`, so the
+/// month position matches any word, not a month name. The weekday tokens are
+/// case-sensitive; there is no `CASE_INSENSITIVE` flag.
+final RegExp _taskDatePattern = RegExp(
+  r'\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[ \t\n\x0B\f\r]\d{1,2},'
+  r'[ \t\n\x0B\f\r]\w+[ \t\n\x0B\f\r]\d{4}\b',
+);
+
+/// Kotlin's `String.toIntOrNull()`, which `int.tryParse` is not.
+///
+/// Two differences decide whether a message is rewritten or shown raw:
+/// `int.tryParse` accepts surrounding whitespace where Kotlin does not, and it
+/// has no 32-bit ceiling — `"2147483648"` is null in Kotlin and a number in
+/// Dart, so the port would have announced 2,147,483,648 undownloaded resources
+/// where the Kotlin shows the raw string.
+///
+/// One divergence is left in place: Kotlin's parser accepts any Unicode decimal
+/// digit (`"٧"` is 7), which is not reproduced. No writer in either app
+/// produces one — the count is composed with `"$resourceCount"` — and this arm
+/// only ever sees a message a writer authored.
+int? kotlinToIntOrNull(String value) {
+  if (!RegExp(r'^[+-]?[0-9]+$').hasMatch(value)) return null;
+  final parsed = int.tryParse(value);
+  if (parsed == null) return null;
+  return (parsed < -2147483648 || parsed > 2147483647) ? null : parsed;
+}
+
+/// A notification's text, as the runs the row draws.
+class FormattedNotification {
+  const FormattedNotification(this.spans);
+
+  /// A single unemphasised run.
+  factory FormattedNotification.plain(String text) =>
+      FormattedNotification([NotificationSpan(text)]);
+
+  final List<NotificationSpan> spans;
+
+  /// The text with the emphasis dropped, for tests, semantics and any caller
+  /// that needs a plain string.
+  String get text => spans.map((span) => span.text).join();
+
+  @override
+  bool operator ==(Object other) =>
+      other is FormattedNotification &&
+      other.spans.length == spans.length &&
+      Iterable<int>.generate(
+        spans.length,
+      ).every((i) => other.spans[i] == spans[i]);
+
+  @override
+  int get hashCode => Object.hashAll(spans);
+
+  @override
+  String toString() => 'FormattedNotification($spans)';
+}
+
+/// One run of a formatted notification. [bold] is Kotlin's `<b>`.
+class NotificationSpan {
+  const NotificationSpan(this.text, {this.bold = false, this.italic = false});
+
+  final String text;
+  final bool bold;
+  final bool italic;
+
+  @override
+  bool operator ==(Object other) =>
+      other is NotificationSpan &&
+      other.text == text &&
+      other.bold == bold &&
+      other.italic == italic;
+
+  @override
+  int get hashCode => Object.hash(text, bold, italic);
+
+  @override
+  String toString() {
+    var out = text;
+    if (italic) out = '<i>$out</i>';
+    if (bold) out = '<b>$out</b>';
+    return out;
+  }
+}
+
+/// The lookups `NotificationsViewModel.loadNotifications` gathers before it
+/// formats a page of notifications (`:71-143`), in one value.
+class NotificationFormatContext {
+  const NotificationFormatContext({
+    required this.taskTeamNames,
+    required this.joinRequestDetails,
+  });
+
+  const NotificationFormatContext.empty()
+    : taskTeamNames = const {},
+      joinRequestDetails = const {};
+
+  /// Task id **and** task title → the owning team's name. Kotlin merges the
+  /// two maps into one and looks the id up first, so they share a namespace.
+  final Map<String, String> taskTeamNames;
+
+  /// Join-request document id → (requester, team). The `''` key is the
+  /// fallback entry for rows that carry no `relatedId`.
+  final Map<String, JoinRequestDetail> joinRequestDetails;
+}
+
+/// Port of the lookup half of `loadNotifications` (`:71-140`).
+///
+/// **The partition is on the raw stored type, not the resolved one**, exactly
+/// as the Kotlin's `notification.type.equals("task", ignoreCase = true)` is. So
+/// a server `newTask` document — which resolves to `task`, groups under Tasks
+/// and routes to the team's task list — never enters `taskNotifications`, never
+/// gets a team-name lookup and renders without the `<b>Team</b>:` prefix.
+/// Resolving before partitioning would be an improvement, not a port, so it is
+/// left alone and recorded in `PHASE_124_NOTES.md`.
+Future<NotificationFormatContext> buildNotificationFormatContext(
+  List<NotificationRow> rows,
+  NotificationsRepository repository,
+) async {
+  final taskRows = rows
+      .where((row) => row.type.toLowerCase() == 'task')
+      .toList(growable: false);
+  final joinRequestRows = rows
+      .where((row) => row.type.toLowerCase() == 'join_request')
+      .toList(growable: false);
+  if (taskRows.isEmpty && joinRequestRows.isEmpty) {
+    return const NotificationFormatContext.empty();
+  }
+
+  // `mapNotNull { it.relatedId }` filters nulls only, so an empty-string
+  // `relatedId` survives into the query list — and also lands in
+  // `joinRequestsWithoutRelatedId`, which tests `isNullOrEmpty`.
+  final taskIds = <String>{
+    for (final row in taskRows)
+      if (row.relatedId != null) row.relatedId!,
+  }.toList(growable: false);
+  final taskTitles = <String>{
+    for (final row in taskRows)
+      if (parseTaskDate(row.message) case final parsed?) parsed.title,
+  }.toList(growable: false);
+  final joinRequestIds = <String>{
+    for (final row in joinRequestRows)
+      if (row.relatedId != null) row.relatedId!,
+  }.toList(growable: false);
+  final hasJoinRequestWithoutRelatedId = joinRequestRows.any(
+    (row) => row.relatedId == null || row.relatedId!.isEmpty,
+  );
+
+  // `async { … }` × 4 in the Kotlin, awaited together. The by-title map is
+  // written first and the by-id map `putAll`-ed over it, so an id wins a
+  // collision.
+  final results = await Future.wait([
+    repository.taskTeamNamesByTaskTitles(taskTitles),
+    repository.taskTeamNamesByTaskIds(taskIds),
+    repository.joinRequestDetailsBatch(joinRequestIds),
+    if (hasJoinRequestWithoutRelatedId) repository.joinRequestDetails(null),
+  ]);
+
+  return NotificationFormatContext(
+    taskTeamNames: {
+      ...results[0] as Map<String, String>,
+      ...results[1] as Map<String, String>,
+    },
+    joinRequestDetails: {
+      ...results[2] as Map<String, JoinRequestDetail>,
+      // Written after the batch, so it overwrites any `""` entry the batch
+      // produced — as Kotlin's `details[""] = fallbackDetail` does.
+      if (hasJoinRequestWithoutRelatedId) '': results[3] as JoinRequestDetail,
+    },
+  );
+}

--- a/flutter/lib/ui/notifications/notification_grouping.dart
+++ b/flutter/lib/ui/notifications/notification_grouping.dart
@@ -135,8 +135,9 @@ List<NotificationListItem> buildGroupedList(
 }
 
 /// The fixed group labels, porting `NotificationsViewModel.typeLabelFor`.
-/// Keyed on the normalized type; the collective labels ("Join Requests",
-/// "Tasks") differ from the per-notification titles in `NotificationsScreen`.
+/// Keyed on the normalized type. These collective labels ("Join Requests",
+/// "Tasks") are now the only place a notification's type is named: the row
+/// itself carries the formatted message, as `row_notifications.xml` does.
 String groupLabelFor(AppLocalizations l10n, String type) {
   switch (type) {
     case 'join_request':

--- a/flutter/lib/ui/notifications/notification_html.dart
+++ b/flutter/lib/ui/notifications/notification_html.dart
@@ -64,6 +64,9 @@ FormattedNotification renderNotificationHtml(String html) {
   void writeText(String text) {
     for (final rune in text.runes) {
       final char = String.fromCharCode(rune);
+      // `\r` rides along with `\n`: an XML parser normalises CRLF to LF before
+      // the converter sees the text, so a lone carriage return never reaches
+      // AOSP's collapsing at all and matching it here is the closer reading.
       if (char == ' ' || char == '\n' || char == '\r') {
         pendingWhitespace = true;
         continue;
@@ -93,13 +96,26 @@ FormattedNotification renderNotificationHtml(String html) {
     if (open > index) {
       writeText(_decodeEntities(html.substring(index, open)));
     }
+    // A `<` only opens a tag when a tag name can follow it — a letter, or a
+    // slash and then a letter. HTML tokenization emits every other `<` as
+    // text, and so must this: `"Compare 3 < 5 > 1 today"` is a plain sentence
+    // a server can send, and treating `< 5 >` as a tag deleted the ` 5 ` from
+    // the middle of the row. Worse, a trimmed `< b >` read as `<b>` and
+    // bolded the rest of the message.
+    if (!_tagStart.hasMatch(
+      html.substring(open, (open + 3).clamp(0, html.length)),
+    )) {
+      writeText(_decodeEntities('<'));
+      index = open + 1;
+      continue;
+    }
     final close = html.indexOf('>', open);
     if (close < 0) {
       // An unterminated `<` is literal text, not a tag.
       writeText(_decodeEntities(html.substring(open)));
       break;
     }
-    final raw = html.substring(open + 1, close).trim();
+    final raw = html.substring(open + 1, close);
     index = close + 1;
     if (raw.isEmpty) continue;
 
@@ -160,6 +176,10 @@ List<NotificationSpan> _trimTrailingNewlines(List<NotificationSpan> spans) {
   }
   return trimmed.isEmpty ? [const NotificationSpan('')] : trimmed;
 }
+
+/// `<` immediately followed by a tag name, or by `/` and a tag name. Anything
+/// else — `< 5`, `<3`, a bare `<` — is text.
+final RegExp _tagStart = RegExp(r'^<\/?[A-Za-z]');
 
 /// The HTML4 entities worth decoding here, plus numeric references.
 const Map<String, String> _entities = {

--- a/flutter/lib/ui/notifications/notification_html.dart
+++ b/flutter/lib/ui/notifications/notification_html.dart
@@ -1,0 +1,197 @@
+/// The port's stand-in for `Html.fromHtml(text, FROM_HTML_MODE_LEGACY)`, which
+/// `NotificationsAdapter.bind` (`NotificationsAdapter.kt:116-127`) runs over
+/// every notification's text before it reaches the row's single TextView.
+///
+/// It is a deliberately small parser rather than a package, because the input
+/// is a closed set: the two strings the port itself composes
+/// (`formatJoinRequestNotification`'s `<b>` prefix and `formatTaskNotification`'s
+/// `<b>` team name) and the messages Planet authors, which carry `<b>` around
+/// the names they mention — `"<b>Jane</b> has requested to join <b>\"My
+/// Team\"</b> team."`, `"You have been added to <b>\"My Team\"</b> team."`,
+/// `"<b>Jane</b> replied to your message."`
+/// (`NotificationsRepositoryImplTest.kt:168,192,214`). Those three shapes are
+/// exactly the arms `formatNotification` passes through unchanged, so a
+/// renderer that drew the message literally would show the tags.
+///
+/// What it reproduces, and why each piece is here:
+///
+/// * `<b>`/`<strong>` and `<i>`/`<em>` become emphasis flags — the markup that
+///   actually occurs.
+/// * An **unknown tag is dropped and its text kept**, as TagSoup does, so a
+///   task titled `Read <chapter 3>` renders the same way in both apps.
+/// * The HTML4 entities that can plausibly appear in a name or a team title are
+///   decoded; an unrecognised entity is left alone, which is also what an
+///   HTML parser does with `&foo;`.
+/// * Runs of spaces and newlines collapse to one, and leading whitespace is
+///   dropped. This is not decoration: `formatStorageNotification` composes
+///   `"$prefix ${it}%"` from a string resource that already ends in a space
+///   (`values/strings.xml:603`), so the Kotlin's own text carries a double
+///   space that only this collapsing hides.
+///
+/// What it does not reproduce: block-level layout. `<p>`/`<div>` and friends
+/// become a single newline where AOSP emits paragraph breaks, and lists lose
+/// their bullets. No notification in the corpus contains one.
+library;
+
+import 'notification_format.dart';
+
+/// Renders [html] into the spans the notification row draws.
+FormattedNotification renderNotificationHtml(String html) {
+  final spans = <NotificationSpan>[];
+  final buffer = StringBuffer();
+  var bold = 0;
+  var italic = 0;
+  // `pending` is the whitespace-collapsing state: a run of spaces or newlines
+  // becomes one character, and one at the very start is dropped entirely.
+  var pendingWhitespace = false;
+  var wroteAnything = false;
+
+  void flush() {
+    // A space held over from before this tag belongs to the run that *ends*
+    // here, not to the one that starts after it: `<b>very <i>late</i></b>` is
+    // "very " in bold, then "late" in bold italic.
+    if (pendingWhitespace && wroteAnything) {
+      buffer.write(' ');
+      pendingWhitespace = false;
+    }
+    if (buffer.isEmpty) return;
+    spans.add(
+      NotificationSpan(buffer.toString(), bold: bold > 0, italic: italic > 0),
+    );
+    buffer.clear();
+  }
+
+  void writeText(String text) {
+    for (final rune in text.runes) {
+      final char = String.fromCharCode(rune);
+      if (char == ' ' || char == '\n' || char == '\r') {
+        pendingWhitespace = true;
+        continue;
+      }
+      if (pendingWhitespace) {
+        pendingWhitespace = false;
+        if (wroteAnything) buffer.write(' ');
+      }
+      buffer.write(char);
+      wroteAnything = true;
+    }
+  }
+
+  void writeNewline() {
+    if (!wroteAnything) return;
+    pendingWhitespace = false;
+    buffer.write('\n');
+  }
+
+  var index = 0;
+  while (index < html.length) {
+    final open = html.indexOf('<', index);
+    if (open < 0) {
+      writeText(_decodeEntities(html.substring(index)));
+      break;
+    }
+    if (open > index) {
+      writeText(_decodeEntities(html.substring(index, open)));
+    }
+    final close = html.indexOf('>', open);
+    if (close < 0) {
+      // An unterminated `<` is literal text, not a tag.
+      writeText(_decodeEntities(html.substring(open)));
+      break;
+    }
+    final raw = html.substring(open + 1, close).trim();
+    index = close + 1;
+    if (raw.isEmpty) continue;
+
+    final isClosing = raw.startsWith('/');
+    final name = (isClosing ? raw.substring(1) : raw)
+        .split(RegExp(r'[\s/]'))
+        .first
+        .toLowerCase();
+
+    switch (name) {
+      case 'b':
+      case 'strong':
+        flush();
+        bold += isClosing ? -1 : 1;
+        if (bold < 0) bold = 0;
+      case 'i':
+      case 'em':
+        flush();
+        italic += isClosing ? -1 : 1;
+        if (italic < 0) italic = 0;
+      case 'br':
+      case 'p':
+      case 'div':
+      case 'li':
+      case 'ul':
+      case 'ol':
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+      case 'blockquote':
+      case 'tr':
+        writeNewline();
+      default:
+        // Every other tag is dropped, its text kept.
+        break;
+    }
+  }
+  flush();
+
+  if (spans.isEmpty) return FormattedNotification.plain('');
+  return FormattedNotification(_trimTrailingNewlines(spans));
+}
+
+List<NotificationSpan> _trimTrailingNewlines(List<NotificationSpan> spans) {
+  final trimmed = [...spans];
+  while (trimmed.isNotEmpty) {
+    final last = trimmed.last;
+    final text = last.text.replaceFirst(RegExp(r'\n+$'), '');
+    if (text == last.text) break;
+    trimmed.removeLast();
+    if (text.isNotEmpty) {
+      trimmed.add(NotificationSpan(text, bold: last.bold, italic: last.italic));
+      break;
+    }
+  }
+  return trimmed.isEmpty ? [const NotificationSpan('')] : trimmed;
+}
+
+/// The HTML4 entities worth decoding here, plus numeric references.
+const Map<String, String> _entities = {
+  'amp': '&',
+  'lt': '<',
+  'gt': '>',
+  'quot': '"',
+  'apos': "'",
+  // U+00A0, not a plain space: an HTML parser decodes it that way and the
+  // whitespace collapsing above leaves it alone, as AOSP's does.
+  'nbsp': '\u00A0',
+  'hellip': '…',
+  'mdash': '—',
+  'ndash': '–',
+  'rsquo': '’',
+  'lsquo': '‘',
+  'ldquo': '“',
+  'rdquo': '”',
+};
+
+String _decodeEntities(String text) {
+  if (!text.contains('&')) return text;
+  return text.replaceAllMapped(RegExp(r'&(#x?[0-9a-fA-F]+|\w+);'), (match) {
+    final body = match.group(1)!;
+    if (body.startsWith('#')) {
+      final isHex = body.length > 1 && (body[1] == 'x' || body[1] == 'X');
+      final digits = body.substring(isHex ? 2 : 1);
+      final code = int.tryParse(digits, radix: isHex ? 16 : 10);
+      if (code == null || code < 0 || code > 0x10FFFF) return match.group(0)!;
+      return String.fromCharCode(code);
+    }
+    // An unrecognised entity stays as written, as a real parser leaves `&foo;`.
+    return _entities[body.toLowerCase()] ?? match.group(0)!;
+  });
+}

--- a/flutter/lib/ui/notifications/notifications_screen.dart
+++ b/flutter/lib/ui/notifications/notifications_screen.dart
@@ -34,7 +34,11 @@ class NotificationsScreen extends ConsumerWidget {
       appBar: AppBar(
         title: Text(l10n.notifications),
         actions: [
-          if (unread > 0)
+          // `count > 0 && currentFilter != "read"`
+          // (`NotificationsFragment.kt:101-102`) — offering "mark all read" on
+          // the Read tab, which the port did, is an action with nothing to act
+          // on.
+          if (unread > 0 && filter != NotificationFilter.read)
             TextButton(
               onPressed: () =>
                   ref.read(notificationActionsProvider).markAllAsRead(),
@@ -236,6 +240,11 @@ class _NotificationTile extends ConsumerWidget {
       child: Opacity(
         opacity: notification.isRead ? 0.6 : 1,
         child: ListTile(
+          // The icon is the port's own: Kotlin draws one per *group* header,
+          // not per row (`iconResFor` is called only from
+          // `HeaderViewHolder.bind`). It stays because it makes a long list
+          // scannable — but it is an addition, which is why the type *label*
+          // was the thing removed: that duplicated the group header outright.
           leading: Badge(
             isLabelVisible: !notification.isRead,
             child: CircleAvatar(
@@ -263,6 +272,19 @@ class _NotificationTile extends ConsumerWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ),
+          // `btn_mark_as_read`, visible on every unread row outside selection
+          // mode (`NotificationsAdapter.kt:137-141`). Without it the port's
+          // only way to mark a single row read was to tap it — which also
+          // navigates away from the list, so a learner could not clear one
+          // notification and keep reading the rest.
+          trailing: notification.isRead
+              ? null
+              : TextButton(
+                  onPressed: () => ref
+                      .read(notificationActionsProvider)
+                      .markAsRead(notification.id),
+                  child: Text(l10n.markAsRead),
+                ),
           // Read notifications remain actionable. Kotlin marks an unread row and
           // navigates on the same tap; making `onTap` null after that first tap
           // prevented learners from ever reopening its destination in Flutter.

--- a/flutter/lib/ui/notifications/notifications_screen.dart
+++ b/flutter/lib/ui/notifications/notifications_screen.dart
@@ -10,6 +10,7 @@ import '../../providers/notifications_provider.dart';
 import '../../repository/notifications_repository.dart';
 import '../router.dart';
 import 'notification_destination.dart';
+import 'notification_format.dart';
 import 'notification_grouping.dart';
 
 /// Port of `ui/notifications/NotificationsFragment.kt`.
@@ -131,6 +132,13 @@ class _GroupedList extends ConsumerWidget {
       collapsedGroups: expansion.collapsed,
       expandedGroups: expansion.expanded,
     );
+    // The team names and join-request details `loadNotifications` gathers
+    // before formatting. Watched, not read: while it resolves the rows still
+    // render, just without the `<b>Team</b>:` prefix, which is what an
+    // uncached row shows in the Kotlin too.
+    final formatContext =
+        ref.watch(notificationFormatContextProvider).valueOrNull ??
+        const NotificationFormatContext.empty();
     return ListView.builder(
       padding: const EdgeInsets.only(bottom: 24),
       itemCount: grouped.length,
@@ -140,6 +148,7 @@ class _GroupedList extends ConsumerWidget {
           NotificationHeaderItem() => _GroupHeader(header: node),
           NotificationEntryItem(:final notification) => _NotificationTile(
             notification: notification,
+            formatContext: formatContext,
           ),
         };
       },
@@ -197,8 +206,12 @@ class _GroupHeader extends ConsumerWidget {
 }
 
 class _NotificationTile extends ConsumerWidget {
-  const _NotificationTile({required this.notification});
+  const _NotificationTile({
+    required this.notification,
+    required this.formatContext,
+  });
   final NotificationRow notification;
+  final NotificationFormatContext formatContext;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -216,40 +229,45 @@ class _NotificationTile extends ConsumerWidget {
         padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Icon(Icons.delete_outline, color: colors.onErrorContainer),
       ),
-      child: ListTile(
-        leading: Badge(
-          isLabelVisible: !notification.isRead,
-          child: CircleAvatar(
-            child: Icon(_iconFor(resolvedNotificationType(notification))),
+      // `NotificationsAdapter.bind` dims a read row to `alpha = 0.6` rather
+      // than un-bolding its text (`:127`), and the formatted text carries its
+      // own emphasis — the join-request prefix, the task's team name — which
+      // bolding the whole line for unread would swallow.
+      child: Opacity(
+        opacity: notification.isRead ? 0.6 : 1,
+        child: ListTile(
+          leading: Badge(
+            isLabelVisible: !notification.isRead,
+            child: CircleAvatar(
+              child: Icon(_iconFor(resolvedNotificationType(notification))),
+            ),
           ),
-        ),
-        title: Text(
-          notification.title?.trim().isNotEmpty == true
-              ? notification.title!
-              : _titleFor(l10n, resolvedNotificationType(notification)),
-          style: TextStyle(
-            fontWeight: notification.isRead
-                ? FontWeight.normal
-                : FontWeight.bold,
+          // The row's one line of text, as `row_notifications.xml` has it: the
+          // rewritten message, not a type label above the raw one. The group
+          // header above already names the type, exactly as in the Kotlin — and
+          // `AppNotification.title`, which this used to prefer, is a column
+          // nothing in either app ever writes.
+          title: _FormattedNotificationText(
+            formatNotification(
+              notification,
+              l10n: l10n,
+              context: formatContext,
+            ),
           ),
-        ),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(notification.message),
-            const SizedBox(height: 4),
-            Text(
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
               DateFormat.yMMMd().add_jm().format(
                 DateTime.fromMillisecondsSinceEpoch(notification.createdAt),
               ),
               style: Theme.of(context).textTheme.bodySmall,
             ),
-          ],
+          ),
+          // Read notifications remain actionable. Kotlin marks an unread row and
+          // navigates on the same tap; making `onTap` null after that first tap
+          // prevented learners from ever reopening its destination in Flutter.
+          onTap: () => _openNotification(context, ref),
         ),
-        // Read notifications remain actionable. Kotlin marks an unread row and
-        // navigates on the same tap; making `onTap` null after that first tap
-        // prevented learners from ever reopening its destination in Flutter.
-        onTap: () => _openNotification(context, ref),
       ),
     );
   }
@@ -316,20 +334,44 @@ IconData _iconFor(String type) => switch (type.toLowerCase()) {
   _ => Icons.notifications_outlined,
 };
 
-String _titleFor(AppLocalizations l10n, String type) =>
-    switch (type.toLowerCase()) {
-      'task' => l10n.taskNotification,
-      'chat' => l10n.chatNotification,
-      'voice_reply' => l10n.replyNotification,
-      'resource' => l10n.resourceNotification,
-      'storage' => l10n.storageNotification,
-      'join_request' => l10n.joinRequestNotification,
-      'team_join' => l10n.teamNotification,
-      _ => l10n.notification,
-    };
-
-/// The group-header label, delegating to [groupLabelFor]. Differs from
-/// [_titleFor]: the grouping labels are collective ("Join Requests",
-/// "Tasks"), not the per-notification titles.
+/// The group-header label, delegating to [groupLabelFor] — collective
+/// ("Join Requests", "Tasks"), and now the only place a type is named, since
+/// the row itself carries the formatted message.
 String _groupLabel(AppLocalizations l10n, String type) =>
     groupLabelFor(l10n, type);
+
+/// Draws a [FormattedNotification]'s runs, with Kotlin's `<b>` as a bold span.
+///
+/// This is what stands in for the `TextView` the adapter hands
+/// `Html.fromHtml`'s `Spanned` to: the markup in these strings is emphasis, so
+/// a `Text.rich` reproduces it exactly without an HTML widget.
+class _FormattedNotificationText extends StatelessWidget {
+  const _FormattedNotificationText(this.formatted);
+
+  final FormattedNotification formatted;
+
+  @override
+  Widget build(BuildContext context) {
+    if (formatted.spans.length == 1 &&
+        !formatted.spans.first.bold &&
+        !formatted.spans.first.italic) {
+      return Text(formatted.text);
+    }
+    return Text.rich(
+      TextSpan(
+        children: [
+          for (final span in formatted.spans)
+            TextSpan(
+              text: span.text,
+              style: (span.bold || span.italic)
+                  ? TextStyle(
+                      fontWeight: span.bold ? FontWeight.bold : null,
+                      fontStyle: span.italic ? FontStyle.italic : null,
+                    )
+                  : null,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/test/core/notifications/task_deadline_notifier_test.dart
+++ b/flutter/test/core/notifications/task_deadline_notifier_test.dart
@@ -35,6 +35,8 @@ void main() {
       teamNotificationDao: db.teamNotificationDao,
       newsDao: db.newsDao,
       teamTaskDao: db.teamTaskDao,
+      teamDao: db.teamDao,
+      userDao: db.userDao,
     );
     presenter = _RecordingPresenter();
   });

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -289,12 +289,14 @@ void main() {
     // app. Its two remaining keys, `unknownUser`/`unknownTeam`, have no Kotlin
     // string to derive from — the Kotlin hardcodes those two in
     // `NotificationsRepositoryImpl` — so they fall back to English.
+    // Phase 124's second pass adds one more, `markAsRead` — the row's own
+    // Mark-as-read button, derived from the Kotlin `mark_as_read`.
     const humanReviewed = {
-      'ar': 401,
-      'es': 454,
-      'fr': 400,
-      'ne': 402,
-      'so': 402,
+      'ar': 402,
+      'es': 455,
+      'fr': 401,
+      'ne': 403,
+      'so': 403,
     };
 
     for (final code in locales) {

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -280,12 +280,21 @@ void main() {
     // user sees changed when they were cleared. If that reading is ever
     // rejected, `_reconcileMachineTranslationFlags`' `already` branch is the
     // one line to revert.
+    //
+    // Phase 124 adds 6 per locale: the notification-format strings
+    // (`resource_notification`, `task_notification`, `storage_running_low`,
+    // `storage_available`, `join_request_prefix`,
+    // `user_requested_to_join_team`), all derived from the Kotlin XML by the
+    // tool and therefore human translations already shipping in the Android
+    // app. Its two remaining keys, `unknownUser`/`unknownTeam`, have no Kotlin
+    // string to derive from — the Kotlin hardcodes those two in
+    // `NotificationsRepositoryImpl` — so they fall back to English.
     const humanReviewed = {
-      'ar': 395,
-      'es': 448,
-      'fr': 394,
-      'ne': 396,
-      'so': 396,
+      'ar': 401,
+      'es': 454,
+      'fr': 400,
+      'ne': 402,
+      'so': 402,
     };
 
     for (final code in locales) {

--- a/flutter/test/repository/notification_type_round_trip_test.dart
+++ b/flutter/test/repository/notification_type_round_trip_test.dart
@@ -36,6 +36,8 @@ void main() {
       teamNotificationDao: database.teamNotificationDao,
       newsDao: database.newsDao,
       teamTaskDao: database.teamTaskDao,
+      teamDao: database.teamDao,
+      userDao: database.userDao,
       api: MockPlanetApi(),
     );
   });

--- a/flutter/test/repository/notifications_repository_test.dart
+++ b/flutter/test/repository/notifications_repository_test.dart
@@ -21,6 +21,8 @@ void main() {
       teamNotificationDao: database.teamNotificationDao,
       newsDao: database.newsDao,
       teamTaskDao: database.teamTaskDao,
+      teamDao: database.teamDao,
+      userDao: database.userDao,
       now: () => DateTime.fromMillisecondsSinceEpoch(1234),
     );
   });
@@ -207,6 +209,114 @@ void main() {
     );
   });
 
+  group('the formatting lookups', () {
+    // Port of `getTaskTeamNamesByTaskIds` / `getTaskTeamNamesByTaskTitles` /
+    // `getJoinRequestDetailsBatch` / `getJoinRequestDetails` — the four calls
+    // `loadNotifications` makes before formatting a page of notifications.
+    setUp(() async {
+      await database.teamDao.upsert(
+        TeamsCompanion.insert(id: 'team-1', name: const Value('Reading Club')),
+      );
+      await database.teamTaskDao.upsert(
+        TeamTasksCompanion.insert(
+          id: 'task-1',
+          teamId: 'team-1',
+          title: const Value('Read chapter 3'),
+        ),
+      );
+    });
+
+    test('resolves a task team name by task id', () async {
+      expect(await repository.taskTeamNamesByTaskIds(['task-1']), {
+        'task-1': 'Reading Club',
+      });
+    });
+
+    test('resolves a task team name by task title', () async {
+      expect(await repository.taskTeamNamesByTaskTitles(['Read chapter 3']), {
+        'Read chapter 3': 'Reading Club',
+      });
+    });
+
+    test(
+      'a task whose team has no cached document is absent, not blank',
+      () async {
+        await database.teamTaskDao.upsert(
+          TeamTasksCompanion.insert(
+            id: 'task-2',
+            teamId: 'team-missing',
+            title: const Value('Orphan'),
+          ),
+        );
+        final names = await repository.taskTeamNamesByTaskIds([
+          'task-1',
+          'task-2',
+        ]);
+        expect(names.containsKey('task-2'), isFalse);
+        expect(names['task-1'], 'Reading Club');
+      },
+    );
+
+    test('an empty request list runs no query and returns nothing', () async {
+      expect(await repository.taskTeamNamesByTaskIds(const []), isEmpty);
+      expect(await repository.taskTeamNamesByTaskTitles(const []), isEmpty);
+      expect(await repository.joinRequestDetailsBatch(const []), isEmpty);
+    });
+
+    test('resolves a join request to its requester and team', () async {
+      await database.teamDao.upsert(
+        TeamsCompanion.insert(
+          id: 'req-1',
+          docType: const Value('request'),
+          teamId: const Value('team-1'),
+          userId: const Value('user-9'),
+        ),
+      );
+      await database.userDao.upsert(
+        UsersCompanion.insert(id: 'user-9', name: const Value('Jane')),
+      );
+
+      expect(await repository.joinRequestDetailsBatch(['req-1']), {
+        'req-1': const JoinRequestDetail(
+          requester: 'Jane',
+          team: 'Reading Club',
+        ),
+      });
+      expect(
+        await repository.joinRequestDetails('req-1'),
+        const JoinRequestDetail(requester: 'Jane', team: 'Reading Club'),
+      );
+    });
+
+    test('an unresolvable requester or team is left null for the caller to '
+        'localise', () async {
+      await database.teamDao.upsert(
+        TeamsCompanion.insert(
+          id: 'req-2',
+          docType: const Value('request'),
+          teamId: const Value('team-missing'),
+          userId: const Value('user-missing'),
+        ),
+      );
+      final details = await repository.joinRequestDetailsBatch(['req-2']);
+      // Kotlin substitutes the English "Unknown User"/"Unknown Team" here; the
+      // port leaves them null so `formatNotification` can use the ARB.
+      expect(details['req-2'], const JoinRequestDetail());
+    });
+
+    test('a null related id yields the unknown pair, as getJoinRequestInfo '
+        'returns null for it', () async {
+      expect(
+        await repository.joinRequestDetails(null),
+        const JoinRequestDetail(),
+      );
+      expect(
+        await repository.joinRequestDetails(''),
+        const JoinRequestDetail(),
+      );
+    });
+  });
+
   group('server notification sync-in', () {
     late MockPlanetApi api;
 
@@ -217,6 +327,8 @@ void main() {
         teamNotificationDao: database.teamNotificationDao,
         newsDao: database.newsDao,
         teamTaskDao: database.teamTaskDao,
+        teamDao: database.teamDao,
+        userDao: database.userDao,
         now: () => DateTime.fromMillisecondsSinceEpoch(1234),
         api: api,
       );

--- a/flutter/test/ui/notification_format_test.dart
+++ b/flutter/test/ui/notification_format_test.dart
@@ -1,0 +1,499 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/l10n/app_localizations.dart';
+import 'package:myplanet/l10n/app_localizations_en.dart';
+import 'package:myplanet/repository/notifications_repository.dart';
+import 'package:myplanet/ui/notifications/notification_format.dart';
+import 'package:myplanet/ui/notifications/notification_html.dart';
+
+/// Port coverage for `NotificationsViewModel.formatNotification` and the four
+/// helpers it delegates to. Where the Kotlin has a unit test
+/// (`NotificationsViewModelTest.kt:45-107`) the case is mirrored exactly, so a
+/// divergence in either app shows up as a disagreement between two suites
+/// rather than as a rendering nobody looks at.
+void main() {
+  final AppLocalizations l10n = AppLocalizationsEn();
+
+  NotificationRow row({
+    required String message,
+    required String type,
+    String? subType,
+    String? relatedId,
+    bool isRead = false,
+  }) => NotificationRow(
+    id: 'n-1',
+    userId: 'user-1',
+    message: message,
+    type: type,
+    subType: subType,
+    relatedId: relatedId,
+    isRead: isRead,
+    createdAt: 1000,
+    priority: 0,
+    isFromServer: false,
+    needsSync: false,
+  );
+
+  group('parseTaskDate', () {
+    // `NotificationsViewModelTest.kt:45-51`.
+    test('splits the title from the date', () {
+      final parsed = parseTaskDate('Complete math assignment Mon 12, Jan 2024');
+      expect(parsed?.title, 'Complete math assignment');
+      expect(parsed?.date, 'Mon 12, Jan 2024');
+    });
+
+    // `:53-58`.
+    test('returns null when the message carries no date', () {
+      expect(parseTaskDate('Some random message without date'), isNull);
+    });
+
+    test('the date runs to the end of the message, not to the end of the '
+        'match', () {
+      // Kotlin is `message.substring(matcher.start())`, so anything trailing
+      // the date rides along with it.
+      final parsed = parseTaskDate('Deadline Wed 03, September 2025 — hurry');
+      expect(parsed?.title, 'Deadline');
+      expect(parsed?.date, 'Wed 03, September 2025 — hurry');
+    });
+
+    test('the weekday is case-sensitive', () {
+      // No CASE_INSENSITIVE flag on the Kotlin pattern.
+      expect(parseTaskDate('Report sun 12, Jan 2024'), isNull);
+    });
+
+    test('the month position is any word, not a month name', () {
+      // Java's `\w` is `[A-Za-z0-9_]` and that is all the pattern asks for.
+      expect(parseTaskDate('Report Mon 12, _ 2024')?.date, 'Mon 12, _ 2024');
+    });
+
+    test('a non-breaking space does not match, as in Java', () {
+      // Dart's `\s` matches U+00A0 and Java's does not; the pattern spells the
+      // ASCII class out so the two agree.
+      expect(parseTaskDate('Report Mon 12, January 2024'), isNull);
+    });
+  });
+
+  group('formatStorageNotification', () {
+    String format(String message) => formatStorageNotification(
+      message,
+      runningLow: l10n.storageRunningLow,
+      available: l10n.storageAvailable,
+    );
+
+    // `NotificationsViewModelTest.kt:60-78` — both arms produce the same text.
+    test('10% and 40% are both "running low"', () {
+      expect(renderedText(format('10%')), 'Storage running low: 10%');
+      expect(renderedText(format('40%')), 'Storage running low: 40%');
+    });
+
+    // `:80-88`.
+    test('above 40% reads as available', () {
+      expect(renderedText(format('50%')), 'Storage available: 50%');
+    });
+
+    // `:90-98`.
+    test('a non-numeric message falls back to itself, % included', () {
+      expect(format('not_an_int'), 'not_an_int');
+      expect(format('lots of space left %'), 'lots of space left %');
+    });
+
+    test('the composed string carries the double space Kotlin composes', () {
+      // The resource string ends in a space and the template adds another;
+      // only the renderer hides it. Composing one space here would look right
+      // and silently diverge from the Kotlin source.
+      expect(format('8%'), 'Storage running low:  8%');
+    });
+  });
+
+  // `NotificationsViewModelTest.kt:100-107`.
+  test('formatJoinRequestNotification bolds the prefix only', () {
+    expect(
+      formatJoinRequestNotification(
+        'Join Request',
+        'John Doe requested to join Awesome Team',
+      ),
+      '<b>Join Request</b> John Doe requested to join Awesome Team',
+    );
+  });
+
+  group('kotlinToIntOrNull', () {
+    test('accepts a plain integer', () {
+      expect(kotlinToIntOrNull('7'), 7);
+      expect(kotlinToIntOrNull('-3'), -3);
+      expect(kotlinToIntOrNull('+3'), 3);
+    });
+
+    test('rejects what Kotlin rejects and Dart would accept', () {
+      // `int.tryParse` trims; `toIntOrNull` does not.
+      expect(kotlinToIntOrNull(' 7'), isNull);
+      expect(kotlinToIntOrNull('7 '), isNull);
+      // 32-bit ceiling.
+      expect(kotlinToIntOrNull('2147483648'), isNull);
+      expect(kotlinToIntOrNull('2147483647'), 2147483647);
+      expect(kotlinToIntOrNull(''), isNull);
+      expect(kotlinToIntOrNull('7.0'), isNull);
+    });
+  });
+
+  group('the resource arm', () {
+    test('rewrites the bare count the port itself stores', () {
+      // `updateResourceNotification` stores the count and nothing else, so this
+      // row rendered as `7` before the format was ported.
+      expect(
+        formatNotification(
+          row(message: '7', type: 'resource', relatedId: '7'),
+          l10n: l10n,
+        ).text,
+        'You have 7 resources not downloaded',
+      );
+    });
+
+    test('a server resource message is shown as written', () {
+      expect(
+        formatNotification(
+          row(message: '4 new resources are available', type: 'resource'),
+          l10n: l10n,
+        ).text,
+        '4 new resources are available',
+      );
+    });
+
+    test('a whitespace-padded count is not a count', () {
+      // `toIntOrNull` rejects the space, so the message is passed through
+      // rather than rewritten — asserted on the composed string, because the
+      // renderer then drops the leading space exactly as `Html.fromHtml` does,
+      // leaving the same bare `7` on screen in both apps.
+      expect(
+        notificationHtml(
+          row(message: ' 7', type: 'resource'),
+          l10n: l10n,
+        ),
+        ' 7',
+      );
+    });
+  });
+
+  group('the task arm', () {
+    test(
+      'rewrites title and date, with no prefix when the team is unknown',
+      () {
+        expect(
+          formatNotification(
+            row(message: 'Read chapter 3 Thu 12, August 2027', type: 'task'),
+            l10n: l10n,
+          ).text,
+          'Read chapter 3 is due in Thu 12, August 2027',
+        );
+      },
+    );
+
+    test('prefixes the team name in bold when the task id is known', () {
+      final formatted = formatNotification(
+        row(
+          message: 'Read chapter 3 Thu 12, August 2027',
+          type: 'task',
+          relatedId: 'task-9',
+        ),
+        l10n: l10n,
+        context: const NotificationFormatContext(
+          taskTeamNames: {'task-9': 'Reading Club'},
+          joinRequestDetails: {},
+        ),
+      );
+      expect(
+        formatted.text,
+        'Reading Club: Read chapter 3 is due in Thu 12, August 2027',
+      );
+      // The colon is *outside* the bold, unlike the join-request prefix.
+      expect(formatted.spans.first.bold, isTrue);
+      expect(formatted.spans.first.text, 'Reading Club');
+      expect(formatted.spans[1].bold, isFalse);
+      expect(formatted.spans[1].text, startsWith(': '));
+    });
+
+    test('falls back to the title key when the id has no entry', () {
+      expect(
+        formatNotification(
+          row(
+            message: 'Read chapter 3 Thu 12, August 2027',
+            type: 'task',
+            relatedId: 'task-9',
+          ),
+          l10n: l10n,
+          context: const NotificationFormatContext(
+            taskTeamNames: {'Read chapter 3': 'Reading Club'},
+            joinRequestDetails: {},
+          ),
+        ).text,
+        'Reading Club: Read chapter 3 is due in Thu 12, August 2027',
+      );
+    });
+
+    test('the id wins over the title', () {
+      expect(
+        formatNotification(
+          row(
+            message: 'Read chapter 3 Thu 12, August 2027',
+            type: 'task',
+            relatedId: 'task-9',
+          ),
+          l10n: l10n,
+          context: const NotificationFormatContext(
+            taskTeamNames: {'task-9': 'By id', 'Read chapter 3': 'By title'},
+            joinRequestDetails: {},
+          ),
+        ).text,
+        startsWith('By id: '),
+      );
+    });
+
+    test('a message with no parseable date is left alone', () {
+      expect(
+        formatNotification(
+          row(message: 'Something is due soon', type: 'task'),
+          l10n: l10n,
+        ).text,
+        'Something is due soon',
+      );
+    });
+  });
+
+  group('the join-request arm', () {
+    test('a raw join_request row is rewritten from the lookup', () {
+      final formatted = formatNotification(
+        row(message: 'ignored', type: 'join_request', relatedId: 'req-1'),
+        l10n: l10n,
+        context: const NotificationFormatContext(
+          taskTeamNames: {},
+          joinRequestDetails: {
+            'req-1': JoinRequestDetail(requester: 'Jane', team: 'My Team'),
+          },
+        ),
+      );
+      expect(
+        formatted.text,
+        'Join Request: Jane has requested to join My Team',
+      );
+      // Here the colon *is* inside the bold — it belongs to the prefix string.
+      expect(
+        formatted.spans.first,
+        const NotificationSpan('Join Request:', bold: true),
+      );
+    });
+
+    test('the raw type test is case-insensitive', () {
+      expect(
+        formatNotification(
+          row(message: 'ignored', type: 'JOIN_REQUEST', relatedId: 'req-1'),
+          l10n: l10n,
+          context: const NotificationFormatContext(
+            taskTeamNames: {},
+            joinRequestDetails: {
+              'req-1': JoinRequestDetail(requester: 'Jane', team: 'My Team'),
+            },
+          ),
+        ).text,
+        'Join Request: Jane has requested to join My Team',
+      );
+    });
+
+    test('an unknown requester and team fall back to the localised pair', () {
+      expect(
+        formatNotification(
+          row(message: 'ignored', type: 'join_request', relatedId: 'req-1'),
+          l10n: l10n,
+        ).text,
+        'Join Request: Unknown User has requested to join Unknown Team',
+      );
+    });
+
+    test('a row with no relatedId reads the "" fallback entry', () {
+      expect(
+        formatNotification(
+          row(message: 'ignored', type: 'join_request'),
+          l10n: l10n,
+          context: const NotificationFormatContext(
+            taskTeamNames: {},
+            joinRequestDetails: {
+              '': JoinRequestDetail(requester: 'Jane', team: 'My Team'),
+            },
+          ),
+        ).text,
+        'Join Request: Jane has requested to join My Team',
+      );
+    });
+
+    test('a server team notification keeps its own sentence', () {
+      // The only path that reaches this arm in production: raw type `team`
+      // with `activeTab: applicantTab`. Kotlin's `if` sends it to the verbatim
+      // branch, and the message it carries is already a sentence — with its own
+      // markup, which the renderer interprets rather than printing.
+      final formatted = formatNotification(
+        row(
+          message: '<b>Jane</b> has requested to join <b>"My Team"</b> team.',
+          type: 'team',
+          subType: 'join_request',
+          relatedId: 'team-1',
+        ),
+        l10n: l10n,
+      );
+      expect(formatted.text, 'Jane has requested to join "My Team" team.');
+      expect(formatted.spans.first, const NotificationSpan('Jane', bold: true));
+    });
+  });
+
+  group('the arms that rewrite nothing', () {
+    test('a team_join message is passed through', () {
+      expect(
+        formatNotification(
+          row(
+            message: 'You have been added to <b>"My Team"</b> team.',
+            type: 'team',
+            relatedId: 'team-1',
+          ),
+          l10n: l10n,
+        ).text,
+        'You have been added to "My Team" team.',
+      );
+    });
+
+    test('a voice reply is passed through', () {
+      expect(
+        formatNotification(
+          row(
+            message: '<b>Jane</b> replied to your message.',
+            type: 'replyMessage',
+            relatedId: 'news-1',
+          ),
+          l10n: l10n,
+        ).text,
+        'Jane replied to your message.',
+      );
+    });
+
+    test('an unresolved notification is passed through', () {
+      expect(
+        formatNotification(
+          row(message: 'Something happened', type: 'somethingElse'),
+          l10n: l10n,
+        ).text,
+        'Something happened',
+      );
+    });
+  });
+
+  group('buildNotificationFormatContext', () {
+    test('partitions on the raw type, so a newTask gets no team name', () async {
+      final repository = _RecordingLookups();
+      await buildNotificationFormatContext([
+        row(
+          message: 'Read chapter 3 Thu 12, August 2027',
+          type: 'newTask',
+          relatedId: 'task-9',
+        ),
+      ], repository);
+      // Nothing was looked up at all: `newTask` is not `task`, so the row never
+      // enters `taskNotifications`. Kotlin has the identical hole.
+      expect(repository.taskIdLookups, isEmpty);
+      expect(repository.taskTitleLookups, isEmpty);
+    });
+
+    test('collects ids and parsed titles from raw task rows', () async {
+      final repository = _RecordingLookups();
+      final context = await buildNotificationFormatContext([
+        row(
+          message: 'Read chapter 3 Thu 12, August 2027',
+          type: 'TaSk',
+          relatedId: 'task-9',
+        ),
+        row(message: 'No date here', type: 'task'),
+      ], repository);
+      expect(repository.taskIdLookups, [
+        ['task-9'],
+      ]);
+      expect(repository.taskTitleLookups, [
+        ['Read chapter 3'],
+      ]);
+      expect(context.taskTeamNames, {
+        'task-9': 'By id',
+        'Read chapter 3': 'By title',
+      });
+    });
+
+    test('a join request without a relatedId adds the "" fallback', () async {
+      final repository = _RecordingLookups();
+      final context = await buildNotificationFormatContext([
+        row(message: 'ignored', type: 'join_request'),
+      ], repository);
+      expect(repository.fallbackCalls, 1);
+      expect(context.joinRequestDetails['']?.requester, 'Fallback');
+    });
+
+    test('no task or join-request row means no queries at all', () async {
+      final repository = _RecordingLookups();
+      final context = await buildNotificationFormatContext([
+        row(message: '7', type: 'resource'),
+      ], repository);
+      expect(repository.taskIdLookups, isEmpty);
+      expect(repository.joinRequestBatches, isEmpty);
+      expect(context.taskTeamNames, isEmpty);
+    });
+  });
+}
+
+/// The rendered text of a composed HTML string — what the row actually shows,
+/// as opposed to what `formatStorageNotification` composes.
+String renderedText(String html) => renderNotificationHtml(html).text;
+
+/// A stand-in for the repository that records which lookups the context builder
+/// asked for — the half of `loadNotifications` that decides whether a row can
+/// have a team prefix at all.
+class _RecordingLookups implements NotificationsRepository {
+  final List<List<String>> taskIdLookups = [];
+  final List<List<String>> taskTitleLookups = [];
+  final List<List<String>> joinRequestBatches = [];
+  int fallbackCalls = 0;
+
+  @override
+  Future<Map<String, String>> taskTeamNamesByTaskIds(
+    List<String> taskIds,
+  ) async {
+    if (taskIds.isEmpty) return const {};
+    taskIdLookups.add(taskIds);
+    return {for (final id in taskIds) id: 'By id'};
+  }
+
+  @override
+  Future<Map<String, String>> taskTeamNamesByTaskTitles(
+    List<String> taskTitles,
+  ) async {
+    if (taskTitles.isEmpty) return const {};
+    taskTitleLookups.add(taskTitles);
+    return {for (final title in taskTitles) title: 'By title'};
+  }
+
+  @override
+  Future<Map<String, JoinRequestDetail>> joinRequestDetailsBatch(
+    List<String> relatedIds,
+  ) async {
+    if (relatedIds.isEmpty) return const {};
+    joinRequestBatches.add(relatedIds);
+    return {
+      for (final id in relatedIds)
+        id: const JoinRequestDetail(requester: 'Batch', team: 'Batch team'),
+    };
+  }
+
+  @override
+  Future<JoinRequestDetail> joinRequestDetails(String? relatedId) async {
+    fallbackCalls++;
+    return const JoinRequestDetail(
+      requester: 'Fallback',
+      team: 'Fallback team',
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('${invocation.memberName} is not used here');
+}

--- a/flutter/test/ui/notification_format_test.dart
+++ b/flutter/test/ui/notification_format_test.dart
@@ -429,6 +429,47 @@ void main() {
       expect(context.joinRequestDetails['']?.requester, 'Fallback');
     });
 
+    test("an empty relatedId is queried AND takes the '' fallback", () async {
+      // `mapNotNull { it.relatedId }` filters nulls only, so `''` survives
+      // into the query list; `joinRequestsWithoutRelatedId` tests
+      // `isNullOrEmpty`, so the same row also triggers the fallback lookup.
+      // The documented asymmetry, pinned.
+      final repository = _RecordingLookups();
+      final context = await buildNotificationFormatContext([
+        row(message: 'ignored', type: 'join_request', relatedId: ''),
+      ], repository);
+      expect(repository.joinRequestBatches, [
+        [''],
+      ]);
+      expect(repository.fallbackCalls, 1);
+      // The fallback entry is written *after* the batch, so it wins the `''`
+      // key — Kotlin's `details[""] = fallbackDetail` at `:118`.
+      expect(context.joinRequestDetails['']?.requester, 'Fallback');
+    });
+
+    test('an empty relatedId on a task row is still queried', () async {
+      final repository = _RecordingLookups();
+      await buildNotificationFormatContext([
+        row(message: 'No date here', type: 'task', relatedId: ''),
+      ], repository);
+      expect(repository.taskIdLookups, [
+        [''],
+      ]);
+    });
+
+    test('a task id beats a task title of the same name', () async {
+      // The merge order: by-title first, by-id `putAll` over it (`:127-129`).
+      final repository = _CollidingLookups();
+      final context = await buildNotificationFormatContext([
+        row(
+          message: 'task-9 Thu 12, August 2027',
+          type: 'task',
+          relatedId: 'task-9',
+        ),
+      ], repository);
+      expect(context.taskTeamNames['task-9'], 'By id');
+    });
+
     test('no task or join-request row means no queries at all', () async {
       final repository = _RecordingLookups();
       final context = await buildNotificationFormatContext([
@@ -496,4 +537,18 @@ class _RecordingLookups implements NotificationsRepository {
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnsupportedError('${invocation.memberName} is not used here');
+}
+
+/// A [_RecordingLookups] whose two maps collide on one key, so the merge order
+/// is observable — the plain recorder returns disjoint keys and cannot see it.
+class _CollidingLookups extends _RecordingLookups {
+  @override
+  Future<Map<String, String>> taskTeamNamesByTaskIds(
+    List<String> taskIds,
+  ) async => taskIds.isEmpty ? const {} : {'task-9': 'By id'};
+
+  @override
+  Future<Map<String, String>> taskTeamNamesByTaskTitles(
+    List<String> taskTitles,
+  ) async => taskTitles.isEmpty ? const {} : {'task-9': 'By title'};
 }

--- a/flutter/test/ui/notification_html_test.dart
+++ b/flutter/test/ui/notification_html_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/ui/notifications/notification_format.dart';
+import 'package:myplanet/ui/notifications/notification_html.dart';
+
+/// Coverage for the `Html.fromHtml` stand-in the notification row renders
+/// through. `NotificationsAdapterTest.kt:86-99` is the Kotlin counterpart: it
+/// binds `"<b>Initial</b> text"` and asserts the TextView reads `Initial text`.
+void main() {
+  test('plain text is one unemphasised run', () {
+    expect(
+      renderNotificationHtml('Storage running low: 8%'),
+      FormattedNotification.plain('Storage running low: 8%'),
+    );
+  });
+
+  // The Kotlin adapter test, ported.
+  test('a bold run is split out and the tags do not survive', () {
+    final rendered = renderNotificationHtml('<b>Initial</b> text');
+    expect(rendered.text, 'Initial text');
+    expect(rendered.spans, const [
+      NotificationSpan('Initial', bold: true),
+      NotificationSpan(' text'),
+    ]);
+  });
+
+  test('the three server messages Planet actually sends', () {
+    // `NotificationsRepositoryImplTest.kt:168,192,214` — the fixtures for the
+    // arms `formatNotification` passes through unchanged. Drawing these
+    // literally would have put `<b>` on screen.
+    expect(
+      renderNotificationHtml(
+        '<b>Jane</b> has requested to join <b>"My Team"</b> team.',
+      ).text,
+      'Jane has requested to join "My Team" team.',
+    );
+    expect(
+      renderNotificationHtml(
+        'You have been added to <b>"My Team"</b> team.',
+      ).spans,
+      const [
+        NotificationSpan('You have been added to '),
+        NotificationSpan('"My Team"', bold: true),
+        NotificationSpan(' team.'),
+      ],
+    );
+    expect(
+      renderNotificationHtml(
+        '<b>Jane</b> replied to your message.',
+      ).spans.first,
+      const NotificationSpan('Jane', bold: true),
+    );
+  });
+
+  test('runs of spaces collapse, which is what hides the storage double '
+      'space', () {
+    // `formatStorageNotification` composes `"Storage running low:  8%"` from a
+    // string resource that already ends in a space. Kotlin only ever shows one.
+    expect(
+      renderNotificationHtml('Storage running low:  8%').text,
+      'Storage running low: 8%',
+    );
+    expect(renderNotificationHtml('a \n  b').text, 'a b');
+  });
+
+  test('leading whitespace is dropped', () {
+    expect(renderNotificationHtml('   7').text, '7');
+  });
+
+  test('a tab is not collapsed', () {
+    // AOSP's converter collapses ' ' and '\n' only.
+    expect(renderNotificationHtml('a\t\tb').text, 'a\t\tb');
+  });
+
+  test('an unknown tag is dropped and its text kept', () {
+    // A task titled `Read <chapter 3>` renders the same way in both apps: the
+    // "tag" vanishes, the rest stays.
+    expect(
+      renderNotificationHtml(
+        'Read <chapter 3> is due in Thu 12, Aug 2027',
+      ).text,
+      'Read is due in Thu 12, Aug 2027',
+    );
+  });
+
+  test('italic markup is emphasis, not literal text', () {
+    expect(renderNotificationHtml('<i>soon</i>').spans, const [
+      NotificationSpan('soon', italic: true),
+    ]);
+    expect(renderNotificationHtml('<em>soon</em>').spans.first.italic, isTrue);
+    expect(
+      renderNotificationHtml('<strong>now</strong>').spans.first.bold,
+      isTrue,
+    );
+  });
+
+  test('nested emphasis keeps both flags', () {
+    expect(renderNotificationHtml('<b>very <i>late</i></b>').spans, const [
+      NotificationSpan('very ', bold: true),
+      NotificationSpan('late', bold: true, italic: true),
+    ]);
+  });
+
+  test('entities are decoded', () {
+    expect(renderNotificationHtml('Tom &amp; Jerry').text, 'Tom & Jerry');
+    expect(renderNotificationHtml('&quot;My Team&quot;').text, '"My Team"');
+    expect(renderNotificationHtml('&#65;&#x42;').text, 'AB');
+    // A non-breaking space decodes to U+00A0 and is not collapsed away.
+    expect(renderNotificationHtml('a&nbsp;&nbsp;b').text, 'a  b');
+  });
+
+  test('an unrecognised entity is left as written', () {
+    expect(renderNotificationHtml('a &foo; b').text, 'a &foo; b');
+  });
+
+  test('an unterminated angle bracket is text, not a tag', () {
+    expect(renderNotificationHtml('2 < 3').text, '2 < 3');
+  });
+
+  test('a break becomes a newline and trailing ones are trimmed', () {
+    expect(renderNotificationHtml('a<br>b').text, 'a\nb');
+    expect(renderNotificationHtml('a<br>').text, 'a');
+  });
+
+  test('an empty string renders as empty rather than throwing', () {
+    expect(renderNotificationHtml('').text, '');
+    expect(renderNotificationHtml('<b></b>').text, '');
+  });
+}

--- a/flutter/test/ui/notification_html_test.dart
+++ b/flutter/test/ui/notification_html_test.dart
@@ -116,6 +116,64 @@ void main() {
     expect(renderNotificationHtml('2 < 3').text, '2 < 3');
   });
 
+  test('a plain-text angle pair is text, not a tag', () {
+    // A `<` only opens a tag when a tag name can follow it. Scanning to the
+    // next `>` regardless deleted the middle of an ordinary sentence, and a
+    // trimmed `< b >` read as `<b>` and bolded everything after it.
+    expect(
+      renderNotificationHtml('Compare 3 < 5 > 1 today').text,
+      'Compare 3 < 5 > 1 today',
+    );
+    final rendered = renderNotificationHtml('is 3 < b > 2?');
+    expect(rendered.text, 'is 3 < b > 2?');
+    expect(rendered.spans.every((span) => !span.bold), isTrue);
+  });
+
+  test('a numeric entity outside the Unicode range is left as written', () {
+    // `String.fromCharCode` throws above U+10FFFF, and this renderer runs
+    // inside `build` — an unguarded one takes the whole bell screen down.
+    expect(renderNotificationHtml('x &#1114112; y').text, 'x &#1114112; y');
+    expect(renderNotificationHtml('x &#x110000; y').text, 'x &#x110000; y');
+  });
+
+  test('a stray closing tag does not disable later emphasis', () {
+    // Without the underflow clamp the counter goes negative and never
+    // recovers, so every later bold run in the row is silently lost.
+    expect(
+      renderNotificationHtml('Jane</b> replied to <b>your</b> note.').spans,
+      contains(const NotificationSpan('your', bold: true)),
+    );
+    expect(
+      renderNotificationHtml('a</i>b<i>c</i>').spans,
+      contains(const NotificationSpan('c', italic: true)),
+    );
+  });
+
+  test('a self-closing break is still a break', () {
+    expect(renderNotificationHtml('a<br/>b').text, 'a\nb');
+    expect(renderNotificationHtml('a<br />b').text, 'a\nb');
+  });
+
+  test('leading whitespace is dropped even when a tag follows it', () {
+    expect(
+      renderNotificationHtml(' <b>Jane</b> replied.').spans.first,
+      const NotificationSpan('Jane', bold: true),
+    );
+  });
+
+  test('an unclosed bold run reaches the end of the text', () {
+    expect(renderNotificationHtml('<b>Jane replied.').spans, const [
+      NotificationSpan('Jane replied.', bold: true),
+    ]);
+  });
+
+  test('a carriage return collapses with the other newlines', () {
+    // XML normalises CRLF to LF before AOSP's converter sees the text, so a
+    // lone `\r` never reaches its collapsing; matching that here is the
+    // closer reading, and this pins which way it went.
+    expect(renderNotificationHtml('a\r\rb').text, 'a b');
+  });
+
   test('a break becomes a newline and trailing ones are trimmed', () {
     expect(renderNotificationHtml('a<br>b').text, 'a\nb');
     expect(renderNotificationHtml('a<br>').text, 'a');

--- a/flutter/test/ui/notifications_screen_test.dart
+++ b/flutter/test/ui/notifications_screen_test.dart
@@ -2,16 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/notifications_provider.dart';
+import 'package:myplanet/ui/notifications/notification_format.dart';
 import 'package:myplanet/ui/notifications/notifications_screen.dart';
 
 import '../support/widget_harness.dart';
 
 void main() {
-  // The row's icon and title read the **resolved** type, like every other
-  // reader. A server `replyMessage` document — outside KNOWN_TYPES, reaching
-  // `voice_reply` only through its message — is the case that shows it: against
-  // the raw type it takes the default bell and the generic "Notification".
-  testWidgets('a server notification gets the icon and title of its resolved '
+  // The row's icon and the group it lands in read the **resolved** type, like
+  // every other reader. A server `replyMessage` document — outside KNOWN_TYPES,
+  // reaching `voice_reply` only through its message — is the case that shows
+  // it: against the raw type it takes the default bell and the "Other" group.
+  //
+  // The row itself no longer carries a type label: Kotlin's row is one line of
+  // formatted text (`row_notifications.xml`), and the group header above it is
+  // where the type is named.
+  testWidgets('a server notification gets the icon and group of its resolved '
       'type', (tester) async {
     final row = NotificationRow(
       id: 'reply-1',
@@ -38,8 +43,11 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('New reply'), findsOneWidget);
-    expect(find.text('Notification'), findsNothing);
+    expect(find.text('Voice Replies'), findsOneWidget);
+    expect(find.text('Other'), findsNothing);
+    // The server's own sentence is the row's text, unrewritten — the
+    // `else -> notification.message` arm of `formatNotification`.
+    expect(find.text('bob replied to your voice'), findsOneWidget);
     expect(find.byIcon(Icons.chat_bubble_outline), findsNWidgets(2));
     expect(find.byIcon(Icons.notifications_outlined), findsNothing);
   });
@@ -147,6 +155,200 @@ void main() {
     expect(find.text('4 new resources are available'), findsOneWidget);
   });
 
+  // The defect this phase exists for. `updateResourceNotification` stores the
+  // count and nothing else, and the row drew `message` verbatim — so the bell
+  // showed a learner the single character `7`.
+  testWidgets('a resource notification reads as a sentence, not a bare digit', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(
+                id: 'user-1:resource:count',
+                message: '7',
+                type: 'resource',
+                relatedId: '7',
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('You have 7 resources not downloaded'), findsOneWidget);
+    expect(find.text('7'), findsNothing);
+  });
+
+  testWidgets('a storage warning reads as a sentence with one space', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(
+                id: 'user-1:storage',
+                message: '8%',
+                type: 'storage',
+                relatedId: 'storage',
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Kotlin composes a double space here and `Html.fromHtml` collapses it.
+    expect(find.text('Storage running low: 8%'), findsOneWidget);
+    expect(find.text('8%'), findsNothing);
+  });
+
+  testWidgets("a server message's markup is emphasis, not visible tags", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(
+                id: 'srv-1',
+                message:
+                    '<b>Jane</b> has requested to join <b>"My Team"</b> team.',
+                type: 'team',
+                subType: 'join_request',
+                relatedId: 'team-1',
+                isFromServer: true,
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final text = tester.widget<Text>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Text &&
+            (widget.textSpan?.toPlainText() ?? '').startsWith('Jane'),
+      ),
+    );
+    expect(
+      text.textSpan!.toPlainText(),
+      'Jane has requested to join "My Team" team.',
+    );
+    final runs = (text.textSpan! as TextSpan).children!.cast<TextSpan>();
+    expect(runs.first.text, 'Jane');
+    expect(runs.first.style?.fontWeight, FontWeight.bold);
+    expect(runs[1].style?.fontWeight, isNull);
+  });
+
+  testWidgets('a task notification carries its team name in bold', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(
+                id: 'task-notif',
+                message: 'Read chapter 3 Thu 12, August 2027',
+                type: 'task',
+                relatedId: 'task-9',
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+          notificationFormatContextProvider.overrideWith(
+            (ref) async => const NotificationFormatContext(
+              taskTeamNames: {'task-9': 'Reading Club'},
+              joinRequestDetails: {},
+            ),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final text = tester.widget<Text>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Text &&
+            (widget.textSpan?.toPlainText() ?? '').startsWith('Reading Club'),
+      ),
+    );
+    expect(
+      text.textSpan!.toPlainText(),
+      'Reading Club: Read chapter 3 is due in Thu 12, August 2027',
+    );
+    final runs = (text.textSpan! as TextSpan).children!.cast<TextSpan>();
+    expect(runs.first.style?.fontWeight, FontWeight.bold);
+    // The colon belongs to the unbolded run, as in the Kotlin.
+    expect(runs[1].text, startsWith(': '));
+  });
+
+  testWidgets('a read row is dimmed rather than un-bolded', (tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(
+                id: 'read-1',
+                message: 'Something happened',
+                type: 'somethingElse',
+                isRead: true,
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(0),
+          ),
+          // A read-only group is collapsed by default, so open it.
+          notificationExpansionProvider.overrideWith(
+            (ref) =>
+                NotificationExpansionNotifier()
+                  ..toggle('notification', const []),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // `binding.root.alpha = if (notification.isRead) 0.6f else 1.0f`.
+    final opacity = tester.widget<Opacity>(
+      find.ancestor(
+        of: find.text('Something happened'),
+        matching: find.byType(Opacity),
+      ),
+    );
+    expect(opacity.opacity, 0.6);
+  });
+
   testWidgets('renders the filter-specific empty state', (tester) async {
     await tester.pumpWidget(
       wrapScreen(
@@ -167,3 +369,25 @@ void main() {
     expect(find.text('No unread notifications'), findsOneWidget);
   });
 }
+
+NotificationRow _row({
+  required String id,
+  required String message,
+  required String type,
+  String? subType,
+  String? relatedId,
+  bool isRead = false,
+  bool isFromServer = false,
+}) => NotificationRow(
+  id: id,
+  userId: 'user-1',
+  message: message,
+  type: type,
+  subType: subType,
+  relatedId: relatedId,
+  isRead: isRead,
+  createdAt: DateTime(2026, 8, 2, 12).millisecondsSinceEpoch,
+  priority: 0,
+  isFromServer: isFromServer,
+  needsSync: false,
+);

--- a/flutter/test/ui/notifications_screen_test.dart
+++ b/flutter/test/ui/notifications_screen_test.dart
@@ -1,6 +1,9 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/notifications_provider.dart';
 import 'package:myplanet/ui/notifications/notification_format.dart';
 import 'package:myplanet/ui/notifications/notifications_screen.dart';
@@ -349,6 +352,234 @@ void main() {
     expect(opacity.opacity, 0.6);
   });
 
+  // The whole fill chain, with nothing overridden between the screen and the
+  // database: `notificationFormatContextProvider` → the repository lookups →
+  // the DAOs → the row. Every other test here supplies the context directly,
+  // so each half was covered and the join between them was not.
+  testWidgets('the team prefix is resolved from the database, end to end', (
+    tester,
+  ) async {
+    final database = AppDatabase.memory();
+    addTearDown(database.close);
+    await database.teamDao.upsert(
+      TeamsCompanion.insert(id: 'team-1', name: const Value('Reading Club')),
+    );
+    await database.teamTaskDao.upsert(
+      TeamTasksCompanion.insert(
+        id: 'task-9',
+        teamId: 'team-1',
+        title: const Value('Read chapter 3'),
+      ),
+    );
+
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          appDatabaseProvider.overrideWithValue(database),
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(
+                id: 'task-notif',
+                message: 'Read chapter 3 Thu 12, August 2027',
+                type: 'task',
+                relatedId: 'task-9',
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final text = tester.widget<Text>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Text &&
+            (widget.textSpan?.toPlainText() ?? '').startsWith('Reading Club'),
+      ),
+    );
+    expect(
+      text.textSpan!.toPlainText(),
+      'Reading Club: Read chapter 3 is due in Thu 12, August 2027',
+    );
+  });
+
+  testWidgets('an unread row is not dimmed', (tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'unread-1', message: '7', type: 'resource'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final opacity = tester.widget<Opacity>(
+      find.ancestor(
+        of: find.text('You have 7 resources not downloaded'),
+        matching: find.byType(Opacity),
+      ),
+    );
+    expect(opacity.opacity, 1);
+  });
+
+  testWidgets('an unread row offers Mark as read without navigating', (
+    tester,
+  ) async {
+    // `btn_mark_as_read` (`NotificationsAdapter.kt:137-141`). The port had no
+    // per-row action at all, so the only way to mark one notification read was
+    // to tap it — which navigates away from the list.
+    final read = <String>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'unread-1', message: '7', type: 'resource'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onRead: read.add),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Mark as read'));
+    await tester.pump();
+    expect(read, ['unread-1']);
+  });
+
+  testWidgets('a read row offers no Mark as read button', (tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'read-1', message: '7', type: 'resource', isRead: true),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(0),
+          ),
+          notificationExpansionProvider.overrideWith(
+            (ref) =>
+                NotificationExpansionNotifier()..toggle('resource', const []),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('You have 7 resources not downloaded'), findsOneWidget);
+    expect(find.text('Mark as read'), findsNothing);
+  });
+
+  testWidgets('Mark all read is hidden on the Read tab', (tester) async {
+    // `count > 0 && currentFilter != "read"` (`NotificationsFragment.kt:101`).
+    final markedAll = <bool>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationFilterProvider.overrideWith(
+            (ref) => NotificationFilter.read,
+          ),
+          notificationsProvider.overrideWith((ref) => Stream.value(const [])),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(3),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onMarkAll: () => markedAll.add(true)),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Mark all read'), findsNothing);
+  });
+
+  testWidgets('Mark all read fires on a tab that has unread rows', (
+    tester,
+  ) async {
+    final markedAll = <bool>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'unread-1', message: '7', type: 'resource'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onMarkAll: () => markedAll.add(true)),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Mark all read'));
+    await tester.pump();
+    expect(markedAll, [true]);
+  });
+
+  testWidgets('swiping a row deletes it', (tester) async {
+    final deleted = <String>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'unread-1', message: '7', type: 'resource'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onDelete: deleted.add),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(
+      find.text('You have 7 resources not downloaded'),
+      const Offset(-500, 0),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(deleted, ['unread-1']);
+  });
+
   testWidgets('renders the filter-specific empty state', (tester) async {
     await tester.pumpWidget(
       wrapScreen(
@@ -391,3 +622,25 @@ NotificationRow _row({
   isFromServer: isFromServer,
   needsSync: false,
 );
+
+/// Records the row actions instead of touching a repository, so a tap on
+/// *Mark as read*, *Mark all read* or a swipe is observable.
+class _RecordingActions implements NotificationActions {
+  _RecordingActions({this.onRead, this.onDelete, this.onMarkAll});
+
+  final void Function(String id)? onRead;
+  final void Function(String id)? onDelete;
+  final void Function()? onMarkAll;
+
+  @override
+  Ref get ref => throw UnsupportedError('the fake talks to no providers');
+
+  @override
+  Future<void> markAsRead(String id) async => onRead?.call(id);
+
+  @override
+  Future<void> delete(String id) async => onDelete?.call(id);
+
+  @override
+  Future<void> markAllAsRead() async => onMarkAll?.call();
+}


### PR DESCRIPTION
Lane C of the Phase 122–124 parallel round. Phase 124. Full write-up in `flutter/PHASE_124_NOTES.md`.

## The defect

`NotificationsViewModel.formatNotification` (`NotificationsViewModel.kt:354-425`) rewrites each notification's text per **resolved** type and renders it through `Html.fromHtml` into the row's single TextView. The port stored the raw message and drew it verbatim, so its own resource notification — whose stored message is only the count — rendered as the bare character `7`. Phase 120 verified this against the Kotlin and deferred it.

Failing-first, before the fix:

```
Expected: exactly one matching candidate
  Actual: _TextWidgetFinder:<Found 0 widgets with text
          "You have 7 resources not downloaded": []>
```

## What each type produces, and which part is the title

There is one part: `row_notifications.xml` has a `title` TextView and a `timestamp` TextView, no per-row icon (`iconResFor` runs once per *group*, from `HeaderViewHolder`) and no subtitle. So the formatted text is the row's primary line, and the port's "type label above the raw message" was invention twice over — `AppNotification.title`, which the row preferred when set, is a column nothing in either app ever writes.

| resolved type | text | markup |
|---|---|---|
| `resource` | `You have 7 resources not downloaded`; a non-numeric message passes through | — |
| `storage` | `Storage running low: 8%`; `<=10` and `<=40` produce identical text, `>40` is `Storage available: N%` | — |
| `task` | `Read chapter 3 is due in Thu 12, August 2027`, prefixed `<b>Team</b>: ` when the team resolves | bold team, colon outside |
| `join_request` | `<b>Join Request:</b> Jane has requested to join My Team` — only when the **raw** type is `join_request`; otherwise the server's sentence verbatim | bold prefix, colon inside |
| `chat` / `team_join` / `voice_reply` / unresolved | the message, verbatim | whatever the server sent |

## The rendering decision

Structured spans **and** a small HTML parser, not one or the other. The structured-only version was written first and the ground-truth audit killed it with the repo's own fixtures: `NotificationsRepositoryImplTest.kt:168,192,214` show Planet sending `<b>Jane</b> has requested to join <b>"My Team"</b> team.` — and those are exactly the arms `formatNotification` passes through unformatted, so a span list built only from the port's own emphasis would have printed `<b>` on screen for the app's most common notifications.

`notification_html.dart` is therefore an `Html.fromHtml` stand-in (b/strong, i/em, unknown tags dropped keeping their text, a small entity table, space/newline collapsing) with **no new dependency**; `Text.rich` draws its spans. The collapsing is load-bearing rather than cosmetic: `storage_running_low` is Android-quoted with a trailing space and the Kotlin template adds a second, so the composition stays byte-faithful to the Kotlin and the renderer hides the double space exactly where Kotlin does.

## Kotlin translations

Six of the eight new ARB keys derived from `values-*/strings.xml` in all five locales — human translations already shipping in the Android app — including Nepali's reordered `{title} {date} मा समाप्त हुन्छ` through Phase 121's placeholder path. Only `unknownUser`/`unknownTeam` fall back to English: Kotlin hardcodes those literals in `NotificationsRepositoryImpl`, and the port localises them instead.

## Guards

Ten reverts each demonstrated red, including `int.tryParse` standing in for `toIntOrNull` (it trims and has no 32-bit ceiling), Dart's wider `\s` in the task-date pattern, partitioning on the resolved instead of the raw type, and the read-row dim. One was a real bug in the parser's first cut, caught by its own tests: whitespace before a tag was landing in the following span.

## Boundaries

`schemaVersion` stays 45. One additive method in Lane A's team-task section (`TeamTaskDao.getByTitles`, the port of `TeamTaskDao.kt:44-45`), +2 lines in `app_providers.dart`, the notifications provider, the ARB files, and the pinned l10n counts. Every crossing is listed in the phase notes, along with what was reported and deliberately not fixed (the row's still-absolute timestamp; a one-line trailing-space defect in `tool/arb_from_strings_xml.dart:211`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lo9kAwHDiUmtNJ2W3uEe4L