### PR TITLE
life: smoother personal dao sorting (fixes #16766)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7052
-        versionName = "0.70.52"
+        versionCode = 7053
+        versionName = "0.70.53"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/PersonalDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/PersonalDao.kt
@@ -21,7 +21,7 @@ interface PersonalDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(item: Personal)
 
-    @Query("SELECT * FROM my_personal WHERE userId = :userId")
+    @Query("SELECT * FROM my_personal WHERE userId = :userId ORDER BY date DESC, title COLLATE NOCASE ASC")
     fun getByUserIdFlow(userId: String): Flow<List<Personal>>
 
     @Query("SELECT * FROM my_personal WHERE userId = :userId AND isUploaded = 0")

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/PersonalDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/PersonalDaoTest.kt
@@ -3,6 +3,8 @@ package org.ole.planet.myplanet.data.room.dao
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -12,12 +14,16 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.data.room.AppDatabase
 import org.ole.planet.myplanet.model.Personal
+import org.ole.planet.myplanet.repository.PersonalsRepositoryImpl
+import org.ole.planet.myplanet.repository.UploadRepository
+import org.ole.planet.myplanet.utils.DeviceNameProvider
 
 @RunWith(AndroidJUnit4::class)
 class PersonalDaoTest {
 
     private lateinit var database: AppDatabase
     private lateinit var personalDao: PersonalDao
+    private lateinit var repository: PersonalsRepositoryImpl
 
     @Before
     fun initDb() {
@@ -26,11 +32,29 @@ class PersonalDaoTest {
             AppDatabase::class.java
         ).allowMainThreadQueries().build()
         personalDao = database.personalDao()
+        repository = PersonalsRepositoryImpl(
+            personalDao,
+            mockk<UploadRepository>(relaxed = true),
+            mockk<DeviceNameProvider>(relaxed = true)
+        )
     }
 
     @After
     fun closeDb() {
         database.close()
+    }
+
+    private fun createPersonal(
+        id: String,
+        userId: String = "user1",
+        title: String,
+        date: Long
+    ) = Personal().apply {
+        this.id = id
+        this._id = id
+        this.userId = userId
+        this.title = title
+        this.date = date
     }
 
     @Test
@@ -103,5 +127,30 @@ class PersonalDaoTest {
         val updated = personalDao.findByDocId("doc-1")
         assertEquals("Original Title", updated?.title)
         assertEquals("Original Description", updated?.description)
+    }
+
+    @Test
+    fun `getPersonalResources flow sorts newer entries first`() = runBlocking {
+        personalDao.insert(createPersonal(id = "p1", title = "Older Document", date = 1000L))
+        personalDao.insert(createPersonal(id = "p2", title = "Newer Document", date = 3000L))
+        personalDao.insert(createPersonal(id = "p3", title = "Middle Document", date = 2000L))
+
+        val result = repository.getPersonalResources("user1").first()
+
+        assertEquals(listOf("p2", "p3", "p1"), result.map { it.id })
+    }
+
+    @Test
+    fun `getPersonalResources flow sorts same date entries by title case insensitively`() = runBlocking {
+        val sameDate = 5000L
+        personalDao.insert(createPersonal(id = "p1", title = "charlie", date = sameDate))
+        personalDao.insert(createPersonal(id = "p2", title = "Apple", date = sameDate))
+        personalDao.insert(createPersonal(id = "p3", title = "banana", date = sameDate))
+        personalDao.insert(createPersonal(id = "p4", title = "DELTA", date = sameDate))
+
+        val result = repository.getPersonalResources("user1").first()
+
+        assertEquals(listOf("p2", "p3", "p1", "p4"), result.map { it.id })
+        assertEquals(listOf("Apple", "banana", "charlie", "DELTA"), result.map { it.title })
     }
 }


### PR DESCRIPTION
Order personal resources in SQL query with tests verifying repository Flow output order.

Fixes #16766

---
*PR created automatically by Jules for task [4547644843512412062](https://jules.google.com/task/4547644843512412062) started by @dogi*