### PR TITLE
login: smoother activities repository user profile view modelling (fixes #16810)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7053
-        versionName = "0.70.53"
+        versionCode = 7054
+        versionName = "0.70.54"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -8,6 +8,12 @@ import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.UserEntity
 
+data class ProfileActivityStats(
+    val mostOpenedResource: Pair<String, Int>?,
+    val lastVisit: Long?,
+    val resourceOpenCount: Long
+)
+
 interface ActivitiesRepository {
     suspend fun getOfflineVisitCount(userId: String): Int
     suspend fun getOfflineLoginCount(userName: String): Int
@@ -20,8 +26,11 @@ interface ActivitiesRepository {
     suspend fun getGlobalLastVisit(): Long?
     suspend fun getLastVisit(userName: String): Long?
     suspend fun logResourceOpen(userName: String?, parentCode: String?, planetCode: String?, title: String?, resourceId: String?, type: String?)
+    suspend fun getResourceOpenCount(userName: String): Long
     suspend fun getResourceOpenCount(userName: String, type: String): Long
+    suspend fun getMostOpenedResource(userName: String): Pair<String, Int>?
     suspend fun getMostOpenedResource(userName: String, type: String): Pair<String, Int>?
+    suspend fun getProfileActivityStats(userName: String): ProfileActivityStats
     suspend fun recordSyncActivity(userId: String)
     suspend fun recordSyncUserChallengeAction(userId: String)
     suspend fun hasUserSyncAction(userId: String?): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -166,8 +166,16 @@ class ActivitiesRepositoryImpl @Inject constructor(
         )
     }
 
+    override suspend fun getResourceOpenCount(userName: String): Long {
+        return getResourceOpenCount(userName, UserSessionManager.KEY_RESOURCE_OPEN)
+    }
+
     override suspend fun getResourceOpenCount(userName: String, type: String): Long {
         return resourceActivityDao.countByUserAndType(userName, type)
+    }
+
+    override suspend fun getMostOpenedResource(userName: String): Pair<String, Int>? {
+        return getMostOpenedResource(userName, UserSessionManager.KEY_RESOURCE_OPEN)
     }
 
     override suspend fun getMostOpenedResource(userName: String, type: String): Pair<String, Int>? = withContext(dispatcherProvider.io) {
@@ -177,6 +185,18 @@ class ActivitiesRepositoryImpl @Inject constructor(
         } else {
             null
         }
+    }
+
+    override suspend fun getProfileActivityStats(userName: String): ProfileActivityStats = coroutineScope {
+        val mostOpenedDeferred = async { getMostOpenedResource(userName) }
+        val lastVisitDeferred = async { getGlobalLastVisit() }
+        val countDeferred = async { getResourceOpenCount(userName) }
+
+        ProfileActivityStats(
+            mostOpenedResource = mostOpenedDeferred.await(),
+            lastVisit = lastVisitDeferred.await(),
+            resourceOpenCount = countDeferred.await()
+        )
     }
 
     private suspend fun getUnuploadedLoginActivities(): List<LoginActivityData> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,7 +11,6 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.UserRepository
-import org.ole.planet.myplanet.services.UserSessionManager
 
 sealed class ProfileUpdateState {
     object Idle : ProfileUpdateState()
@@ -127,18 +124,12 @@ class UserProfileViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val fullName = userRepository.getUserModel()?.name ?: ""
-            coroutineScope {
-                val resultDeferred = async { activitiesRepository.getMostOpenedResource(fullName, UserSessionManager.KEY_RESOURCE_OPEN) }
-                val lastVisitDeferred = async { activitiesRepository.getGlobalLastVisit() }
-                val countDeferred = async { activitiesRepository.getResourceOpenCount(fullName, UserSessionManager.KEY_RESOURCE_OPEN) }
-
-                val result = resultDeferred.await()
-                _maxOpenedResource.value = if (result == null) "" else "${result.first} opened ${result.second} times"
-                _lastVisit.value = lastVisitDeferred.await()
-
-                val count = countDeferred.await()
-                _numberOfResourceOpen.value = if (count == 0L) "" else "Resource opened $count times."
-            }
+            val stats = activitiesRepository.getProfileActivityStats(fullName)
+            val result = stats.mostOpenedResource
+            _maxOpenedResource.value = if (result == null) "" else "${result.first} opened ${result.second} times"
+            _lastVisit.value = stats.lastVisit
+            val count = stats.resourceOpenCount
+            _numberOfResourceOpen.value = if (count == 0L) "" else "Resource opened $count times."
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
@@ -259,6 +259,13 @@ class ActivitiesRepositoryImplTest {
     }
 
     @Test
+    fun `getResourceOpenCount without type defaults to visit`() = runTest {
+        coEvery { resourceActivityDao.countByUserAndType("john", UserSessionManager.KEY_RESOURCE_OPEN) } returns 7L
+        val result = repository.getResourceOpenCount("john")
+        assertEquals(7L, result)
+    }
+
+    @Test
     fun `getMostOpenedResource returns null when no activities`() = testScope.runTest {
         coEvery { resourceActivityDao.getMostOpenedResource("john", "pdf") } returns null
         val result = repository.getMostOpenedResource("john", "pdf")
@@ -274,6 +281,34 @@ class ActivitiesRepositoryImplTest {
 
         assertEquals("Res 1", result?.first)
         assertEquals(2, result?.second)
+    }
+
+    @Test
+    fun `getMostOpenedResource without type defaults to visit`() = testScope.runTest {
+        coEvery {
+            resourceActivityDao.getMostOpenedResource("john", UserSessionManager.KEY_RESOURCE_OPEN)
+        } returns ResourceOpenCount("Res 1", 1)
+
+        val result = repository.getMostOpenedResource("john")
+
+        assertEquals("Res 1", result?.first)
+        assertEquals(1, result?.second)
+    }
+
+    @Test
+    fun `getProfileActivityStats aggregates mostOpened lastVisit and openCount`() = testScope.runTest {
+        coEvery {
+            resourceActivityDao.getMostOpenedResource("john", UserSessionManager.KEY_RESOURCE_OPEN)
+        } returns ResourceOpenCount("Res 1", 1)
+        coEvery { offlineActivityDao.getGlobalLastVisit() } returns 123456L
+        coEvery { resourceActivityDao.countByUserAndType("john", UserSessionManager.KEY_RESOURCE_OPEN) } returns 3L
+
+        val stats = repository.getProfileActivityStats("john")
+
+        assertEquals("Res 1", stats.mostOpenedResource?.first)
+        assertEquals(1, stats.mostOpenedResource?.second)
+        assertEquals(123456L, stats.lastVisit)
+        assertEquals(3L, stats.resourceOpenCount)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/ui/user/UserProfileViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/user/UserProfileViewModelTest.kt
@@ -15,8 +15,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.repository.ProfileActivityStats
 import org.ole.planet.myplanet.repository.UserRepository
-import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 
@@ -49,11 +49,22 @@ class UserProfileViewModelTest {
         every { mockUser.name } returns "Test User"
         coEvery { userRepository.getUserModel() } returns mockUser
 
-        coEvery { activitiesRepository.getMostOpenedResource("Test User", UserSessionManager.KEY_RESOURCE_OPEN) } returns Pair("Test Resource", 5)
-        coEvery { activitiesRepository.getGlobalLastVisit() } returns 123456789L
-        coEvery { activitiesRepository.getResourceOpenCount("Test User", UserSessionManager.KEY_RESOURCE_OPEN) } returns 10L
+        coEvery { activitiesRepository.getProfileActivityStats("Test User") } returns ProfileActivityStats(
+            mostOpenedResource = Pair("Test Resource", 5),
+            lastVisit = 123456789L,
+            resourceOpenCount = 10L
+        )
 
         viewModel = UserProfileViewModel(userRepository, activitiesRepository)
+    }
+
+    @Test
+    fun `init loads profile activity stats into state flows`() = runTest {
+        advanceUntilIdle()
+
+        assertEquals("Test Resource opened 5 times", viewModel.maxOpenedResource.value)
+        assertEquals(123456789L, viewModel.lastVisit.value)
+        assertEquals("Resource opened 10 times.", viewModel.numberOfResourceOpen.value)
     }
 
     @Test


### PR DESCRIPTION
Collapsed the profile activity-stats fan-out and moved KEY_RESOURCE_OPEN behind ActivitiesRepository. Added ProfileActivityStats aggregate and convenience repository methods, updated UserProfileViewModel to call ActivitiesRepository.getProfileActivityStats, dropped UserSessionManager import from UserProfileViewModel, and updated unit tests.

Fixes #16810

---
*PR created automatically by Jules for task [5864234466437606679](https://jules.google.com/task/5864234466437606679) started by @dogi*