### PR TITLE
Phase 125: fix the course-attached survey `parentId` key so a completed survey unblocks the course

### DIFF
--- a/flutter/PHASE_125_NOTES.md
+++ b/flutter/PHASE_125_NOTES.md
@@ -1,9 +1,338 @@
 # Phase 125 — the mandatory-survey key (`parentId`)
 
-Lane A. In progress.
+Lane A of a three-lane round. One defect, carried over from
+`PHASE_123_NOTES.md` §"Found, not fixed" item 0, where Phase 123 called it
+*"a live defect… the most severe thing in this file"* and left it for its own
+phase because the fix is a design call rather than a one-liner.
 
-Target: `PHASE_123_NOTES.md` §"Found, not fixed" item 0 — every port writer
-stores a course-attached survey's `parentId` as the bare survey id while
-`hasUnfinishedSurveys` looks for `surveyId@courseId`, so a learner who has
-completed the attached survey is still told they have not, and
-`MANDATORY_SURVEY_COURSE_ID` cannot be finished.
+**Every port writer stored a course-attached survey's submission `parentId` as
+the bare survey id, and `hasUnfinishedSurveys` — the gate on finishing
+`MANDATORY_SURVEY_COURSE_ID` — queried `"$surveyId@$courseId"`.** The count was
+always 0, so a learner who *had* answered the attached survey was told they had
+not, and the MyPlanet Onboarding course could not be completed however many
+times they answered.
+
+This is the port's recurring shape at its most expensive: **a writer and a
+reader disagreeing about a key, where each half passes its own test and only
+the pair is wrong** — Phase 74's reactions, Phase 100's photo id, Phase 116's
+community feed identifier, Phase 120's `parent.questions`. The reader's own
+test is the tell. It seeded its row through `upsertDocuments` with a
+hand-written `'parentId': 'survey-a@course-1'`, a key the port's own writers
+could not produce, and passed for the four phases the gate was broken. **A
+fixture that fabricates the key is not evidence.**
+
+---
+
+## The key both sides now use
+
+`"$surveyId@$courseId"` when the survey has a non-empty `courseId`, else the
+bare survey id — `SubmissionsRepository.examParentId`, which the exam path has
+used since Phase 110 and which every survey writer now shares.
+
+That is Kotlin's key, and Kotlin is internally consistent about it:
+`createExamSubmission` (`SubmissionsRepositoryImpl.kt:449-456`) builds it from
+**the exam row's own `courseId`** — the request carries no course id, and
+`startExamSession`'s `parentId` parameter is used only for the pre-existing-row
+lookup (`:414`), never by the writer; Kotlin's own test pins it
+(`SubmissionsRepositoryImplTest.kt:401-405`). `createBulkSurveySubmissions`
+(`:201-207`) reaches the same string through `examDao.getById(examId)?.courseId`
+and then reads with it too (`getPendingByUsersAndParent`, `:210`).
+`hasSubmission` (`:174-190`) queries exactly it.
+
+| writer | before | now |
+|---|---|---|
+| `createSurveyDraft:111` | `survey.id` | `examParentId(examId: survey.id, courseId: survey.courseId)` |
+| `createBulkSurveySubmissions:522` | passed the bare `surveyId` through | resolves `surveyDao.getById(surveyId)?.courseId` **once, before the loop**, as Kotlin does |
+| `getOrCreateSurveySubmission:539` | stored its `parentId` argument | unchanged — Kotlin's `getOrCreateSubmission` (`:624-642`, and dead in Kotlin: zero callers in `app/src`) also stores its argument verbatim and leaves the shape to the caller. Its one caller is the row above |
+| `createSurveyAdoptionSubmission` | bare | **deliberately still bare** |
+
+The adoption marker is the one row that must keep the bare id.
+`createMappedSubmission` (`SurveysRepositoryImpl.kt:221`) writes
+`parentId = examId` with no course suffix and `findExistingAdoption`
+(`:205-207`) recognises it by comparing the whole column, so routing it through
+`examParentId` would make every adoption invisible to its own lookup and
+re-adopt on each load. It follows that a bare-id `type = 'survey'` row is not
+always a stale answer sheet — which is what the repair's `status != ''` clause
+is for, and it is not theoretical: see *the reverts* below.
+
+`hasUnfinishedSurveys` now derives its key through `examParentId` too rather
+than interpolating its own string, so the two cannot drift apart again.
+
+## What happens to existing bare-id rows
+
+**They are repaired in place, and they had to be: they do not heal on their
+own.** I checked the sync path rather than assuming. The port uploads a
+submission with whatever `parentId` the row carries (`serialize`:
+`'parentId': row.parentId ?? ''`), and `upsertDocuments` writes `parentId`
+straight back from the document (`:1312`), so a pull re-asserts the bare id
+rather than correcting it. Kotlin confirms the shape from the other side: it
+uploads `parentId` verbatim (`:775`, `:827`), reads it back verbatim (`:671`,
+`:684`), has no Room migrations at all
+(`RoomModule.kt:60` `fallbackToDestructiveMigration(true)`), and therefore
+**normalises nothing** — a bare-id row round-trips as a bare-id row forever.
+
+Left alone, a learner who had already answered the mandatory survey would be
+told to answer it again: the entire bug, survived once more, plus a duplicate
+answer sheet in the reporting the survey exists to produce.
+
+So `repairCourseSurveyParentIds(courseId)` rewrites them — a lazy, idempotent
+`UPDATE` returning how many rows it changed, called from the top of
+`hasUnfinishedSurveys`.
+
+**It needs no schema number, and a bump would be the wrong tool.** No DDL
+changes — `parentId` has always been on `Submissions` — and `submissions` is in
+`localAuthorityTables`, so an upgrade *preserves* exactly the rows that need
+repairing and repairs none of them. `schemaVersion` stays 46 and no generated
+output moved.
+
+Two rows it must not touch, both `type = 'survey'` with a bare id: the adoption
+marker (`status = ''`), above; and a submission for a survey with no `courseId`,
+whose bare id is already what `examParentId` produces. Both are pinned.
+
+Calling a write from inside a boolean read is the one thing here I would rather
+not have done. The alternatives were worse: a migration step needs a schema
+number I do not have, and a repair hung off the submissions sync leaves an
+offline learner — the normal case for this app — blocked until they next reach
+a server. `hasUnfinishedSurveys` is the only read in either tree whose
+predicate is the whole `parentId`, so it is the only read a stale row can
+answer wrongly, and it runs at exactly the moment the answer matters: when the
+learner taps Finish.
+
+## The completed-survey-to-finished-course round trip
+
+`test/repository/mandatory_survey_round_trip_test.dart` — 11 tests, named for
+the shape rather than the file, alongside the port's other reachability guards.
+Every survey row comes out of `SurveyMapper.fromCourseDoc` reading a course
+document shaped like the server's, and every submission is authored by the
+production writer through `SurveysRepository.submitResponse` or
+`createBulkSurveySubmissions`. Nothing hand-writes a key. The first test
+asserts the mapper really did set `courseId`, because the rest of the file
+proves nothing if it did not.
+
+The user-visible half is a widget test in
+`test/ui/courses/take_course_screen_test.dart`: seed the onboarding course and
+its attached survey, answer it through the real writer, tap **Finish**. Pre-fix
+it failed with
+
+```
+Expected: no matching candidates
+  Actual: Found 1 widget with text "please complete the survey to finish the course"
+```
+
+and post-fix the finish reaches the rating dialog it is gated in front of.
+
+## Each defect, with failing-first evidence
+
+Every row below was demonstrated red by replaying the exact revert it guards.
+
+| # | defect | pre-fix failure |
+|---|---|---|
+| 1 | a learner who answered the attached survey is still blocked | `hasUnfinishedSurveys` → `Expected: false / Actual: true` |
+| 1 | the same, at the screen | the toast on a Finish tap after answering |
+| 1 | the sheet's key | `Expected: 'survey-1@course-1' / Actual: 'survey-1'` |
+| 1 | `createBulkSurveySubmissions`' key | `Expected: 'survey-1@course-1' / Actual: 'survey-1'` |
+| 2 | a bare-id sheet an earlier build wrote (the repair) | `Expected: false / Actual: true` |
+| 3 | `updateSurveyResponse` read the whole `parentId` as a survey id | with the writers fixed and this reader raw: `Expected: ['It was fine'] / Actual: []` — resuming a pending sheet found no questions and wrote **no answers at all** |
+| 4 | the dashboard pending-survey prompt keyed on the raw value | `Expected: length of <1> / Actual: []` — the prompt silently dropped every pending survey belonging to a course |
+| 5 | the repair without its `status != ''` clause | `Expected: true / Actual: false` — it rewrote the **adoption marker** into the composite key, which then satisfied the status-blind count and **spuriously unblocked the course** |
+
+Defect 5 is the one worth remembering: the guard I added on the audit's
+reasoning turned out to be load-bearing when replayed. `countByUserParentAndType`
+has no status filter (Kotlin's `SubmissionDao.kt:23` has none either), so any
+row that reaches the composite key counts as a completed survey.
+
+Readers I checked and left alone because they are already right:
+`progress_repository._examIdFromParent` and `courses_providers`'
+`split('@').lastWhere(courseIdSet.contains)` both split; `_deleteExamSubmissions`
+and `latestPendingByUserAndParent` are passed the composite by their callers;
+`surveys_repository:146`'s adoption check compares a bare id to a bare row.
+`_liveParentDocument` hand-rolled its own `split('@').first` and now shares
+`parentBaseId`, so there is one derivation rather than four.
+
+---
+
+## Two things the ground-truth audit overturned
+
+Both were mine, and the second changes what this fix *is*.
+
+**`adoptSurvey` does not always produce a course-less survey.** I had assumed a
+team clone could never carry a `courseId`, which is what makes
+`SurveyDao.getByCourseId`'s lack of a team filter safe. Kotlin's
+`createMappedSurvey` copies **both** `courseId` and `stepId` from the source
+(`SurveysRepositoryImpl.kt:181-182`), and `getAdoptableTeamSurveys` filters only
+on `type = "surveys" AND isTeamShareAllowed = 1` (`ExamDao.kt:30-31`) — so a
+course-attached survey whose document sets `teamShareAllowed: true` *is*
+adoptable and the Kotlin clone inherits the course join. The **port's** clone
+omits both columns (`surveys_repository.dart:99-118`), and that omission is now
+load-bearing rather than incidental: if anyone "fixes" the clone to copy
+`courseId` for parity, this gate starts demanding that the learner complete
+every team's copy of the survey. Pinned by a test.
+
+**Kotlin's mandatory-survey gate is almost certainly dead, so this is internal
+consistency rather than restored parity.** `getSurveysByCourseId` (`:366-368`)
+filters `examDao.getByCourseIdAndType(courseId, "survey")` — **singular** —
+while `StepExam.type` is the embedded document's own `type`
+(`CoursesRepositoryImpl.kt:744`: `if (examJson.has("type")) … else examKey`),
+which for a survey document is `"surveys"`. Every other Kotlin reader uses the
+plural: the Take Survey button itself is `getByStepIdAndType(stepId, "surveys")`
+(`:531`), the surveys list is `getByType("surveys")`, `ExamDao`'s three defaults
+are `"surveys"`, and `docs/DOMAIN_MODEL.md:100` states it independently.
+
+The two queries are mutually exclusive, so **at most one of the Take Survey
+button and the mandatory block can ever see a given survey**. A document
+carrying `type: "surveys"` — the weight of evidence, since that is what the
+`exams` database holds and the button is a long-standing shipping feature —
+gets a button and never blocks. A document carrying no `type` blocks forever
+with no button that could satisfy it.
+
+The port cannot reproduce that split even if it wanted to: `Surveys` has no
+`type` column, because `ExamMapper.fromDoc` uses the document's `type` to
+*choose the table* and then discards it. Its reader is `getByCourseId` with no
+type filter, so it finds the survey the button opens — which is the behaviour
+the Kotlin feature was written to have. **The port's symptom, "the onboarding
+course cannot be finished", is port-only; the fix makes a behaviour Kotlin does
+not have internally consistent.** The composite key is still the right thing to
+converge on: it is what Kotlin uploads, what Planet joins on, and what the
+port's own exam path has always written. Documented at the code, at
+`hasUnfinishedSurveys`.
+
+**This belongs under *Faithful quirks* in `docs/kotlin-to-flutter-migration.md`**
+and I have not put it there — that file is not this lane's to edit. Integrator:
+the paragraph above is the text.
+
+## Divergences from `hasSubmission` kept deliberately
+
+1. **The null-user guard.** Kotlin has none in `hasUnfinishedSurveys`; the
+   guard is inside `hasSubmission`, which returns `false` for a blank `userId`,
+   inverting to "unfinished" — so Kotlin blocks a null user. The port returns
+   `false` early. It is a real logic divergence and unobservable in Kotlin
+   (the survey list is always empty there, per the typo above); the port's
+   version cannot block a user it has no id to check. Kept. The blank-*course*
+   half is not a divergence at all: `getByCourseIdAndType("", …)` matches
+   nothing either.
+2. **`questionDao.countByExamId(stepExamId) == 0 → false` is not ported.** In
+   `getCourseStepData` that rule reads sanely — do not claim a submission
+   exists for an exam whose questions have not synced. Inside
+   `hasUnfinishedSurveys` it inverts into "a question-less survey blocks the
+   course forever". Porting it would reintroduce the exact user-blocking bug
+   this phase exists to remove, for a survey nobody can answer. Not ported,
+   and recorded rather than silently skipped.
+3. **`countByUserParentAndType` stays status-blind**, as Kotlin's is: a sheet
+   the learner has merely *opened* satisfies the gate. Faithful, and the reason
+   the repair must not touch adoption markers.
+
+---
+
+## `pendingUploads` scoping — the brief's second item
+
+The brief asked me to check Phase 123's notes before assuming this was done.
+**It is done**, and the notes are not "partially examined" on it — D2 is the
+larger half of that phase. I re-read the query rather than the prose:
+`SubmissionDao.pendingUploads` (`app_database.dart:2319-2340`) is unscoped
+(`isUpdated = true`), excludes a guest *exam* attempt but not a guest's
+completed survey (Kotlin's own asymmetry between `UploadConfigs.ExamResults`
+and `UploadConfigs.Submissions`), excludes the anonymous `public_%` sheet, and
+coalesces both guest operands. Six tests in
+`submissions_repository_test.dart` were each demonstrated red against the exact
+revert they guard, and Phase 123's second audit added a two-owner `queuePending`
+test after finding the whole user-visible effect revertible with the suite
+green. Nothing here needed changing.
+
+What remains on that path is Phase 123's own "found, not fixed" list — items 1,
+2, 5 and 6 (the stored exam blob's field list, the two-serializer split,
+`sender`/`source`/`parentCode`, and POST-where-Kotlin-PUTs) — none of which is
+about scoping.
+
+---
+
+## Files touched outside this lane's set
+
+Both crossings are for a defect the writer fix would otherwise have caused, not
+for tidiness, and each is one expression plus its comment.
+
+| file | why |
+|---|---|
+| `lib/repository/surveys_repository.dart` | `updateSurveyResponse` read the whole `parentId` as a survey id. With the writers corrected it found no questions and wrote **no answers at all** — a learner resuming a sent sheet would have uploaded it empty. Demonstrated red. |
+| `lib/providers/dashboard_providers.dart` | `pendingSurveysProvider` keyed its dedupe map and its `getByIds` lookup on the raw `parentId`, where Kotlin's `getUniquePendingSurveys` uses `examIdFromParentId()`. With the writers corrected the prompt dropped every pending course-attached survey. Demonstrated red. Plus one import. |
+
+Lane B (18 upstream master commits) and Lane C (`lib/ui/notifications/`,
+`lib/l10n/`, `lib/ui/components/relative_time.dart`) — no overlap either way.
+No new l10n keys; `app_en.arb` untouched.
+
+---
+
+## Found, not fixed
+
+The next round's highest-yield brief is this list, so it is precise.
+
+**1. The step tile never says "Redo survey" or "Retake test", and this is the
+only user-visible Kotlin reader of the composite survey key.**
+`CourseStepFragment.hideTestIfNoQuestion` (`:242-262`) swaps
+`record_survey` → `redo_survey` and `take_test` → `retake_test` off
+`getCourseStepData`'s `hasExam`/`hasSurvey`, which are
+`hasSubmission(stepExams[0].id, step.courseId, userId, "exam"/"survey")`
+(`CoursesRepositoryImpl.kt:530-542`) — the composite key, on the *plural*-typed
+rows, so unlike the mandatory gate **this one works in the shipping Kotlin
+app**. The port hardcodes `l10n.takeTest` and `l10n.recordSurvey`
+(`take_course_screen.dart:395,416`). Deliberately not done here: it needs two
+new ARB keys (Kotlin's `take_test`/`retake_test` carry a `%d` count the port's
+`takeTest` does not), a port of `hasSubmission` itself, and a provider in
+`courses_providers.dart` — a file this round's other lanes could touch, and
+exactly the collision *Running parallel lanes* warns about. It is a missing
+feature rather than a defect in the key, so widening this diff for it would
+have been the wrong call. **It is the natural next phase, and my writer fix is
+its precondition** — without the composite key the survey half of the swap
+could not have worked.
+
+**2. A locally-authored submission that is uploaded and then pulled back
+probably duplicates.** `upsertDocuments` keys its row on the document `_id`
+(`:1300`) while a locally-authored row's primary key is a sha1 and
+`markUploaded` only fills in `couchId`/`rev` — so the pull inserts a *second*
+row for a submission the device already has. The port has already solved this
+shape once, for team tasks: `TeamTaskDao.getByAnyIds` (`app_database.dart:500`)
+exists precisely because "`markUploaded` fills in `_id`/`_rev` and leaves `id`
+alone… so a sync-in keyed on the document `_id` would insert a second row".
+`SubmissionDao` has `getByIdOrRemoteId`, so the machinery is there and unused
+by the walk. I did not confirm it end to end and it is outside this diff, but
+it bears on this phase: it is *why* the repair survives a sync (the repaired
+sha1-keyed row is not the row the pull overwrites) and it would double every
+submission in the list and the exporter.
+
+**3. Kotlin's `exams.courseId` is not stable, so its reader could not have been
+written the port's way.** `bulkInsertExamsFromSync` calls
+`insertCourseStepsExams("", "", jsonDoc, "")` (`SurveysRepositoryImpl.kt:387`),
+`checkIdsAndInsert` skips blank ids (`StepExam.kt:61-68`) leaving
+`courseId`/`stepId` null, and Room's `@Upsert` is a full-row replace — with
+`"exams"` and `"courses"` in the *same parallel batch* (`SyncManager.kt:143-168`),
+whichever lands last decides whether a course-attached survey still knows its
+course. Phase 110 recorded this and the port already diverges
+(`_presentOrAbsent`, `survey_mapper.dart:93`). Worth knowing: even with the
+singular/plural typo corrected, Kotlin's `getByCourseIdAndType` would be a coin
+flip.
+
+**4. The port's public-survey sheet now uploads a composite `parentId` where
+Kotlin's would upload a bare one**, because `SurveyMapper.fromDoc` keeps a
+document's `courseId` while Kotlin's public path stores the survey with
+`courseId = null`. Nothing on either side reads it back by the bare id — the
+port resolves the row by the `submissionId` `createSurveyDraft` returned, and
+`countByUserParentAndType` is user-scoped so a `public_<millis>` sheet cannot
+unblock a signed-in learner's course. Composite is also the more correct value
+for Planet to join on. Recorded because it is a change on the wire that no test
+pins from the public side.
+
+**5. Kotlin's `deleteCourseProgress` deletes no exam submissions at all**
+(`CoursesRepositoryImpl.kt:589-598`): it collects `examDao.getByCourseId(courseId)`
+ids — bare — and passes them to `getUnuploadedNonSurveyByParentIds`, whose
+predicate is `parentId IN (:parentIds)`, while every submission for those exams
+carries the composite key. Same defect class as this phase's, in the Kotlin. The
+port has no `deleteCourseProgress`, so it inherited neither the method nor the
+bug; if anyone ports it, port the fix.
+
+**6. Phase 123's items 0b and 4 are still open and still coupled.** The port's
+team-survey sharing does not reach the server by any path
+(`UploadConfigs.AdoptedSurveys` unported), and because nothing uploads the
+adopted row, `SurveyDao.deleteNotIn` deletes it on the next complete exams walk
+— after which a member who answered that survey offline uploads a two-key
+`parent` and the second device renders answers with no questions. My adoption
+test now pins the clone's *shape* (no `courseId`, no `stepId`); it does not
+touch the upload gap.

--- a/flutter/PHASE_125_NOTES.md
+++ b/flutter/PHASE_125_NOTES.md
@@ -52,8 +52,9 @@ The adoption marker is the one row that must keep the bare id.
 (`:205-207`) recognises it by comparing the whole column, so routing it through
 `examParentId` would make every adoption invisible to its own lookup and
 re-adopt on each load. It follows that a bare-id `type = 'survey'` row is not
-always a stale answer sheet — which is what the repair's `status != ''` clause
-is for, and it is not theoretical: see *the reverts* below.
+always a stale answer sheet — which is what the repair's status clause is for,
+and it is not theoretical: replaying its removal spuriously unblocks the course,
+and the *first cut of that clause was itself a live defect*. See below.
 
 `hasUnfinishedSurveys` now derives its key through `examParentId` too rather
 than interpolating its own string, so the two cannot drift apart again.
@@ -86,8 +87,11 @@ repairing and repairs none of them. `schemaVersion` stays 46 and no generated
 output moved.
 
 Two rows it must not touch, both `type = 'survey'` with a bare id: the adoption
-marker (`status = ''`), above; and a submission for a survey with no `courseId`,
-whose bare id is already what `examParentId` produces. Both are pinned.
+marker, above; and a submission for a survey with no `courseId`, whose bare id
+is already what `examParentId` produces. Both are pinned. It also skips
+`exam`-typed rows, which matters because the two id spaces are not disjoint —
+`_liveParentDocument`'s own comment says so — and an exam attempt's key belongs
+to the exam path.
 
 Calling a write from inside a boolean read is the one thing here I would rather
 not have done. The alternatives were worse: a migration step needs a schema
@@ -100,7 +104,7 @@ learner taps Finish.
 
 ## The completed-survey-to-finished-course round trip
 
-`test/repository/mandatory_survey_round_trip_test.dart` — 11 tests, named for
+`test/repository/mandatory_survey_round_trip_test.dart` — 16 tests, named for
 the shape rather than the file, alongside the port's other reachability guards.
 Every survey row comes out of `SurveyMapper.fromCourseDoc` reading a course
 document shaped like the server's, and every submission is authored by the
@@ -123,23 +127,35 @@ and post-fix the finish reaches the rating dialog it is gated in front of.
 
 ## Each defect, with failing-first evidence
 
-Every row below was demonstrated red by replaying the exact revert it guards.
 
-| # | defect | pre-fix failure |
-|---|---|---|
-| 1 | a learner who answered the attached survey is still blocked | `hasUnfinishedSurveys` → `Expected: false / Actual: true` |
-| 1 | the same, at the screen | the toast on a Finish tap after answering |
-| 1 | the sheet's key | `Expected: 'survey-1@course-1' / Actual: 'survey-1'` |
-| 1 | `createBulkSurveySubmissions`' key | `Expected: 'survey-1@course-1' / Actual: 'survey-1'` |
-| 2 | a bare-id sheet an earlier build wrote (the repair) | `Expected: false / Actual: true` |
-| 3 | `updateSurveyResponse` read the whole `parentId` as a survey id | with the writers fixed and this reader raw: `Expected: ['It was fine'] / Actual: []` — resuming a pending sheet found no questions and wrote **no answers at all** |
-| 4 | the dashboard pending-survey prompt keyed on the raw value | `Expected: length of <1> / Actual: []` — the prompt silently dropped every pending survey belonging to a course |
-| 5 | the repair without its `status != ''` clause | `Expected: true / Actual: false` — it rewrote the **adoption marker** into the composite key, which then satisfied the status-blind count and **spuriously unblocked the course** |
+Each row names the revert it was replayed against, because **which** revert
+matters: the writer fix and the repair are defence in depth for the same
+symptom, so a test that only asserts "the course can be finished" cannot tell
+them apart.
 
-Defect 5 is the one worth remembering: the guard I added on the audit's
-reasoning turned out to be load-bearing when replayed. `countByUserParentAndType`
-has no status filter (Kotlin's `SubmissionDao.kt:23` has none either), so any
-row that reaches the composite key counts as a completed survey.
+| # | defect | revert replayed | pre-fix failure |
+|---|---|---|---|
+| 1 | a learner who answered the attached survey is still blocked | the whole diff (the pre-fix head) | `hasUnfinishedSurveys` → `Expected: false / Actual: true` |
+| 1 | the same, at the screen | the whole diff | the toast on a Finish tap after answering |
+| 1 | the sheet's key | `createSurveyDraft`'s key alone | `Expected: 'survey-1@course-1' / Actual: 'survey-1'` |
+| 1 | `createBulkSurveySubmissions`' key | the bulk writer alone | `Expected: 'survey-1@course-1' / Actual: 'survey-1'` |
+| 2 | a bare-id sheet an earlier build wrote | the repair call | `Expected: false / Actual: true` |
+| 3 | `updateSurveyResponse` read the whole `parentId` as a survey id | that reader alone, writers left fixed | `Expected: ['It was fine'] / Actual: []` — resuming a pending sheet found no questions and wrote **no answers at all** |
+| 4 | the dashboard prompt keyed on the raw value | that reader alone, writers left fixed | `Expected: length of <1> / Actual: []` — the prompt silently dropped every pending survey belonging to a course |
+| 5 | the repair rewrote the **adoption marker** | the `status` clause | `Expected: true / Actual: false` — the marker reached the composite key, the status-blind count accepted it, and the course was **spuriously unblocked** |
+| 6 | the repair rewrote an **exam** attempt sharing a survey's id | the `type` clause | `Expected: 0 / Actual: 1` |
+| 7 | re-sending a survey duplicated a legacy pending sheet | the bulk pre-loop repair | `Expected: length of <1> / Actual: [2 rows]` |
+
+**Two rows are the whole diff rather than one rule, and that is a real
+limitation, not shorthand.** Reverting `createSurveyDraft`'s key alone leaves
+2189 of 2190 tests green, because `repairCourseSurveyParentIds` heals the bare
+id at read time — so both headline behavioural tests, including the screen one,
+still pass. They discriminate *writer OR repair*, not the writer. The writer is
+pinned by the two key assertions and nothing else. The first draft of these
+notes claimed every row had been demonstrated red against the exact rule it
+guards; the implementation audit caught that, and it was wrong for the screen
+row. Next lane: revert a survey writer and you get one repository failure and
+green at every screen.
 
 Readers I checked and left alone because they are already right:
 `progress_repository._examIdFromParent` and `courses_providers`'
@@ -200,7 +216,136 @@ port's own exam path has always written. Documented at the code, at
 and I have not put it there — that file is not this lane's to edit. Integrator:
 the paragraph above is the text.
 
+## The second audit found a live defect in my own repair
+
+An audit of the ground truth does not audit the implementation. The diff was
+green — format clean, analyze clean, 2184 tests, CI green on `62ecebc` — which
+is exactly the state Phase 120 and Phase 123 shipped defects in. The second
+`parity-auditor` pass found one live defect, four unguarded halves and two
+overstated claims.
+
+### The live defect: `isNotValue('')` is `IS NOT`, not `!=`
+
+The repair's guard was `row.status.isNotValue('')`, meant to negate Kotlin's
+`it.status.orEmpty().isEmpty()` (`SurveysRepositoryImpl.kt:203-207`). Drift's
+`isNotValue` emits the SQL infix operator **`IS NOT`**
+(`drift-2.34.3/.../expression.dart:118-120` → `:148-154`), and `NULL IS NOT ''`
+is **true** — so the guard admitted every null-status row, which is exactly the
+class it existed to exclude.
+
+**And a marker reaches null status by an ordinary route.**
+`createSurveyAdoptionSubmission` writes `status: ''` *and* `isUpdated: true`, so
+the generic `pendingUploads` sweep uploads it (Phase 123's item 4 is right that
+`UploadConfigs.AdoptedSurveys` is unported, but the generic sweep still carries
+the row); `serialize` sends `'status': ''`; and `upsertDocuments` reads it back
+through `JsonUtils.getStringOrNull`, which maps the empty string to **null**
+(`json_utils.dart:19-22`). So every marker that has round-tripped, and every
+marker a Kotlin handset in the same deployment published, arrives with
+`status = NULL`.
+
+The consequence is the harm this phase exists to prevent, caused by the fix: the
+marker was rewritten to `survey-1@course-1`, the status-blind count accepted it,
+and a learner's Finish sailed past a survey they had never answered. Reproduced
+against the then-current head:
+
+```
+Expected: true
+  Actual: <false>
+nothing has been answered; the marker is not an answer sheet
+```
+
+**In a real mixed fleet this is the repair's *most likely* match, not a corner
+case.** A bare-id *answer sheet* can only come from a pre-Phase-125 build of an
+unshipped port, or from Kotlin's `exams.courseId` race (item 3 below). A bare-id
+*adoption marker* is written that way on purpose by every Kotlin handset there
+is. The load-bearing half of the discriminator was the half that failed.
+
+Now `coalesce([status, '']).equals('').not()` — the same idiom, for the same
+reason, as `SubmissionDao.pendingUploads`' coalesced guest operands. **A drift
+`isNotValue` is `IS NOT`; when you mean `orEmpty().isEmpty()`, coalesce.**
+
+### The unguarded halves, and one more defect they exposed
+
+| finding | now |
+|---|---|
+| a null-status bare-id row was untested | the reproduction above, as a test |
+| **`createBulkSurveySubmissions` duplicated a legacy pending sheet** | `_repairSurveyParentId` runs before the loop; test red on its removal |
+| `row.type.equals('survey')` was revertible with the suite green | an `exam` attempt sharing a survey's id; red on its removal |
+| the null-user divergence was pinned only against a course with *no* surveys, where Kotlin agrees | pinned against a course that has one |
+| the writer fix is masked by the repair at every screen | said plainly above, rather than over-claimed |
+
+The duplicate is a defect the writer fix itself opened, and worth stating:
+`getOrCreateSurveySubmission`'s existence check is
+`latestPendingByUserAndParent`, a comparison of the **whole** `parentId`.
+Pre-Phase-125 the writer and that lookup agreed on the bare key. With the writer
+corrected and no repair, a legacy bare-id pending sheet is invisible to it, so
+re-sending the survey gives the member a *second* sheet: their prompt dedupes to
+the older one, they answer it, and the leftover row re-offers the same survey
+until they answer it twice — two answer sheets uploaded for one survey.
+
+`if (target == survey.id) continue;` was dead when the repair was only reachable
+by `courseId` (every row `getByCourseId` returns has a non-empty `courseId` by
+exact equality, so the target can never equal the bare id). It is live now that
+`createBulkSurveySubmissions` hands it an arbitrary survey, and pinned. Two
+clauses remain non-discriminating and are kept for clarity rather than
+behaviour: the `courseId.isEmpty` early return (an empty `courseId` selects no
+rows anyway) and, strictly, the dead-branch short-circuit when reached by
+course — both are early-outs for an identical result, not guards.
+
+### Two claims of mine it overstated
+
+**"The port cannot reproduce that split."** It cannot on `type` — `Surveys` has
+no `type` column. But the gate reads `courseId` and the button reads `stepId`,
+and `SurveyMapper.fromDoc` writes each independently with `_presentOrAbsent`
+(`survey_mapper.dart:93-94`), so a document carrying `courseId` and no `stepId`
+lands found-by-the-gate and offered-by-no-button: the same shape I attributed to
+Kotlin alone. Kotlin genuinely cannot do it (`StepExam.insertCourseStepsExams`
+never reads either key from the document, `StepExam.kt:36-58`). Corrected at the
+code.
+
+**A test that seeds its own key.** The dashboard test hand-wrote
+`'survey-1@course-1'` — the fixture shape these notes criticise two paragraphs
+in. It now drives `createBulkSurveySubmissions`, so it covers the pair. Writing
+it that way exposed a second flaw of mine: the leftover bare-id row I had added
+*rescued* the assertion, so the test passed with the reader reverted. It is now
+two tests — one with only the composite row, which discriminates the reader
+(`Actual: []` on its revert), and one with both, which pins the
+prompt-once-not-twice guarantee and is honestly labelled as not failing-first
+evidence.
+
+### Recorded, not changed
+
+**The repair never reaches Planet.** It writes only `parentId` and leaves
+`isUpdated` alone, so an already-uploaded row is repaired locally while the
+CouchDB document keeps the bare key permanently — every other device needs its
+own local repair. A payload already snapshotted into the outbox by `queuePending`
+also POSTs the bare key. Re-queueing *would* be safe (`serialize` emits
+`_id`/`_rev` when present, so CouchDB updates in place rather than duplicating),
+and I am still not doing it: silently rewriting historical server documents on a
+Finish tap is a bigger action than unblocking a learner, and Kotlin never
+rewrites an uploaded `parentId` either. What needed correcting is the
+justification — "the port uploads whatever `parentId` the row carries" is true
+of the *general* case and precisely not of the already-uploaded rows the repair
+fixes. The residue is real: Planet keeps a bare-id document its own joins may
+not match to the survey.
+
+**Confirmed at parity, stated because a clean result is useful.** The audit
+independently checked every writer of a submission `parentId` (five; none
+missed), every reader (my list of three was complete — it found no fourth, and
+confirmed `submissions_exporter.dart`, `submission_detail_screen.dart`,
+`submissions_screen.dart`, `user_information_screen.dart` and
+`public_survey_uploader.dart` never read it), that composite is what Kotlin
+uploads for the same row, that the repair causes no stream churn when it no-ops
+(`UpdateStatement` notifies only `if (rows > 0)`), that calling it from a
+boolean read breaks neither caller, and that both paths the fix serves are
+reachable — the step's Take Survey tile into `submitResponse`, and the home
+prompt's stripped `surveyId` into `updateSurveyResponse`. Neither fix guards a
+dead path.
+
 ## Divergences from `hasSubmission` kept deliberately
+
+These are now documented at the code as well as here — the implementation
+audit noted that only (c) had made it into the doc comment.
 
 1. **The null-user guard.** Kotlin has none in `hasUnfinishedSurveys`; the
    guard is inside `hasSubmission`, which returns `false` for a blank `userId`,

--- a/flutter/PHASE_125_NOTES.md
+++ b/flutter/PHASE_125_NOTES.md
@@ -1,0 +1,9 @@
+# Phase 125 — the mandatory-survey key (`parentId`)
+
+Lane A. In progress.
+
+Target: `PHASE_123_NOTES.md` §"Found, not fixed" item 0 — every port writer
+stores a course-attached survey's `parentId` as the bare survey id while
+`hasUnfinishedSurveys` looks for `surveyId@courseId`, so a learner who has
+completed the attached survey is still told they have not, and
+`MANDATORY_SURVEY_COURSE_ID` cannot be finished.

--- a/flutter/lib/providers/dashboard_providers.dart
+++ b/flutter/lib/providers/dashboard_providers.dart
@@ -9,6 +9,7 @@ import '../core/network/network_result.dart';
 import '../core/utils/url_utils.dart';
 import '../data/local/app_database.dart';
 import '../repository/notifications_repository.dart';
+import '../repository/submissions_repository.dart';
 import 'app_providers.dart';
 
 /// The home dashboard's card data, replacing `DashboardViewModel.loadUserContent`
@@ -181,10 +182,17 @@ final pendingSurveysProvider =
           .pendingSurveySubmissions(userId);
 
       // One submission per survey, first (oldest) wins — LinkedHashMap order,
-      // as the Kotlin's dedupe does.
+      // as the Kotlin's dedupe does. The key is the **stripped** parent id:
+      // `getUniquePendingSurveys` dedupes and resolves by
+      // `examIdFromParentId()` (`SubmissionsRepositoryImpl.kt:108-121`), never
+      // by the whole column, because a course-attached survey's `parentId` is
+      // `"$surveyId@$courseId"` (Phase 125). Reading it raw sent the composite
+      // to `getByIds`, which matched nothing, so the prompt silently dropped
+      // every pending survey belonging to a course.
       final bySurveyId = <String, SubmissionRow>{};
       for (final submission in submissions) {
-        final surveyId = submission.parentId ?? '';
+        final surveyId =
+            SubmissionsRepository.parentBaseId(submission.parentId) ?? '';
         if (surveyId.isEmpty) continue;
         bySurveyId.putIfAbsent(surveyId, () => submission);
       }

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -108,7 +108,12 @@ class SubmissionsRepository {
       [
         SubmissionsCompanion.insert(
           id: id,
-          parentId: Value(survey.id),
+          // `"$surveyId@$courseId"` for a course-attached survey, as
+          // `createExamSubmission` writes it — see [examParentId]. Storing the
+          // bare id here is what made the mandatory-survey gate unsatisfiable.
+          parentId: Value(
+            examParentId(examId: survey.id, courseId: survey.courseId),
+          ),
           parent: Value(jsonEncode({'_id': survey.id, 'name': survey.name})),
           userId: Value(userId),
           type: const Value('survey'),
@@ -344,12 +349,45 @@ class SubmissionsRepository {
   /// (`SubmissionsRepositoryImpl.kt:449-456`) and `deleteExamSubmissions`
   /// searches by (`:344-350`).
   ///
+  /// **This is the key for a survey as much as for an exam.** Kotlin has one
+  /// `exams` table and one writer: `createExamSubmission` is what
+  /// `ExamTakingFragment` reaches for whether the step carries an exam or a
+  /// survey (`type` is the only difference), and `createBulkSurveySubmissions`
+  /// (`:201-206`) resolves `examDao.getById(examId)?.courseId` to build the
+  /// same string. `hasSubmission` (`:174-190`) then queries exactly it. The
+  /// port had split the two apart: every survey writer stored the bare id
+  /// while [hasUnfinishedSurveys] looked for the composite, so a learner who
+  /// *had* answered a course-attached survey was still told they had not — and
+  /// since that check is what gates finishing `MANDATORY_SURVEY_COURSE_ID`,
+  /// the onboarding course could not be completed at all. Phase 125.
+  ///
   /// The port used to store the bare `courseId` here, which
   /// `ProgressRepository._examIdFromParent` reads as the exam id — it takes
   /// the leading `@`-delimited segment — so the per-step mistake counts could
   /// never find their exam even once `mistakes` was populated.
   static String examParentId({required String examId, String? courseId}) =>
       (courseId?.isNotEmpty ?? false) ? '$examId@$courseId' : examId;
+
+  /// The exam/survey id inside a `parentId` — Kotlin's
+  /// `Submission.examIdFromParentId()`, `parentId?.substringBefore("@")`
+  /// (`SubmissionsRepositoryImpl.kt:64-66`).
+  ///
+  /// Every Kotlin reader that needs to map a submission back to its exam goes
+  /// through this rather than comparing the whole column: `getUniquePendingSurveys`
+  /// (`:108-121`), `getSurveyTitlesFromSubmissions` (`:129-139`), `getExamMap`
+  /// (`:146`) and `ProgressRepositoryImpl.getParentBaseId`. Only two readers in
+  /// either tree compare the whole value — `hasSubmission`'s count, which builds
+  /// the composite itself, and `SurveysRepositoryImpl.findExistingAdoption`
+  /// (`:205-207`), whose rows are written with the bare id on purpose.
+  ///
+  /// `substringBefore` returns the whole string when the delimiter is absent,
+  /// so a bare id passes through unchanged — which is what makes this safe on
+  /// rows an older build of the port wrote.
+  static String? parentBaseId(String? parentId) {
+    if (parentId == null) return null;
+    final at = parentId.indexOf('@');
+    return at < 0 ? parentId : parentId.substring(0, at);
+  }
 
   /// Records one answer and returns whether it was **correct** — the verdict
   /// `updateAnsDb` hands back to `btnNext`/`btnSubmit`, which is what makes a
@@ -511,16 +549,23 @@ class SubmissionsRepository {
 
   /// Creates empty pending survey submissions for each selected user.
   /// Port of `SubmissionsRepositoryImpl.createBulkSurveySubmissions`.
+  ///
+  /// The course id is resolved **once**, before the per-user loop, exactly as
+  /// the Kotlin does (`:201-206`: `val courseId = examDao.getById(examId)?.courseId`
+  /// then one `parentId` for the whole batch). Passing the bare `surveyId`
+  /// through, as this used to, wrote a key [hasUnfinishedSurveys] cannot match.
   Future<void> createBulkSurveySubmissions(
     String surveyId,
     List<String> userIds, {
     DateTime? now,
     String Function()? createId,
   }) async {
+    final courseId = (await _surveyDao.getById(surveyId))?.courseId;
+    final parentId = examParentId(examId: surveyId, courseId: courseId);
     for (final userId in userIds) {
       await getOrCreateSurveySubmission(
         userId: userId,
-        parentId: surveyId,
+        parentId: parentId,
         now: now,
         createId: createId,
       );
@@ -528,6 +573,11 @@ class SubmissionsRepository {
   }
 
   /// Port of `SubmissionsRepositoryImpl.getOrCreateSubmission`.
+  ///
+  /// [parentId] is taken whole, as Kotlin's is: `getOrCreateSubmission`
+  /// (`:624-642`) stores its argument unchanged and leaves building the
+  /// `"$examId@$courseId"` shape to the caller. Callers must pass what
+  /// [examParentId] returns, not a bare survey id.
   Future<SubmissionRow> getOrCreateSurveySubmission({
     required String userId,
     required String parentId,
@@ -563,6 +613,17 @@ class SubmissionsRepository {
   Future<List<SubmissionRow>> submissionsForUserWithoutTeam(String userId) =>
       _dao.byUserWithoutTeam(userId);
 
+  /// The team-survey adoption marker. **Its `parentId` is deliberately the
+  /// bare survey id** and must stay that way: `createMappedSubmission`
+  /// (`SurveysRepositoryImpl.kt:210-241`) writes `parentId = examId` with no
+  /// course suffix, and `findExistingAdoption` (`:205-207`) recognises the row
+  /// by comparing the whole column to that bare id. Running it through
+  /// [examParentId] like the answer-sheet writers would make every adoption
+  /// invisible to its own lookup, and re-adopt on every load.
+  ///
+  /// It follows that a bare-id, `type = 'survey'` row is not *always* a
+  /// stale answer sheet, which is why [repairCourseSurveyParentIds] skips
+  /// `status = ''`.
   Future<void> createSurveyAdoptionSubmission({
     required String id,
     required String surveyId,
@@ -600,16 +661,116 @@ class SubmissionsRepository {
   /// signed-in learner.
   Future<List<SubmissionRow>> pendingUploads() => _dao.pendingUploads();
 
+  /// Rewrites a course-attached survey's answer sheets from the bare survey id
+  /// to `"$surveyId@$courseId"`, and returns how many rows it changed.
+  ///
+  /// This is the field-data half of the Phase 125 fix. Correcting the writers
+  /// leaves every row an earlier build already stored keyed the old way, and
+  /// **those rows do not heal on their own**: the port uploads a submission
+  /// with whatever `parentId` the row carries, and [upsertDocuments] writes
+  /// `parentId` straight back from the document, so a pull re-asserts the bare
+  /// id rather than correcting it. Left alone, a learner who has already
+  /// answered the mandatory survey would be told to answer it again — which is
+  /// the entire bug, survived once more, plus a duplicate answer sheet in the
+  /// reporting the survey exists to produce.
+  ///
+  /// It is **not** a schema migration and needs no `schemaVersion`: no DDL
+  /// changes, `parentId` has always been on the table, and a bump would be the
+  /// wrong tool anyway — `submissions` is in `localAuthorityTables`, so an
+  /// upgrade preserves exactly the rows that need repairing and repairs none
+  /// of them.
+  ///
+  /// Two rows it must not touch, both `type = 'survey'` with a bare id:
+  ///
+  /// * **the adoption marker** (`status = ''`), whose bare id is Kotlin's and
+  ///   is how `findExistingAdoption` finds it — see
+  ///   [createSurveyAdoptionSubmission];
+  /// * a submission for a survey with no `courseId`, whose bare id is already
+  ///   what [examParentId] would produce.
+  ///
+  /// Idempotent: after the first pass no row matches the bare id any more.
+  Future<int> repairCourseSurveyParentIds(String courseId) async {
+    if (courseId.isEmpty) return 0;
+    final surveys = await _surveyDao.getByCourseId(courseId);
+    var repaired = 0;
+    for (final survey in surveys) {
+      final target = examParentId(examId: survey.id, courseId: survey.courseId);
+      // A survey with no `courseId` of its own keys to the bare id already.
+      if (target == survey.id) continue;
+      // Built here rather than in `SubmissionDao` for the same reason
+      // `_deleteExamSubmissions` is: `app_database.dart` belongs to another
+      // lane this round. It should move there.
+      repaired +=
+          await (_dao.update(_dao.submissions)..where(
+                (row) =>
+                    row.parentId.equals(survey.id) &
+                    row.type.equals('survey') &
+                    row.status.isNotValue(''),
+              ))
+              .write(SubmissionsCompanion(parentId: Value(target)));
+    }
+    return repaired;
+  }
+
   /// Port of `SubmissionsRepositoryImpl.hasUnfinishedSurveys`. Returns true
   /// if the course has any attached survey the user has not yet submitted.
   ///
   /// Also aliased as `hasPendingSurvey` — the challenge dialog's name for the
   /// same check. The Kotlin has both methods; they are identical.
+  ///
+  /// [repairCourseSurveyParentIds] runs first. This is the one read in either
+  /// tree whose predicate is the whole `parentId`, so it is the one read that
+  /// a stale bare-id row can answer wrongly — and it runs at exactly the
+  /// moment the answer matters, when the learner taps Finish. Kotlin needs no
+  /// such call because it never wrote the bare id.
+  ///
+  /// **A deliberate deviation, found by the Phase 125 ground-truth audit and
+  /// worth knowing before anyone "fixes" this method toward Kotlin.** This gate
+  /// is live in the port and almost certainly dead in the shipping Kotlin app.
+  /// `getSurveysByCourseId` filters `examDao.getByCourseIdAndType(courseId,
+  /// "survey")` — **singular** — while `StepExam.type` is the embedded
+  /// document's own `type` (`CoursesRepositoryImpl.kt:744`:
+  /// `if (examJson.has("type")) … else examKey`), which for a survey is
+  /// `"surveys"`. Every other Kotlin reader uses the plural: the Take Survey
+  /// button itself is `getByStepIdAndType(stepId, "surveys")` (`:531`), the
+  /// surveys list is `getByType("surveys")`, and `ExamDao`'s defaults are
+  /// `"surveys"`. So the two queries are mutually exclusive and at most one of
+  /// the button and this block can ever see a given survey: a document carrying
+  /// `type: "surveys"` gets a button and never blocks, a document carrying no
+  /// `type` blocks forever with no button that could satisfy it.
+  ///
+  /// The port cannot reproduce that split even if it wanted to: `Surveys` has
+  /// no `type` column, because `ExamMapper.fromDoc` uses the document's `type`
+  /// to *choose the table* and then discards it. Its reader is
+  /// `SurveyDao.getByCourseId` with no type filter, so it finds the survey the
+  /// button opens — which is the behaviour the Kotlin feature was written to
+  /// have. Making the writers agree with it (Phase 125) is therefore internal
+  /// consistency, not restored parity, and the composite key is still the right
+  /// one to converge on: it is what Kotlin uploads, what Planet joins on, and
+  /// what the port's own exam path has always written.
+  ///
+  /// Two things the audit established that keep this reader safe, both pinned
+  /// by tests in `mandatory_survey_round_trip_test.dart`:
+  ///
+  /// * Kotlin's `createMappedSurvey` copies the source survey's `courseId` and
+  ///   `stepId` into an adopted team clone (`SurveysRepositoryImpl.kt:181-182`),
+  ///   so a Kotlin course step can serve a clone and this block would demand
+  ///   every team's copy. The port's `adoptSurvey` omits both columns, and that
+  ///   omission is what makes an unfiltered `getByCourseId` correct here.
+  /// * `countByUserParentAndType` is status-blind, as Kotlin's is
+  ///   (`SubmissionDao.kt:23`) — a sheet the learner has merely *opened*
+  ///   satisfies the gate. That is also why the adoption marker, which is
+  ///   `type = 'survey'` with a bare id, must never be repaired into this key.
   Future<bool> hasUnfinishedSurveys(String courseId, String? userId) async {
     if (courseId.isEmpty || (userId ?? '').isEmpty) return false;
+    await repairCourseSurveyParentIds(courseId);
     final surveys = await _surveyDao.getByCourseId(courseId);
     for (final survey in surveys) {
-      final parentId = '${survey.id}@$courseId';
+      // Routed through the writers' own derivation so the two cannot drift
+      // apart again. `courseId` is non-empty by the guard above and equal to
+      // `survey.courseId` by the query that produced the row, so this is
+      // `hasSubmission`'s literal `"$stepExamId@$courseId"`.
+      final parentId = examParentId(examId: survey.id, courseId: courseId);
       final count = await _dao.countByUserParentAndType(
         userId!,
         parentId,
@@ -854,8 +1015,10 @@ class SubmissionsRepository {
     String? type,
   ) async {
     // `parentId.substringBefore("@")` — the parent id is `examId@courseId`
-    // for a course-attached exam or survey and the bare id otherwise.
-    final examId = (parentId ?? '').split('@').first;
+    // for a course-attached exam or survey and the bare id otherwise. Routed
+    // through [parentBaseId] so there is one derivation, not a re-implemented
+    // split per reader.
+    final examId = parentBaseId(parentId) ?? '';
     if (examId.isEmpty) return null;
 
     Future<Map<String, dynamic>?> fromExams() async {

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -560,8 +560,17 @@ class SubmissionsRepository {
     DateTime? now,
     String Function()? createId,
   }) async {
-    final courseId = (await _surveyDao.getById(surveyId))?.courseId;
-    final parentId = examParentId(examId: surveyId, courseId: courseId);
+    final survey = await _surveyDao.getById(surveyId);
+    final parentId = examParentId(examId: surveyId, courseId: survey?.courseId);
+    // The existence check below is `latestPendingByUserAndParent`, a comparison
+    // of the **whole** `parentId` — so a pending sheet an earlier build stored
+    // under the bare id would not be found, and re-sending the survey would
+    // give the member a *second* pending sheet. Their dashboard prompt dedupes
+    // to the older one, they answer it, and the leftover row re-offers the same
+    // survey until they answer it twice. Repairing first is what keeps the
+    // writer and its own lookup on one key; pre-Phase-125 they agreed on the
+    // bare one, so this gap is the writer fix's to close.
+    if (survey != null) await _repairSurveyParentId(survey);
     for (final userId in userIds) {
       await getOrCreateSurveySubmission(
         userId: userId,
@@ -682,34 +691,61 @@ class SubmissionsRepository {
   ///
   /// Two rows it must not touch, both `type = 'survey'` with a bare id:
   ///
-  /// * **the adoption marker** (`status = ''`), whose bare id is Kotlin's and
-  ///   is how `findExistingAdoption` finds it — see
+  /// * **the adoption marker**, whose bare id is Kotlin's and is how
+  ///   `findExistingAdoption` finds it — see
   ///   [createSurveyAdoptionSubmission];
   /// * a submission for a survey with no `courseId`, whose bare id is already
-  ///   what [examParentId] would produce.
+  ///   what [examParentId] would produce. Reachable through
+  ///   [_repairSurveyParentId]'s other caller, which is handed an arbitrary
+  ///   survey rather than one selected by `courseId`.
   ///
   /// Idempotent: after the first pass no row matches the bare id any more.
   Future<int> repairCourseSurveyParentIds(String courseId) async {
     if (courseId.isEmpty) return 0;
-    final surveys = await _surveyDao.getByCourseId(courseId);
     var repaired = 0;
-    for (final survey in surveys) {
-      final target = examParentId(examId: survey.id, courseId: survey.courseId);
-      // A survey with no `courseId` of its own keys to the bare id already.
-      if (target == survey.id) continue;
-      // Built here rather than in `SubmissionDao` for the same reason
-      // `_deleteExamSubmissions` is: `app_database.dart` belongs to another
-      // lane this round. It should move there.
-      repaired +=
-          await (_dao.update(_dao.submissions)..where(
-                (row) =>
-                    row.parentId.equals(survey.id) &
-                    row.type.equals('survey') &
-                    row.status.isNotValue(''),
-              ))
-              .write(SubmissionsCompanion(parentId: Value(target)));
+    for (final survey in await _surveyDao.getByCourseId(courseId)) {
+      repaired += await _repairSurveyParentId(survey);
     }
     return repaired;
+  }
+
+  /// One survey's share of [repairCourseSurveyParentIds].
+  ///
+  /// **The status test is `coalesce(status, '') != ''`, not `status IS NOT ''`,
+  /// and the difference was a live defect.** Kotlin's predicate is
+  /// `it.status.orEmpty().isEmpty()` (`SurveysRepositoryImpl.kt:203-207`), so
+  /// negating it has to treat a null status and an empty one alike. Drift's
+  /// `isNotValue` emits SQL `IS NOT` rather than `!=`
+  /// (`expression.dart:118-120` → `:148-154`), and `NULL IS NOT ''` is **true**
+  /// — so the first cut of this admitted exactly the rows it existed to skip.
+  ///
+  /// A marker reaches null status by an ordinary route, not a corner case.
+  /// [createSurveyAdoptionSubmission] writes `status: ''` **and**
+  /// `isUpdated: true`, so the generic `pendingUploads` sweep uploads it;
+  /// [serialize] sends `'status': ''`; and [upsertDocuments] reads it back
+  /// through `JsonUtils.getStringOrNull`, which maps the empty string to null
+  /// (`json_utils.dart:19-22`). Every marker that has round-tripped — and
+  /// every marker a Kotlin handset in the same deployment published, since
+  /// Kotlin writes them bare on purpose — arrives with `status = NULL`. In a
+  /// real mixed fleet that is the repair's *most likely* match, where a bare-id
+  /// answer sheet can only come from a pre-Phase-125 build.
+  ///
+  /// `coalesce` on the status is the same idiom, for the same reason, as
+  /// `SubmissionDao.pendingUploads`' coalesced guest operands.
+  Future<int> _repairSurveyParentId(SurveyRow survey) async {
+    final target = examParentId(examId: survey.id, courseId: survey.courseId);
+    // A survey with no `courseId` of its own keys to the bare id already.
+    if (target == survey.id) return 0;
+    // Built here rather than in `SubmissionDao` for the same reason
+    // `_deleteExamSubmissions` is: `app_database.dart` belongs to another
+    // lane this round. It should move there.
+    return (_dao.update(_dao.submissions)..where(
+          (row) =>
+              row.parentId.equals(survey.id) &
+              row.type.equals('survey') &
+              coalesce([row.status, const Constant('')]).equals('').not(),
+        ))
+        .write(SubmissionsCompanion(parentId: Value(target)));
   }
 
   /// Port of `SubmissionsRepositoryImpl.hasUnfinishedSurveys`. Returns true
@@ -739,15 +775,26 @@ class SubmissionsRepository {
   /// `type: "surveys"` gets a button and never blocks, a document carrying no
   /// `type` blocks forever with no button that could satisfy it.
   ///
-  /// The port cannot reproduce that split even if it wanted to: `Surveys` has
-  /// no `type` column, because `ExamMapper.fromDoc` uses the document's `type`
-  /// to *choose the table* and then discards it. Its reader is
+  /// The port cannot reproduce that split *on `type`*: `Surveys` has no `type`
+  /// column, because `ExamMapper.fromDoc` uses the document's `type` to
+  /// *choose the table* and then discards it. Its reader is
   /// `SurveyDao.getByCourseId` with no type filter, so it finds the survey the
   /// button opens — which is the behaviour the Kotlin feature was written to
   /// have. Making the writers agree with it (Phase 125) is therefore internal
   /// consistency, not restored parity, and the composite key is still the right
   /// one to converge on: it is what Kotlin uploads, what Planet joins on, and
   /// what the port's own exam path has always written.
+  ///
+  /// It can reproduce the *shape* by another route, though, so this is not a
+  /// class of bug the port has escaped. The gate reads `courseId` and the
+  /// button reads `stepId`, and `SurveyMapper.fromDoc` writes each
+  /// independently with `_presentOrAbsent` (`survey_mapper.dart:93-94`) — so a
+  /// document carrying `courseId` and no `stepId` lands with a course join and
+  /// no step join: found here, offered by no button. Kotlin genuinely cannot do
+  /// that, since `StepExam.insertCourseStepsExams` never reads either key from
+  /// the document (`StepExam.kt:36-58`) and the exams walk passes
+  /// `("", "", doc, "")`. Whether it is live depends on Planet's document
+  /// shape, which nothing in this tree settles.
   ///
   /// Two things the audit established that keep this reader safe, both pinned
   /// by tests in `mandatory_survey_round_trip_test.dart`:
@@ -761,6 +808,25 @@ class SubmissionsRepository {
   ///   (`SubmissionDao.kt:23`) — a sheet the learner has merely *opened*
   ///   satisfies the gate. That is also why the adoption marker, which is
   ///   `type = 'survey'` with a bare id, must never be repaired into this key.
+  ///
+  /// **Two further deviations from `hasSubmission`, both deliberate.**
+  ///
+  /// 1. The blank-user guard below returns `false`. Kotlin has no guard in
+  ///    `hasUnfinishedSurveys`; it lives in `hasSubmission` (`:181-183`), which
+  ///    returns `false` for a blank `userId` and so inverts to *unfinished* —
+  ///    Kotlin **blocks** a null user on a course that has surveys. Reachable
+  ///    here through `challenge_provider`, which passes a nullable id. Blocking
+  ///    a learner whose id we do not have cannot be satisfied by answering, and
+  ///    the Kotlin behaviour is unobservable anyway (its survey list is always
+  ///    empty, above). The blank-*course* half is not a divergence at all:
+  ///    `getByCourseIdAndType("", …)` matches nothing either.
+  /// 2. `questionDao.countByExamId(stepExamId) == 0 → false` (`:185-187`) is
+  ///    **not** ported. In `getCourseStepData` that rule reads sanely — do not
+  ///    claim a submission exists for an exam whose questions have not synced.
+  ///    Here it inverts into "a question-less survey blocks the course
+  ///    forever", and because the short-circuit precedes the count, no
+  ///    submission can ever satisfy it. Porting it would reintroduce the exact
+  ///    user-blocking bug this phase removes, for a survey nobody can answer.
   Future<bool> hasUnfinishedSurveys(String courseId, String? userId) async {
     if (courseId.isEmpty || (userId ?? '').isEmpty) return false;
     await repairCourseSurveyParentIds(courseId);

--- a/flutter/lib/repository/surveys_repository.dart
+++ b/flutter/lib/repository/surveys_repository.dart
@@ -225,8 +225,12 @@ class SurveysRepository {
   }) async {
     final submission = await _submissions.getById(submissionId);
     if (submission == null) return null;
-    final surveyId = submission.parentId;
-    if (surveyId == null) return null;
+    // `examIdFromParentId()` — a course-attached survey's `parentId` is
+    // `"$surveyId@$courseId"` (Phase 125), and the whole value is not a survey
+    // id. Reading it raw found no questions, so resuming a pending sheet for a
+    // course survey replaced its answers with an empty set.
+    final surveyId = SubmissionsRepository.parentBaseId(submission.parentId);
+    if (surveyId == null || surveyId.isEmpty) return null;
     final questions = await _dao.questionsFor(surveyId);
     await _submissions.updateSurveyAnswers(
       submissionId: submissionId,

--- a/flutter/test/providers/dashboard_providers_test.dart
+++ b/flutter/test/providers/dashboard_providers_test.dart
@@ -4,6 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/dashboard_providers.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+
+import '../support/mock_planet_api.dart';
 
 void main() {
   late AppDatabase db;
@@ -97,15 +100,9 @@ void main() {
       expect(pending.single.submissionId, 'sub-1');
     });
 
-    test('resolves a course-attached survey through the composite key', () async {
-      // Phase 125. A course-attached survey's `parentId` is
-      // `"$surveyId@$courseId"` — what `createBulkSurveySubmissions` now writes
-      // and what Kotlin has always written. `getUniquePendingSurveys` dedupes
-      // and resolves by `examIdFromParentId()`
-      // (`SubmissionsRepositoryImpl.kt:108-121`), never by the whole column.
-      // Keying on the raw value sent the composite to `getByIds`, which matched
-      // nothing, so the prompt silently dropped every pending survey belonging
-      // to a course — pre-fix this failed with `Actual: []`.
+    /// Seeds one pending sheet for a course-attached survey **through the
+    /// production writer**, so the key under test is the one the app mints.
+    Future<void> sendCourseSurvey() async {
       await db.surveyDao.upsertAll([
         SurveysCompanion.insert(
           id: 'survey-1',
@@ -113,12 +110,26 @@ void main() {
           name: const Value('Onboarding'),
         ),
       ], const {});
-      await db.submissionDao.upsertAll([
-        submission('sub-1', 'survey-1@course-1'),
-        // Two sheets for the same survey still dedupe to one, which they only
-        // do if both strip to the same key.
-        submission('sub-2', 'survey-1@course-1'),
-      ]);
+      await SubmissionsRepository(
+        MockPlanetApi(),
+        db.submissionDao,
+        db.submitPhotosDao,
+        db.surveyDao,
+        db.examDao,
+      ).createBulkSurveySubmissions('survey-1', const ['user-1']);
+    }
+
+    test('resolves a course-attached survey through the composite key', () async {
+      // Phase 125, and the **pair**: the writer that mints the key and the
+      // reader that has to strip it. A course-attached survey's `parentId` is
+      // `"$surveyId@$courseId"`, and `getUniquePendingSurveys` dedupes and
+      // resolves by `examIdFromParentId()`
+      // (`SubmissionsRepositoryImpl.kt:108-121`), never by the whole column.
+      // Keying on the raw value sent the composite to `getByIds`, which
+      // matched nothing, so the prompt silently dropped every pending survey
+      // belonging to a course. Demonstrated red by reverting this reader alone
+      // with the writers left correct: `Expected: length of <1> / Actual: []`.
+      await sendCourseSurvey();
 
       final pending = await container.read(
         pendingSurveysProvider('user-1').future,
@@ -127,7 +138,25 @@ void main() {
       expect(pending, hasLength(1));
       expect(pending.single.surveyId, 'survey-1');
       expect(pending.single.name, 'Onboarding');
-      expect(pending.single.submissionId, 'sub-1');
+    });
+
+    test('a leftover bare-id sheet folds into the same prompt entry', () async {
+      // The shape a pre-Phase-125 build, or a Kotlin handset that lost
+      // `exams.courseId`, leaves behind: two pending sheets for one survey
+      // under two different keys. The learner must be prompted once, not
+      // twice. A behavioural guarantee rather than failing-first evidence —
+      // the raw reader also yields one entry here, because the bare row
+      // resolves while the composite one does not, which is exactly why the
+      // test above deliberately seeds no legacy row.
+      await sendCourseSurvey();
+      await db.submissionDao.upsertAll([submission('legacy', 'survey-1')]);
+
+      final pending = await container.read(
+        pendingSurveysProvider('user-1').future,
+      );
+
+      expect(pending, hasLength(1));
+      expect(pending.single.surveyId, 'survey-1');
     });
   });
 

--- a/flutter/test/providers/dashboard_providers_test.dart
+++ b/flutter/test/providers/dashboard_providers_test.dart
@@ -96,6 +96,39 @@ void main() {
       expect(pending.single.name, 'Individual');
       expect(pending.single.submissionId, 'sub-1');
     });
+
+    test('resolves a course-attached survey through the composite key', () async {
+      // Phase 125. A course-attached survey's `parentId` is
+      // `"$surveyId@$courseId"` — what `createBulkSurveySubmissions` now writes
+      // and what Kotlin has always written. `getUniquePendingSurveys` dedupes
+      // and resolves by `examIdFromParentId()`
+      // (`SubmissionsRepositoryImpl.kt:108-121`), never by the whole column.
+      // Keying on the raw value sent the composite to `getByIds`, which matched
+      // nothing, so the prompt silently dropped every pending survey belonging
+      // to a course — pre-fix this failed with `Actual: []`.
+      await db.surveyDao.upsertAll([
+        SurveysCompanion.insert(
+          id: 'survey-1',
+          courseId: const Value('course-1'),
+          name: const Value('Onboarding'),
+        ),
+      ], const {});
+      await db.submissionDao.upsertAll([
+        submission('sub-1', 'survey-1@course-1'),
+        // Two sheets for the same survey still dedupe to one, which they only
+        // do if both strip to the same key.
+        submission('sub-2', 'survey-1@course-1'),
+      ]);
+
+      final pending = await container.read(
+        pendingSurveysProvider('user-1').future,
+      );
+
+      expect(pending, hasLength(1));
+      expect(pending.single.surveyId, 'survey-1');
+      expect(pending.single.name, 'Onboarding');
+      expect(pending.single.submissionId, 'sub-1');
+    });
   });
 
   group('myTeamsStreamProvider', () {

--- a/flutter/test/repository/mandatory_survey_round_trip_test.dart
+++ b/flutter/test/repository/mandatory_survey_round_trip_test.dart
@@ -1,0 +1,295 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// **The pair, not the halves.** Phase 125.
+///
+/// Every writer of a course-attached survey's submission stored the bare survey
+/// id; `hasUnfinishedSurveys` — the gate on finishing
+/// `MANDATORY_SURVEY_COURSE_ID` — queried `"$surveyId@$courseId"`. Each half had
+/// a passing test: the writers were pinned on the fields they set, and the
+/// reader's own test seeded its row through `upsertDocuments` with a
+/// **hand-written** `'parentId': 'survey-a@course-1'` — a key the port's own
+/// writers could not produce. So nothing failed, and a learner who had answered
+/// the survey was told to answer it again, forever.
+///
+/// Every submission here is authored by the production writer and every survey
+/// row comes out of `SurveyMapper.fromCourseDoc` reading a course document
+/// shaped like the server's, so the `surveys.courseId` the writer reads and the
+/// `courseId` the reader is asked about are the same value for the same reason
+/// they are in the field.
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository submissions;
+  late SurveysRepository surveys;
+
+  /// A course document with one step carrying one survey, put through the real
+  /// mappers — the shape `CoursesRepository.sync` writes.
+  const courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'MyPlanet Onboarding',
+    'steps': [
+      {
+        'stepTitle': 'First',
+        'survey': {
+          '_id': 'survey-1',
+          'type': 'surveys',
+          'name': 'Onboarding survey',
+          'questions': [
+            {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+          ],
+        },
+      },
+    ],
+  };
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    final api = MockPlanetApi();
+    submissions = SubmissionsRepository(
+      api,
+      database.submissionDao,
+      database.submitPhotosDao,
+      database.surveyDao,
+      database.examDao,
+    );
+    surveys = SurveysRepository(
+      api,
+      database.surveyDao,
+      database.examDao,
+      submissions,
+    );
+
+    final parsed = CourseMapper.fromDoc(courseDoc)!;
+    await database.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      courseDoc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+  });
+
+  tearDown(() => database.close());
+
+  test('the mapped survey really is attached to the course', () async {
+    // If this fails the rest of the file proves nothing: the reader looks the
+    // survey up by `courseId`, so a mapper that dropped the column would make
+    // every assertion below vacuous.
+    final attached = await database.surveyDao.getByCourseId('course-1');
+    expect(attached.map((row) => row.id), ['survey-1']);
+    expect(attached.single.courseId, 'course-1');
+  });
+
+  test(
+    'a learner who answered the attached survey can finish the course',
+    () async {
+      // Pre-fix: `createSurveyDraft` stored `parentId: 'survey-1'` and
+      // `hasUnfinishedSurveys` counted `'survey-1@course-1'`, so this was
+      // `Expected: false / Actual: true` — the toast on every Finish tap.
+      expect(
+        await submissions.hasUnfinishedSurveys('course-1', 'user-1'),
+        isTrue,
+        reason: 'nothing answered yet',
+      );
+
+      final id = await surveys.submitResponse('survey-1', 'user-1', const {});
+      expect(id, isNotNull);
+
+      expect(
+        await submissions.hasUnfinishedSurveys('course-1', 'user-1'),
+        isFalse,
+        reason: 'the learner answered the attached survey',
+      );
+    },
+  );
+
+  test('the answer sheet carries Kotlin\'s composite key', () async {
+    final id = await surveys.submitResponse('survey-1', 'user-1', const {});
+    final row = await submissions.getById(id!);
+    // `createExamSubmission` (`SubmissionsRepositoryImpl.kt:449-456`).
+    expect(row!.parentId, 'survey-1@course-1');
+  });
+
+  test('another learner is still blocked by their own survey', () async {
+    await surveys.submitResponse('survey-1', 'user-1', const {});
+    // `countByUserParentAndType` is scoped to the user, so one learner's sheet
+    // must not unblock the course for the next one on a shared handset.
+    expect(
+      await submissions.hasUnfinishedSurveys('course-1', 'user-2'),
+      isTrue,
+    );
+  });
+
+  test('a bare-id sheet an earlier build wrote unblocks the course', () async {
+    // The field-data case: this device answered the survey before the writers
+    // were corrected, so the row on disk carries the bare id. It does not heal
+    // on sync — the port uploads the row's own `parentId` and `upsertDocuments`
+    // writes the document's value straight back — so without the repair the
+    // learner is told to answer again.
+    final id = await surveys.submitResponse('survey-1', 'user-1', const {});
+    await (database.update(database.submissions)
+          ..where((row) => row.id.equals(id!)))
+        .write(const SubmissionsCompanion(parentId: Value('survey-1')));
+
+    expect(
+      await submissions.hasUnfinishedSurveys('course-1', 'user-1'),
+      isFalse,
+    );
+    // Repaired in place rather than answered a second time.
+    final row = await submissions.getById(id!);
+    expect(row!.parentId, 'survey-1@course-1');
+    expect(
+      await database.submissionDao.getSurveySubmissionsByUser('user-1'),
+      hasLength(1),
+    );
+  });
+
+  test('a pending sheet sent to the learner blocks and then resumes', () async {
+    // `SendSurveyFragment` -> `createBulkSurveySubmissions`, then the learner
+    // opens the sheet from the dashboard prompt and `updateSurveyResponse`
+    // resumes it. Three keys have to agree across that path.
+    await submissions.createBulkSurveySubmissions('survey-1', const ['user-1']);
+    final pending = await database.submissionDao.getSurveySubmissionsByUser(
+      'user-1',
+    );
+    expect(pending.single.parentId, 'survey-1@course-1');
+    // A sent-but-unanswered sheet is `pending`, and `countByUserParentAndType`
+    // has no status filter, so Kotlin counts it: the course is not blocked by a
+    // survey the learner has been *sent*.
+    expect(
+      await submissions.hasUnfinishedSurveys('course-1', 'user-1'),
+      isFalse,
+    );
+
+    // With the writers corrected and this reader left raw,
+    // `updateSurveyResponse` looked `'survey-1@course-1'` up as a survey id,
+    // found no questions, and wrote **no answers at all** — the learner's
+    // resumed sheet went up empty.
+    final questions = await database.surveyDao.questionsFor('survey-1');
+    final resumed = await surveys.updateSurveyResponse(
+      pending.single.id,
+      answers: {
+        questions.single.id: const SubmissionDraftAnswer(
+          questionId: 's1',
+          value: 'It was fine',
+        ),
+      },
+    );
+    expect(resumed, pending.single.id);
+    final answers = await database.submissionDao.answersFor(pending.single.id);
+    expect(answers.map((row) => row.value), ['It was fine']);
+  });
+
+  test('an adopted team clone is not counted by the course gate', () async {
+    // The Phase 125 audit overturned my reading here. Kotlin's
+    // `createMappedSurvey` copies the source survey's `courseId` **and**
+    // `stepId` into the clone (`SurveysRepositoryImpl.kt:181-182`), and
+    // `getAdoptableTeamSurveys` filters only on `teamShareAllowed` — so a
+    // course-attached survey is adoptable and the Kotlin clone inherits the
+    // course join. `SurveyDao.getByCourseId` has no team or adoption filter,
+    // so if the port's clone ever copied those columns this gate would start
+    // demanding that the learner complete every team's copy of the survey.
+    // The port's `adoptSurvey` omits both, and that omission is load-bearing.
+    await surveys.adoptSurvey(
+      surveyId: 'survey-1',
+      userId: 'user-1',
+      teamId: 'team-1',
+      isTeam: true,
+      teamName: 'Team One',
+    );
+    final clone = await database.surveyDao.adoptedTeamSurvey(
+      'team-1',
+      'survey-1',
+    );
+    expect(clone, isNotNull);
+    expect(clone!.courseId, isNull, reason: 'a clone must not join the course');
+    expect(clone.stepId, isNull);
+    expect(await database.surveyDao.getByCourseId('course-1'), hasLength(1));
+
+    // And the adoption marker it wrote — bare id, `status = ''` — must not be
+    // mistaken for an answered sheet, nor repaired into the composite key.
+    expect(
+      await submissions.hasUnfinishedSurveys('course-1', 'user-1'),
+      isTrue,
+    );
+    final marker = (await database.submissionDao.getSurveySubmissionsByUser(
+      'user-1',
+    )).singleWhere((row) => row.status == '');
+    expect(marker.parentId, 'survey-1');
+    expect(await submissions.repairCourseSurveyParentIds('course-1'), 0);
+    expect(
+      (await submissions.getById(marker.id))!.parentId,
+      'survey-1',
+      reason: '`findExistingAdoption` looks this up by the bare id',
+    );
+  });
+
+  test('the repair is idempotent and reports what it changed', () async {
+    final id = await surveys.submitResponse('survey-1', 'user-1', const {});
+    await (database.update(database.submissions)
+          ..where((row) => row.id.equals(id!)))
+        .write(const SubmissionsCompanion(parentId: Value('survey-1')));
+
+    expect(await submissions.repairCourseSurveyParentIds('course-1'), 1);
+    expect(await submissions.repairCourseSurveyParentIds('course-1'), 0);
+    expect(await submissions.repairCourseSurveyParentIds(''), 0);
+  });
+
+  test('the repair leaves a survey with no course alone', () async {
+    // Its bare id is already what `examParentId` produces, so there is nothing
+    // to rewrite and rewriting it would invent a course join.
+    await database.surveyDao.upsertAll([
+      SurveysCompanion.insert(id: 'standalone', name: const Value('Loose')),
+    ], {});
+    final standalone = (await database.surveyDao.getById('standalone'))!;
+    final id = await submissions.createSurveyDraft(
+      survey: standalone,
+      questions: const [],
+      userId: 'user-1',
+    );
+    expect((await submissions.getById(id))!.parentId, 'standalone');
+    await submissions.repairCourseSurveyParentIds('course-1');
+    expect((await submissions.getById(id))!.parentId, 'standalone');
+  });
+
+  test('createBulkSurveySubmissions keys a course-less survey bare', () async {
+    await database.surveyDao.upsertAll([
+      SurveysCompanion.insert(id: 'standalone', name: const Value('Loose')),
+    ], {});
+    await submissions.createBulkSurveySubmissions('standalone', const [
+      'user-1',
+    ]);
+    final rows = await database.submissionDao.getSurveySubmissionsByUser(
+      'user-1',
+    );
+    // `createBulkSurveySubmissions` (`:201-206`) falls back to the bare exam id
+    // when the lookup finds no course.
+    expect(rows.single.parentId, 'standalone');
+  });
+
+  group('parentBaseId', () {
+    test('strips the course half and passes a bare id through', () {
+      expect(
+        SubmissionsRepository.parentBaseId('survey-1@course-1'),
+        'survey-1',
+      );
+      expect(SubmissionsRepository.parentBaseId('survey-1'), 'survey-1');
+      expect(SubmissionsRepository.parentBaseId(null), isNull);
+      // `substringBefore` on a leading delimiter yields the empty string, and
+      // callers treat that as "no id" rather than matching every row.
+      expect(SubmissionsRepository.parentBaseId('@course-1'), '');
+    });
+  });
+}

--- a/flutter/test/repository/mandatory_survey_round_trip_test.dart
+++ b/flutter/test/repository/mandatory_survey_round_trip_test.dart
@@ -292,4 +292,148 @@ void main() {
       expect(SubmissionsRepository.parentBaseId('@course-1'), '');
     });
   });
+
+  test('a synced adoption marker is not repaired into the gate key', () async {
+    // **The live defect the second audit found in the repair itself**, and it
+    // arrives by a route the locally-authored case cannot show.
+    //
+    // An adoption marker is `status = ''` on the device that wrote it, and
+    // `createSurveyAdoptionSubmission` also sets `isUpdated: true` — so the
+    // generic `pendingUploads` sweep uploads it. `serialize` sends
+    // `'status': ''`, and the pull reads it back through
+    // `JsonUtils.getStringOrNull`, which maps the empty string to **null**
+    // (`json_utils.dart:19-22`). So every marker that has round-tripped, and
+    // every marker a Kotlin handset in the same deployment published, carries
+    // `status = NULL` rather than `''`.
+    //
+    // The guard was `row.status.isNotValue('')`, and drift's `isNotValue`
+    // emits SQL `IS NOT`, not `!=` (`expression.dart:118-120` -> `:148-154`).
+    // `NULL IS NOT ''` is **true**, so the guard admitted exactly the rows it
+    // existed to skip: the marker was rewritten to `survey-1@course-1`, the
+    // status-blind count accepted it, and the learner's Finish sailed past a
+    // survey they had never answered. Kotlin's own predicate is
+    // `it.status.orEmpty().isEmpty()` (`SurveysRepositoryImpl.kt:203-207`) —
+    // negating that needs `coalesce(status, '') != ''`, which is the idiom
+    // `pendingUploads` already uses for the same reason.
+    //
+    // In a real deployment this is the repair's *most likely* match, not a
+    // corner case: a bare-id answer sheet can only come from a pre-Phase-125
+    // port build, while a bare-id adoption marker is written on purpose by
+    // every Kotlin handset there is.
+    await submissions.upsertDocuments([
+      {
+        '_id': 'adopt-doc-1',
+        '_rev': '1-a',
+        'parentId': 'survey-1',
+        'type': 'survey',
+        'status': '',
+        'user': {'_id': 'org.couchdb.user:ada'},
+      },
+    ]);
+    final synced = await submissions.getById('adopt-doc-1');
+    expect(synced!.status, isNull, reason: 'the pull nulls an empty status');
+
+    expect(
+      await submissions.hasUnfinishedSurveys(
+        'course-1',
+        'org.couchdb.user:ada',
+      ),
+      isTrue,
+      reason: 'nothing has been answered; the marker is not an answer sheet',
+    );
+    expect(
+      (await submissions.getById('adopt-doc-1'))!.parentId,
+      'survey-1',
+      reason: '`findExistingAdoption` looks this up by the bare id',
+    );
+  });
+
+  test(
+    're-sending a survey does not duplicate a legacy pending sheet',
+    () async {
+      // Finding 2 of the implementation audit, and a gap the writer fix itself
+      // opened. `getOrCreateSurveySubmission`'s existence check is
+      // `latestPendingByUserAndParent`, which compares the **whole** `parentId`.
+      // Pre-fix the writer and that lookup agreed on the bare key; with the
+      // writer corrected and no repair, a legacy bare-id pending sheet is
+      // invisible to it and the member gets a second sheet for one survey.
+      await submissions.createBulkSurveySubmissions('survey-1', const [
+        'user-1',
+      ]);
+      final first = (await database.submissionDao.getSurveySubmissionsByUser(
+        'user-1',
+      )).single;
+      await (database.update(database.submissions)
+            ..where((row) => row.id.equals(first.id)))
+          .write(const SubmissionsCompanion(parentId: Value('survey-1')));
+
+      await submissions.createBulkSurveySubmissions('survey-1', const [
+        'user-1',
+      ]);
+
+      final rows = await database.submissionDao.getSurveySubmissionsByUser(
+        'user-1',
+      );
+      expect(rows, hasLength(1), reason: 'one survey, one pending sheet');
+      expect(rows.single.id, first.id, reason: 'the existing sheet was reused');
+      expect(rows.single.parentId, 'survey-1@course-1');
+    },
+  );
+
+  test('the repair only touches survey-typed rows for this course', () async {
+    // Findings 4 and 5: three clauses that were each revertible with the whole
+    // suite green. The exam row matters because the two id spaces are not
+    // disjoint — `_liveParentDocument`'s own comment says so — and an exam
+    // attempt's key is the exam path's to write.
+    await database.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 'exam-attempt',
+        userId: const Value('user-1'),
+        parentId: const Value('survey-1'),
+        type: const Value('exam'),
+        status: const Value('requires grading'),
+      ),
+      SubmissionsCompanion.insert(
+        id: 'other-course-sheet',
+        userId: const Value('user-1'),
+        parentId: const Value('survey-elsewhere'),
+        type: const Value('survey'),
+        status: const Value('complete'),
+      ),
+    ]);
+
+    expect(await submissions.repairCourseSurveyParentIds('course-1'), 0);
+    expect((await submissions.getById('exam-attempt'))!.parentId, 'survey-1');
+    expect(
+      (await submissions.getById('other-course-sheet'))!.parentId,
+      'survey-elsewhere',
+    );
+  });
+
+  test('the repair keys a course-less survey bare when handed one', () async {
+    // The `target == survey.id` branch. It is unreachable through
+    // `repairCourseSurveyParentIds`, whose rows are selected by an exact
+    // `courseId` match, and reachable through `createBulkSurveySubmissions`,
+    // which repairs whatever survey it was handed.
+    await database.surveyDao.upsertAll([
+      SurveysCompanion.insert(id: 'standalone', name: const Value('Loose')),
+    ], {});
+    await submissions.createBulkSurveySubmissions('standalone', const [
+      'user-1',
+    ]);
+    final rows = await database.submissionDao.getSurveySubmissionsByUser(
+      'user-1',
+    );
+    expect(rows.single.parentId, 'standalone');
+  });
+
+  test('a null user does not block a course that has surveys', () async {
+    // A deliberate divergence, and it was unpinned: the existing coverage
+    // asserts a null user against a database with **no** surveys, where Kotlin
+    // agrees. Kotlin's guard is inside `hasSubmission` (`:181-183`) and inverts
+    // to *unfinished*, so Kotlin blocks here. Blocking a learner whose id we do
+    // not have cannot be satisfied by answering.
+    expect(await submissions.hasUnfinishedSurveys('course-1', null), isFalse);
+    expect(await submissions.hasUnfinishedSurveys('course-1', ''), isFalse);
+  });
 }

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -12,6 +12,8 @@ import 'package:myplanet/providers/courses_providers.dart';
 import 'package:myplanet/providers/ratings_provider.dart';
 import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/repository/ratings_repository.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
 import 'package:myplanet/ui/courses/take_course_screen.dart';
 
 import '../../support/widget_harness.dart';
@@ -274,6 +276,107 @@ void main() {
       findsOneWidget,
     );
     expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('a completed attached survey lets the course finish', (
+    tester,
+  ) async {
+    // **The round trip, at the screen the learner actually taps.** Phase 125.
+    //
+    // Pre-fix this test failed with the toast still on screen and no rating
+    // dialog: `createSurveyDraft` stored `parentId: 'survey-mandatory'` while
+    // `hasUnfinishedSurveys` counted `'survey-mandatory@<course>'`, so the
+    // MyPlanet Onboarding course could not be finished however many times the
+    // learner answered its survey.
+    //
+    // The submission is authored by the production writer through
+    // `SurveysRepository.submitResponse`, not inserted by hand — a fixture
+    // that writes the key itself is what let the defect survive four phases of
+    // green tests.
+    final db = AppDatabase.memory();
+    addTearDown(db.close);
+    await db.surveyDao.upsertAll([
+      SurveysCompanion.insert(
+        id: 'survey-mandatory',
+        courseId: const Value(mandatoryCourseId),
+        name: const Value('Onboarding survey'),
+      ),
+    ], {});
+    final api = MockPlanetApi();
+    final submissions = SubmissionsRepository(
+      api,
+      db.submissionDao,
+      db.submitPhotosDao,
+      db.surveyDao,
+      db.examDao,
+    );
+    final answered = await SurveysRepository(
+      api,
+      db.surveyDao,
+      db.examDao,
+      submissions,
+    ).submitResponse('survey-mandatory', 'user-1', const {});
+    expect(answered, isNotNull);
+
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') {
+                router.push('/take');
+              }
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (context) =>
+              const TakeCourseScreen(courseId: mandatoryCourseId),
+        },
+        overrides: [
+          sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
+          courseProvider(mandatoryCourseId).overrideWith(
+            (ref) => Stream.value(
+              buildCourseRow(id: mandatoryCourseId, courseTitle: 'Onboarding'),
+            ),
+          ),
+          courseStepsProvider(mandatoryCourseId).overrideWith(
+            (ref) => Stream.value([buildStepRow(id: 's1', stepTitle: 'First')]),
+          ),
+          appDatabaseProvider.overrideWith((ref) {
+            ref.onDispose(db.close);
+            return db;
+          }),
+          ratingSummaryProvider((
+            type: 'course',
+            itemId: mandatoryCourseId,
+          )).overrideWith(
+            (ref) => Stream.value(
+              const RatingSummary(average: 0, total: 0, userRating: null),
+            ),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Finish'));
+    await tester.pumpAndSettle();
+
+    // No toast, and the finish reached the rating dialog it is gated in front
+    // of — the learner's answer counted.
+    expect(
+      find.text('please complete the survey to finish the course'),
+      findsNothing,
+    );
+    expect(find.byType(AlertDialog), findsOneWidget);
   });
 
   /// Fills an in-memory database from a real-shaped course document through


### PR DESCRIPTION
Lane A of the Phase 125 round. **Draft — work in progress.**

## The defect

`PHASE_123_NOTES.md` §"Found, not fixed" item 0, reproduced against the current head:

> Every port writer stores a course-attached survey's `parentId` as the bare survey id, and the mandatory-survey check looks for `surveyId@courseId`. So it never matches, and a learner who *has* completed the attached survey is still told they have not.

Kotlin is internally consistent — `createBulkSurveySubmissions` and `createExamSubmission` both build `"$examId@$courseId"` when the exam has a course, and `hasSubmission` queries exactly that. The port writes the bare id from three writers while `hasUnfinishedSurveys` (Phase 52's port of `hasSubmission`) builds `'${survey.id}@$courseId'`.

This is user-blocking: the mandatory-survey toast is what stops a learner finishing the MyPlanet Onboarding course, so the defect makes that course uncompletable for anyone it fires on.

## Scope

- `lib/repository/submissions_repository.dart`, `lib/repository/submissions_exporter.dart`
- `lib/ui/courses/take_course_screen.dart`, `lib/ui/surveys/`, `lib/ui/submissions/`
- plus their tests

Notes land in `flutter/PHASE_125_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXPpose6d1g71aSccYck9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqXPpose6d1g71aSccYck9)_