### PR TITLE
fix(flutter): phase 123 — the submission upload shape

### DIFF
--- a/flutter/PHASE_123_NOTES.md
+++ b/flutter/PHASE_123_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 123 — the submission upload shape
+
+Work in progress. Two defects Phase 120 verified and reported but left to this
+lane:
+
+1. `parent.questions` is dropped on upload — silent cross-device data loss.
+2. `pendingUploads` is scoped the opposite way to Kotlin.
+

--- a/flutter/PHASE_123_NOTES.md
+++ b/flutter/PHASE_123_NOTES.md
@@ -1,8 +1,364 @@
 # Phase 123 — the submission upload shape
 
-Work in progress. Two defects Phase 120 verified and reported but left to this
-lane:
+Lane B of a three-lane round. Two defects Phase 120 verified and reported
+without fixing (`PHASE_120_NOTES.md` §"Reported, not fixed", items 1 and 2),
+both in the submissions upload path, both the shape this port keeps paying
+for: **a writer and a reader disagreeing about a key, where each half passes
+its own test and only the pair is wrong.**
 
-1. `parent.questions` is dropped on upload — silent cross-device data loss.
-2. `pendingUploads` is scoped the opposite way to Kotlin.
+---
 
+## D1 — `parent.questions` was dropped on upload
+
+### What the Kotlin does
+
+`serializeSubmission` (`SubmissionsRepositoryImpl.kt:813-862`) does **not**
+upload the `parent` blob the submission row carries. It asks `getPayloadData`
+(`:756-761`) for the live exam —
+
+```kotlin
+val examId = submission.examIdFromParentId()          // parentId.substringBefore("@")
+val exam = examId?.let { examDao.getById(it) }
+val questions = exam?.id?.let { questionDao.getByExamId(it) } ?: emptyList()
+```
+
+— and emits `StepExam.serializeExam(exam, questions)` when it finds one
+(`:840-841`), whose `StepExam.kt:92` adds
+`object.add("questions", ExamQuestion.serializeQuestions(questions))`. The
+stored blob is the `else if` for an exam this device no longer has (`:842`).
+
+### What the port did
+
+`SubmissionsRepository.serialize` always sent the stored blob. That blob is
+tiny: `_openExamSession` writes `{_id,_rev,name,courseId,totalMarks}` and
+`createSurveyDraft` writes `{_id,name}`. Neither carries `questions`.
+
+The reader half is the port's own: `upsertDocuments` fills the
+`submission_questions` table from `parentJson?['questions']` — a table Kotlin
+does not have, because Kotlin's detail screen reaches the questions through the
+`ExamQuestion` rows it already holds. So the port had a reader for a key its
+own writer never emitted.
+
+**The consequence is silent cross-device data loss.** A learner completes an
+exam or a survey on handset A; it uploads; handset B — or Planet web, or the
+same handset after a reinstall — pulls the document and renders an answer sheet
+of answers with no questions to put them against. Nothing errors, nothing logs,
+and the detail screen looks merely empty rather than broken.
+
+### The fix
+
+`serialize` now resolves the parent the way Kotlin does and falls back to the
+blob only when the row is gone. Because the port splits Kotlin's single `exams`
+table into `Exams` and `Surveys` (`ExamMapper.fromDoc`: `type == 'surveys'` goes
+to `SurveyMapper`, everything else is an exam), the one `examDao.getById` in the
+Kotlin is two lookups here — `ExamDao` then `SurveyDao`. `SubmissionsRepository`
+gains `ExamDao` as a constructor dependency, which is exactly what
+`SubmissionsRepositoryImpl` injects (`examDao`, `questionDao`) for the same
+reason.
+
+`examParentDocument` and `surveyParentDocument` are static and pure, so the
+field list is pinned by a test rather than reachable only through an upload.
+
+**Two deliberate departures from `serializeExam`, both documented at the code:**
+
+1. **`type` is not emitted — on either side.** Kotlin writes `exam.type` off the
+   single table; the port's `Exams` has no such column, because the mapper uses
+   the document's `type` to *choose the table* and then discards it. Adding the
+   column is a schema change, and 46 belongs to Lane A this round — but the
+   value is not recoverable from the table anyway: a course test carries
+   `'courses'` (`CoursesRepositoryImpl.kt:744` keeps the document's own key), a
+   standalone one with no `type` becomes `'exam'` (`StepExam.kt:39`), and
+   nothing on `ExamRow` tells the two apart. Nothing in either tree reads a
+   submission's `parent.type`, so the key is omitted rather than guessed.
+
+   The first cut of this emitted `'surveys'` from `surveyParentDocument`, on the
+   reasoning that the exams-database walk routes on `type == 'surveys'` and so
+   pins the value. **The first `parity-auditor` pass overturned it**:
+   `SurveyMapper.fromCourseDoc`'s second pass files every `steps[i].survey` into
+   `Surveys` with **no** type filter at all, and Kotlin types one of those
+   `"survey"` — singular. For exactly the rows the exam branch refuses to guess
+   for, that would have been a guess.
+2. **Each question carries its `id`, and its label under `title` as well as
+   `header`.** `ExamQuestion.serializeQuestions` (`ExamQuestion.kt:110-124`)
+   emits seven keys — `header`, `body`, `type`, `marks`, `choices`,
+   `correctChoice`, `hasOtherOption` — with no id, and the label under `header`.
+
+   The **id** matters because `_questionFromJson` keys the pulled row on it and
+   falls back to a positional `<submissionId>-q<index>`, while the answers
+   alongside it carry the real question id. A faithful upload hands the second
+   device a question set its own answers cannot be joined to — and the audit
+   showed that is *worse* than sending no questions at all: `submissions_exporter`
+   prints the answers only through its `questions.isEmpty` fallback, so
+   unjoinable questions print every prompt with no answer and drop the answers
+   entirely.
+
+   The **label** matters because `header` is a key no real document has. Every
+   reader of a question in either tree takes it from `title` — Kotlin's
+   `insertExamQuestions` (`ExamQuestion.kt:76`), the port's
+   `ExamMapper.parseQuestions` and `SurveyMapper` — so what
+   `serializeQuestions` uploads cannot be read back by the code that reads every
+   other copy of the same question. Kotlin demonstrates that on itself:
+   `SurveysRepositoryImpl.adoptSurvey:90-93` feeds `serializeQuestions` straight
+   into `insertExamQuestions`, and **every adopted team survey in the shipping
+   Kotlin app loses each question's id and its label.** Both keys are sent.
+
+Same call as Phase 120's `answers.examId`: keep the quirk unless it breaks a
+reader the port has and Kotlin does not.
+
+`SurveyQuestions` has no `marks`, `correctChoice` or `hasOtherOption` column, so
+a survey's questions omit those three keys rather than inventing defaults; a
+survey question has no correct answer to lose. (Kotlin would send `""`, `[]` and
+`false` there — `JsonUtils` defaults, not data.) Its `id` is `_rawQuestionId`
+(`questionId ?? id`), which is what the answer's `questionId` carries and what
+`createSurveyDraft` keys the local rows by.
+
+**Worth saying out loud, so nobody goes looking for the Kotlin counterpart:**
+Kotlin's submissions pull never reads `parent.questions` at all
+(`upsertRoomSubmissionsFromSync:662-736` stores the blob and stops), because
+Kotlin reaches a submission's questions through the `ExamQuestion` rows it
+already holds. `submission_questions` is a port-only mechanism. This fix is not
+restoring a Kotlin capability — it is feeding a reader Kotlin does not have,
+which is exactly why the two departures above are justified.
+
+### The evidence
+
+`test/repository/submissions_sync_round_trip_test.dart` gains a group that
+builds a **second `AppDatabase`** — a second handset that has never synced the
+`exams` database, which is also what Planet web looks like — uploads from the
+first and pulls into the second. All three were red before the fix:
+
+| test | pre-fix failure |
+|---|---|
+| an exam attempt keeps its questions | `Expected: ['Capital of France?'] Actual: []` |
+| the answers still line up with the questions | `Bad state: No element` — no question rows at all |
+| a survey submission keeps its questions | `Expected: ['How is the water?'] Actual: []` |
+
+Five more pin the document itself — `serializeExam` field for field, the three
+`if`-guarded fields (`_rev`, `sourceSurveyId`, `teamId`), the question shape,
+the survey's *absent* `type`, and the blob fallback — so the rest of the parent
+cannot be quietly dropped again.
+
+---
+
+## D2 — `pendingUploads` was scoped the opposite way to Kotlin
+
+### What I verified before changing it
+
+The brief warned that widening an upload query is safe in a test and surprising
+on a shared handset, so this is what I read rather than what Phase 120 said.
+
+Kotlin reaches the `submissions` endpoint through **two** upload configs, and
+neither is scoped to a user:
+
+| config | query | serializer | guests |
+|---|---|---|---|
+| `UploadConfigs.Submissions` (`:253-267`) | `getPendingSubmissions()` — `status = 'complete' AND (isUpdated = 1 OR _id IS NULL OR _id = '')` (`SubmissionDao.kt:41`) | `serializeSubmission` | not filtered |
+| `UploadConfigs.ExamResults` (`:239-251`) | `getPendingExamResults()` — `type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND (_id IS NULL OR _id = '')` (`:40`) | `getExamUploadPayload` | `filterGuests = true`, `userId.startsWith("guest")` (`UploadConfig.kt:41-44`) |
+
+The port has **one** uploader standing in for both, and its query was
+`userId = ? AND isUpdated = true`.
+
+### What changed, and what deliberately did not
+
+- **The user scope is gone.** This is the actual defect. A shared handset is the
+  normal deployment for this app: member A finishes a survey
+  (`status = 'complete'`, `isUpdated = 1`, no `_id`) and signs out without
+  syncing; member B signs in and syncs; arm B, being unscoped, sends A's sheet.
+  Under the session scope it never left the device — and nothing in the port
+  rescans, so *never* was literal.
+
+  **It is not the bulk-survey send that depends on this**, which is the claim
+  the brief inherited and the first `parity-auditor` pass overturned:
+  `SendSurveyFragment` → `SurveysViewModel.sendSurveyToUsers` →
+  `createBulkSurveySubmissions` writes each member's sheet `pending` and not yet
+  updated, matching *neither* Kotlin arm, and the only writer of an answer is
+  `saveExamAnswer` under the signed-in user. On the answering turn, scoped and
+  unscoped agree. Someone would have checked that claim and found it does not
+  hold.
+- **`isUpdated` stays the status gate**, rather than Kotlin's
+  `status = 'complete'`. The port merges the two configs, and an exam is never
+  `complete` — it finishes at `requires grading`
+  (`SubmissionsRepositoryImpl.kt:549-553`) — so filtering on `complete` would
+  strand every exam attempt. The existing code comment already argued this; I
+  re-derived it rather than trusting it.
+- **`ExamResults`' guest filter is ported**, since the `isUpdated` arm is what
+  stands in for that config: an exam attempt whose `userId` starts with `guest`
+  is not queued. A guest's *completed survey* still is, because
+  `UploadConfigs.Submissions` has no guest filter — the asymmetry is Kotlin's.
+- Both operands are `coalesce`d. `type = 'exam' AND userId LIKE 'guest%'` is SQL
+  `NULL` on a null column and `NOT NULL` is `NULL`, so the uncoalesced form
+  drops a row that is nobody's guest exam rather than keeping it. That is its
+  own test.
+- **The anonymous public-survey answer sheet is excluded, and this one has no
+  Kotlin counterpart.** It is the hazard the first audit ranked first, and it is
+  exactly the "safe in a test, surprising on a real handset" case the brief
+  warned about. `public_survey_screen:246` mints `public_<millis>` as the owner
+  of a respondent who has no account — a sentinel Kotlin has no equivalent of,
+  because `PublicSurveyActivity` runs the ordinary exam fragment and its sheet
+  is authored by the signed-in user or nobody. The sheet is `status =
+  'complete'`, `isUpdated = 1`, no `couchId`, and belongs to the **public**
+  endpoint, which is not a CouchDB insert.
+
+  Concretely, on a configured, signed-in handset — a supported flow: open the
+  deep link, answer, tap Save on the profile step. `UserInformationScreen
+  ._queueUpload` resolves the *signed-in* session and calls
+  `queuePending`. Unscoped without this exclusion, that queues the respondent's
+  sheet to the authenticated `<db>/submissions` with
+  `user._id = "public_1770000000000"` — and then `markUploaded` sets
+  `uploaded`, which is the exact flag `PublicSurveyUploader.queue` refuses to
+  queue on (`public_survey_uploader.dart:66`). The answers reach the wrong
+  database and the right one declines them.
+
+### Three things I read and deliberately left alone
+
+1. **`ExamResults`' status-blind arm is not ported.** Read literally, `type =
+   'exam' AND (_id IS NULL OR _id = '')` uploads a *half-finished* attempt the
+   moment any sync runs; `markUploaded` then stamps `_id`, and the finished
+   attempt at `requires grading` matches **neither** arm afterwards — arm A
+   because it now has an `_id`, arm B because its status is not `complete`. So
+   porting it faithfully would let a mid-attempt sync permanently strand the
+   finished attempt. The port's `isUpdated` gate reaches the same place for the
+   ordinary case — take the exam offline, sync afterwards — without that hole.
+2. **The survey-adoption record keeps uploading — as a hold-harmless choice,
+   not a requirement.** Kotlin's `SurveysRepositoryImpl.createMappedSubmission`
+   (`:210-242`) writes `status = ""`, `isUpdated = true`, no `_id`, which
+   matches neither arm, so Kotlin never uploads it: it is a purely local marker
+   read by `findExistingAdoption` and `getTeamSubmissionExamIds`. My first
+   rationale for keeping the port's upload was that narrowing would risk the
+   port's team-survey sharing, and **the audit showed that rationale is wrong**:
+   Kotlin gets the adoption to the server by a different route entirely, as an
+   *exam* document — `adoptSurvey:85-98` writes a `StepExam` with
+   `sourceSurveyId` set and `_rev = null`, and `UploadConfigs.AdoptedSurveys`
+   (`UploadConfigs.kt:186-195`) POSTs it to the `exams` endpoint via
+   `ExamDao.getPendingAdoptedSurveys()`. Continuing to upload the adoption
+   *submission* changes nothing and cannot lose data, so it stays; the real gap
+   it uncovered is below.
+3. **Kotlin's `_id IS NULL` disjunct is not added.** It looks like free
+   fidelity, and it is not. The port's public-survey path is
+   `createSurveyDraft` (`status = 'complete'`) followed by
+   `markPublicSubmitted`, which clears `isUpdated` but records no `_id`, because
+   the public endpoint is not a CouchDB insert and returns no document handle.
+   Adding the disjunct would re-queue every delivered public answer sheet into
+   the *regular* submissions uploader and POST it a second time. Kotlin cannot
+   hit this: `PublicSurveyActivity` posts the answers directly
+   (`SurveysRepositoryImpl.submitPublicSurvey:470`) and writes no local row at
+   all — so the disjunct guards a case that exists only in the port, and guards
+   it wrongly.
+
+### The evidence
+
+Six tests in `test/repository/submissions_repository_test.dart`, each
+demonstrated red by replaying the exact revert it guards:
+
+| test | reverted to | pre-fix result |
+|---|---|---|
+| a second learner's completed survey is still queued | the session scope | `Actual: []` |
+| a sheet answered before the next member signs in still goes out | the session scope | `Bad state: No element` |
+| a guest's completed survey is queued, as in Kotlin | the session scope | `Bad state: No element` |
+| a guest's exam attempt is never queued | no guest clause | `Expected: empty` |
+| a row with no type or owner is not mistaken for a guest exam | uncoalesced operands | `Bad state: No element` |
+| an anonymous public answer sheet is not queued here | no `public_%` clause | `Expected: empty` |
+
+---
+
+## `app_database.dart`, line by line
+
+Lane A owns `schemaVersion` 46, the migration, and the ratings/team-task
+sections of this file. **This lane's whole diff there is one method in the
+submissions DAO section**, and there is no schema change:
+
+| what | change |
+|---|---|
+| `SubmissionDao.pendingUploads` | the query above, plus its doc comment. The signature drops its `String userId` parameter. |
+
+Nothing else in the file is touched. `schemaVersion` stays 45; no table, column
+or converter changed, so no generated output moved.
+
+---
+
+## Files touched outside this lane's set
+
+| file | why |
+|---|---|
+| `lib/providers/app_providers.dart` | one line — `ref.watch(examDaoProvider)` in `submissionsRepositoryProvider`, the production half of D1's new dependency |
+| `lib/repository/submissions_uploader.dart` | `queuePending` calls `pendingUploads()` with no argument; `userId` stays as the outbox row's session tag, now documented as not a filter |
+| nine test files | one added constructor argument each (`database.examDao`); three of them also drop `pendingUploads`' argument. No assertion changed: `exam_flow`, `public_survey_uploader`, `step_assessment_sync`, `submissions_uploader`, `submit_photos_uploader`, `surveys_repository`, `survey_export`, `ui/exam/take_exam_screen`, `ui/courses/course_progress_screen`. |
+
+---
+
+## Found, not fixed
+
+1. **The stored exam blob is not Kotlin's.** `_openExamSession` writes
+   `{_id,_rev,name,courseId,totalMarks}` where `createExamSubmission`
+   (`SubmissionsRepositoryImpl.kt:456-464`) writes
+   `{_id,name,courseId,sourcePlanet,teamShareAllowed,noOfQuestions,isFromNation}`
+   — no `_rev`, no `totalMarks`, four fields the port omits. Now that the live
+   exam wins on upload, the blob is only the fallback for an exam this device
+   has deleted, and the one field anything reads from it (`name`, via
+   `submissionDisplayTitle`) is in both. Left alone to keep this diff to the two
+   reported defects.
+2. **The port has one serializer where Kotlin has two.** `getExamUploadPayload`
+   (`:763-811`) differs from `serializeSubmission` in three ways: it adds a
+   `team` object from `submission.teamObject`, it sends `parentId`/`type`/
+   `status` raw instead of Kotlin's `""`/`"survey"`/`"pending"` defaults, and it
+   always writes `parent` — even as `null` — rather than omitting it. Merging
+   the two is what D2's single query stands on; splitting them is its own phase.
+3. **The adoption record's uploaded `parent` changes shape** as a side effect of
+   D1: it used to carry `SurveysRepository`'s hand-built
+   `{_id,name,courseId,sourcePlanet,teamShareAllowed,noOfQuestions,isFromNation}`
+   and now carries the live survey document. That is what Kotlin's serializer
+   would do with the same row, so it is a move toward parity rather than away —
+   but Kotlin never uploads the record at all, so nothing upstream pins it.
+4. **`UploadConfigs.AdoptedSurveys` is unported, and it is a bigger hole than
+   either defect above.** Kotlin publishes an adopted team survey by POSTing the
+   new `StepExam` to the `exams` endpoint (`UploadConfigs.kt:186-195`, driven
+   from `AutoSyncWorker:134` and `SubmissionsUploader:86`). The port's
+   `SurveysRepository.adoptSurvey` (`:78-179`) writes the adopted `Surveys` row
+   and its questions locally and nothing anywhere uploads them — grep
+   `AdoptedSurveys` across `flutter/lib` returns only l10n strings. **The port's
+   team-survey sharing does not reach the server today by any path.** Found by
+   the first audit while checking a rationale of mine that turned out to be
+   wrong; it wants its own phase.
+5. **`serialize` still omits `sender`, `source` and `parentCode`**, which
+   `serializeSubmission:835-837` always sends, and `createSurveyAdoptionSubmission`
+   stores `source` and `parentCode` on the row only for them to be dropped. The
+   file's existing comment calls the planet identifiers a known community-code
+   gap; `sender` is not covered by that and is a plain omission. Three lines to
+   close, left out to keep this diff to the two reported defects.
+6. **The port POSTs where Kotlin PUTs.** `UploadCoordinator.kt:135-149` routes an
+   item with a non-empty `_id` to `PUT <base>/submissions/<id>`; only a
+   null/empty `_id` gets a POST. `SubmissionsUploader.handler` always POSTs
+   (`submissions_uploader.dart:58-63`). CouchDB treats a POST carrying
+   `_id`+`_rev` as an update, so this is equivalent in practice — but the branch
+   is live, because `markComplete` sets `isUpdated` without clearing `couchId`.
+7. **`examParentDocument` exports the port's own `correctChoice` normalisation.**
+   The port stores lowercased choice **ids** (`ExamMapper._parseCorrectChoices`)
+   where Kotlin's `correctChoiceArray` holds a choice's `res` value or the raw
+   entries. It round-trips self-consistently — `_questionFromJson` lowercases
+   whatever it reads — but it is new on the wire, and worth knowing if Planet
+   ever compares the two.
+
+---
+
+## The audits
+
+Two `parity-auditor` passes at `effort: max`, per the brief.
+
+**The first, on the ground truth, before implementing.** It confirmed the
+Kotlin reading behind both fixes — including, in more detail than I had, why
+`ExamResults`' status-blind arm must not be ported — and overturned four things:
+
+| what I had | what the Kotlin says |
+|---|---|
+| two conditional fields in `serializeExam` | three — `_rev` is guarded too (`StepExam.kt:73-75`) |
+| `surveyParentDocument` can recover `type` as `'surveys'` | only for the exams-database walk; `SurveyMapper.fromCourseDoc` files a course step's survey with no type filter |
+| the unscoping is what the bulk-survey flow needs | it is not; the shared handset is |
+| keeping the adoption upload protects team-survey sharing | it does not — Kotlin publishes the adoption as an *exam* document, and that path is unported |
+
+It also ranked first a hazard I had not seen at all: the anonymous
+public-survey sheet, above. And it argued the `title` key, which I had left at
+Kotlin's `header` — having already broken fidelity for `id` on precisely that
+reasoning, emitting one and not the other was an inconsistency rather than a
+decision.
+
+**The second, on the finished diff.** Recorded below.

--- a/flutter/PHASE_123_NOTES.md
+++ b/flutter/PHASE_123_NOTES.md
@@ -288,6 +288,38 @@ or converter changed, so no generated output moved.
 
 ## Found, not fixed
 
+**0. A live defect, found while checking my own notes, and the most severe thing
+in this file.** It is not part of either reported defect and is not fixed here.
+
+**Every port writer stores a course-attached survey's `parentId` as the bare
+survey id, and the mandatory-survey check looks for `surveyId@courseId`.** So it
+never matches, and a learner who *has* completed the attached survey is still
+told they have not.
+
+Kotlin is internally consistent: `createBulkSurveySubmissions` (`:201-228`)
+builds `"$examId@$courseId"` when the exam has a course, `createExamSubmission`
+(`:449-456`) does the same, and `hasSubmission` (`:175-190`) queries exactly
+that. The port writes the bare id from `createSurveyDraft` (`:102`),
+`getOrCreateSurveySubmission` (`:539`) and `createBulkSurveySubmissions`
+(`:522`), while `hasUnfinishedSurveys` (`:604`) — the port of `hasSubmission`,
+Phase 52 — builds `'${survey.id}@$courseId'`.
+
+Reproduced against the current head: seed a survey with `courseId: 'course-1'`,
+run `createSurveyDraft` for `user-1` (which stores `parentId: survey-1`,
+`status: complete`), then ask `hasUnfinishedSurveys('course-1', 'user-1')` —
+it answers `true`. Its two readers are `take_course_screen._onFinish`, which
+blocks the pop with the mandatory-survey toast, and `challenge_provider`, which
+counts the challenge task incomplete. So on the current build a learner cannot
+finish `MANDATORY_SURVEY_COURSE_ID` at all, however many times they answer.
+
+Left for its own phase because the fix is a design call, not a one-liner: making
+the *writers* Kotlin-shaped changes the stored `parentId` on devices in the
+field and ripples through `latestPendingByUserAndParent`,
+`_deleteExamSubmissions`, `countByUserParentAndType` and the dashboard's
+pending-survey prompt; making the *reader* use the bare id leaves the port
+internally consistent but still unlike Kotlin. Guessing between those inside an
+upload-shape diff is exactly how a lane ships a regression.
+
 1. **The stored exam blob is not Kotlin's.** `_openExamSession` writes
    `{_id,_rev,name,courseId,totalMarks}` where `createExamSubmission`
    (`SubmissionsRepositoryImpl.kt:456-464`) writes

--- a/flutter/PHASE_123_NOTES.md
+++ b/flutter/PHASE_123_NOTES.md
@@ -320,6 +320,27 @@ pending-survey prompt; making the *reader* use the bare id leaves the port
 internally consistent but still unlike Kotlin. Guessing between those inside an
 upload-shape diff is exactly how a lane ships a regression.
 
+**0b. D1 is still open for a team-adopted survey, and the second audit
+demonstrated it.** The fix treats the stored blob as the fallback for an exam
+this device no longer has. For a team survey that is not a rare case, it is the
+case after the next sync.
+
+`SurveysRepository.adoptSurvey` mints a **local-only** id, `'${surveyId}_$teamId'`,
+with no `stepId` and no `courseId`. `SurveyDao.deleteNotIn` spares only rows with
+a `stepId`, and the exams-database walk calls it with server ids on every
+complete pass — and nothing uploads the adopted row (item 4 below), so it is
+never in that keep set. It is deleted. A member who answers a shared team survey
+offline, then syncs before the outbox drains, uploads a two-key `parent` and the
+second device renders answers with no questions: exactly the failure D1's three
+round-trip tests were written to prevent. They pass because they never prune.
+
+Kotlin cannot reach this — it stores the adopted survey as a `StepExam` and
+publishes it through `UploadConfigs.AdoptedSurveys`, so the row is in the exams
+walk's keep set on the next pull. **The root cause is item 4, not the parent
+lookup**, and the fix lives in `surveys_repository.dart` and the surveys DAO
+section of `app_database.dart` — neither of which is this lane's to edit. It
+belongs with item 4 in the same phase.
+
 1. **The stored exam blob is not Kotlin's.** `_openExamSession` writes
    `{_id,_rev,name,courseId,totalMarks}` where `createExamSubmission`
    (`SubmissionsRepositoryImpl.kt:456-464`) writes
@@ -393,4 +414,67 @@ Kotlin's `header` — having already broken fidelity for `id` on precisely that
 reasoning, emitting one and not the other was an inconsistency rather than a
 decision.
 
-**The second, on the finished diff.** Recorded below.
+**The second, on the finished diff.** Phase 120's lesson repeated: an audit of
+the ground truth does not audit the implementation. The diff was green — format
+clean, analyze clean, 2062 tests, and CI green on `c30f1e9` — which is exactly
+the state Phase 120 shipped a rendering bug in. The second pass replayed 24
+reverts and injections against the full suite and found **one live defect and
+five unguarded halves**.
+
+### The live defect it found: the parent lookup preferred the wrong table
+
+`_liveParentDocument` tried `Exams` and then `Surveys`, and the notes treated
+that order as a formality. **The two id spaces are not disjoint.**
+`ExamMapper.mapStepExams` synthesizes `'$courseId-$stepId-$examKey'` for an
+embedded step document with no `_id`, and `SurveyMapper.fromCourseDoc`'s first
+pass uses the same `examKey: 'exam'` — so one `steps[i].exam` produces the same
+id string whichever table its `type` files it under. Flip that `type` on Planet
+and the next courses walk writes the row to the other table while the first
+copy survives, because neither `deleteNotIn` prunes a row that still has a
+`stepId`.
+
+Kotlin cannot reach this: one table, one row, `@Upsert` overwrites `type` in
+place. So there is no Kotlin order to port — but there is a disambiguator the
+port has and Kotlin does not need: **the submission's own `type`**. An answer
+sheet knows whether it was answering a survey or a test. `_liveParentDocument`
+now takes it and tries that table first, defaulting to the survey side to match
+`serializeSubmission:828`'s own `submission.type ?: "survey"`. Two tests pin
+both directions; the survey one is red on the old unconditional order, uploading
+`Stale test` where the sheet answered `Live survey`.
+
+### The five unguarded halves, each now pinned
+
+Each could be reverted with all 2062 tests green, and each is something this
+file or a code comment calls load-bearing:
+
+| unguarded | now pinned by |
+|---|---|
+| the `Exams`/`Surveys` lookup order | the two collision tests above |
+| **D2's entire user-visible effect** — a Dart-side `.where((row) => row.userId == userId)` re-added in `queuePending` re-scoped the uploader with the suite green | a two-owner `queuePending` test asserting both sheets are enqueued and each document keeps its own owner |
+| `surveyParentDocument`'s field list — five of its six rules reverted green, `title` and all three `if`-guards among them | a field-for-field test, plus an `if`-guard test |
+| the `coalesce` on the guest `type` operand | a guest row with a null `type` |
+| the `coalesce` on the guest `userId` operand | an exam attempt with a null `userId` |
+
+The last two are the subtle pair. The existing test seeds a row with **both**
+columns null, and SQL's `FALSE AND NULL = FALSE` means either `coalesce` alone
+rescues it — so removing one at a time was invisible. Both of the inputs each
+one actually protects are writable by the sync-in: `normalizeSubmissionUserId`
+returns null for an empty `user._id`, and `type` comes straight from a document
+that may omit it.
+
+### Two findings recorded rather than fixed
+
+**`serialize` has a new throw surface, and it diverges from Kotlin in the
+port's favour.** Kotlin wraps the whole of `serializeSubmission` in
+`try { … } catch { printStackTrace() }` (`:812-861`) with `getPayloadData` as
+its first statement, so a Kotlin DAO failure uploads an empty `{}` document.
+The port propagates, `queuePending`'s loop aborts with the rows before it
+already enqueued, and the screen reports the failure. That is better behaviour,
+but it is not the Kotlin's, the diff widens the surface from one DAO read per
+row to three or four, and the loop now iterates the whole handset's backlog
+rather than one user's. Saying so here rather than changing it.
+
+**The `public_%` pattern's `_` is LIKE's wildcard, not an escaped literal.**
+The code comment claimed the choice was deliberate; the two patterns differ only
+on the bare string `public`, and no id the port mints is either one. The comment
+now says that instead of overstating it.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -2293,8 +2293,11 @@ class SubmissionDao extends DatabaseAccessor<AppDatabase>
           (row) =>
               row.isUpdated.equals(true) &
               isGuestExamAttempt(row).not() &
-              // `_` is a single-character wildcard in LIKE and is left as
-              // one: the sentinel always has `_<millis>` after the prefix.
+              // The `_` is LIKE's single-character wildcard, not an escaped
+              // literal, and nothing turns on that: the two patterns differ
+              // only on the bare string `public`, and no id the port mints —
+              // `org.couchdb.user:<name>`, `guest_<name>`, a millisecond
+              // string — is either one.
               owner(row).like('public_%').not(),
         ))
         .get();

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -2230,11 +2230,75 @@ class SubmissionDao extends DatabaseAccessor<AppDatabase>
             ..orderBy([(row) => OrderingTerm(expression: row.startTime)]))
           .get();
 
-  Future<List<SubmissionRow>> pendingUploads(String userId) =>
-      (select(submissions)..where(
-            (row) => row.userId.equals(userId) & row.isUpdated.equals(true),
-          ))
-          .get();
+  /// Everything on this handset that still owes the server an upload —
+  /// **not** just the signed-in learner's rows.
+  ///
+  /// Kotlin reaches the `submissions` endpoint through two upload configs, and
+  /// neither is scoped to a user:
+  ///
+  ///  * `UploadConfigs.Submissions` -> `SubmissionDao.getPendingSubmissions()`
+  ///    (`SubmissionDao.kt:41`), `status = 'complete' AND (isUpdated = 1 OR
+  ///    _id IS NULL OR _id = '')`;
+  ///  * `UploadConfigs.ExamResults` -> `getPendingExamResults()` (`:40`),
+  ///    `type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND
+  ///    (_id IS NULL OR _id = '')`, with `filterGuests = true`
+  ///    (`UploadConfigs.kt:249-250`, `UploadConfig.shouldFilter`:
+  ///    `userId.startsWith("guest")`).
+  ///
+  /// The port had `userId = ? AND isUpdated = true`, which is the opposite
+  /// scoping. **A shared handset is the normal deployment for this app**, and
+  /// that is the flow that needs this: member A finishes a survey
+  /// (`status = 'complete'`, `isUpdated = 1`, no `_id`) and signs out without
+  /// syncing; member B signs in and syncs; arm B, being unscoped, sends A's
+  /// sheet. Under the session scope it never left the device — and nothing in
+  /// the port rescans, so never was literal.
+  ///
+  /// It is **not** the bulk-survey send that depends on this, though that is
+  /// the easy claim to make: `createBulkSurveySubmissions` writes each member's
+  /// sheet `pending` and not yet updated, and the only thing that flags one is
+  /// that member answering it while signed in. On the answering turn scoped and
+  /// unscoped agree.
+  ///
+  /// `isUpdated` stays the status gate rather than Kotlin's
+  /// `status = 'complete'`, because the port merges the two configs into one
+  /// uploader: an exam is never `complete` (it finishes at
+  /// `requires grading`), so filtering on that would strand every exam
+  /// attempt. The exam arm it stands in for is `ExamResults`, whose guest
+  /// filter is ported alongside it — a guest's attempt is answer-sheet
+  /// practice, and Kotlin does not send it. Both operands are coalesced so a
+  /// null `type` or `userId` cannot turn the test into SQL NULL and drop a row
+  /// that is nobody's guest exam.
+  ///
+  /// The one exclusion with no Kotlin counterpart is the **anonymous
+  /// public-survey answer sheet**. `public_survey_screen` mints a
+  /// `public_<millis>` owner for a respondent who has no account, a sentinel
+  /// the Kotlin has no equivalent of (`PublicSurveyActivity` runs the ordinary
+  /// exam fragment, so its sheet is authored by the signed-in user or nobody).
+  /// That sheet is `status = 'complete'`, `isUpdated = 1` and belongs to the
+  /// **public** endpoint, which is not a CouchDB insert; unscoping without this
+  /// would hand it to the authenticated uploader on the next `queuePending` —
+  /// and worse, `markUploaded` would then set `uploaded`, which is exactly what
+  /// `PublicSurveyUploader.queue` refuses to queue on. The respondent's answers
+  /// would go to the wrong database and the right one would decline them.
+  Future<List<SubmissionRow>> pendingUploads() {
+    // Coalesced: `type = 'exam' AND userId LIKE 'guest%'` is SQL NULL on a null
+    // column and `NOT NULL` is NULL, which drops a row that is nobody's guest
+    // exam rather than keeping it.
+    Expression<String> owner($SubmissionsTable row) =>
+        coalesce([row.userId, const Constant('')]);
+    Expression<bool> isGuestExamAttempt($SubmissionsTable row) =>
+        coalesce([row.type, const Constant('')]).equals('exam') &
+        owner(row).like('guest%');
+    return (select(submissions)..where(
+          (row) =>
+              row.isUpdated.equals(true) &
+              isGuestExamAttempt(row).not() &
+              // `_` is a single-character wildcard in LIKE and is left as
+              // one: the sentinel always has `_<millis>` after the prefix.
+              owner(row).like('public_%').not(),
+        ))
+        .get();
+  }
 
   Future<int> markUploaded(String id, String couchId, String rev) =>
       (update(submissions)..where((row) => row.id.equals(id))).write(

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -441,6 +441,7 @@ final submissionsRepositoryProvider = Provider<SubmissionsRepository>(
     ref.watch(submissionDaoProvider),
     ref.watch(submitPhotosDaoProvider),
     ref.watch(surveyDaoProvider),
+    ref.watch(examDaoProvider),
   ),
 );
 

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -815,33 +815,66 @@ class SubmissionsRepository {
   /// half passing its own test: Phase 74's reactions, Phase 100's photo id.
   ///
   /// **Kotlin keeps surveys and tests in one `exams` table; the port splits
-  /// them**, so the lookup tries [ExamDao] and then [SurveyDao] — one
-  /// `examDao.getById` in the Kotlin is two here.
+  /// them**, so one `examDao.getById` in the Kotlin is two lookups here — see
+  /// [_liveParentDocument] for why which one goes first is load-bearing.
   Future<Object?> _parentDocument(SubmissionRow row) async {
-    final live = await _liveParentDocument(row.parentId);
+    final live = await _liveParentDocument(row.parentId, row.type);
     if (live != null) return live;
     // `!submission.parent.isNullOrEmpty()` (`:842`) — an empty blob is
     // omitted, not sent as an empty string.
     return (row.parent?.isEmpty ?? true) ? null : _asDocument(row.parent);
   }
 
-  Future<Map<String, dynamic>?> _liveParentDocument(String? parentId) async {
+  /// The live parent, looked up in whichever of the two tables the submission
+  /// says it was answering, and in the other only as a fallback.
+  ///
+  /// **The two id spaces are not disjoint**, which is why the order is a
+  /// decision rather than a formality. `ExamMapper.mapStepExams` synthesizes
+  /// `'$courseId-$stepId-$examKey'` for an embedded step document with no
+  /// `_id`, and `SurveyMapper.fromCourseDoc`'s first pass uses the same
+  /// `examKey: 'exam'` — so one `steps[i].exam` produces the *same id string*
+  /// whether the document's `type` files it under [Exams] or [Surveys]. Flip
+  /// that `type` on Planet and the next courses walk writes the row to the
+  /// other table while the first one's copy survives: neither `deleteNotIn`
+  /// prunes a row that still has a `stepId`, so the loser lingers until a
+  /// later completed exams walk.
+  ///
+  /// Kotlin cannot have this problem — one `exams` table, one row, `@Upsert`
+  /// overwrites `type` in place — so there is no Kotlin order to port. The
+  /// submission's own `type` is the disambiguator the port has and Kotlin does
+  /// not need: an answer sheet knows whether it was answering a survey or a
+  /// test, and the row it should upload is the one of that kind. Trying
+  /// [Exams] first unconditionally uploaded the stale test to a survey's
+  /// answer sheet.
+  ///
+  /// `type` defaults to the survey side, matching `serializeSubmission:828`'s
+  /// own `submission.type ?: "survey"`.
+  Future<Map<String, dynamic>?> _liveParentDocument(
+    String? parentId,
+    String? type,
+  ) async {
     // `parentId.substringBefore("@")` — the parent id is `examId@courseId`
     // for a course-attached exam or survey and the bare id otherwise.
     final examId = (parentId ?? '').split('@').first;
     if (examId.isEmpty) return null;
-    final exam = await _examDao.getById(examId);
-    if (exam != null) {
-      return examParentDocument(exam, await _examDao.questionsFor(examId));
+
+    Future<Map<String, dynamic>?> fromExams() async {
+      final exam = await _examDao.getById(examId);
+      return exam == null
+          ? null
+          : examParentDocument(exam, await _examDao.questionsFor(examId));
     }
-    final survey = await _surveyDao.getById(examId);
-    if (survey != null) {
-      return surveyParentDocument(
-        survey,
-        await _surveyDao.questionsFor(examId),
-      );
+
+    Future<Map<String, dynamic>?> fromSurveys() async {
+      final survey = await _surveyDao.getById(examId);
+      return survey == null
+          ? null
+          : surveyParentDocument(survey, await _surveyDao.questionsFor(examId));
     }
-    return null;
+
+    return type == 'exam'
+        ? await fromExams() ?? await fromSurveys()
+        : await fromSurveys() ?? await fromExams();
   }
 
   /// Port of `StepExam.serializeExam` (`StepExam.kt:70-94`), field for field

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -20,6 +20,7 @@ class SubmissionsRepository {
     this._dao,
     this._photosDao,
     this._surveyDao,
+    this._examDao,
   );
 
   static const int initialBatchSize = 100;
@@ -28,6 +29,14 @@ class SubmissionsRepository {
   final SubmissionDao _dao;
   final SubmitPhotosDao _photosDao;
   final SurveyDao _surveyDao;
+
+  /// Kotlin's `SubmissionsRepositoryImpl` injects `examDao` and `questionDao`
+  /// alongside its own, because [serialize] resolves the **live** exam for the
+  /// `parent` object it uploads (`getPayloadData`,
+  /// `SubmissionsRepositoryImpl.kt:756-761`). The port splits Kotlin's single
+  /// `exams` table into [Exams] and [Surveys], so the lookup needs both this
+  /// and `_surveyDao`.
+  final ExamDao _examDao;
 
   Stream<List<SubmissionRow>> watchForUser(String userId) =>
       _dao.watchForUser(userId);
@@ -586,8 +595,10 @@ class SubmissionsRepository {
     ]);
   }
 
-  Future<List<SubmissionRow>> pendingUploads(String userId) =>
-      _dao.pendingUploads(userId);
+  /// Every row on the handset that still owes the server an upload — see
+  /// [SubmissionDao.pendingUploads] for why this is not scoped to the
+  /// signed-in learner.
+  Future<List<SubmissionRow>> pendingUploads() => _dao.pendingUploads();
 
   /// Port of `SubmissionsRepositoryImpl.hasUnfinishedSurveys`. Returns true
   /// if the course has any attached survey the user has not yet submitted.
@@ -746,6 +757,7 @@ class SubmissionsRepository {
   /// sync-in's matching read of it went unnoticed. See [_userDocument].
   Future<Map<String, dynamic>> serialize(SubmissionRow row) async {
     final answers = await _dao.answersFor(row.id);
+    final parent = await _parentDocument(row);
     return {
       if (row.couchId != null && row.couchId!.isNotEmpty) '_id': row.couchId,
       if (row.rev != null && row.rev!.isNotEmpty) '_rev': row.rev,
@@ -760,11 +772,7 @@ class SubmissionsRepository {
       // Omitted rather than sent as null when there is nothing to send —
       // `serializeSubmission` guards both with an `if` and has no `else`
       // (`:840-857`).
-      // `!submission.parent.isNullOrEmpty()` (`:842`) — an empty blob is
-      // omitted, not sent as an empty string.
-      'parent': ?((row.parent?.isEmpty ?? true)
-          ? null
-          : _asDocument(row.parent)),
+      'parent': ?parent,
       'user': ?_userDocument(row),
       'answers': [
         for (final answer in answers)
@@ -785,6 +793,183 @@ class SubmissionsRepository {
       ],
     };
   }
+
+  /// The `parent` object the upload carries: the **live** exam or survey when
+  /// this device still has it, and only otherwise the blob stored on the row.
+  ///
+  /// That order is Kotlin's. `serializeSubmission` asks `getPayloadData`
+  /// (`SubmissionsRepositoryImpl.kt:756-761`) for
+  /// `examDao.getById(parentId.substringBefore("@"))` plus
+  /// `questionDao.getByExamId`, and emits
+  /// `StepExam.serializeExam(exam, questions)` when the exam is there
+  /// (`:840-841`); `submission.parent` is the `else if` for an exam this
+  /// device no longer has (`:842`).
+  ///
+  /// The port used to send the blob unconditionally, and the blob is tiny:
+  /// [_openExamSession] writes `{_id,_rev,name,courseId,totalMarks}` and
+  /// [createSurveyDraft] writes `{_id,name}`. Neither carries `questions` —
+  /// and the port's own pull fills `submission_questions` from
+  /// `parent['questions']` ([upsertDocuments]), so an answer sheet uploaded
+  /// here and pulled on a second device rendered answers with no questions to
+  /// put them against. A writer and a reader disagreeing about a key, each
+  /// half passing its own test: Phase 74's reactions, Phase 100's photo id.
+  ///
+  /// **Kotlin keeps surveys and tests in one `exams` table; the port splits
+  /// them**, so the lookup tries [ExamDao] and then [SurveyDao] — one
+  /// `examDao.getById` in the Kotlin is two here.
+  Future<Object?> _parentDocument(SubmissionRow row) async {
+    final live = await _liveParentDocument(row.parentId);
+    if (live != null) return live;
+    // `!submission.parent.isNullOrEmpty()` (`:842`) — an empty blob is
+    // omitted, not sent as an empty string.
+    return (row.parent?.isEmpty ?? true) ? null : _asDocument(row.parent);
+  }
+
+  Future<Map<String, dynamic>?> _liveParentDocument(String? parentId) async {
+    // `parentId.substringBefore("@")` — the parent id is `examId@courseId`
+    // for a course-attached exam or survey and the bare id otherwise.
+    final examId = (parentId ?? '').split('@').first;
+    if (examId.isEmpty) return null;
+    final exam = await _examDao.getById(examId);
+    if (exam != null) {
+      return examParentDocument(exam, await _examDao.questionsFor(examId));
+    }
+    final survey = await _surveyDao.getById(examId);
+    if (survey != null) {
+      return surveyParentDocument(
+        survey,
+        await _surveyDao.questionsFor(examId),
+      );
+    }
+    return null;
+  }
+
+  /// Port of `StepExam.serializeExam` (`StepExam.kt:70-94`), field for field
+  /// and in its order, with two deliberate departures.
+  ///
+  /// **`type` is not emitted.** Kotlin writes `exam.type` from the single
+  /// `exams` table; the port's [Exams] has no such column, because
+  /// `ExamMapper.fromDoc` uses the document's `type` to *choose the table* and
+  /// then discards it. Adding the column is a schema change, which this round
+  /// is not this lane's to make — and the value is not recoverable from the
+  /// table anyway: a course test carries `'courses'`
+  /// (`CoursesRepositoryImpl.kt:744` keeps the document's own key), a
+  /// standalone one with no `type` becomes `'exam'` (`StepExam.kt:39`), and
+  /// nothing on [ExamRow] tells the two apart. Omitting the key leaves it
+  /// undefined on Planet rather than guessing; nothing in either tree reads a
+  /// submission's `parent.type`.
+  ///
+  /// **Each question carries its `id`, and its label under `title` as well as
+  /// `header`.** `ExamQuestion.serializeQuestions` (`ExamQuestion.kt:110-124`)
+  /// emits seven keys, no id, and the label under `header`. Both are Kotlin
+  /// quirks the port cannot afford.
+  ///
+  /// The id, because `_questionFromJson` keys the pulled row on it and falls
+  /// back to a positional `<submissionId>-q<index>`, while the answers
+  /// alongside it carry the real question id — so a faithful upload hands the
+  /// second device a question set its own answers cannot be joined to, and
+  /// that is *worse* than sending no questions at all: `submissions_exporter`
+  /// prints the answers only through its `questions.isEmpty` fallback, so
+  /// unjoinable questions print every prompt with no answer and drop the
+  /// answers entirely.
+  ///
+  /// The label, because `header` is a key no real document has. Every reader
+  /// of a question in either tree takes it from `title` — Kotlin's
+  /// `ExamQuestion.insertExamQuestions` (`:76`), `ExamMapper.parseQuestions`,
+  /// `SurveyMapper` — so the snapshot `serializeQuestions` uploads cannot be
+  /// read back by the code that reads every other copy of the same question.
+  /// Kotlin demonstrates that on itself: `SurveysRepositoryImpl.adoptSurvey`
+  /// (`:90-93`) feeds `serializeQuestions` straight into
+  /// `insertExamQuestions`, and every adopted team survey loses each
+  /// question's id *and* its label. Sending both keys costs nothing.
+  ///
+  /// Same call as Phase 120's `answers.examId`: keep the quirk unless it
+  /// breaks a reader the port has and Kotlin does not.
+  static Map<String, dynamic> examParentDocument(
+    ExamRow exam,
+    List<ExamQuestionRow> questions,
+  ) => {
+    '_id': exam.id,
+    // `if (exam._rev != null)` (`:73-75`).
+    if (exam.rev != null) '_rev': exam.rev,
+    'name': exam.name,
+    'description': exam.description,
+    'passingPercentage': exam.passingPercentage,
+    'updatedDate': exam.updatedDate,
+    'createdDate': exam.createdDate,
+    'adoptionDate': exam.adoptionDate,
+    'sourcePlanet': exam.sourcePlanet,
+    'totalMarks': exam.totalMarks,
+    'createdBy': exam.createdBy,
+    // Both conditional in the Kotlin (`:86-91`).
+    if (exam.sourceSurveyId != null) 'sourceSurveyId': exam.sourceSurveyId,
+    if (exam.teamId != null) 'teamId': exam.teamId,
+    'questions': [
+      for (final question in questions)
+        {
+          'id': question.id,
+          'title': question.header,
+          'header': question.header,
+          'body': question.body,
+          'type': question.type,
+          'marks': question.marks,
+          'choices': [for (final choice in question.choices) choice.toJson()],
+          'correctChoice': question.correctChoices,
+          'hasOtherOption': question.hasOtherOption,
+        },
+    ],
+  };
+
+  /// The same document for a row the port filed under [Surveys].
+  ///
+  /// `type` is omitted here too, and for the same reason as
+  /// [examParentDocument] rather than the one it first looks like. The
+  /// *exams-database* walk does route on `type == 'surveys'`, so a row from
+  /// that walk could recover the value — but `SurveyMapper.fromCourseDoc`'s
+  /// second pass files every `steps[i].survey` here with **no** type filter at
+  /// all, and Kotlin types one of those `"survey"`, singular. Emitting
+  /// `'surveys'` would be a guess for exactly the rows the exam branch refuses
+  /// to guess for.
+  ///
+  /// [SurveyQuestions] has no `marks`, `correctChoice` or `hasOtherOption`
+  /// column — Kotlin's one `ExamQuestion` type carries all three for a survey
+  /// too, but the port's survey pull has never stored them and there is
+  /// nothing to send. The keys are omitted rather than sent as invented
+  /// defaults; a survey question has no correct answer to lose.
+  ///
+  /// The question `id` is [_rawQuestionId], not the row's own composite key,
+  /// because that is what the answer's `questionId` carries — the same
+  /// identity rule [createSurveyDraft] uses when it keys the local
+  /// `submission_questions` rows.
+  static Map<String, dynamic> surveyParentDocument(
+    SurveyRow survey,
+    List<SurveyQuestionRow> questions,
+  ) => {
+    '_id': survey.id,
+    if (survey.rev != null) '_rev': survey.rev,
+    'name': survey.name,
+    'description': survey.description,
+    'passingPercentage': survey.passingPercentage,
+    'updatedDate': survey.updatedDate,
+    'createdDate': survey.createdDate,
+    'adoptionDate': survey.adoptionDate,
+    'sourcePlanet': survey.sourcePlanet,
+    'totalMarks': survey.totalMarks,
+    'createdBy': survey.createdBy,
+    if (survey.sourceSurveyId != null) 'sourceSurveyId': survey.sourceSurveyId,
+    if (survey.teamId != null) 'teamId': survey.teamId,
+    'questions': [
+      for (final question in questions)
+        {
+          'id': _rawQuestionId(question),
+          'title': question.header,
+          'header': question.header,
+          'body': question.body,
+          'type': question.type,
+          'choices': [for (final choice in question.choices) choice.toJson()],
+        },
+    ],
+  };
 
   /// Port of `Answer.valueChoicesArray`, which sends each stored choice as the
   /// object it came from (`gson.fromJson(choice, JsonObject::class.java)`):

--- a/flutter/lib/repository/submissions_uploader.dart
+++ b/flutter/lib/repository/submissions_uploader.dart
@@ -26,11 +26,19 @@ class SubmissionsUploader {
   static String endpointFor(ServerConfig config) =>
       '${UrlUtils.credentialFreeDbUrl(config)}/submissions';
 
+  /// Queues every submission on the handset that still owes an upload.
+  ///
+  /// [userId] is the signed-in session, recorded on the outbox row — it is
+  /// **not** a filter. Kotlin's two submission upload configs are both
+  /// handset-wide (see [SubmissionDao.pendingUploads]), and the rows go up on
+  /// the session's credentials the way `UploadCoordinator` sends them; each
+  /// row's own owner rides in the document's `user` object, which is where
+  /// Planet and the sync-in both read it from.
   Future<int> queuePending({
     required ServerConfig config,
     required String userId,
   }) async {
-    final rows = await _submissions.pendingUploads(userId);
+    final rows = await _submissions.pendingUploads();
     final identity = rows.isEmpty ? null : await _identity.read();
     for (final row in rows) {
       await _outbox.enqueue(

--- a/flutter/test/repository/exam_flow_test.dart
+++ b/flutter/test/repository/exam_flow_test.dart
@@ -33,6 +33,7 @@ void main() {
       database.submissionDao,
       database.submitPhotosDao,
       database.surveyDao,
+      database.examDao,
     );
     surveys = SurveysRepository(
       api,
@@ -319,7 +320,7 @@ void main() {
         hasLength(2),
       );
       expect(
-        await submissions.pendingUploads('ada'),
+        await submissions.pendingUploads(),
         isEmpty,
         reason: 'a half-finished attempt must not go up',
       );
@@ -484,7 +485,7 @@ void main() {
       // queue selects on.
       expect(row.status, 'requires grading');
       expect(row.grade, 0, reason: 'Planet marks it, not the device');
-      expect(await submissions.pendingUploads('ada'), hasLength(1));
+      expect(await submissions.pendingUploads(), hasLength(1));
 
       final answers = await database.submissionDao.answersFor(id);
       expect(answers.every((answer) => answer.isPassed), isTrue);
@@ -512,7 +513,7 @@ void main() {
 
       expect(verdicts, [true, false]);
       expect((await database.submissionDao.getById(id))!.status, 'pending');
-      expect(await submissions.pendingUploads('ada'), isEmpty);
+      expect(await submissions.pendingUploads(), isEmpty);
     });
 
     test('the mistake counts and verdicts reach the upload payload', () async {
@@ -685,7 +686,7 @@ void main() {
       expect(jsonDecode(row!.user!)['gender'], 'female');
       // Back in the pending set, or the edit would never be sent.
       expect(row.uploaded, isFalse);
-      expect(await submissions.pendingUploads('ada'), hasLength(1));
+      expect(await submissions.pendingUploads(), hasLength(1));
     });
   });
 }

--- a/flutter/test/repository/public_survey_uploader_test.dart
+++ b/flutter/test/repository/public_survey_uploader_test.dart
@@ -32,6 +32,7 @@ void main() {
       database.submissionDao,
       database.submitPhotosDao,
       database.surveyDao,
+      database.examDao,
     );
     surveys = SurveysRepository(
       api,

--- a/flutter/test/repository/step_assessment_sync_test.dart
+++ b/flutter/test/repository/step_assessment_sync_test.dart
@@ -54,6 +54,7 @@ void main() {
         db.submissionDao,
         db.submitPhotosDao,
         db.surveyDao,
+        db.examDao,
       ),
     );
   });

--- a/flutter/test/repository/submissions_exporter_test.dart
+++ b/flutter/test/repository/submissions_exporter_test.dart
@@ -22,6 +22,7 @@ void main() {
       db.submissionDao,
       db.submitPhotosDao,
       db.surveyDao,
+      db.examDao,
     );
     exporter = SubmissionsExporter(repository);
   });

--- a/flutter/test/repository/submissions_repository_test.dart
+++ b/flutter/test/repository/submissions_repository_test.dart
@@ -383,6 +383,52 @@ void main() {
         );
       },
     );
+
+    /// The row above has **both** columns null, and SQL's
+    /// `FALSE AND NULL = FALSE` means either `coalesce` alone rescues it — so
+    /// removing one operand at a time left the suite green. These are the two
+    /// inputs each one actually protects, and both are writable: the sync-in
+    /// stores a null `userId` when the document's `user._id` is empty
+    /// (`normalizeSubmissionUserId`) and a null `type` when the document omits
+    /// it.
+    test('an ownerless exam attempt survives the guest test', () async {
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'ownerless-exam',
+          type: const Value('exam'),
+          status: const Value('requires grading'),
+          isUpdated: const Value(true),
+        ),
+      ]);
+
+      expect(
+        (await repository.pendingUploads()).single.id,
+        'ownerless-exam',
+        reason:
+            "uncoalesced, `'exam' = 'exam' AND NULL LIKE 'guest%'` is NULL and "
+            '`NOT NULL` is NULL, so the row is dropped from the backlog',
+      );
+    });
+
+    test("a guest's typeless row survives the guest test", () async {
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'typeless-guest',
+          userId: const Value('guest_ada'),
+          status: const Value('complete'),
+          isUpdated: const Value(true),
+        ),
+      ]);
+
+      expect(
+        (await repository.pendingUploads()).single.id,
+        'typeless-guest',
+        reason:
+            "uncoalesced, `NULL = 'exam' AND TRUE` is NULL and `NOT NULL` is "
+            'NULL — and this row is not a guest exam but a guest survey, which '
+            '`UploadConfigs.Submissions` does upload',
+      );
+    });
   });
 
   test('caches a synced question choice by its display label', () async {

--- a/flutter/test/repository/submissions_repository_test.dart
+++ b/flutter/test/repository/submissions_repository_test.dart
@@ -31,6 +31,7 @@ void main() {
       database.submissionDao,
       database.submitPhotosDao,
       database.surveyDao,
+      database.examDao,
     );
   });
 
