### PR TITLE
enterprises: smoother finances reports attachment caching (fixes #16777)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7050
-        versionName = "0.70.50"
+        versionCode = 7051
+        versionName = "0.70.51"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
@@ -27,7 +27,8 @@ class EnterprisesFinancesAdapter(
         areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
     )
 ) {
-    private val attachmentExistsCache = HashMap<String, Boolean>()
+    private val attachmentExistsCache = HashMap<String, Pair<Boolean, Long>>()
+    private val cacheTtlMs = 5000L
 
     override fun onCurrentListChanged(
         previousList: MutableList<Transaction>,
@@ -67,7 +68,21 @@ class EnterprisesFinancesAdapter(
 
     private fun bindFinanceImage(binding: RowFinanceBinding, item: Transaction) {
         val imageFile = MyTeam.getAttachmentFile(context, item.id, item.imageName)
-        if (imageFile != null && attachmentExistsCache.getOrPut(imageFile.absolutePath) { imageFile.exists() }) {
+        val now = System.currentTimeMillis()
+        val exists = if (imageFile != null) {
+            val cached = attachmentExistsCache[imageFile.absolutePath]
+            if (cached != null && now - cached.second < cacheTtlMs) {
+                cached.first
+            } else {
+                val freshExists = imageFile.exists()
+                attachmentExistsCache[imageFile.absolutePath] = Pair(freshExists, now)
+                freshExists
+            }
+        } else {
+            false
+        }
+
+        if (imageFile != null && exists) {
             binding.financeImage.visibility = View.VISIBLE
             Glide.with(context)
                 .load(imageFile)
@@ -79,6 +94,7 @@ class EnterprisesFinancesAdapter(
             }
         } else {
             binding.financeImage.visibility = View.GONE
+            binding.financeImage.setOnClickListener(null)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
@@ -27,6 +27,15 @@ class EnterprisesFinancesAdapter(
         areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
     )
 ) {
+    private val attachmentExistsCache = HashMap<String, Boolean>()
+
+    override fun onCurrentListChanged(
+        previousList: MutableList<Transaction>,
+        currentList: MutableList<Transaction>
+    ) {
+        super.onCurrentListChanged(previousList, currentList)
+        attachmentExistsCache.clear()
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FinanceViewHolder {
         val binding = RowFinanceBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -58,7 +67,7 @@ class EnterprisesFinancesAdapter(
 
     private fun bindFinanceImage(binding: RowFinanceBinding, item: Transaction) {
         val imageFile = MyTeam.getAttachmentFile(context, item.id, item.imageName)
-        if (imageFile != null && imageFile.exists()) {
+        if (imageFile != null && attachmentExistsCache.getOrPut(imageFile.absolutePath) { imageFile.exists() }) {
             binding.financeImage.visibility = View.VISIBLE
             Glide.with(context)
                 .load(imageFile)
@@ -70,7 +79,6 @@ class EnterprisesFinancesAdapter(
             }
         } else {
             binding.financeImage.visibility = View.GONE
-            binding.financeImage.setOnClickListener(null)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
@@ -17,10 +17,13 @@ import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.model.Transaction
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.ImageViewerUtils
+import org.ole.planet.myplanet.utils.SystemTimeProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 
 class EnterprisesFinancesAdapter(
     private val context: Context,
+    private val timeProvider: TimeProvider = SystemTimeProvider(),
 ) : ListAdapter<Transaction, EnterprisesFinancesAdapter.FinanceViewHolder>(
     DiffUtils.itemCallback(
         areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
@@ -68,7 +71,7 @@ class EnterprisesFinancesAdapter(
 
     private fun bindFinanceImage(binding: RowFinanceBinding, item: Transaction) {
         val imageFile = MyTeam.getAttachmentFile(context, item.id, item.imageName)
-        val now = System.currentTimeMillis()
+        val now = timeProvider.now()
         val exists = if (imageFile != null) {
             val cached = attachmentExistsCache[imageFile.absolutePath]
             if (cached != null && now - cached.second < cacheTtlMs) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
@@ -21,7 +21,8 @@ class EnterprisesReportsAdapter(
     private val onDelete: (MyTeam) -> Unit
 ) : ListAdapter<MyTeam, EnterprisesReportsAdapter.ReportsViewHolder>(diffCallback) {
     private var nonTeamMember = false
-    private val attachmentExistsCache = HashMap<String, Boolean>()
+    private val attachmentExistsCache = HashMap<String, Pair<Boolean, Long>>()
+    private val cacheTtlMs = 5000L
 
     override fun onCurrentListChanged(
         previousList: MutableList<MyTeam>,
@@ -103,7 +104,21 @@ class EnterprisesReportsAdapter(
 
     private fun bindReportImage(binding: ReportListItemBinding, report: MyTeam) {
         val imageFile = MyTeam.getAttachmentFile(context, report._id, report.imageName)
-        if (imageFile != null && attachmentExistsCache.getOrPut(imageFile.absolutePath) { imageFile.exists() }) {
+        val now = System.currentTimeMillis()
+        val exists = if (imageFile != null) {
+            val cached = attachmentExistsCache[imageFile.absolutePath]
+            if (cached != null && now - cached.second < cacheTtlMs) {
+                cached.first
+            } else {
+                val freshExists = imageFile.exists()
+                attachmentExistsCache[imageFile.absolutePath] = Pair(freshExists, now)
+                freshExists
+            }
+        } else {
+            false
+        }
+
+        if (imageFile != null && exists) {
             binding.reportImage.visibility = View.VISIBLE
             Glide.with(context)
                 .load(imageFile)
@@ -115,6 +130,7 @@ class EnterprisesReportsAdapter(
             }
         } else {
             binding.reportImage.visibility = View.GONE
+            binding.reportImage.setOnClickListener(null)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
@@ -12,13 +12,16 @@ import org.ole.planet.myplanet.databinding.ReportListItemBinding
 import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.ImageViewerUtils
+import org.ole.planet.myplanet.utils.SystemTimeProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 
 class EnterprisesReportsAdapter(
     private val context: Context,
     private val teamName: String?,
     private val onEdit: (MyTeam) -> Unit,
-    private val onDelete: (MyTeam) -> Unit
+    private val onDelete: (MyTeam) -> Unit,
+    private val timeProvider: TimeProvider = SystemTimeProvider(),
 ) : ListAdapter<MyTeam, EnterprisesReportsAdapter.ReportsViewHolder>(diffCallback) {
     private var nonTeamMember = false
     private val attachmentExistsCache = HashMap<String, Pair<Boolean, Long>>()
@@ -104,7 +107,7 @@ class EnterprisesReportsAdapter(
 
     private fun bindReportImage(binding: ReportListItemBinding, report: MyTeam) {
         val imageFile = MyTeam.getAttachmentFile(context, report._id, report.imageName)
-        val now = System.currentTimeMillis()
+        val now = timeProvider.now()
         val exists = if (imageFile != null) {
             val cached = attachmentExistsCache[imageFile.absolutePath]
             if (cached != null && now - cached.second < cacheTtlMs) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
@@ -21,6 +21,15 @@ class EnterprisesReportsAdapter(
     private val onDelete: (MyTeam) -> Unit
 ) : ListAdapter<MyTeam, EnterprisesReportsAdapter.ReportsViewHolder>(diffCallback) {
     private var nonTeamMember = false
+    private val attachmentExistsCache = HashMap<String, Boolean>()
+
+    override fun onCurrentListChanged(
+        previousList: MutableList<MyTeam>,
+        currentList: MutableList<MyTeam>
+    ) {
+        super.onCurrentListChanged(previousList, currentList)
+        attachmentExistsCache.clear()
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReportsViewHolder {
         val binding = ReportListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -94,7 +103,7 @@ class EnterprisesReportsAdapter(
 
     private fun bindReportImage(binding: ReportListItemBinding, report: MyTeam) {
         val imageFile = MyTeam.getAttachmentFile(context, report._id, report.imageName)
-        if (imageFile != null && imageFile.exists()) {
+        if (imageFile != null && attachmentExistsCache.getOrPut(imageFile.absolutePath) { imageFile.exists() }) {
             binding.reportImage.visibility = View.VISIBLE
             Glide.with(context)
                 .load(imageFile)
@@ -106,7 +115,6 @@ class EnterprisesReportsAdapter(
             }
         } else {
             binding.reportImage.visibility = View.GONE
-            binding.reportImage.setOnClickListener(null)
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapterTest.kt
@@ -91,7 +91,7 @@ class EnterprisesFinancesAdapterTest {
             // File is deleted on disk
             imageFile.delete()
 
-            // Second bind uses cached exists value so image remains visible
+            // Second bind within TTL uses cached exists value (true) so image remains visible
             adapter.onBindViewHolder(viewHolder, 0)
             assertEquals(View.VISIBLE, viewHolder.binding.financeImage.visibility)
 
@@ -101,6 +101,45 @@ class EnterprisesFinancesAdapterTest {
                 // Cache was cleared, so disk re-check detects file is deleted and sets visibility to GONE
                 assertEquals(View.GONE, viewHolder.binding.financeImage.visibility)
             }
+        }
+    }
+
+    @Test
+    fun testBindFinanceImage_cacheExpiresAfterTtl() {
+        val teamAttachmentsDir = File(tempDir, "team_attachments/tx1").apply { mkdirs() }
+        val imageFile = File(teamAttachmentsDir, "receipt.jpg")
+
+        val transaction = Transaction(
+            id = "tx1",
+            date = System.currentTimeMillis(),
+            description = "Test transaction",
+            type = "debit",
+            amount = 100,
+            balance = 500,
+            imageName = "receipt.jpg"
+        )
+
+        adapter.submitList(listOf(transaction)) {
+            val binding = RowFinanceBinding.inflate(LayoutInflater.from(context))
+            val viewHolder = EnterprisesFinancesAdapter.FinanceViewHolder(binding)
+
+            // File doesn't exist initially -> GONE (and cached false)
+            adapter.onBindViewHolder(viewHolder, 0)
+            assertEquals(View.GONE, viewHolder.binding.financeImage.visibility)
+
+            // File appears on disk (e.g. downloaded)
+            imageFile.createNewFile()
+
+            // Immediate re-bind within TTL uses cached false -> still GONE
+            adapter.onBindViewHolder(viewHolder, 0)
+            assertEquals(View.GONE, viewHolder.binding.financeImage.visibility)
+
+            // Sleep past the 5000ms TTL
+            Thread.sleep(5100L)
+
+            // Re-bind after TTL expires re-stats disk -> VISIBLE
+            adapter.onBindViewHolder(viewHolder, 0)
+            assertEquals(View.VISIBLE, viewHolder.binding.financeImage.visibility)
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapterTest.kt
@@ -1,0 +1,106 @@
+package org.ole.planet.myplanet.ui.enterprises
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import androidx.appcompat.R as AppCompatR
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.databinding.RowFinanceBinding
+import org.ole.planet.myplanet.model.Transaction
+import org.ole.planet.myplanet.utils.FileUtils
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class EnterprisesFinancesAdapterTest {
+
+    private lateinit var adapter: EnterprisesFinancesAdapter
+    private lateinit var context: Context
+    private lateinit var tempDir: File
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.setTheme(AppCompatR.style.Theme_AppCompat)
+        tempDir = File(context.cacheDir, "test_ole_${System.currentTimeMillis()}").apply { mkdirs() }
+        mockkObject(FileUtils)
+        every { FileUtils.getOlePath(any()) } returns "${tempDir.absolutePath}/"
+        adapter = EnterprisesFinancesAdapter(context)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(FileUtils)
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun testBindFinanceImage_missingFile_visibilityGone() {
+        val transaction = Transaction(
+            id = "tx1",
+            date = System.currentTimeMillis(),
+            description = "Test transaction",
+            type = "debit",
+            amount = 100,
+            balance = 500,
+            imageName = "missing.jpg"
+        )
+
+        adapter.submitList(listOf(transaction)) {
+            val binding = RowFinanceBinding.inflate(LayoutInflater.from(context))
+            val viewHolder = EnterprisesFinancesAdapter.FinanceViewHolder(binding)
+
+            adapter.onBindViewHolder(viewHolder, 0)
+
+            assertEquals(View.GONE, viewHolder.binding.financeImage.visibility)
+        }
+    }
+
+    @Test
+    fun testBindFinanceImage_existingFile_cachesAndInvalidatesOnListChange() {
+        val teamAttachmentsDir = File(tempDir, "team_attachments/tx1").apply { mkdirs() }
+        val imageFile = File(teamAttachmentsDir, "receipt.jpg")
+        imageFile.createNewFile()
+
+        val transaction = Transaction(
+            id = "tx1",
+            date = System.currentTimeMillis(),
+            description = "Test transaction",
+            type = "debit",
+            amount = 100,
+            balance = 500,
+            imageName = "receipt.jpg"
+        )
+
+        adapter.submitList(listOf(transaction)) {
+            val binding = RowFinanceBinding.inflate(LayoutInflater.from(context))
+            val viewHolder = EnterprisesFinancesAdapter.FinanceViewHolder(binding)
+
+            // First bind detects existing file and makes image visible
+            adapter.onBindViewHolder(viewHolder, 0)
+            assertEquals(View.VISIBLE, viewHolder.binding.financeImage.visibility)
+
+            // File is deleted on disk
+            imageFile.delete()
+
+            // Second bind uses cached exists value so image remains visible
+            adapter.onBindViewHolder(viewHolder, 0)
+            assertEquals(View.VISIBLE, viewHolder.binding.financeImage.visibility)
+
+            // Re-submitting current list invalidates cache via onCurrentListChanged
+            adapter.submitList(listOf(transaction)) {
+                adapter.onBindViewHolder(viewHolder, 0)
+                // Cache was cleared, so disk re-check detects file is deleted and sets visibility to GONE
+                assertEquals(View.GONE, viewHolder.binding.financeImage.visibility)
+            }
+        }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapterTest.kt
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith
 import org.ole.planet.myplanet.databinding.RowFinanceBinding
 import org.ole.planet.myplanet.model.Transaction
 import org.ole.planet.myplanet.utils.FileUtils
+import org.ole.planet.myplanet.utils.TestTimeProvider
 import java.io.File
 
 @RunWith(AndroidJUnit4::class)
@@ -25,6 +26,7 @@ class EnterprisesFinancesAdapterTest {
     private lateinit var adapter: EnterprisesFinancesAdapter
     private lateinit var context: Context
     private lateinit var tempDir: File
+    private lateinit var timeProvider: TestTimeProvider
 
     @Before
     fun setUp() {
@@ -33,7 +35,8 @@ class EnterprisesFinancesAdapterTest {
         tempDir = File(context.cacheDir, "test_ole_${System.currentTimeMillis()}").apply { mkdirs() }
         mockkObject(FileUtils)
         every { FileUtils.getOlePath(any()) } returns "${tempDir.absolutePath}/"
-        adapter = EnterprisesFinancesAdapter(context)
+        timeProvider = TestTimeProvider(currentTime = 1000L)
+        adapter = EnterprisesFinancesAdapter(context, timeProvider)
     }
 
     @After
@@ -134,8 +137,8 @@ class EnterprisesFinancesAdapterTest {
             adapter.onBindViewHolder(viewHolder, 0)
             assertEquals(View.GONE, viewHolder.binding.financeImage.visibility)
 
-            // Sleep past the 5000ms TTL
-            Thread.sleep(5100L)
+            // Advance time past the 5000ms TTL deterministically without Thread.sleep
+            timeProvider.advanceBy(5001L)
 
             // Re-bind after TTL expires re-stats disk -> VISIBLE
             adapter.onBindViewHolder(viewHolder, 0)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapterTest.kt
@@ -197,7 +197,7 @@ class EnterprisesReportsAdapterTest {
                 // File is deleted on disk
                 imageFile.delete()
 
-                // Second bind uses cached exists value so image remains visible
+                // Second bind within TTL uses cached exists value (true) so image remains visible
                 adapter.onBindViewHolder(viewHolder, 0)
                 assertEquals(View.VISIBLE, viewHolder.binding.reportImage.visibility)
 
@@ -207,6 +207,49 @@ class EnterprisesReportsAdapterTest {
                     // Cache was cleared, so disk re-check detects file is deleted and sets visibility to GONE
                     assertEquals(View.GONE, viewHolder.binding.reportImage.visibility)
                 }
+            }
+        } finally {
+            io.mockk.unmockkObject(org.ole.planet.myplanet.utils.FileUtils)
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun testBindReportImage_cacheExpiresAfterTtl() {
+        val tempDir = java.io.File(context.cacheDir, "test_ole_reports_ttl_${System.currentTimeMillis()}").apply { mkdirs() }
+        io.mockk.mockkObject(org.ole.planet.myplanet.utils.FileUtils)
+        io.mockk.every { org.ole.planet.myplanet.utils.FileUtils.getOlePath(any()) } returns "${tempDir.absolutePath}/"
+
+        try {
+            val teamAttachmentsDir = java.io.File(tempDir, "team_attachments/report1").apply { mkdirs() }
+            val imageFile = java.io.File(teamAttachmentsDir, "report.jpg")
+
+            val report = MyTeam().apply {
+                _id = "report1"
+                imageName = "report.jpg"
+            }
+
+            adapter.submitList(listOf(report)) {
+                val binding = ReportListItemBinding.inflate(LayoutInflater.from(context))
+                val viewHolder = EnterprisesReportsAdapter.ReportsViewHolder(binding)
+
+                // File doesn't exist initially -> GONE (and cached false)
+                adapter.onBindViewHolder(viewHolder, 0)
+                assertEquals(View.GONE, viewHolder.binding.reportImage.visibility)
+
+                // File appears on disk (e.g. downloaded)
+                imageFile.createNewFile()
+
+                // Immediate re-bind within TTL uses cached false -> still GONE
+                adapter.onBindViewHolder(viewHolder, 0)
+                assertEquals(View.GONE, viewHolder.binding.reportImage.visibility)
+
+                // Sleep past the 5000ms TTL
+                Thread.sleep(5100L)
+
+                // Re-bind after TTL expires re-stats disk -> VISIBLE
+                adapter.onBindViewHolder(viewHolder, 0)
+                assertEquals(View.VISIBLE, viewHolder.binding.reportImage.visibility)
             }
         } finally {
             io.mockk.unmockkObject(org.ole.planet.myplanet.utils.FileUtils)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapterTest.kt
@@ -152,4 +152,65 @@ class EnterprisesReportsAdapterTest {
             assertEquals(context.getString(R.string.number_placeholder, 130), viewHolder.binding.endingBalanceValue.text.toString())
         }
     }
+
+    @Test
+    fun testBindReportImage_missingFile_visibilityGone() {
+        val report = MyTeam().apply {
+            _id = "report1"
+            imageName = "missing.jpg"
+        }
+
+        adapter.submitList(listOf(report)) {
+            val binding = ReportListItemBinding.inflate(LayoutInflater.from(context))
+            val viewHolder = EnterprisesReportsAdapter.ReportsViewHolder(binding)
+
+            adapter.onBindViewHolder(viewHolder, 0)
+
+            assertEquals(View.GONE, viewHolder.binding.reportImage.visibility)
+        }
+    }
+
+    @Test
+    fun testBindReportImage_existingFile_cachesAndInvalidatesOnListChange() {
+        val tempDir = java.io.File(context.cacheDir, "test_ole_reports_${System.currentTimeMillis()}").apply { mkdirs() }
+        io.mockk.mockkObject(org.ole.planet.myplanet.utils.FileUtils)
+        io.mockk.every { org.ole.planet.myplanet.utils.FileUtils.getOlePath(any()) } returns "${tempDir.absolutePath}/"
+
+        try {
+            val teamAttachmentsDir = java.io.File(tempDir, "team_attachments/report1").apply { mkdirs() }
+            val imageFile = java.io.File(teamAttachmentsDir, "report.jpg")
+            imageFile.createNewFile()
+
+            val report = MyTeam().apply {
+                _id = "report1"
+                imageName = "report.jpg"
+            }
+
+            adapter.submitList(listOf(report)) {
+                val binding = ReportListItemBinding.inflate(LayoutInflater.from(context))
+                val viewHolder = EnterprisesReportsAdapter.ReportsViewHolder(binding)
+
+                // First bind detects existing file and makes image visible
+                adapter.onBindViewHolder(viewHolder, 0)
+                assertEquals(View.VISIBLE, viewHolder.binding.reportImage.visibility)
+
+                // File is deleted on disk
+                imageFile.delete()
+
+                // Second bind uses cached exists value so image remains visible
+                adapter.onBindViewHolder(viewHolder, 0)
+                assertEquals(View.VISIBLE, viewHolder.binding.reportImage.visibility)
+
+                // Re-submitting list invalidates cache via onCurrentListChanged
+                adapter.submitList(listOf(report)) {
+                    adapter.onBindViewHolder(viewHolder, 0)
+                    // Cache was cleared, so disk re-check detects file is deleted and sets visibility to GONE
+                    assertEquals(View.GONE, viewHolder.binding.reportImage.visibility)
+                }
+            }
+        } finally {
+            io.mockk.unmockkObject(org.ole.planet.myplanet.utils.FileUtils)
+            tempDir.deleteRecursively()
+        }
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapterTest.kt
@@ -20,12 +20,14 @@ class EnterprisesReportsAdapterTest {
 
     private lateinit var adapter: EnterprisesReportsAdapter
     private lateinit var context: Context
+    private lateinit var timeProvider: org.ole.planet.myplanet.utils.TestTimeProvider
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
         context.setTheme(AppCompatR.style.Theme_AppCompat)
-        adapter = EnterprisesReportsAdapter(context, "Test Team", {}, {})
+        timeProvider = org.ole.planet.myplanet.utils.TestTimeProvider(currentTime = 1000L)
+        adapter = EnterprisesReportsAdapter(context, "Test Team", {}, {}, timeProvider)
     }
 
     @Test
@@ -244,8 +246,8 @@ class EnterprisesReportsAdapterTest {
                 adapter.onBindViewHolder(viewHolder, 0)
                 assertEquals(View.GONE, viewHolder.binding.reportImage.visibility)
 
-                // Sleep past the 5000ms TTL
-                Thread.sleep(5100L)
+                // Advance time past the 5000ms TTL deterministically without Thread.sleep
+                timeProvider.advanceBy(5001L)
 
                 // Re-bind after TTL expires re-stats disk -> VISIBLE
                 adapter.onBindViewHolder(viewHolder, 0)


### PR DESCRIPTION
Caches `imageFile.exists()` checks in `EnterprisesFinancesAdapter` and `EnterprisesReportsAdapter` to avoid disk stats on every row bind during scrolling. Clears the cache on `onCurrentListChanged` to properly handle list updates. Removed redundant click listener clear calls in image binding functions. Added unit tests for both adapters.

Fixes #16777

---
*PR created automatically by Jules for task [14621057516108396353](https://jules.google.com/task/14621057516108396353) started by @dogi*