@@ -225,7 +226,7 @@ void main() {
         now: DateTime.fromMillisecondsSinceEpoch(1000),
       );
 
-      final pending = await repository.pendingUploads('user-1');
+      final pending = await repository.pendingUploads();
       expect(pending.single.id, id);
       expect(pending.single.isUpdated, isTrue);
       final payload = await repository.serialize(pending.single);
@@ -233,6 +234,156 @@ void main() {
       expect((payload['answers'] as List).single, containsPair('value', '42'));
     },
   );
+
+  /// **A shared handset is the normal deployment for this app**, and both of
+  /// Kotlin's submission upload configs are handset-wide:
+  /// `getPendingSubmissions` (`SubmissionDao.kt:41`) and
+  /// `getPendingExamResults` (`:40`) name no user. The port scoped its one
+  /// merged query to the signed-in learner, so a sheet another member
+  /// completed before signing out could never leave the device.
+  group('the upload backlog is the handset, not the session', () {
+    test("a second learner's completed survey is still queued", () async {
+      await repository.createSurveyDraft(
+        survey: const SurveyRow(
+          id: 'survey-1',
+          name: 'Water',
+          createdDate: 0,
+          updatedDate: 0,
+          adoptionDate: 0,
+          totalMarks: 0,
+          isFromNation: false,
+          teamShareAllowed: false,
+        ),
+        questions: const [],
+        userId: 'user-2',
+      );
+
+      final pending = await repository.pendingUploads();
+
+      expect(
+        pending.map((row) => row.userId),
+        ['user-2'],
+        reason:
+            'the bulk-survey flow writes a sheet per member; scoped to the '
+            'session, only the last member signed in ever uploaded theirs',
+      );
+    });
+
+    /// The flow that actually needs the unscoping — **not** the bulk send
+    /// itself. `createBulkSurveySubmissions` writes each member's sheet
+    /// `pending` and not yet updated, and the only thing that flags one is
+    /// that member answering it while signed in; on the answering turn scoped
+    /// and unscoped agree. What differs is the next sync, which somebody else
+    /// runs.
+    test(
+      'a sheet answered before the next member signs in still goes out',
+      () async {
+        await repository.createBulkSurveySubmissions('survey-1', [
+          'user-1',
+          'user-2',
+          'user-3',
+        ]);
+        // `getOrCreateSurveySubmission` writes each sheet `pending` and not yet
+        // updated; answering one is what flags it, and each member does that on
+        // their own turn at the handset.
+        final sheets = await repository.watchForUser('user-2').first;
+        await repository.updateSurveyAnswers(
+          submissionId: sheets.single.id,
+          questions: const [],
+          answers: const {},
+        );
+
+        expect((await repository.pendingUploads()).single.userId, 'user-2');
+      },
+    );
+
+    /// `UploadConfigs.ExamResults` sets `filterGuests = true` with
+    /// `guestUserIdExtractor = { it.userId }`, and `UploadConfig.shouldFilter`
+    /// drops any `userId.startsWith("guest")`. `Submissions` sets neither, so
+    /// the filter is the exam arm's alone.
+    test("a guest's exam attempt is never queued", () async {
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'guest-attempt',
+          userId: const Value('guest_ada'),
+          parentId: const Value('exam-1@course-1'),
+          type: const Value('exam'),
+          status: const Value('requires grading'),
+          isUpdated: const Value(true),
+        ),
+      ]);
+
+      expect(await repository.pendingUploads(), isEmpty);
+    });
+
+    test("a guest's completed survey is queued, as in Kotlin", () async {
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'guest-survey',
+          userId: const Value('guest_ada'),
+          parentId: const Value('survey-1'),
+          type: const Value('survey'),
+          status: const Value('complete'),
+          isUpdated: const Value(true),
+        ),
+      ]);
+
+      expect(
+        (await repository.pendingUploads()).single.id,
+        'guest-survey',
+        reason:
+            '`UploadConfigs.Submissions` has no guest filter — only '
+            '`ExamResults` does',
+      );
+    });
+
+    /// **The one exclusion with no Kotlin counterpart.**
+    /// `public_survey_screen` mints a `public_<millis>` owner for a respondent
+    /// who has no account; Kotlin has no such sentinel, because
+    /// `PublicSurveyActivity` runs the ordinary exam fragment and its sheet is
+    /// authored by the signed-in user or nobody.
+    ///
+    /// That sheet is `status = 'complete'`, `isUpdated = 1`, and belongs to the
+    /// **public** endpoint — which is not a CouchDB insert. Unscoping without
+    /// this hands it to the authenticated uploader on the next `queuePending`
+    /// (`UserInformationScreen._queueUpload` calls exactly that, under the
+    /// signed-in session), and `markUploaded` then sets `uploaded` — which is
+    /// what `PublicSurveyUploader.queue` refuses to queue on. The respondent's
+    /// answers would reach the wrong database and the right one would decline
+    /// them.
+    test("an anonymous public answer sheet is not queued here", () async {
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'public-sheet',
+          userId: const Value('public_1770000000000'),
+          parentId: const Value('survey-9'),
+          type: const Value('survey'),
+          status: const Value('complete'),
+          isUpdated: const Value(true),
+        ),
+      ]);
+
+      expect(await repository.pendingUploads(), isEmpty);
+    });
+
+    test(
+      'a row with no type or owner is not mistaken for a guest exam',
+      () async {
+        await database.submissionDao.upsertAll([
+          SubmissionsCompanion.insert(id: 'bare', isUpdated: const Value(true)),
+        ]);
+
+        expect(
+          (await repository.pendingUploads()).single.id,
+          'bare',
+          reason:
+              'an uncoalesced `type = \'exam\' AND userId LIKE \'guest%\'` is SQL '
+              'NULL on a null column, and NOT NULL is NULL — the row would be '
+              'dropped from the backlog rather than kept',
+        );
+      },
+    );
+  });
 
   test('caches a synced question choice by its display label', () async {
     // `ExamAnswerUtils.choiceDisplayValue` is `text` first and `res` only as
@@ -512,7 +663,7 @@ void main() {
 
       await repository.sync(config: config);
 
-      expect(await repository.pendingUploads('user-1'), hasLength(1));
+      expect(await repository.pendingUploads(), hasLength(1));
     },
   );
 

--- a/flutter/test/repository/submissions_sync_round_trip_test.dart
+++ b/flutter/test/repository/submissions_sync_round_trip_test.dart
@@ -577,6 +577,204 @@ void main() {
       expect(document['_id'], 'survey-1');
     });
 
+    /// `surveyParentDocument`'s own field list. The exam builder had one of
+    /// these from the start and the survey builder did not, which the second
+    /// audit found by reverting five of its six rules with the suite still
+    /// green — `title`, both `if`-guarded fields, `_rev`, and `header`.
+    test('a survey is `serializeExam` minus what the port cannot store', () {
+      final document = SubmissionsRepository.surveyParentDocument(
+        SurveyRow(
+          id: 'survey-1',
+          rev: '2-bbb',
+          name: 'Water',
+          description: 'How is it',
+          createdDate: 10,
+          updatedDate: 20,
+          adoptionDate: 30,
+          createdBy: 'org.couchdb.user:tutor',
+          totalMarks: 0,
+          passingPercentage: '50',
+          sourcePlanet: 'lea',
+          isFromNation: false,
+          teamId: 'team-9',
+          teamShareAllowed: false,
+          sourceSurveyId: 'survey-0',
+          courseId: 'course-1',
+        ),
+        const [
+          SurveyQuestionRow(
+            id: 'survey-1:q1',
+            surveyId: 'survey-1',
+            questionId: 'q1',
+            header: 'How is the water?',
+            body: 'Pick one',
+            type: 'select',
+            choices: [ExamChoice(id: 'c1', text: 'Clean')],
+            required: false,
+            position: 0,
+          ),
+        ],
+      );
+
+      expect(document, {
+        '_id': 'survey-1',
+        '_rev': '2-bbb',
+        'name': 'Water',
+        'description': 'How is it',
+        'passingPercentage': '50',
+        'updatedDate': 20,
+        'createdDate': 10,
+        'adoptionDate': 30,
+        'sourcePlanet': 'lea',
+        'totalMarks': 0,
+        'createdBy': 'org.couchdb.user:tutor',
+        'sourceSurveyId': 'survey-0',
+        'teamId': 'team-9',
+        'questions': [
+          {
+            // `_rawQuestionId`, not the composite row key: it is what the
+            // answer's `questionId` carries.
+            'id': 'q1',
+            'title': 'How is the water?',
+            'header': 'How is the water?',
+            'body': 'Pick one',
+            'type': 'select',
+            'choices': [
+              {'id': 'c1', 'text': 'Clean'},
+            ],
+          },
+        ],
+      });
+    });
+
+    /// An adopted survey has `rev == null`, so the unconditional form would
+    /// send `"_rev": null` inside `parent` — which is exactly what
+    /// `StepExam.kt:73-75` guards against.
+    test('a survey omits the three fields Kotlin guards with an `if`', () {
+      final document = SubmissionsRepository.surveyParentDocument(
+        SurveyRow(
+          id: 'survey-1',
+          createdDate: 0,
+          updatedDate: 0,
+          adoptionDate: 0,
+          totalMarks: 0,
+          isFromNation: false,
+          teamShareAllowed: false,
+        ),
+        const [],
+      );
+
+      expect(document.containsKey('_rev'), isFalse);
+      expect(document.containsKey('sourceSurveyId'), isFalse);
+      expect(document.containsKey('teamId'), isFalse);
+    });
+
+    /// **The two id spaces are not disjoint.**
+    /// `ExamMapper.mapStepExams` synthesizes `'$courseId-$stepId-$examKey'`
+    /// for an embedded step document with no `_id`, and
+    /// `SurveyMapper.fromCourseDoc`'s first pass uses the same
+    /// `examKey: 'exam'` — so one `steps[i].exam` yields the same id string
+    /// whichever table its `type` files it under, and flipping that `type` on
+    /// Planet leaves a copy in both. Kotlin cannot reach this: one table, one
+    /// row, `@Upsert` overwrites `type` in place. The submission's own `type`
+    /// is the disambiguator the port has, and trying `Exams` first
+    /// unconditionally uploaded the stale test to a survey's answer sheet.
+    test(
+      'a survey sheet takes the survey when both tables hold the id',
+      () async {
+        const sharedId = 'course-1-course-1:0-exam';
+        await database.examDao.upsertAll(
+          [
+            ExamsCompanion.insert(
+              id: sharedId,
+              name: const Value('Stale test'),
+              stepId: const Value('course-1:0'),
+            ),
+          ],
+          {
+            sharedId: [
+              ExamQuestionsCompanion.insert(
+                id: '$sharedId-q1',
+                examId: sharedId,
+                header: const Value('Old exam question'),
+                position: 0,
+              ),
+            ],
+          },
+        );
+        await database.surveyDao.upsertAll(
+          [
+            SurveysCompanion.insert(
+              id: sharedId,
+              name: const Value('Live survey'),
+              stepId: const Value('course-1:0'),
+            ),
+          ],
+          {
+            sharedId: [
+              SurveyQuestionsCompanion.insert(
+                id: '$sharedId:q1',
+                surveyId: sharedId,
+                questionId: const Value('q1'),
+                header: const Value('How is the water?'),
+                position: 0,
+              ),
+            ],
+          },
+        );
+        final localId = await repository.createSurveyDraft(
+          survey: (await database.surveyDao.getById(sharedId))!,
+          questions: await database.surveyDao.questionsFor(sharedId),
+          userId: 'org.couchdb.user:ada',
+        );
+
+        final payload = await repository.serialize(
+          (await repository.getById(localId))!,
+        );
+
+        final parent = payload['parent']! as Map<String, dynamic>;
+        expect(parent['name'], 'Live survey');
+        expect(
+          (parent['questions']! as List).single,
+          containsPair('title', 'How is the water?'),
+        );
+      },
+    );
+
+    /// The mirror of the above: an exam attempt takes the exam row.
+    test(
+      'an exam attempt takes the exam when both tables hold the id',
+      () async {
+        const sharedId = 'course-1-course-1:0-exam';
+        await database.surveyDao.upsertAll([
+          SurveysCompanion.insert(
+            id: sharedId,
+            name: const Value('Stale survey'),
+            stepId: const Value('course-1:0'),
+          ),
+        ], const {});
+        await database.examDao.upsertAll([
+          ExamsCompanion.insert(
+            id: sharedId,
+            name: const Value('Live test'),
+            stepId: const Value('course-1:0'),
+          ),
+        ], const {});
+        final questions = await database.examDao.questionsFor(sharedId);
+        final localId = await repository.startExamSession(
+          exam: (await database.examDao.getById(sharedId))!,
+          questions: questions,
+          userId: 'org.couchdb.user:ada',
+        );
+
+        final payload = await repository.serialize(
+          (await repository.getById(localId))!,
+        );
+
+        expect((payload['parent']! as Map)['name'], 'Live test');
+      },
+    );
+
     /// The blob is the `else if` branch (`SubmissionsRepositoryImpl.kt:842`),
     /// not the default: a device that no longer has the exam still uploads
     /// what it stored.

--- a/flutter/test/repository/submissions_sync_round_trip_test.dart
+++ b/flutter/test/repository/submissions_sync_round_trip_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:drift/drift.dart' show Value, driftRuntimeOptions;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/config/server_config.dart';
@@ -7,6 +8,7 @@ import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/converters.dart';
 import 'package:myplanet/repository/submissions_repository.dart';
 
 /// Upload a submission, then pull the same document back.
@@ -26,6 +28,11 @@ import 'package:myplanet/repository/submissions_repository.dart';
 class MockPlanetApi extends Mock implements PlanetApi {}
 
 void main() {
+  // The cross-device group below opens a second in-memory database on purpose:
+  // two handsets, two separate executors, which is the case drift's warning is
+  // not about.
+  driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+
   late AppDatabase database;
   late SubmissionsRepository repository;
 
@@ -36,6 +43,7 @@ void main() {
       database.submissionDao,
       database.submitPhotosDao,
       database.surveyDao,
+      database.examDao,
     );
   });
   tearDown(() => database.close());
@@ -188,10 +196,7 @@ void main() {
           {...planetDocument(), 'isUpdated': true},
         ]);
         expect((await repository.getById('planet-1'))!.isUpdated, isFalse);
-        expect(
-          await repository.pendingUploads('org.couchdb.user:ada'),
-          isEmpty,
-        );
+        expect(await repository.pendingUploads(), isEmpty);
       },
     );
 
@@ -242,6 +247,355 @@ void main() {
     });
   });
 
+  /// **The cross-device half of the round trip.** Everything above uploads and
+  /// pulls through one database; this group builds a *second* one that has
+  /// never seen the exam or the survey, which is what a real second handset
+  /// looks like before it has synced the `exams` database — and what Planet
+  /// web looks like always.
+  ///
+  /// Kotlin's `serializeSubmission` prefers the **live** exam over the stored
+  /// blob: `getPayloadData` (`SubmissionsRepositoryImpl.kt:756-761`) resolves
+  /// `examDao.getById(parentId.substringBefore("@"))` plus its questions and
+  /// emits `StepExam.serializeExam(exam, questions)`, whose `StepExam.kt:92`
+  /// adds the `questions` array. The stored blob is only the fallback for an
+  /// exam this device no longer has (`:842`).
+  ///
+  /// The port always sent the blob, which `_openExamSession` writes as
+  /// `{_id,_rev,name,courseId,totalMarks}` and `createSurveyDraft` as
+  /// `{_id,name}` — no questions at all. The port's own pull then fills
+  /// `submission_questions` from `parent['questions']`, so the answer sheet
+  /// arrived on the second device with answers and nothing to put them
+  /// against. Writer and reader disagreeing about a key, each half passing its
+  /// own test: Phase 74's reactions, Phase 100's photo id, Phase 116's feed.
+  group('a submission pulled on a device that has never seen the exam', () {
+    late AppDatabase secondDevice;
+    late SubmissionsRepository secondRepository;
+
+    setUp(() {
+      secondDevice = AppDatabase.memory();
+      secondRepository = SubmissionsRepository(
+        MockPlanetApi(),
+        secondDevice.submissionDao,
+        secondDevice.submitPhotosDao,
+        secondDevice.surveyDao,
+        secondDevice.examDao,
+      );
+    });
+    tearDown(() => secondDevice.close());
+
+    Future<ExamRow> seedExam() async {
+      await database.examDao.upsertAll(
+        [
+          ExamsCompanion.insert(
+            id: 'exam-1',
+            rev: const Value('4-eee'),
+            name: const Value('Week 1 quiz'),
+            description: const Value('The first week'),
+            courseId: const Value('course-1'),
+            totalMarks: const Value(2),
+            passingPercentage: const Value('50'),
+            createdBy: const Value('org.couchdb.user:tutor'),
+            sourcePlanet: const Value('lea'),
+            createdDate: const Value(100),
+            updatedDate: const Value(200),
+          ),
+        ],
+        {
+          'exam-1': [
+            ExamQuestionsCompanion.insert(
+              id: 'exam-1-q1',
+              examId: 'exam-1',
+              header: const Value('Capital of France?'),
+              body: const Value('Pick one'),
+              type: const Value('select'),
+              marks: const Value('1'),
+              choices: const Value([
+                ExamChoice(id: 'c1', text: 'Paris'),
+                ExamChoice(id: 'c2', text: 'Lyon'),
+              ]),
+              correctChoices: const Value(['c1']),
+              position: 0,
+            ),
+          ],
+        },
+      );
+      return (await database.examDao.getById('exam-1'))!;
+    }
+
+    test('an exam attempt keeps its questions', () async {
+      final exam = await seedExam();
+      final localId = await repository.startExamSession(
+        exam: exam,
+        questions: await database.examDao.questionsFor('exam-1'),
+        userId: 'org.couchdb.user:ada',
+      );
+      final payload = await repository.serialize(
+        (await repository.getById(localId))!,
+      );
+
+      await secondRepository.upsertDocuments([
+        asStoredByCouch(payload, id: 'couch-exam-1'),
+      ]);
+
+      final questions = await secondRepository
+          .watchQuestions('couch-exam-1')
+          .first;
+      expect(
+        questions.map((question) => question.header),
+        ['Capital of France?'],
+        reason:
+            'the upload carried the stored blob, which has no `questions` — so '
+            'the second device drew an answer sheet with no questions',
+      );
+      expect(questions.single.choices, ['Paris', 'Lyon']);
+    });
+
+    test('the answers still line up with the questions', () async {
+      final exam = await seedExam();
+      final questionRows = await database.examDao.questionsFor('exam-1');
+      final localId = await repository.startExamSession(
+        exam: exam,
+        questions: questionRows,
+        userId: 'org.couchdb.user:ada',
+      );
+      await repository.saveExamAnswer(
+        submissionId: localId,
+        question: questionRows.single,
+        answer: const ExamDraftAnswer(choiceIds: ['c1']),
+        isFinal: true,
+        isExplicitSubmission: true,
+      );
+      final payload = await repository.serialize(
+        (await repository.getById(localId))!,
+      );
+
+      await secondRepository.upsertDocuments([
+        asStoredByCouch(payload, id: 'couch-exam-1'),
+      ]);
+
+      final questions = await secondRepository
+          .watchQuestions('couch-exam-1')
+          .first;
+      final answers = await secondRepository.answersFor('couch-exam-1');
+      expect(
+        answers.single.questionId,
+        'exam-1-q1',
+        reason: 'the answer records the id of the question it was given',
+      );
+      expect(
+        questions.single.id,
+        'couch-exam-1:exam-1-q1',
+        reason:
+            'Kotlin `serializeQuestions` emits no question id, so a faithful '
+            'upload leaves the pull falling back to a positional '
+            '`<submission>-q<index>` key the answer cannot be joined to',
+      );
+    });
+
+    test('a survey submission keeps its questions', () async {
+      await database.surveyDao.upsertAll(
+        [SurveysCompanion.insert(id: 'survey-1', name: const Value('Water'))],
+        {
+          'survey-1': [
+            SurveyQuestionsCompanion.insert(
+              id: 'survey-1:q1',
+              surveyId: 'survey-1',
+              questionId: const Value('q1'),
+              header: const Value('How is the water?'),
+              type: const Value('select'),
+              choices: const Value([
+                ExamChoice(id: 'c1', text: 'Clean'),
+                ExamChoice(id: 'c2', text: 'Dirty'),
+              ]),
+              position: 0,
+            ),
+          ],
+        },
+      );
+      final localId = await repository.createSurveyDraft(
+        survey: (await database.surveyDao.getById('survey-1'))!,
+        questions: await database.surveyDao.questionsFor('survey-1'),
+        userId: 'org.couchdb.user:ada',
+      );
+      final payload = await repository.serialize(
+        (await repository.getById(localId))!,
+      );
+
+      await secondRepository.upsertDocuments([
+        asStoredByCouch(payload, id: 'couch-survey-1'),
+      ]);
+
+      final questions = await secondRepository
+          .watchQuestions('couch-survey-1')
+          .first;
+      expect(questions.map((question) => question.header), [
+        'How is the water?',
+      ]);
+      expect(questions.single.id, 'couch-survey-1:q1');
+    });
+  });
+
+  /// The `parent` object itself, field for field against
+  /// `StepExam.serializeExam` (`StepExam.kt:70-94`). The round-trip tests
+  /// above only prove the questions arrive; this one is what stops the rest of
+  /// the document being quietly dropped again.
+  group('the parent object the upload carries', () {
+    test('is `serializeExam`, minus the type the port cannot know', () {
+      final document = SubmissionsRepository.examParentDocument(
+        ExamRow(
+          id: 'exam-1',
+          rev: '4-eee',
+          name: 'Week 1 quiz',
+          description: 'The first week',
+          courseId: 'course-1',
+          stepId: 'step-1',
+          createdDate: 100,
+          updatedDate: 200,
+          adoptionDate: 300,
+          createdBy: 'org.couchdb.user:tutor',
+          totalMarks: 2,
+          passingPercentage: '50',
+          sourcePlanet: 'lea',
+          isFromNation: false,
+          teamId: 'team-9',
+          teamShareAllowed: false,
+          sourceSurveyId: 'survey-0',
+          noOfQuestions: 1,
+        ),
+        const [],
+      );
+
+      expect(document, {
+        '_id': 'exam-1',
+        '_rev': '4-eee',
+        'name': 'Week 1 quiz',
+        'description': 'The first week',
+        'passingPercentage': '50',
+        'updatedDate': 200,
+        'createdDate': 100,
+        'adoptionDate': 300,
+        'sourcePlanet': 'lea',
+        'totalMarks': 2,
+        'createdBy': 'org.couchdb.user:tutor',
+        'sourceSurveyId': 'survey-0',
+        'teamId': 'team-9',
+        'questions': <Object?>[],
+      });
+    });
+
+    test('omits the two fields Kotlin guards with an `if`', () {
+      final document = SubmissionsRepository.examParentDocument(
+        ExamRow(
+          id: 'exam-1',
+          createdDate: 0,
+          updatedDate: 0,
+          adoptionDate: 0,
+          totalMarks: 0,
+          isFromNation: false,
+          teamShareAllowed: false,
+          noOfQuestions: 0,
+        ),
+        const [],
+      );
+
+      expect(document.containsKey('_rev'), isFalse);
+      expect(document.containsKey('sourceSurveyId'), isFalse);
+      expect(document.containsKey('teamId'), isFalse);
+    });
+
+    test('carries every field `serializeQuestions` writes', () {
+      final document = SubmissionsRepository.examParentDocument(
+        ExamRow(
+          id: 'exam-1',
+          createdDate: 0,
+          updatedDate: 0,
+          adoptionDate: 0,
+          totalMarks: 0,
+          isFromNation: false,
+          teamShareAllowed: false,
+          noOfQuestions: 1,
+        ),
+        const [
+          ExamQuestionRow(
+            id: 'exam-1-q1',
+            examId: 'exam-1',
+            header: 'Capital of France?',
+            body: 'Pick one',
+            type: 'select',
+            marks: '1',
+            correctChoices: ['c1'],
+            choices: [
+              ExamChoice(id: 'c1', text: 'Paris'),
+              ExamChoice(id: 'c2', text: 'Lyon'),
+            ],
+            hasOtherOption: false,
+            scaleMax: 9,
+            position: 0,
+          ),
+        ],
+      );
+
+      expect((document['questions'] as List).single, {
+        'id': 'exam-1-q1',
+        // Neither is Kotlin's: `serializeQuestions` emits no id, and it puts
+        // the label under `header`, a key no real document has. See
+        // `examParentDocument`.
+        'title': 'Capital of France?',
+        'header': 'Capital of France?',
+        'body': 'Pick one',
+        'type': 'select',
+        'marks': '1',
+        'choices': [
+          {'id': 'c1', 'text': 'Paris'},
+          {'id': 'c2', 'text': 'Lyon'},
+        ],
+        'correctChoice': ['c1'],
+        'hasOtherOption': false,
+      });
+    });
+
+    /// The exams-database walk routes on `type == 'surveys'`, but
+    /// `SurveyMapper.fromCourseDoc`'s second pass files a course step's survey
+    /// here with no type filter — so the value is a guess for exactly the rows
+    /// the exam branch refuses to guess for, and neither side emits it.
+    test('a survey does not guess back the type the split discarded', () {
+      final document = SubmissionsRepository.surveyParentDocument(
+        SurveyRow(
+          id: 'survey-1',
+          name: 'Water',
+          createdDate: 0,
+          updatedDate: 0,
+          adoptionDate: 0,
+          totalMarks: 0,
+          isFromNation: false,
+          teamShareAllowed: false,
+        ),
+        const [],
+      );
+
+      expect(document.containsKey('type'), isFalse);
+      expect(document['_id'], 'survey-1');
+    });
+
+    /// The blob is the `else if` branch (`SubmissionsRepositoryImpl.kt:842`),
+    /// not the default: a device that no longer has the exam still uploads
+    /// what it stored.
+    test('falls back to the stored blob when the exam is gone', () async {
+      final id = await repository.createDraft(
+        userId: 'org.couchdb.user:ada',
+        type: 'survey',
+        title: 'Water survey',
+        answers: const [],
+      );
+
+      final payload = await repository.serialize(
+        (await repository.getById(id))!,
+      );
+
+      expect(payload['parent'], 'Water survey');
+    });
+  });
+
   group('the walk leaves local work alone', () {
     const config = ServerConfig(
       serverUrl: 'https://planet.example.org',
@@ -257,6 +611,7 @@ void main() {
         database.submissionDao,
         database.submitPhotosDao,
         database.surveyDao,
+        database.examDao,
       );
     });
 

--- a/flutter/test/repository/submissions_uploader_test.dart
+++ b/flutter/test/repository/submissions_uploader_test.dart
@@ -76,6 +76,48 @@ void main() {
     expect((await repository.getById(id))?.couchId, 'server-id');
   });
 
+  /// **The shared handset, end to end.** `SubmissionDao.pendingUploads` is
+  /// pinned by its own tests, but until this one nothing drove `queuePending`
+  /// with more than one owner — so a Dart-side `.where((row) => row.userId ==
+  /// userId)` here would have re-scoped the uploader with the whole suite
+  /// green, reinstating exactly the defect the DAO change fixed. The
+  /// `userId` parameter is the outbox row's session tag, not a filter.
+  test('queues every owner on the handset, not just the session', () async {
+    await repository.createDraft(
+      userId: 'org.couchdb.user:ada',
+      type: 'survey',
+      title: "Ada's sheet",
+      answers: const [],
+    );
+    await repository.createDraft(
+      userId: 'org.couchdb.user:bob',
+      type: 'survey',
+      title: "Bob's sheet",
+      answers: const [],
+    );
+
+    // Bob is the one signed in and syncing; Ada answered and signed out.
+    final queued = await uploader.queuePending(
+      config: config,
+      userId: 'org.couchdb.user:bob',
+    );
+
+    expect(queued, 2);
+    final owners = [
+      for (final row in await outbox.due())
+        ((jsonDecode(row.payload) as Map<String, dynamic>)['user']
+                as Map<String, dynamic>)['_id']
+            as String,
+    ];
+    expect(
+      owners,
+      containsAll(<String>['org.couchdb.user:ada', 'org.couchdb.user:bob']),
+      reason:
+          "each document is attributed to its own owner; only the outbox row's "
+          'session tag is the signed-in user',
+    );
+  });
+
   test('an already-uploaded submission is updated, not duplicated', () async {
     // A submission the server already holds, marked dirty again — which is
     // exactly what `upsertDocuments` produces when a synced document carries

--- a/flutter/test/repository/submissions_uploader_test.dart
+++ b/flutter/test/repository/submissions_uploader_test.dart
@@ -35,6 +35,7 @@ void main() {
       db.submissionDao,
       db.submitPhotosDao,
       db.surveyDao,
+      db.examDao,
     );
     outbox = OutboxRepository(db.outboxDao);
     uploader = SubmissionsUploader(api, repository, outbox, testDeviceIdentity);
@@ -71,7 +72,7 @@ void main() {
     final result = await uploader.handler(operation, const {}, 'Basic test');
 
     expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
-    expect(await repository.pendingUploads('user-1'), isEmpty);
+    expect(await repository.pendingUploads(), isEmpty);
     expect((await repository.getById(id))?.couchId, 'server-id');
   });
 
@@ -92,7 +93,7 @@ void main() {
     ]);
 
     final payload = await repository.serialize(
-      (await db.submissionDao.pendingUploads('user-1')).single,
+      (await db.submissionDao.pendingUploads()).single,
     );
 
     // Kotlin's serializeSubmission adds both when present; CouchDB needs them

--- a/flutter/test/repository/submit_photos_uploader_test.dart
+++ b/flutter/test/repository/submit_photos_uploader_test.dart
@@ -38,6 +38,7 @@ void main() {
       database.submissionDao,
       database.submitPhotosDao,
       database.surveyDao,
+      database.examDao,
     );
     outbox = OutboxRepository(database.outboxDao);
     uploader = SubmitPhotosUploader(

--- a/flutter/test/repository/survey_export_test.dart
+++ b/flutter/test/repository/survey_export_test.dart
@@ -29,6 +29,7 @@ void main() {
       database.submissionDao,
       database.submitPhotosDao,
       database.surveyDao,
+      database.examDao,
     );
   });
   tearDown(() => database.close());

--- a/flutter/test/repository/surveys_repository_test.dart
+++ b/flutter/test/repository/surveys_repository_test.dart
@@ -37,6 +37,7 @@ void main() {
         database.submissionDao,
         database.submitPhotosDao,
         database.surveyDao,
+        database.examDao,
       ),
     );
   });
@@ -331,6 +332,7 @@ void main() {
           database.submissionDao,
           database.submitPhotosDao,
           database.surveyDao,
+          database.examDao,
         ),
         urlMapper: ServerUrlMapper(
           mappings: {'http://local.example': 'https://alt.example'},
@@ -420,6 +422,7 @@ void main() {
         database.submissionDao,
         database.submitPhotosDao,
         database.surveyDao,
+        database.examDao,
       ).markSubmissionComplete(id!, {'birthYear': '2000', 'gender': 'male'});
 
       Map<String, dynamic>? capturedBody;
@@ -497,6 +500,7 @@ void main() {
             database.submissionDao,
             database.submitPhotosDao,
             database.surveyDao,
+            database.examDao,
           ),
           urlMapper: ServerUrlMapper(
             mappings: {'http://local.example': 'https://alt.example'},

--- a/flutter/test/ui/courses/course_progress_screen_test.dart
+++ b/flutter/test/ui/courses/course_progress_screen_test.dart
@@ -238,6 +238,7 @@ void main() {
         database.submissionDao,
         database.submitPhotosDao,
         database.surveyDao,
+        database.examDao,
       );
 
       final submissionId = await repository.startExamSession(

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -742,7 +742,7 @@ void main() {
       // port stored the bare course id, so the per-step mistake counts could
       // never match their exam.
       expect(saved.single.parentId, 'exam-1@course-1');
-      expect(await db.submissionDao.pendingUploads('user-1'), hasLength(1));
+      expect(await db.submissionDao.pendingUploads(), hasLength(1));
 
       final answers = await db.select(db.submissionAnswers).get();
       expect(answers, hasLength(2));
@@ -1070,6 +1070,7 @@ void main() {
         db.submissionDao,
         db.submitPhotosDao,
         db.surveyDao,
+        db.examDao,
       );
       final flaky = _FlakySubmissionsRepository(real);
 


### PR DESCRIPTION
Lane B of the Phase 123 parallel round. Draft, opened as the lane's first action so PR comments can reach the session.

Two submission defects Phase 120 verified and reported but left outside its own lane:

1. **`parent.questions` is dropped on upload.** `serializeSubmission:840-841` prefers the live exam (`StepExam.serializeExam`, whose `:92` adds `questions`) over the stored blob; the port always sends the blob, which for a local exam attempt is just `{_id, _rev, name, courseId, totalMarks}`. The port's own pull reads `parent['questions']` to fill `submission_questions`, so a submission uploaded here and pulled on a second device yields a detail screen of answers with no questions.
2. **`pendingUploads` is scoped the opposite way to Kotlin.** `SubmissionDao.kt:41` is `status = 'complete' AND (isUpdated = 1 OR _id IS NULL OR _id = '')` — every user's completed submissions on the handset. The port's is `userId = ? AND isUpdated = true`.

Files owned by this lane: `lib/repository/submissions_repository.dart`, `lib/repository/submissions_exporter.dart`, `lib/ui/submissions/`, their mappers and tests, and **the submissions DAO section only** of `lib/data/local/app_database.dart`. No schema change: `schemaVersion` stays 45 (Lane A takes it to 46).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp3CPagF47dvGcwksQDhPK)_