### PR TITLE
Phase 127 (Lane C): notification row relative timestamp + selection mode

### DIFF
--- a/flutter/PHASE_127_NOTES.md
+++ b/flutter/PHASE_127_NOTES.md
@@ -1,0 +1,3 @@
+# Phase 127 — the bell row's timestamp, and selection mode
+
+Phase 124's two self-reported items. Work in progress.

--- a/flutter/PHASE_127_NOTES.md
+++ b/flutter/PHASE_127_NOTES.md
@@ -4,8 +4,15 @@ Phase 124's two self-reported items, in the order it recommended: the timestamp
 first, because it is wrong on every row, and selection mode second, because it
 is additive.
 
-Two `parity-auditor` passes at `effort: max`, one on the Kotlin before any Dart
-and one on the finished diff. The first overturned a conclusion this lane had
+Two `parity-auditor` passes at `effort: max` were run, one on the Kotlin before
+any Dart and one on the finished diff. **The second did not finish** — it hung
+on a probe of its own that drove the real screen through `pumpAndSettle`, which
+is the documented trap for this port (the loading `CircularProgressIndicator`
+spins it to its ten-minute default), and it was stopped after ~50 minutes. Its
+injections up to that point were replayed by hand and are in the table below;
+two of them found tests that were not load-bearing. What a completed pass would
+still have covered — the `_selectedIds` lifecycle across a stream re-emit, and
+the two `getByIds`-then-write pairs — is named in *Reported, not fixed*. The first overturned a conclusion this lane had
 already written into a code comment, and the reason it could is worth stating
 plainly: **the lane's own first reading of the Kotlin was wrong, in exactly the
 way this document keeps warning about.** See *The reading that was wrong* below.
@@ -338,25 +345,61 @@ the screen path restamps, because the Kotlin does
     Actual: <2>                      // returned a count, not the ids that existed
 ```
 
-Confirmed red, with the output above:
+Every revert below was replayed and confirmed red, then restored.
 
 | revert | red |
 |---|---|
 | the row draws `DateFormat.yMMMd().add_jm()` again | 2 screen tests |
 | the tray path stamps `createdAt` | 2 |
 | the bulk path returns a count instead of the ids that existed | 2 |
+| the absolute arm passes no locale | 1 |
+| the absolute arm loses its unknown-locale fallback | 1 (`so` throws out of `build`) |
+| `relativeTimeLabel` left pointing at the Kotlin-named keys | 2 |
+| `markAllAsRead` stamps outside its `isRead = 0` scope | 2 |
+| the `days_ago` boundary widens from 7 days to 8 | 1 |
+| the swipe stays armed in selection mode | 1 (**after the test was fixed** — see below) |
+| the row's checkbox takes a non-null `onChanged` | 1 (**added below**) |
 
-**Still to replay** — listed so the gap is visible rather than implied, and
-being worked through with the second `parity-auditor` pass: the absolute arm
-passing no locale; the absolute arm losing its unknown-locale fallback (`so`
-throwing out of `build`); `relativeTimeLabel` left pointing at the renamed
-plural keys, which is the interesting one because it **compiles** — the old key
-generated `String minutesAgo(num count)` and the new one `String
-minutesAgo(int count)`, and `elapsed.inMinutes` satisfies both, so the
-dashboard and profile would have switched to `5 min ago` silently and
-`relativeTimeLabel(l10n, day)` would have rendered the ungrammatical `1 days
-ago` that its day bucket *can* reach where the notification row's cannot; and
-`markAllAsRead` stamping outside its `isRead = 0` scope.
+The `relativeTimeLabel` one is the one to remember, because **it compiles and
+`flutter analyze` reports no issues**: the old key generated
+`String minutesAgo(num count)` and the new one `String minutesAgo(int count)`,
+and `elapsed.inMinutes` satisfies both. Left unrepointed, the dashboard's
+last-sync strip and the profile's last-login row would have switched silently to
+`5 min ago`, and `relativeTimeLabel(l10n, day)` would have rendered the
+ungrammatical `1 days ago` — which **its** day bucket starts at, where the
+notification row's cannot reach it. A rename with no compiler error is exactly
+the shape that ships.
+
+### Two tests that were not load-bearing
+
+Green is not evidence, so each guard was re-checked by **injecting the defect it
+claims to catch**. Two survived, both in selection mode.
+
+**The swipe guard.** `swiping is disabled while selecting` asserted only that
+nothing was deleted — and nothing is deleted either way, because an armed swipe
+reaches `confirmDismiss`, opens the confirmation dialog and returns false. The
+test passed for the wrong reason. It now drags **outside** selection mode first
+as a control (the dialog appears, and is dismissed), then drags inside it and
+asserts **no dialog** — which is what distinguishes "the swipe was never armed"
+from "the swipe was armed and declined".
+
+**The checkbox.** Nothing pinned `onChanged: null`. A Checkbox with a non-null
+handler *absorbs* the tap rather than letting it reach the row, so the one
+control that looks most tappable in selection mode would have done nothing at
+all. Kotlin's `cbSelect` is `clickable="false"` `focusable="false"` and the row
+owns the click. A test now taps the checkbox and asserts the row toggled.
+
+### One injection that turned out to be a non-difference
+
+Arming `onLongPress` in selection mode leaves the suite green, and **that is
+correct** rather than a gap. With `onLongPress: null` no long-press recognizer
+is registered, so a press-and-release is recognised as a *tap* and toggles;
+armed, the long-press handler toggles. Same outcome. Android agrees —
+`setOnLongClickListener(null)` leaves the click listener active, so a long press
+there also falls through to `onClick`. The `null` is a faithful transcription of
+`NotificationsAdapter.kt:134` with no observable consequence, and the test
+written to pin it was deleted rather than kept asserting a premise that is not
+true of either app.
 
 ---
 
@@ -395,3 +438,14 @@ ago` that its day bucket *can* reach where the notification row's cannot; and
 5. **A `%d` in a relative string renders ASCII digits** where an Arabic or
    Nepali device shows its own. Explained above; `intl` cannot reproduce the
    Kotlin's per-locale choice in either direction.
+6. **The second audit pass did not complete**, so two areas are less examined
+   than the rest and are named rather than implied. First, the `_selectedIds`
+   lifecycle against a *live* stream: the tests drive selection over a
+   `Stream.value`, so nothing exercises a re-emit that removes a selected row
+   mid-selection. Kotlin's equivalent quirk is known and reproduced by
+   construction (`loadNotifications` never clears `_selectedIds`, and the port
+   holds the set outside the stream the same way), but it is reasoned, not
+   measured. Second, `markAsRead` and `deleteNotifications` both read
+   `getByIds` and then write, which is two statements where Kotlin also uses
+   two (`getIdsByIds` then the update) — so the interleaving is at parity, but
+   neither app takes a transaction and nothing here tests concurrent callers.

--- a/flutter/PHASE_127_NOTES.md
+++ b/flutter/PHASE_127_NOTES.md
@@ -1,3 +1,397 @@
 # Phase 127 — the bell row's timestamp, and selection mode
 
-Phase 124's two self-reported items. Work in progress.
+Phase 124's two self-reported items, in the order it recommended: the timestamp
+first, because it is wrong on every row, and selection mode second, because it
+is additive.
+
+Two `parity-auditor` passes at `effort: max`, one on the Kotlin before any Dart
+and one on the finished diff. The first overturned a conclusion this lane had
+already written into a code comment, and the reason it could is worth stating
+plainly: **the lane's own first reading of the Kotlin was wrong, in exactly the
+way this document keeps warning about.** See *The reading that was wrong* below.
+
+---
+
+## Item 1 — what each bucket formats to
+
+`NotificationsAdapter.ItemViewHolder.formatRelativeTime`
+(`NotificationsAdapter.kt:152-163`) and `getDateFormatter()` (`:43-53`). `diff`
+is `System.currentTimeMillis() - createdAt`, computed once per bind; the
+absolute arm formats **`createdAt`**, not `diff`.
+
+| `diff` | arm | English |
+|---|---|---|
+| `< 60_000` | `just_now` | `Just now` |
+| `< 3_600_000` | `minutes_ago`, `diff / 60_000` | `1 min ago` … `59 min ago` |
+| `< 86_400_000` | `hours_ago`, `diff / 3_600_000` | `1 hr ago` … `23 hr ago` |
+| `< 172_800_000` | `yesterday` | `Yesterday` |
+| `< 604_800_000` | `days_ago`, `diff / 86_400_000` | `2 days ago` … `6 days ago` |
+| otherwise | `MMM d, yyyy` of `createdAt` | `Aug 31, 2026` |
+
+Three things the arithmetic decides, all pinned:
+
+* **No bucket can render a zero.** Each arm's lower bound is the divisor, so
+  integer division yields 1 or more. `0 min ago` is unreachable.
+* **`days_ago` renders 2..6 — never 1, never 7.** The `yesterday` arm owns the
+  whole of day one, and 7 days *exactly* is `else`, since the comparison is `<`.
+  So the ungrammatical `1 days ago` that the Kotlin string would produce never
+  renders — by the arrangement of the arms, not by anything in the string.
+  Phase 124's note called the bucket "2–7 days", which is off by the upper
+  bound.
+* **A future `createdAt` reads "Just now".** `diff < 60_000L` is satisfied by
+  every negative value, so clock skew lands in the first arm and no `~/` ever
+  sees a negative dividend. This is reachable: `parseNotification` takes
+  `createdAt` from the *server's* `time` field, and these devices are offline
+  with drifting clocks.
+
+The >7-day arm **drops the time of day**, which the port's
+`DateFormat.yMMMd().add_jm()` did not.
+
+## `relative_time.dart`: a second formatter, not an extended one
+
+Phase 124 flagged `relativeTimeLabel` as "not a drop-in" and was right, but the
+reason it gave — different buckets — is the weakest of the three. The decisive
+one is that **the Android app renders two different sentences**:
+
+| | ports | source of strings | 5 minutes |
+|---|---|---|---|
+| `relativeTimeLabel` | `TimeUtils.getRelativeTime` → `DateUtils.getRelativeTimeSpanString` | the Android **framework**'s own strings | `5 minutes ago` |
+| `notificationTimestampLabel` | `NotificationsAdapter.formatRelativeTime` | **`strings.xml`**, `minutes_ago` = `%1$d min ago` | `5 min ago` |
+
+Plus: no `Yesterday` bucket and no absolute arm in the former. Folding the
+notification row into `relativeTimeLabel` would have had to change the wording
+on either the bell or the dashboard/profile, and both changes are wrong. So:
+two functions, **in the same file**, with the difference documented at the
+second one — because two relative-time formatters in two files is precisely how
+the port ended up with two disagreeing `normalizeText`s (Phase 78).
+
+Both take the two instants as parameters rather than reading the clock, which is
+the shape `relativeTimeLabel`'s callers already use (they subtract at the call
+site) — and the absolute arm needs `createdAt` itself, not just the elapsed
+time.
+
+### The ARB keys: why three of them could never derive
+
+`justNow` was already the Kotlin `just_now`, translated in all five locales. The
+other three were **the port's own ICU plurals** (`{count, plural, =1{1 minute
+ago} …}`) sitting under `minutesAgo`/`hoursAgo`/`daysAgo` — the camelCase names
+of Kotlin's single-form strings. `tool/arb_from_strings_xml.dart` skips plurals
+outright and says why (filling `other` from the Kotlin and leaving `=1` in
+English puts two languages in one rendered string), so the tool could see a name
+match and had to refuse it. Every locale carried bare English, flagged `x-mt`.
+
+The fix is a rename, and it is contained: **the plurals moved to
+`relativeMinutesAgo`/`relativeHoursAgo`/`relativeDaysAgo`** (values and `x-mt`
+flags intact — nothing was lost, they were English), and the Kotlin names now
+hold the Kotlin strings. Then the derivation ran.
+
+### Did the `yesterday` translations come across? All four keys, all five locales
+
+Yes — **20 human translations already shipping in the Android app, for free.**
+`yesterday` derived by name (rule 1); the three format strings derived through
+Phase 121's placeholder path, which lines `%1$d` up with `{count}` by argument
+index.
+
+| ARB key | from | ar | es | fr | ne | so |
+|---|---|---|---|---|---|---|
+| `yesterday` | `yesterday` | `أمس` | `Ayer` | `Hier` | `हिजो` | `Shalay` |
+| `minutesAgo` | `minutes_ago` | `منذ {count} دقيقة` | `Hace {count} min` | `Il y a {count} min` | `{count} मिनेट अघि` | `{count} daqiiqo ka hor` |
+| `hoursAgo` | `hours_ago` | `منذ {count} ساعة` | `Hace {count} h` | `Il y a {count} h` | `{count} घण्टा अघि` | `{count} saacad ka hor` |
+| `daysAgo` | `days_ago` | `منذ {count} أيام` | `Hace {count} día(s)` | `Il y a {count} jour(s)` | `{count} दिन अघि` | `{count} maalmood ka hor` |
+
+Note `ne`/`so` put the count *first* and the Semitic/Romance locales put it
+after a preposition — the reordering Phase 121 exists for.
+
+### One divergence that survives, and one that was fixed on audit
+
+**Digits diverge.** Kotlin reaches the relative strings through
+`Resources.getString(id, args)` → `String.format(configLocale, …)`, which
+localises `%d`, so an Arabic device shows `منذ ٥ دقيقة` in Arabic-Indic digits;
+`gen-l10n` emits a bare `'$count'`, so the port shows ASCII. It cannot be
+reproduced faithfully even with `NumberFormat`, because `intl`'s own `ar`
+symbols carry an ASCII zero digit while `ne`'s carry `०`. The test that
+asserts the Arabic strings now **says so in a comment**, because otherwise it
+reads as evidence of parity on the one point where the apps differ.
+
+**The absolute arm's locale was fixed.** The first draft passed no locale and
+justified it with "`initializeDateFormatting` is never called, so a locale
+argument would throw for `ar`/`ne`/`so`". That was wrong for two of the three:
+`flutter_localizations` registers the date tables through
+`initializeDateFormattingCustom`, and `ar` and `ne` both resolve. Measured, in a
+widget test with the app's real delegates:
+
+```
+en -> Aug 31, 2026     ne -> अगस्ट ३१, २०२६
+ar -> أغسطس 31, 2026    so -> THREW ArgumentError: Invalid locale "so"
+es -> ago 31, 2026     fr -> août 31, 2026
+```
+
+So the arm now formats with `l10n.localeName`, cached per locale as Kotlin
+caches per `Locale`, and falls back to the unlocalised formatter on any failure.
+Somali is the only locale that needs the fallback (it is in neither
+`flutter_localizations`' generated table nor `intl`'s own
+`date_symbol_data_local`), and it gets English month names where the Kotlin gives
+it `Abr`/`Lul`.
+
+The `catch` is deliberately **broad**, not a `so` allowlist and not one exception
+type: `intl` raises `ArgumentError` for a locale missing from a registered set
+and `LocaleDataException` when nothing is registered at all — a bare unit test
+sees the second. A date is not worth an exception escaping `build`, which is the
+Phase 95 shape.
+
+Kotlin renders ASCII digits in this arm for *every* locale, because
+`DateTimeFormatterBuilder.toFormatter(Locale)` uses `DecimalStyle.STANDARD`
+rather than the locale's; `intl` uses the locale's, so Nepali reads
+`अगस्ट ३१, २०२६` against Kotlin's `अगस्ट 31, 2026`. Nepali digits in a Nepali
+sentence are not a defect, and chasing byte parity would mean reproducing a Java
+quirk that the Kotlin's own relative arms already contradict — the Android app
+mixes numbering systems inside one list.
+
+---
+
+## The reading that was wrong
+
+Phase 124 recorded that `markAsRead` stamps `createdAt = now` "faithfully", and
+asked this lane to establish whether Kotlin does the same before treating it as
+a bug. This lane's first answer was **no, it is a defect** — and wrote a test
+group, a DAO method and three doc comments on that basis. It was wrong, and the
+ground-truth audit is what caught it.
+
+There are **two** Kotlin `markAsRead` DAO queries differing in exactly one
+column, and two repository methods over them, belonging to two different
+screens:
+
+| DAO | stamps `createdAt`? | repository method | reached from |
+|---|---|---|---|
+| `markAsRead(notificationId)` (`NotificationDao.kt:15-16`) | **no** | `markNotificationAsRead(id, userId)` (`:36-43`) | `DashboardActivity.markDatabaseNotificationAsRead` (`:701-703`) — a tap on an Android tray notification's *body* |
+| `markAsRead(ids, createdAt)` (`:45-46`) | **yes** | `markNotificationsAsRead(Set)` (`:113-120`) | the notifications screen, and the tray's *Mark as Read* action button (`NotificationActionReceiver.kt:81`) |
+| `markAllUnreadAsRead(userId, createdAt)` (`:48-49`) | **yes** | `markAllUnreadAsRead` (`:122-128`) | *Mark all read* |
+| `markSummaryAsRead(userId, type)` (`:12-13`) | **no** | the `summary_` branch of the first | the tray |
+
+`NotificationsViewModel.markAsRead(id)` (`:207-209`) calls
+`markNotificationsAsRead(**setOf(id)**)` — the bulk, **stamping** one. So the
+row's *Mark as read* button and a row tap **do** restamp `createdAt` in the
+Android app. It is a quirk, not a bug to fix: the list is sorted
+`isRead ASC, createdAt DESC`, so a read row jumps to the top of its group and,
+now that the timestamp is relative, reads "Just now". Both apps have to share it
+or their lists order differently. Kotlin even has a path that shows it
+immediately — the tray action stamps and then broadcasts
+`NOTIFICATION_READ_FROM_SYSTEM`, which `DashboardActivity` turns into a full
+`loadNotifications`.
+
+The port had **one** method blending the two: the summary branch of the tray
+handler with the stamping of the screen's. The screen accidentally matched
+Kotlin; the tray path did not. Both are now separate:
+
+* the screen calls `markAsRead({id})`, which stamps and returns the ids that
+  existed (Kotlin filters through `getIdsByIds` and its caller gates on the
+  result);
+* `markNotificationAsRead` keeps its `summary_` branch and no longer stamps,
+  over a new `NotificationDao.markOneAsRead`.
+
+**`markNotificationAsRead` now has no caller in the port**, because
+`NotificationActionReceiver` and the dashboard's tray handling are unported. It
+is kept rather than deleted, and pinned by tests, precisely because the screen
+was wired to it by mistake: the phase that ports tray actions needs it to be
+right, and a silently-stamping tray path is the defect that was already there.
+Recorded here rather than left for an audit to find — see *Reported, not fixed*.
+
+**And the stamp is uploaded.** `TransactionSyncManager.kt:464-503` PUTs
+`addProperty("time", notification.createdAt.time)`, the stamped value, and the
+port's `syncNotificationReads` sends `'time': notification.createdAt`. So
+reading a notification rewrites the server document's time in both apps and the
+"Just now" propagates cross-device. At parity, and worth knowing before someone
+reports it as a port bug.
+
+One behavioural difference the reactive stream creates, not this phase:
+`notificationsProvider` watches the drift stream, so a just-read row **moves
+immediately** in Flutter, where Kotlin's ViewModel updates its in-memory copy
+with `notif.copy(isRead = true)` and keeps the old `createdAt` and the old
+position until the next reload. Visible before this phase too — the port already
+drew the stamped date — but it is louder now that the text changes as well.
+
+---
+
+## Item 2 — selection mode
+
+`NotificationsAdapter.bind`'s `isSelectionMode` branch (`:129-149`),
+`_selectedIds` and the three actions over it
+(`NotificationsViewModel.kt:39,145-153,173-205`), and the bulk bar
+(`NotificationsFragment.kt:104-107`, `fragment_notifications.xml:44-93`).
+
+Held as **local widget state** in a `ConsumerStatefulWidget`, following Phase
+50's resource catalog (`resources_screen.dart:35`) rather than inventing a second
+pattern — and, like the Kotlin, **there is no mode flag**: `isSelectionMode` is
+`_selectedIds.isNotEmpty()`, derived. That single fact is what makes "deselect
+the last row" an exit, in both apps, with no code for it.
+
+| Kotlin | port |
+|---|---|
+| long-press any row (`:145-148`) | `ListTile.onLongPress` |
+| `cbSelect` visible, `clickable="false"` (`row_notifications.xml:33-42`) | a non-interactive `Checkbox` as the tile's `leading`, replacing the port's icon |
+| `btnMarkAsRead` hidden (`:132`) | `trailing: null` while selecting |
+| row tap toggles; long-press listener set to **null** (`:133-134`) | `onTap` toggles, `onLongPress: null` |
+| `ltBulkActionBar` shown, `ltTopBar` hidden (`:104-107`) | the AppBar becomes count + *Mark read* + *Delete* + close |
+| `tvSelectedCount` = `selected_count` | `l10n.selectedCount(n)` |
+
+Kotlin's `ltTopBar` holds **both** *Mark all as read* and the all/read/unread
+spinner, so selection mode hides the filter too. That is not cosmetic: it is what
+stops the quirk below from being trivially reachable.
+
+### The quirks reproduced rather than corrected
+
+Each of these is Kotlin behaviour, read from source (there is almost no Kotlin
+test coverage here — `NotificationsViewModelTest.kt:216-233` covers the toggle
+and nothing else), and each has a test saying so:
+
+* **A read row can be selected**, and re-marking it is not a no-op:
+  `markNotificationsAsRead` does not filter on `isRead`, so it re-stamps
+  `createdAt` and re-flags `needsSync` for every selected server row. Gating
+  selection on unread would be an improvement, not a port.
+* **A group header stays selection-unaware** — `NotificationListItem.Header`
+  carries neither `isSelected` nor `isSelectionMode`, and `HeaderViewHolder.bind`
+  wires only the expansion toggle. So a group can be collapsed while its rows are
+  selected: the bar still counts them and the bulk action still acts on rows the
+  user cannot see.
+* **There is no *select all***, no back-button handling (no
+  `OnBackPressedCallback` in the fragment; `resources_screen.dart` has no
+  `PopScope` either, so this is parity by omission) and **no confirmation on the
+  bulk delete**.
+* **`deleteSelected` is a plain local `DELETE`.** Nothing is enqueued, no
+  tombstone, no `_deleted` document — `UploadConfigs` mentions notifications
+  nowhere — and the notifications sync-in deliberately runs no `deleteNotIn`
+  (Phase 98's reasoning: a prune would evict the locally-authored count/storage
+  rows that have no server document). So **a deleted server-originated
+  notification comes back on the next sync.** A round-trip test states it rather
+  than leaving it to be discovered.
+
+### One deliberate difference
+
+The port's **swipe-to-delete is not a port of anything** — Kotlin has no
+`ItemTouchHelper` anywhere and deletes only through the bulk bar. It stays
+(Phase 124 shipped it), but it now **yields** while selecting
+(`DismissDirection.none`), on the same reasoning that makes Kotlin disarm the
+long-press there: while a selection is open the row's gestures belong to the
+selection. The row's own confirmation dialog is also why the bulk delete has
+none — the swipe confirms because it is a Flutter gesture that can fire by
+accident, and Kotlin has no dialog to copy for the button.
+
+### l10n, and a fourth key repaired
+
+`selectedCount`, `markSelectedAsRead` and `cancelSelection` are new and derive
+from `selected_count`/`mark_selected_as_read`/`cancel_selection` in all five
+locales. *Delete* reuses the existing `delete` — which is Kotlin's
+`delete_selected` text exactly (`Delete`), where the port's existing
+`deleteSelected` key says "Delete Selected" and belongs to the storage screen.
+
+`selectedCount` is deliberately **not** the existing `storageSelectedCount`,
+though its English is identical and `resources_screen.dart` reuses that one:
+Kotlin ships two strings here and they disagree in Arabic
+(`تم تحديد %1$d` against `%1$d محدد`). The notifications screen shows what
+Kotlin's notifications screen shows.
+
+And `markAllRead` was repaired. It was named and worded just differently enough
+from Kotlin's `mark_all_as_read` — "Mark all read" against "Mark all as read" —
+that **neither** derivation rule could fire: the camelCase of the Kotlin name is
+`markAllAsRead`, and the English did not match either. Renamed, with Kotlin's
+exact English. Nepali and Somali had no value at all; Arabic and French carried
+`x-mt` machine output, so those were deleted and re-derived (the documented
+workflow, and a repair — machine output replaced by the human translation
+shipping in the Android app). French's machine output happened to *equal* the
+human translation, so only its flag changed; Arabic's did not. **Spanish already
+held the Kotlin value unflagged and was left alone** — replacing one valid
+translation with another is not a repair. Hence es +3 where the rest are +4.
+
+`test/l10n/placeholder_integrity_test.dart`'s pinned counts move to
+ar 410, es 462, fr 409, ne 411, so 411.
+
+---
+
+## Failing-first evidence
+
+Item 1 is a behaviour change, so each claim was demonstrated red first. Item 2
+is additive; its tests are new coverage of new code, and the reverts below are
+what makes them load-bearing rather than incidental.
+
+The starting point the brief asked for — a screen test asserting the row shows
+an absolute date today:
+
+```
+a row older than a week reads as a date with no time of day
+  Expected: exactly one matching candidate
+    Actual: _TextWidgetFinder:<Found 0 widgets with text "Aug 8, 2026": []>
+
+a recent row reads as a relative time, not an absolute date
+  Expected: exactly one matching candidate
+    Actual: _TextWidgetFinder:<Found 0 widgets with text "5 min ago": []>
+```
+
+And the mark-as-read split, red on the pre-fix repository:
+
+```
+the tray path leaves createdAt alone, because that SQL has no createdAt
+  Expected: <500>
+    Actual: <1788776537131>          // the wall clock, over the row's real age
+
+the screen path restamps, because the Kotlin does
+  Expected: Set:['task-1', 'task-2']
+    Actual: <2>                      // returned a count, not the ids that existed
+```
+
+Confirmed red, with the output above:
+
+| revert | red |
+|---|---|
+| the row draws `DateFormat.yMMMd().add_jm()` again | 2 screen tests |
+| the tray path stamps `createdAt` | 2 |
+| the bulk path returns a count instead of the ids that existed | 2 |
+
+**Still to replay** — listed so the gap is visible rather than implied, and
+being worked through with the second `parity-auditor` pass: the absolute arm
+passing no locale; the absolute arm losing its unknown-locale fallback (`so`
+throwing out of `build`); `relativeTimeLabel` left pointing at the renamed
+plural keys, which is the interesting one because it **compiles** — the old key
+generated `String minutesAgo(num count)` and the new one `String
+minutesAgo(int count)`, and `elapsed.inMinutes` satisfies both, so the
+dashboard and profile would have switched to `5 min ago` silently and
+`relativeTimeLabel(l10n, day)` would have rendered the ungrammatical `1 days
+ago` that its day bucket *can* reach where the notification row's cannot; and
+`markAllAsRead` stamping outside its `isRead = 0` scope.
+
+---
+
+## Reported, not fixed
+
+1. **`NotificationsRepository.markNotificationAsRead` has no caller.** It is the
+   correct port of Kotlin's tray/dashboard handler, and it is now correct where
+   before it silently stamped — but `NotificationActionReceiver` and
+   `DashboardActivity.handleNotificationIntent` are unported, so nothing reaches
+   it. Under this document's reachability doctrine that is a "ported, tested,
+   green and dead" row, and it is named here rather than left for an audit. The
+   argument for keeping it: the screen *was* wired to it, the summary branch is
+   real Kotlin, and deleting it means the next phase re-derives the same
+   distinction from scratch. `NotificationDao.markSummaryAsRead` was already in
+   this position before this phase.
+2. **`ARB` derivation still loses a deliberate trailing space** on the
+   plain-text by-name path (`tool/arb_from_strings_xml.dart:211` writes
+   `translated[exactNamed]?.trim()` without `_mirrorTrailingSpace`). Phase 124
+   reported it and declined on ownership grounds; this lane owns `tool/` and
+   still declines, for a different reason: no key this phase adds goes through
+   that path with a trailing space, so a fix would be untested by anything here.
+   It wants its own change with a key that demonstrates it.
+3. **Every date in the port except this one is `en_US`.** `DateFormat` is
+   constructed without a locale in `edit_achievement_screen.dart:731` and
+   `task_deadline_notifier.dart:59`, and `initializeDateFormatting` is never
+   called — the notification row works only because `flutter_localizations`
+   registers the tables as a side effect. Fixing it properly is one
+   initialization call plus a sweep of every date in the app, which is a phase,
+   not a hunk. This phase leaves the app inconsistent on purpose: one screen
+   right beats every screen wrong.
+4. **The read row moves immediately in Flutter** and only on the next reload in
+   Kotlin, because the port's list is a drift stream and Kotlin's is a
+   `StateFlow` of an in-memory copy. Not introduced here and not fixable without
+   giving the port its own in-memory shadow of the list, which would be a worse
+   trade.
+5. **A `%d` in a relative string renders ASCII digits** where an Arabic or
+   Nepali device shows its own. Explained above; `intl` cannot reproduce the
+   Kotlin's per-locale choice in either direction.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1654,9 +1654,36 @@ class NotificationDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
-  /// Port of `NotificationDao.markAsRead(ids, createdAt)`. Sets `isRead`,
-  /// stamps a fresh `createdAt` (Kotlin's `Date`), and flags server-originated
-  /// rows for read-state upload via `needsSync`.
+  /// Port of `NotificationDao.markAsRead(notificationId)`
+  /// (`NotificationDao.kt:15-16`) — the **single-row** overload, whose SQL does
+  /// not mention `createdAt`:
+  ///
+  ///   `UPDATE notifications SET isRead = 1, needsSync = CASE … WHERE id = :id`
+  ///
+  /// It exists separately from [markAsRead] because the two Kotlin queries
+  /// differ in exactly that column, and the port had collapsed both onto the
+  /// stamping one. That rewrote a row's `createdAt` to now whenever a learner
+  /// tapped it or its *Mark as read* button — invisible while the row drew an
+  /// absolute date, loud once it draws a relative one (a week-old notification
+  /// reads "Just now"), and destructive either way: `watchForUser` sorts on
+  /// `createdAt DESC`, and the row's real age is gone.
+  Future<int> markOneAsRead(String id) => customUpdate(
+    'UPDATE notifications SET is_read = 1, '
+    'needs_sync = CASE WHEN is_from_server = 1 THEN 1 ELSE needs_sync END '
+    'WHERE id = ?',
+    variables: [Variable.withString(id)],
+    updates: {notifications},
+  );
+
+  /// Port of `NotificationDao.markAsRead(ids, createdAt)`
+  /// (`NotificationDao.kt:45-46`) — the **bulk** overload, which does stamp a
+  /// fresh `createdAt` (Kotlin's `Date`), and flags server-originated rows for
+  /// read-state upload via `needsSync`.
+  ///
+  /// Selection mode's "mark selected as read" is its one caller, and the stamp
+  /// is deliberate there: it moves the marked rows to the top of the list in
+  /// the Android app, so the port has to do the same or the two lists order
+  /// differently. See [markOneAsRead] for the single-row path.
   Future<int> markAsRead(Iterable<String> ids, {int? createdAt}) async {
     final values = ids.toList(growable: false);
     if (values.isEmpty) return 0;

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1724,6 +1724,27 @@ class NotificationDao extends DatabaseAccessor<AppDatabase>
   Future<int> deleteById(String id) =>
       (delete(notifications)..where((row) => row.id.equals(id))).go();
 
+  /// Port of `NotificationDao.deleteByIds` (`NotificationDao.kt:64-65`), which
+  /// selection mode's *Delete* uses.
+  ///
+  /// A plain local `DELETE`: nothing is enqueued, no tombstone is written, and
+  /// the notifications sync-in runs no `deleteNotIn`, so a deleted
+  /// *server-originated* row comes back on the next sync. That is the Kotlin's
+  /// behaviour too — `deleteNotifications` reaches the same statement and
+  /// `UploadConfigs` mentions notifications nowhere — so it is reproduced, not
+  /// fixed.
+  Future<int> deleteByIds(Iterable<String> ids) async {
+    final values = ids.toList(growable: false);
+    if (values.isEmpty) return 0;
+    var deleted = 0;
+    for (final chunk in _chunked(values, _sqliteVariableChunk)) {
+      deleted += await (delete(
+        notifications,
+      )..where((row) => row.id.isIn(chunk))).go();
+    }
+    return deleted;
+  }
+
   /// Port of `NotificationDao.getPendingSyncNotifications` — server-originated
   /// rows flagged for read-state upload. Only rows with a server `rev` can be
   /// PUT back (no rev means the row was authored locally, not yet on the

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -446,10 +446,6 @@
   "@notificationsUnavailable": {
     "x-mt": true
   },
-  "markAllRead": "وضع علامة على كل قراءة",
-  "@markAllRead": {
-    "x-mt": true
-  },
   "all": "الكل",
   "read": "يقرأ",
   "@read": {
@@ -2148,5 +2144,9 @@
   "minutesAgo": "منذ {count} دقيقة",
   "hoursAgo": "منذ {count} ساعة",
   "yesterday": "أمس",
-  "daysAgo": "منذ {count} أيام"
+  "daysAgo": "منذ {count} أيام",
+  "markAllAsRead": "وضع علامة \"مقروء\" على الجميع",
+  "selectedCount": "تم تحديد {count}",
+  "markSelectedAsRead": "تعليم كمقروء",
+  "cancelSelection": "إلغاء التحديد"
 }

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -236,16 +236,16 @@
   },
   "neverSynced": "لم يتم المزامنة أبدا",
   "justNow": "الآن",
-  "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
-  "@minutesAgo": {
+  "relativeMinutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@relativeMinutesAgo": {
     "x-mt": true
   },
-  "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
-  "@hoursAgo": {
+  "relativeHoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@relativeHoursAgo": {
     "x-mt": true
   },
-  "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
-  "@daysAgo": {
+  "relativeDaysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@relativeDaysAgo": {
     "x-mt": true
   },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
@@ -2144,5 +2144,9 @@
   "storageAvailable": "التخزين المتاح:",
   "joinRequestPrefix": "طلب الانضمام:",
   "userRequestedToJoinTeam": "{user} قد طلب الانضمام إلى {team}",
-  "markAsRead": "وضع علامة كمقروء"
+  "markAsRead": "وضع علامة كمقروء",
+  "minutesAgo": "منذ {count} دقيقة",
+  "hoursAgo": "منذ {count} ساعة",
+  "yesterday": "أمس",
+  "daysAgo": "منذ {count} أيام"
 }

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -164,7 +164,7 @@
   },
   "neverSynced": "Never synced",
   "justNow": "Just now",
-  "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "minutesAgo": "{count} min ago",
   "@minutesAgo": {
     "placeholders": {
       "count": {
@@ -172,7 +172,7 @@
       }
     }
   },
-  "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "hoursAgo": "{count} hr ago",
   "@hoursAgo": {
     "placeholders": {
       "count": {
@@ -180,8 +180,33 @@
       }
     }
   },
-  "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "yesterday": "Yesterday",
+  "daysAgo": "{count} days ago",
   "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relativeMinutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@relativeMinutesAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relativeHoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@relativeHoursAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relativeDaysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@relativeDaysAgo": {
     "placeholders": {
       "count": {
         "type": "int"

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -365,7 +365,17 @@
   "notifications": "Notifications",
   "notification": "Notification",
   "notificationsUnavailable": "Notifications unavailable",
-  "markAllRead": "Mark all read",
+  "markAllAsRead": "Mark all as read",
+  "selectedCount": "{count} selected",
+  "@selectedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedAsRead": "Mark read",
+  "cancelSelection": "Cancel selection",
   "markAsRead": "Mark as read",
   "@markAsRead": {
     "description": "The per-row action on an unread notification, porting the Kotlin row's btn_mark_as_read."

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -248,16 +248,16 @@
   "lastSynced": "Última sincronización: {time}",
   "neverSynced": "nunca sincronizado",
   "justNow": "Ahora mismo",
-  "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
-  "@minutesAgo": {
+  "relativeMinutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@relativeMinutesAgo": {
     "x-mt": true
   },
-  "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
-  "@hoursAgo": {
+  "relativeHoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@relativeHoursAgo": {
     "x-mt": true
   },
-  "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
-  "@daysAgo": {
+  "relativeDaysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@relativeDaysAgo": {
     "x-mt": true
   },
   "syncingResources": "Sincronizando recursos... {completed} de {total}",
@@ -2142,5 +2142,9 @@
   "storageAvailable": "Almacenamiento disponible:",
   "joinRequestPrefix": "Solicitud de Unión:",
   "userRequestedToJoinTeam": "{user} ha solicitado unirse a {team}",
-  "markAsRead": "Marcar como leído"
+  "markAsRead": "Marcar como leído",
+  "minutesAgo": "Hace {count} min",
+  "hoursAgo": "Hace {count} h",
+  "yesterday": "Ayer",
+  "daysAgo": "Hace {count} día(s)"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -484,7 +484,7 @@
   "@notificationsUnavailable": {
     "x-mt": true
   },
-  "markAllRead": "Marcar todo como leído",
+  "markAllAsRead": "Marcar todo como leído",
   "all": "Todos",
   "read": "Leer",
   "@read": {
@@ -2146,5 +2146,8 @@
   "minutesAgo": "Hace {count} min",
   "hoursAgo": "Hace {count} h",
   "yesterday": "Ayer",
-  "daysAgo": "Hace {count} día(s)"
+  "daysAgo": "Hace {count} día(s)",
+  "selectedCount": "{count} seleccionado(s)",
+  "markSelectedAsRead": "Marcar como leído",
+  "cancelSelection": "Cancelar selección"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -260,16 +260,16 @@
   },
   "neverSynced": "jamais synchronisé",
   "justNow": "À l'instant",
-  "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
-  "@minutesAgo": {
+  "relativeMinutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@relativeMinutesAgo": {
     "x-mt": true
   },
-  "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
-  "@hoursAgo": {
+  "relativeHoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@relativeHoursAgo": {
     "x-mt": true
   },
-  "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
-  "@daysAgo": {
+  "relativeDaysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@relativeDaysAgo": {
     "x-mt": true
   },
   "syncingResources": "Synchronisation des ressources… {completed} sur {total}",
@@ -2287,5 +2287,9 @@
   "storageAvailable": "Espace de stockage disponible:",
   "joinRequestPrefix": "Demande d'adhésion :",
   "userRequestedToJoinTeam": "{user} a demandé à rejoindre {team}",
-  "markAsRead": "Marquer comme lu"
+  "markAsRead": "Marquer comme lu",
+  "minutesAgo": "Il y a {count} min",
+  "hoursAgo": "Il y a {count} h",
+  "yesterday": "Hier",
+  "daysAgo": "Il y a {count} jour(s)"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -494,10 +494,6 @@
   "@notificationsUnavailable": {
     "x-mt": true
   },
-  "markAllRead": "Marquer tout comme lu",
-  "@markAllRead": {
-    "x-mt": true
-  },
   "all": "Tous",
   "read": "Lire",
   "@read": {
@@ -2291,5 +2287,9 @@
   "minutesAgo": "Il y a {count} min",
   "hoursAgo": "Il y a {count} h",
   "yesterday": "Hier",
-  "daysAgo": "Il y a {count} jour(s)"
+  "daysAgo": "Il y a {count} jour(s)",
+  "markAllAsRead": "Marquer tout comme lu",
+  "selectedCount": "{count} sélectionné(s)",
+  "markSelectedAsRead": "Marquer comme lu",
+  "cancelSelection": "Annuler la sélection"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -513,5 +513,9 @@
   "minutesAgo": "{count} मिनेट अघि",
   "hoursAgo": "{count} घण्टा अघि",
   "yesterday": "हिजो",
-  "daysAgo": "{count} दिन अघि"
+  "daysAgo": "{count} दिन अघि",
+  "markAllAsRead": "सबैलाई पढिएको रूपमा चिन्ह लगाउनुहोस्",
+  "selectedCount": "{count} छानिएको",
+  "markSelectedAsRead": "पढेको चिन्ह लगाउनुहोस्",
+  "cancelSelection": "चयन रद्द गर्नुहोस्"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -44,16 +44,16 @@
   },
   "neverSynced": "कहिले पनि समक्रमित भएन",
   "justNow": "अहिले नै",
-  "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
-  "@minutesAgo": {
+  "relativeMinutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@relativeMinutesAgo": {
     "x-mt": true
   },
-  "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
-  "@hoursAgo": {
+  "relativeHoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@relativeHoursAgo": {
     "x-mt": true
   },
-  "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
-  "@daysAgo": {
+  "relativeDaysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@relativeDaysAgo": {
     "x-mt": true
   },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
@@ -509,5 +509,9 @@
   "storageAvailable": "स्टोरेज उपलब्ध:",
   "joinRequestPrefix": "सामेल हुने अनुरोध:",
   "userRequestedToJoinTeam": "{user} ले {team} मा सामेल हुन अनुरोध गरेको छ",
-  "markAsRead": "पढिएको रूपमा चिन्ह लगाउनुहोस्"
+  "markAsRead": "पढिएको रूपमा चिन्ह लगाउनुहोस्",
+  "minutesAgo": "{count} मिनेट अघि",
+  "hoursAgo": "{count} घण्टा अघि",
+  "yesterday": "हिजो",
+  "daysAgo": "{count} दिन अघि"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -44,16 +44,16 @@
   },
   "neverSynced": "waligeyn la isku midayn",
   "justNow": "Hadda uun",
-  "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
-  "@minutesAgo": {
+  "relativeMinutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@relativeMinutesAgo": {
     "x-mt": true
   },
-  "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
-  "@hoursAgo": {
+  "relativeHoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@relativeHoursAgo": {
     "x-mt": true
   },
-  "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
-  "@daysAgo": {
+  "relativeDaysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@relativeDaysAgo": {
     "x-mt": true
   },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
@@ -509,5 +509,9 @@
   "storageAvailable": "Xaddida maaliyadeed waa heli kara:",
   "joinRequestPrefix": "Codsi ku biirid:",
   "userRequestedToJoinTeam": "{user} ayaa codsaday ku biirista {team}",
-  "markAsRead": "Calaamadee sidii la aqriyay"
+  "markAsRead": "Calaamadee sidii la aqriyay",
+  "minutesAgo": "{count} daqiiqo ka hor",
+  "hoursAgo": "{count} saacad ka hor",
+  "yesterday": "Shalay",
+  "daysAgo": "{count} maalmood ka hor"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -513,5 +513,9 @@
   "minutesAgo": "{count} daqiiqo ka hor",
   "hoursAgo": "{count} saacad ka hor",
   "yesterday": "Shalay",
-  "daysAgo": "{count} maalmood ka hor"
+  "daysAgo": "{count} maalmood ka hor",
+  "markAllAsRead": "Calaamadee dhammaan sidii la aqriyay",
+  "selectedCount": "{count} la doortay",
+  "markSelectedAsRead": "Calaamadee akhrinta",
+  "cancelSelection": "Jooji doortashada"
 }

--- a/flutter/lib/providers/notifications_provider.dart
+++ b/flutter/lib/providers/notifications_provider.dart
@@ -41,11 +41,14 @@ class NotificationActions {
 
   final Ref ref;
 
+  /// `NotificationsViewModel.markAsRead(notificationId)`
+  /// (`NotificationsViewModel.kt:207-209`), which goes to
+  /// `markNotificationsAsRead(setOf(id))` — the screen's path. The port used to
+  /// call `markNotificationAsRead`, which is the Android tray's handler
+  /// (`DashboardActivity`, `NotificationActionReceiver`); the two differ in
+  /// whether they restamp `createdAt`, and the screen's does.
   Future<void> markAsRead(String id) async {
-    final userId = ref.read(sessionProvider).valueOrNull?.id;
-    await ref
-        .read(notificationsRepositoryProvider)
-        .markNotificationAsRead(id, userId);
+    await ref.read(notificationsRepositoryProvider).markAsRead({id});
   }
 
   Future<void> markAllAsRead() async {

--- a/flutter/lib/providers/notifications_provider.dart
+++ b/flutter/lib/providers/notifications_provider.dart
@@ -63,6 +63,20 @@ class NotificationActions {
   Future<void> delete(String id) async {
     await ref.read(notificationsRepositoryProvider).delete(id);
   }
+
+  /// `NotificationsViewModel.markSelectedAsRead` (`:173-191`) — the bulk bar's
+  /// *Mark read*. Empty selections are a no-op there and here.
+  Future<Set<String>> markSelectedAsRead(Set<String> ids) async {
+    if (ids.isEmpty) return const {};
+    return ref.read(notificationsRepositoryProvider).markAsRead(ids);
+  }
+
+  /// `NotificationsViewModel.deleteSelected` (`:193-205`) — the bulk bar's
+  /// *Delete*.
+  Future<Set<String>> deleteSelected(Set<String> ids) async {
+    if (ids.isEmpty) return const {};
+    return ref.read(notificationsRepositoryProvider).deleteNotifications(ids);
+  }
 }
 
 final notificationActionsProvider = Provider(NotificationActions.new);

--- a/flutter/lib/repository/notifications_repository.dart
+++ b/flutter/lib/repository/notifications_repository.dart
@@ -51,20 +51,62 @@ class NotificationsRepository {
   Stream<int> watchUnreadCount(String userId, {bool isAdmin = false}) =>
       _dao.watchUnreadCount(userId, isAdmin: isAdmin);
 
-  Future<int> markAsRead(Iterable<String> ids) => _dao.markAsRead(ids);
+  /// Port of `NotificationsRepositoryImpl.markNotificationsAsRead`
+  /// (`:113-120`) — the **notifications screen's** mark-as-read, for one row or
+  /// for a selection.
+  ///
+  /// `NotificationsViewModel.markAsRead(id)` calls it with a set of one
+  /// (`:207-209`), so the per-row *Mark as read* button and a row tap come
+  /// through here too, not through [markNotificationAsRead]. That matters
+  /// because this DAO overload stamps `createdAt` and the other does not: in
+  /// the Android app a row jumps to the top of its group when read (the list is
+  /// sorted `isRead ASC, createdAt DESC`) and its timestamp reads "Just now".
+  /// A quirk, and one both apps have to share or their lists order
+  /// differently.
+  ///
+  /// Returns the ids that actually existed, which is what the Kotlin returns
+  /// and what its caller uses to update the in-memory list: an id that is not
+  /// in the table would otherwise be reported as marked and the row it names
+  /// redrawn as read. The stamped `createdAt` is the bulk DAO overload's, not
+  /// an accident — see [NotificationDao.markOneAsRead].
+  Future<Set<String>> markAsRead(Iterable<String> ids) async {
+    final wanted = ids.toList(growable: false);
+    if (wanted.isEmpty) return const {};
+    final existing = (await _dao.getByIds(wanted)).keys.toSet();
+    if (existing.isEmpty) return const {};
+    // The repository's own clock, as the Kotlin passes its own `Date()`.
+    // Reading the wall clock inside the DAO instead left the one column this
+    // path deliberately writes untestable.
+    await _dao.markAsRead(existing, createdAt: _now().millisecondsSinceEpoch);
+    return existing;
+  }
 
-  /// Port of `NotificationsRepositoryImpl.markNotificationAsRead` — a
-  /// `summary_`-prefixed id marks every notification of that type for [userId]
-  /// read (the dashboard's "mark all" by type); any other id marks a single
-  /// row. Server-originated rows are flagged for read-state upload.
+  /// Port of `NotificationsRepositoryImpl.markNotificationAsRead` (`:36-43`) —
+  /// the **tray and dashboard** handler, not the notifications screen's.
+  ///
+  /// A `summary_`-prefixed id marks every notification of that type for
+  /// [userId] read; any other id marks a single row. Server-originated rows are
+  /// flagged for read-state upload. Neither statement touches `createdAt`,
+  /// which is what separates this from [markAsRead] — see the note there.
+  ///
+  /// Its one Kotlin caller is `DashboardActivity.markDatabaseNotificationAsRead`
+  /// (`:701-703`), reached when the user taps an Android tray notification's
+  /// *body*; `summary_` ids are minted only by
+  /// `NotificationUtils.createSummaryNotification` (`:190`) for the tray. The
+  /// tray's *Mark as Read* action button is **not** this path — it goes through
+  /// `NotificationActionReceiver` (`:81`) to [markAsRead], and so does stamp.
+  /// The port has no tray handling yet, so this has no caller: it is kept (and
+  /// pinned by tests) because the screen was wired to it by mistake, and the
+  /// phase that ports tray actions needs it to be right.
   Future<int> markNotificationAsRead(String id, String? userId) {
     if (id.startsWith('summary_')) {
       return _dao.markSummaryAsRead(userId, id.substring('summary_'.length));
     }
-    return _dao.markAsRead([id]);
+    return _dao.markOneAsRead(id);
   }
 
-  Future<int> markAllAsRead(String userId) => _dao.markAllAsRead(userId);
+  Future<int> markAllAsRead(String userId) =>
+      _dao.markAllAsRead(userId, createdAt: _now().millisecondsSinceEpoch);
   Future<int> delete(String id) => _dao.deleteById(id);
 
   /// Port of `TransactionSyncManager.syncNotificationReads`.

--- a/flutter/lib/repository/notifications_repository.dart
+++ b/flutter/lib/repository/notifications_repository.dart
@@ -109,6 +109,21 @@ class NotificationsRepository {
       _dao.markAllAsRead(userId, createdAt: _now().millisecondsSinceEpoch);
   Future<int> delete(String id) => _dao.deleteById(id);
 
+  /// Port of `NotificationsRepositoryImpl.deleteNotifications` (`:418-425`) —
+  /// selection mode's *Delete*.
+  ///
+  /// Returns the ids that existed, as the Kotlin does, for the same reason
+  /// [markAsRead] does: its caller uses the set to decide whether anything
+  /// happened.
+  Future<Set<String>> deleteNotifications(Iterable<String> ids) async {
+    final wanted = ids.toList(growable: false);
+    if (wanted.isEmpty) return const {};
+    final existing = (await _dao.getByIds(wanted)).keys.toSet();
+    if (existing.isEmpty) return const {};
+    await _dao.deleteByIds(existing);
+    return existing;
+  }
+
   /// Port of `TransactionSyncManager.syncNotificationReads`.
   ///
   /// PUTs each server-originated notification marked for read-state upload

--- a/flutter/lib/ui/components/relative_time.dart
+++ b/flutter/lib/ui/components/relative_time.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 import '../../l10n/app_localizations.dart';
 
 /// Localized "n minutes ago" for an elapsed duration in milliseconds.
@@ -10,13 +12,101 @@ import '../../l10n/app_localizations.dart';
 ///
 /// Shared by the dashboard's last-sync strip and the profile's last-login row —
 /// the two screens that show a relative time — so they cannot drift apart.
+///
+/// **Not** the notification row's formatter; see
+/// [notificationTimestampLabel] below for why there are two.
 String relativeTimeLabel(AppLocalizations l10n, int elapsedMillis) {
   if (elapsedMillis <= 0 ||
       elapsedMillis < const Duration(minutes: 1).inMilliseconds) {
     return l10n.justNow;
   }
   final elapsed = Duration(milliseconds: elapsedMillis);
-  if (elapsed.inHours < 1) return l10n.minutesAgo(elapsed.inMinutes);
-  if (elapsed.inDays < 1) return l10n.hoursAgo(elapsed.inHours);
-  return l10n.daysAgo(elapsed.inDays);
+  if (elapsed.inHours < 1) return l10n.relativeMinutesAgo(elapsed.inMinutes);
+  if (elapsed.inDays < 1) return l10n.relativeHoursAgo(elapsed.inHours);
+  return l10n.relativeDaysAgo(elapsed.inDays);
+}
+
+const _minuteMillis = 60 * 1000;
+const _hourMillis = 60 * _minuteMillis;
+const _dayMillis = 24 * _hourMillis;
+
+/// `MMM d, yyyy` per locale, as `NotificationsAdapter.getDateFormatter()`
+/// builds it (`NotificationsAdapter.kt:43-53`): `DateTimeFormatter.ofPattern`
+/// with `Locale.getDefault()`, which `LocaleUtils` sets from the in-app
+/// language picker, and cached until that locale changes. The cache here is the
+/// same, keyed by locale rather than invalidated on change.
+///
+/// `intl` knows five of the port's six languages. `so` is in neither
+/// `flutter_localizations`' generated date table nor `intl`'s own
+/// `date_symbol_data_local`, and `DateFormat('MMM d, yyyy', 'so')` throws
+/// `ArgumentError` — out of `build`, which would take the whole bell screen
+/// down (the Phase 95 shape). Hence the fallback to the unlocalised formatter,
+/// which is what the port drew for every locale before: a Somali reader sees
+/// English month names, where the Kotlin gives them `Abr`/`Lul`. The catch is
+/// deliberately not a `so` allowlist — it is `intl`'s locale table that decides,
+/// not ours.
+///
+/// One divergence that survives: Kotlin renders ASCII digits here whatever the
+/// locale, because `DateTimeFormatterBuilder.toFormatter(Locale)` uses
+/// `DecimalStyle.STANDARD` rather than the locale's. `intl` uses the locale's,
+/// so Nepali reads `अगस्ट ३१, २०२६` against Kotlin's `अगस्ट 31, 2026`. Nepali
+/// digits in a Nepali sentence are not a defect, and chasing byte parity here
+/// would mean reproducing a Java quirk that the Kotlin's own relative arms
+/// already contradict (those go through `String.format`, which *does* localise
+/// `%d`, so the Android app mixes numbering systems inside one list).
+DateFormat _notificationDateFormat(String localeName) =>
+    _dateFormatCache.putIfAbsent(localeName, () {
+      try {
+        return DateFormat('MMM d, yyyy', localeName);
+      } catch (_) {
+        return DateFormat('MMM d, yyyy');
+      }
+    });
+
+final _dateFormatCache = <String, DateFormat>{};
+
+/// Localized timestamp for one notification row.
+///
+/// Port of `NotificationsAdapter.ItemViewHolder.formatRelativeTime`
+/// (`NotificationsAdapter.kt:152-163`), which is a *different* function from the
+/// one [relativeTimeLabel] ports, in three ways that all matter:
+///
+///   * it has a **Yesterday** bucket, covering the whole second day, which
+///     `DateUtils.getRelativeTimeSpanString` does not;
+///   * beyond a week it stops being relative at all and shows an absolute date;
+///   * and it reads `strings.xml` — `minutes_ago` is `%1$d min ago` — where
+///     `getRelativeTimeSpanString` reads the Android framework's own strings,
+///     which say "5 minutes ago". So the two render different sentences *in the
+///     Kotlin app*, and folding this into [relativeTimeLabel] would have had to
+///     change the wording on one screen or the other.
+///
+/// They live in the same file so that difference stays visible: two relative-
+/// time formatters in two files is how the port ended up with two disagreeing
+/// `normalizeText`s (Phase 78).
+///
+/// Both instants are parameters rather than read from the clock, matching how
+/// [relativeTimeLabel]'s callers already subtract at the call site — and the
+/// absolute arm needs `createdAtMillis` itself, not just the elapsed time.
+///
+/// A `createdAtMillis` in the future makes `diff` negative, which satisfies the
+/// first arm and reads as "Just now", exactly as the Kotlin's `diff < 60_000L`
+/// does. Every `~/` below therefore sees a non-negative dividend.
+String notificationTimestampLabel(
+  AppLocalizations l10n, {
+  required int createdAtMillis,
+  required int now,
+}) {
+  final diff = now - createdAtMillis;
+  if (diff < _minuteMillis) return l10n.justNow;
+  // Integer division, as Kotlin's `diff / 60_000L` is. Each bucket's own lower
+  // bound keeps the quotient at 1 or more, so no arm can render a zero.
+  if (diff < _hourMillis) return l10n.minutesAgo(diff ~/ _minuteMillis);
+  if (diff < _dayMillis) return l10n.hoursAgo(diff ~/ _hourMillis);
+  if (diff < 2 * _dayMillis) return l10n.yesterday;
+  // 2..6, so the ungrammatical "1 days ago" that `days_ago` would produce is
+  // unreachable — the Yesterday arm above owns the whole of day one.
+  if (diff < 7 * _dayMillis) return l10n.daysAgo(diff ~/ _dayMillis);
+  return _notificationDateFormat(
+    l10n.localeName,
+  ).format(DateTime.fromMillisecondsSinceEpoch(createdAtMillis));
 }

--- a/flutter/lib/ui/notifications/notifications_screen.dart
+++ b/flutter/lib/ui/notifications/notifications_screen.dart
@@ -18,11 +18,32 @@ import 'notification_grouping.dart';
 /// grouping model added to `NotificationsViewModel` (commit 8f4d06d5d). A
 /// group is expanded by default only while it has unread items; tapping a
 /// header overrides that, and *Mark all read* collapses every group.
-class NotificationsScreen extends ConsumerWidget {
+class NotificationsScreen extends ConsumerStatefulWidget {
   const NotificationsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<NotificationsScreen> createState() =>
+      _NotificationsScreenState();
+}
+
+class _NotificationsScreenState extends ConsumerState<NotificationsScreen> {
+  /// `NotificationsViewModel._selectedIds` (`:39`). Local widget state rather
+  /// than a provider, following the port's own multi-select (Phase 50's
+  /// `resources_screen.dart:35`) — and, like the Kotlin, there is no separate
+  /// mode flag: `isSelectionMode` is `_selectedIds.isNotEmpty()` (`:44-46`).
+  final Set<String> _selectedIds = {};
+
+  bool get _selecting => _selectedIds.isNotEmpty;
+
+  /// `toggleSelection` (`:145-149`).
+  void _toggleSelection(String id) {
+    setState(() {
+      if (!_selectedIds.add(id)) _selectedIds.remove(id);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final filter = ref.watch(notificationFilterProvider);
     final notifications = ref.watch(notificationsProvider);
@@ -31,47 +52,80 @@ class NotificationsScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(l10n.notifications),
+        // `ltBulkActionBar` replaces `ltTopBar` outright while selecting
+        // (`NotificationsFragment.kt:104-107`). In Kotlin that bar is a
+        // LinearLayout above the list holding the count, *Mark read*, *Delete*
+        // and a close button; here it is the AppBar, which is where the port
+        // already puts *Mark all read* and where Phase 50 put the resource
+        // catalog's equivalent.
+        leading: _selecting
+            ? IconButton(
+                icon: const Icon(Icons.close),
+                tooltip: l10n.cancelSelection,
+                onPressed: () => setState(_selectedIds.clear),
+              )
+            : null,
+        title: Text(
+          _selecting
+              ? l10n.selectedCount(_selectedIds.length)
+              : l10n.notifications,
+        ),
         actions: [
+          if (_selecting) ...[
+            TextButton(
+              onPressed: _markSelectedAsRead,
+              child: Text(l10n.markSelectedAsRead),
+            ),
+            // No confirmation, because Kotlin's `btnBulkDelete` has none — and
+            // the row's swipe, which does confirm, is the port's own addition
+            // rather than a port of anything.
+            TextButton(onPressed: _deleteSelected, child: Text(l10n.delete)),
+          ]
           // `count > 0 && currentFilter != "read"`
           // (`NotificationsFragment.kt:101-102`) — offering "mark all read" on
           // the Read tab, which the port did, is an action with nothing to act
-          // on.
-          if (unread > 0 && filter != NotificationFilter.read)
+          // on. It sits inside `ltTopBar`, so selection mode hides it too.
+          else if (unread > 0 && filter != NotificationFilter.read)
             TextButton(
               onPressed: () =>
                   ref.read(notificationActionsProvider).markAllAsRead(),
-              child: Text(l10n.markAllRead),
+              child: Text(l10n.markAllAsRead),
             ),
         ],
       ),
       body: Column(
         children: [
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.all(12),
-            child: SegmentedButton<NotificationFilter>(
-              segments: [
-                ButtonSegment(
-                  value: NotificationFilter.all,
-                  label: Text(l10n.all),
-                ),
-                ButtonSegment(
-                  value: NotificationFilter.unread,
-                  label: Text(l10n.unreadCount(unread)),
-                ),
-                ButtonSegment(
-                  value: NotificationFilter.read,
-                  label: Text(l10n.read),
-                ),
-              ],
-              selected: {filter},
-              onSelectionChanged: (selected) {
-                ref.read(notificationFilterProvider.notifier).state =
-                    selected.single;
-              },
+          // The all/unread/read spinner is inside `ltTopBar` too, so it goes
+          // with it. That is not only cosmetic: `loadNotifications` never
+          // clears `_selectedIds`, so a filter change during selection would
+          // leave ids selected whose rows have left the list — see the quirk
+          // reproduced in `_markSelectedAsRead`.
+          if (!_selecting)
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.all(12),
+              child: SegmentedButton<NotificationFilter>(
+                segments: [
+                  ButtonSegment(
+                    value: NotificationFilter.all,
+                    label: Text(l10n.all),
+                  ),
+                  ButtonSegment(
+                    value: NotificationFilter.unread,
+                    label: Text(l10n.unreadCount(unread)),
+                  ),
+                  ButtonSegment(
+                    value: NotificationFilter.read,
+                    label: Text(l10n.read),
+                  ),
+                ],
+                selected: {filter},
+                onSelectionChanged: (selected) {
+                  ref.read(notificationFilterProvider.notifier).state =
+                      selected.single;
+                },
+              ),
             ),
-          ),
           Expanded(
             child: notifications.when(
               loading: () => const Center(child: CircularProgressIndicator()),
@@ -79,12 +133,46 @@ class NotificationsScreen extends ConsumerWidget {
                   Center(child: Text(l10n.notificationsUnavailable)),
               data: (items) => items.isEmpty
                   ? _EmptyNotifications(filter: filter)
-                  : _GroupedList(items: items, expansion: expansion),
+                  : _GroupedList(
+                      items: items,
+                      expansion: expansion,
+                      selectedIds: _selectedIds,
+                      selecting: _selecting,
+                      onToggleSelection: _toggleSelection,
+                    ),
             ),
           ),
         ],
       ),
     );
+  }
+
+  /// `markSelectedAsRead` (`:173-191`), which clears the selection only when
+  /// the repository reports that something was marked.
+  ///
+  /// The ids are taken from `_selectedIds` as-is, with no check that each is
+  /// still in the visible list. That is Kotlin's behaviour and it is reachable:
+  /// a group can be collapsed while its rows are selected (the header stays
+  /// selection-unaware and still toggles), so the action can act on rows the
+  /// user cannot see. The repository filters out ids that are not in the table
+  /// at all, which is a different thing.
+  Future<void> _markSelectedAsRead() async {
+    final marked = await ref
+        .read(notificationActionsProvider)
+        .markSelectedAsRead(Set.of(_selectedIds));
+    if (!mounted || marked.isEmpty) return;
+    setState(_selectedIds.clear);
+  }
+
+  /// `deleteSelected` (`:193-205`). A local delete with no tombstone, so a
+  /// server-originated notification returns on the next sync — see
+  /// `NotificationDao.deleteByIds`.
+  Future<void> _deleteSelected() async {
+    final deleted = await ref
+        .read(notificationActionsProvider)
+        .deleteSelected(Set.of(_selectedIds));
+    if (!mounted || deleted.isEmpty) return;
+    setState(_selectedIds.clear);
   }
 }
 
@@ -123,10 +211,19 @@ class _EmptyNotifications extends StatelessWidget {
 /// Renders the grouped list, porting `NotificationsAdapter`'s header/item
 /// view types. A header tap toggles that group's expansion.
 class _GroupedList extends ConsumerWidget {
-  const _GroupedList({required this.items, required this.expansion});
+  const _GroupedList({
+    required this.items,
+    required this.expansion,
+    required this.selectedIds,
+    required this.selecting,
+    required this.onToggleSelection,
+  });
 
   final List<NotificationRow> items;
   final NotificationExpansionState expansion;
+  final Set<String> selectedIds;
+  final bool selecting;
+  final void Function(String id) onToggleSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -149,9 +246,15 @@ class _GroupedList extends ConsumerWidget {
         final node = grouped[index];
         return switch (node) {
           NotificationHeaderItem() => _GroupHeader(header: node),
+          // Only `NotificationListItem.Item` carries `isSelected`/
+          // `isSelectionMode` in the Kotlin model — a header is never
+          // selectable, and stays tappable-to-collapse even mid-selection.
           NotificationEntryItem(:final notification) => _NotificationTile(
             notification: notification,
             formatContext: formatContext,
+            selected: selectedIds.contains(notification.id),
+            selecting: selecting,
+            onToggleSelection: onToggleSelection,
           ),
         };
       },
@@ -212,9 +315,15 @@ class _NotificationTile extends ConsumerWidget {
   const _NotificationTile({
     required this.notification,
     required this.formatContext,
+    required this.selected,
+    required this.selecting,
+    required this.onToggleSelection,
   });
   final NotificationRow notification;
   final NotificationFormatContext formatContext;
+  final bool selected;
+  final bool selecting;
+  final void Function(String id) onToggleSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -222,7 +331,14 @@ class _NotificationTile extends ConsumerWidget {
     final colors = Theme.of(context).colorScheme;
     return Dismissible(
       key: ValueKey(notification.id),
-      direction: DismissDirection.endToStart,
+      // Swipe-to-delete is the port's own affordance — Kotlin has no
+      // `ItemTouchHelper` anywhere and deletes only through the bulk bar — so
+      // it yields to selection mode rather than competing with it. Kotlin
+      // disarms the row's long-press there for the same reason: while a
+      // selection is open, the row's gestures belong to the selection.
+      direction: selecting
+          ? DismissDirection.none
+          : DismissDirection.endToStart,
       confirmDismiss: (_) => _confirmDelete(context),
       onDismissed: (_) =>
           ref.read(notificationActionsProvider).delete(notification.id),
@@ -244,12 +360,19 @@ class _NotificationTile extends ConsumerWidget {
           // `HeaderViewHolder.bind`). It stays because it makes a long list
           // scannable — but it is an addition, which is why the type *label*
           // was the thing removed: that duplicated the group header outright.
-          leading: Badge(
-            isLabelVisible: !notification.isRead,
-            child: CircleAvatar(
-              child: Icon(_iconFor(resolvedNotificationType(notification))),
-            ),
-          ),
+          // `cbSelect` (`row_notifications.xml:33-42`), visible only in
+          // selection mode. It is `clickable="false"` there — the row handles
+          // the tap — so this one is not interactive either.
+          leading: selecting
+              ? Checkbox(value: selected, onChanged: null)
+              : Badge(
+                  isLabelVisible: !notification.isRead,
+                  child: CircleAvatar(
+                    child: Icon(
+                      _iconFor(resolvedNotificationType(notification)),
+                    ),
+                  ),
+                ),
           // The row's one line of text, as `row_notifications.xml` has it: the
           // rewritten message, not a type label above the raw one. The group
           // header above already names the type, exactly as in the Kotlin — and
@@ -282,7 +405,9 @@ class _NotificationTile extends ConsumerWidget {
           // only way to mark a single row read was to tap it — which also
           // navigates away from the list, so a learner could not clear one
           // notification and keep reading the rest.
-          trailing: notification.isRead
+          // `binding.btnMarkAsRead.visibility = View.GONE` in the
+          // selection branch (`NotificationsAdapter.kt:132`).
+          trailing: notification.isRead || selecting
               ? null
               : TextButton(
                   onPressed: () => ref
@@ -290,10 +415,27 @@ class _NotificationTile extends ConsumerWidget {
                       .markAsRead(notification.id),
                   child: Text(l10n.markAsRead),
                 ),
+          // A read row keeps its tint, in both modes, so the selection
+          // affordance does not fight the read one
+          // (`NotificationsAdapter.kt:127` sets `alpha` before the branch).
+          selected: selected,
+          // In selection mode a tap toggles instead of navigating, and the
+          // long-press listener is set to null
+          // (`NotificationsAdapter.kt:133-134`); outside it, long-press is how
+          // selection starts (`:145-148`).
+          //
           // Read notifications remain actionable. Kotlin marks an unread row and
           // navigates on the same tap; making `onTap` null after that first tap
           // prevented learners from ever reopening its destination in Flutter.
-          onTap: () => _openNotification(context, ref),
+          onTap: selecting
+              ? () => onToggleSelection(notification.id)
+              : () => _openNotification(context, ref),
+          // No `isRead` gate: Kotlin arms the long-press on every row, so an
+          // already-read notification can be selected (and re-marked, which
+          // re-stamps it — its own quirk, reproduced).
+          onLongPress: selecting
+              ? null
+              : () => onToggleSelection(notification.id),
         ),
       ),
     );

--- a/flutter/lib/ui/notifications/notifications_screen.dart
+++ b/flutter/lib/ui/notifications/notifications_screen.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
-
 import '../../data/local/app_database.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/notifications_provider.dart';
 import '../../repository/notifications_repository.dart';
+import '../components/relative_time.dart';
 import '../router.dart';
 import 'notification_destination.dart';
 import 'notification_format.dart';
@@ -263,11 +262,17 @@ class _NotificationTile extends ConsumerWidget {
               context: formatContext,
             ),
           ),
+          // `NotificationsAdapter.formatRelativeTime` (`:152-163`), not the
+          // stored millisecond value formatted. `System.currentTimeMillis()` is
+          // read once per bind there and once per build here: neither app runs
+          // a ticker, so a row's timestamp text is frozen until it rebuilds.
           subtitle: Padding(
             padding: const EdgeInsets.only(top: 4),
             child: Text(
-              DateFormat.yMMMd().add_jm().format(
-                DateTime.fromMillisecondsSinceEpoch(notification.createdAt),
+              notificationTimestampLabel(
+                l10n,
+                createdAtMillis: notification.createdAt,
+                now: DateTime.now().millisecondsSinceEpoch,
               ),
               style: Theme.of(context).textTheme.bodySmall,
             ),

--- a/flutter/test/data/local/notification_dao_test.dart
+++ b/flutter/test/data/local/notification_dao_test.dart
@@ -41,7 +41,7 @@ void main() {
     );
     expect(await database.notificationDao.watchUnreadCount('user-1').first, 2);
 
-    await database.notificationDao.markAsRead(['newer']);
+    await database.notificationDao.markAsRead(['newer'], createdAt: 555);
     expect(
       (await database.notificationDao
               .watchForUser('user-1', filter: 'read')
@@ -52,8 +52,20 @@ void main() {
     );
     expect(await database.notificationDao.watchUnreadCount('user-1').first, 1);
 
-    await database.notificationDao.markAllAsRead('user-1');
+    await database.notificationDao.markAllAsRead('user-1', createdAt: 999);
     expect(await database.notificationDao.watchUnreadCount('user-1').first, 0);
+    // `markAllUnreadAsRead(userId, createdAt)` (`NotificationDao.kt:48-49`)
+    // stamps, and now that the row renders a *relative* time the stamp is
+    // visible: everything just marked reads "Just now". `older` was already
+    // read by the line above, so it keeps its own createdAt — the `isRead = 0`
+    // scope is what stops one tap rewriting the whole history.
+    final marked = {
+      for (final row
+          in await database.notificationDao.watchForUser('user-1').first)
+        row.id: row.createdAt,
+    };
+    expect(marked['older'], 999);
+    expect(marked['newer'], 555, reason: 'already read, so out of scope');
     await database.notificationDao.deleteById('older');
     expect(
       await database.notificationDao.watchForUser('user-1').first,

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -291,12 +291,24 @@ void main() {
     // `NotificationsRepositoryImpl` — so they fall back to English.
     // Phase 124's second pass adds one more, `markAsRead` — the row's own
     // Mark-as-read button, derived from the Kotlin `mark_as_read`.
+    //
+    // Phase 127 adds 4 per locale for the notification row's relative
+    // timestamp: `minutesAgo`, `hoursAgo`, `daysAgo` and the new `yesterday`,
+    // all four derived from the Kotlin `minutes_ago`/`hours_ago`/`days_ago`/
+    // `yesterday` and therefore human translations already shipping in the
+    // Android app. Three of them could not derive before, because those ARB
+    // keys held the port's own ICU *plurals* — a shape the tool skips for good
+    // reason — under the camelCase names of Kotlin's single-form strings. The
+    // plurals moved to `relativeMinutesAgo`/`relativeHoursAgo`/
+    // `relativeDaysAgo`, keeping their `x-mt` flags (their values were still
+    // bare English in every locale), and the Kotlin names now hold the Kotlin
+    // strings.
     const humanReviewed = {
-      'ar': 402,
-      'es': 455,
-      'fr': 401,
-      'ne': 403,
-      'so': 403,
+      'ar': 406,
+      'es': 459,
+      'fr': 405,
+      'ne': 407,
+      'so': 407,
     };
 
     for (final code in locales) {

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -303,12 +303,25 @@ void main() {
     // `relativeDaysAgo`, keeping their `x-mt` flags (their values were still
     // bare English in every locale), and the Kotlin names now hold the Kotlin
     // strings.
+    //
+    // Selection mode adds three more per locale — `selectedCount`,
+    // `markSelectedAsRead`, `cancelSelection`, from the Kotlin
+    // `selected_count`/`mark_selected_as_read`/`cancel_selection` — and repairs
+    // `markAllRead`, which was named and worded just differently enough from
+    // Kotlin's `mark_all_as_read` ("Mark all read" against "Mark all as read")
+    // that neither derivation rule could fire. Renamed to `markAllAsRead` with
+    // the Kotlin English: Nepali and Somali had no value at all, Arabic and
+    // French carried `x-mt` machine output (French's happened to equal the
+    // human translation, Arabic's did not), so all four derive now. Spanish
+    // already held the Kotlin value unflagged and is left alone — replacing one
+    // valid translation with another is not a repair. That makes es +3 where
+    // the rest are +4.
     const humanReviewed = {
-      'ar': 406,
-      'es': 459,
-      'fr': 405,
-      'ne': 407,
-      'so': 407,
+      'ar': 410,
+      'es': 462,
+      'fr': 409,
+      'ne': 411,
+      'so': 411,
     };
 
     for (final code in locales) {

--- a/flutter/test/repository/notifications_repository_test.dart
+++ b/flutter/test/repository/notifications_repository_test.dart
@@ -160,6 +160,68 @@ void main() {
     });
   });
 
+  group('the bulk delete behind selection mode', () {
+    // `NotificationsRepositoryImpl.deleteNotifications` (`:418-425`) over
+    // `NotificationDao.deleteByIds` (`:64-65`) — a plain local DELETE.
+    Future<void> seed(String id, {bool fromServer = false}) =>
+        database.notificationDao.upsert(
+          NotificationsCompanion.insert(
+            id: id,
+            userId: 'user-1',
+            type: const Value('task'),
+            message: Value('row $id'),
+            createdAt: 500,
+            isFromServer: Value(fromServer),
+          ),
+        );
+
+    test('deletes the selection and reports what existed', () async {
+      await seed('a');
+      await seed('b');
+
+      expect(await repository.deleteNotifications(['a', 'ghost']), {'a'});
+
+      expect((await repository.watch('user-1').first).map((r) => r.id), ['b']);
+    });
+
+    test('an empty or all-missing selection runs no delete', () async {
+      await seed('a');
+
+      expect(await repository.deleteNotifications(const <String>[]), isEmpty);
+      expect(await repository.deleteNotifications(['ghost']), isEmpty);
+
+      expect(await repository.watch('user-1').first, hasLength(1));
+    });
+
+    test('a deleted server notification comes back on the next sync', () async {
+      // Not a defect to fix. Nothing is enqueued, no tombstone is written, and
+      // `NotificationsRepository.sync` deliberately runs no `deleteNotIn` (the
+      // Kotlin walk does not either, and a prune would evict the
+      // locally-authored count/storage rows that have no server document). So
+      // a server-originated row the user deleted is re-pulled. Kotlin behaves
+      // identically — `UploadConfigs` mentions notifications nowhere — and this
+      // test exists so the round trip is stated rather than discovered.
+      await seed('server-1', fromServer: true);
+
+      expect(await repository.deleteNotifications(['server-1']), {'server-1'});
+      expect(await repository.watch('user-1').first, isEmpty);
+
+      // The sync-in re-upserts it, as it would for any server document.
+      await database.notificationDao.upsertAll([
+        NotificationsCompanion.insert(
+          id: 'server-1',
+          userId: 'user-1',
+          type: const Value('task'),
+          message: const Value('row server-1'),
+          createdAt: 500,
+          isFromServer: const Value(true),
+        ),
+      ]);
+
+      expect(await repository.watch('user-1').first, hasLength(1));
+    });
+  });
+
   test('warns only at or below ten percent storage availability', () async {
     await repository.updateStorageNotification('user-1', 10);
     expect((await repository.watch('user-1').first).single.message, '10%');

--- a/flutter/test/repository/notifications_repository_test.dart
+++ b/flutter/test/repository/notifications_repository_test.dart
@@ -48,6 +48,118 @@ void main() {
     expect(await repository.watch('user-1').first, isEmpty);
   });
 
+  group('the two mark-as-read paths, which Kotlin keeps separate', () {
+    // Kotlin has *two* `markAsRead` DAO queries differing in exactly one
+    // column, and two repository methods over them, and they belong to two
+    // different screens. Getting this wrong is easy: the first reading of it in
+    // this phase concluded the notifications screen must not restamp, which is
+    // the opposite of what the screen does.
+    //
+    //   * `NotificationDao.markAsRead(notificationId)` (`:15-16`) never
+    //     mentions `createdAt`. Its repository method is
+    //     `markNotificationAsRead(id, userId)`, which also handles a
+    //     `summary_`-prefixed id — and its callers are `DashboardActivity`
+    //     (`:702`) and `NotificationActionReceiver` (`:34,41,52`), i.e. the
+    //     Android tray. `summary_` ids are minted by
+    //     `NotificationUtils.createSummaryNotification` (`:190`) for the tray
+    //     and are never rows in the screen's list.
+    //   * `NotificationDao.markAsRead(ids, createdAt)` (`:45-46`) does stamp.
+    //     Its repository method is `markNotificationsAsRead(Set<String>)`, and
+    //     `NotificationsViewModel.markAsRead(id)` calls it with a **set of
+    //     one** (`:207-209`) — so the screen's row tap and its per-row
+    //     *Mark as read* button restamp `createdAt` in the Android app.
+    //
+    // That restamp is a quirk, not a bug to fix: the list is sorted
+    // `isRead ASC, createdAt DESC`, so a row jumps to the top of its group on
+    // being read, and with a relative timestamp it now reads "Just now". Both
+    // apps have to agree or the two lists order differently.
+    //
+    // The port had one method blending the two: the summary branch of the tray
+    // handler with the stamping of the screen's. The screen accidentally
+    // matched; the tray path did not, and it has no caller in the port yet
+    // (`NotificationActionReceiver` is unported), which is exactly how it went
+    // unnoticed.
+    Future<void> seed(String id, {bool fromServer = false}) =>
+        database.notificationDao.upsert(
+          NotificationsCompanion.insert(
+            id: id,
+            userId: 'user-1',
+            type: const Value('task'),
+            message: const Value('Read chapter 3 is due'),
+            createdAt: 500,
+            isFromServer: Value(fromServer),
+          ),
+        );
+
+    test(
+      'the screen path restamps createdAt, because the Kotlin does',
+      () async {
+        await seed('task-1');
+
+        final marked = await repository.markAsRead(['task-1']);
+
+        final row = (await repository.watch('user-1').first).single;
+        expect(marked, {'task-1'});
+        expect(row.isRead, isTrue);
+        expect(row.createdAt, 1234, reason: 'the injected clock, not the wall');
+      },
+    );
+
+    test(
+      'the tray path leaves createdAt alone, because that SQL has no createdAt',
+      () async {
+        await seed('task-1');
+
+        await repository.markNotificationAsRead('task-1', 'user-1');
+
+        final row = (await repository.watch('user-1').first).single;
+        expect(row.isRead, isTrue);
+        expect(row.createdAt, 500);
+      },
+    );
+
+    test('both paths still flag a server row for read-state upload', () async {
+      // The `needsSync` half of both statements has to survive: dropping it
+      // strands the read locally and the next sync pulls the row back unread.
+      await seed('screen-row', fromServer: true);
+      await seed('tray-row', fromServer: true);
+
+      await repository.markAsRead(['screen-row']);
+      await repository.markNotificationAsRead('tray-row', 'user-1');
+
+      final rows = {
+        for (final row in await repository.watch('user-1').first) row.id: row,
+      };
+      expect(rows['screen-row']!.needsSync, isTrue);
+      expect(rows['tray-row']!.needsSync, isTrue);
+    });
+
+    test('the summary path leaves createdAt alone too', () async {
+      // `markSummaryAsRead`'s SQL has no `createdAt` either, and the port's
+      // already matched. Pinned so the tray fix above cannot be "made
+      // consistent" in the wrong direction.
+      await seed('task-1');
+
+      await repository.markNotificationAsRead('summary_task', 'user-1');
+
+      expect((await repository.watch('user-1').first).single.createdAt, 500);
+    });
+
+    test('the screen path reports only the ids that existed', () async {
+      // `markNotificationsAsRead` filters through `getIdsByIds` and returns
+      // what it found (`NotificationsRepositoryImpl.kt:113-120`). The caller
+      // uses that set to update the list in place, so reporting an id that is
+      // not in the table would redraw a row the screen does not have — and
+      // `NotificationsViewModel.markAsRead` gates its whole in-memory update on
+      // `markedIds.contains(notificationId)`.
+      await seed('task-1');
+
+      expect(await repository.markAsRead(['task-1', 'ghost']), {'task-1'});
+      expect(await repository.markAsRead(const <String>[]), isEmpty);
+      expect(await repository.markAsRead(['ghost']), isEmpty);
+    });
+  });
+
   test('warns only at or below ten percent storage availability', () async {
     await repository.updateStorageNotification('user-1', 10);
     expect((await repository.watch('user-1').first).single.message, '10%');

--- a/flutter/test/ui/notification_timestamp_test.dart
+++ b/flutter/test/ui/notification_timestamp_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+import 'package:myplanet/l10n/app_localizations.dart';
+import 'package:myplanet/l10n/app_localizations_ar.dart';
+import 'package:myplanet/l10n/app_localizations_en.dart';
+import 'package:myplanet/l10n/app_localizations_fr.dart';
+import 'package:myplanet/l10n/app_localizations_ne.dart';
+import 'package:myplanet/l10n/app_localizations_so.dart';
+import 'package:myplanet/ui/components/relative_time.dart';
+
+/// `NotificationsAdapter.ItemViewHolder.formatRelativeTime`
+/// (`NotificationsAdapter.kt:152-163`), bucket by bucket and boundary by
+/// boundary.
+///
+/// The Kotlin's own tests are at `NotificationsAdapterTest.kt:52-84`; the cases
+/// there are mirrored here so a divergence in either app shows up as two suites
+/// disagreeing.
+void main() {
+  // The absolute arm formats through `intl`, whose locale table is registered by
+  // `flutter_localizations` in the running app and by nothing at all in a bare
+  // unit test — where every locale would silently fall back to `en_US` and the
+  // month-name assertions below would pass for the wrong reason. Loading the
+  // same CLDR data here is what makes them mean something.
+  setUpAll(initializeDateFormatting);
+
+  final AppLocalizations l10n = AppLocalizationsEn();
+
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  // An arbitrary fixed "now". Nothing here reads the wall clock: the formatter
+  // takes both instants, which is the same shape `relativeTimeLabel`'s callers
+  // use (they subtract at the call site).
+  final now = DateTime(2026, 9, 7, 15, 30).millisecondsSinceEpoch;
+
+  String at(int diff) =>
+      notificationTimestampLabel(l10n, createdAtMillis: now - diff, now: now);
+
+  group('the five relative buckets', () {
+    test('under a minute is Just now, including the boundary below it', () {
+      expect(at(0), 'Just now');
+      expect(at(minute - 1), 'Just now');
+    });
+
+    test('a minute exactly is the first minutes-ago row', () {
+      // `diff / 60_000L` is integer division, so this bucket renders 1..59 and
+      // never 0 — the arm below it has already claimed everything under a
+      // minute.
+      expect(at(minute), '1 min ago');
+      expect(at(5 * minute), '5 min ago');
+      expect(at(hour - 1), '59 min ago');
+    });
+
+    test('an hour exactly is the first hours-ago row', () {
+      expect(at(hour), '1 hr ago');
+      expect(at(2 * hour), '2 hr ago');
+      expect(at(day - 1), '23 hr ago');
+    });
+
+    test('a day exactly is Yesterday, for the whole of the second day', () {
+      expect(at(day), 'Yesterday');
+      expect(at(day + 1000), 'Yesterday');
+      expect(at(2 * day - 1), 'Yesterday');
+    });
+
+    test('two days exactly is the first days-ago row', () {
+      // The bucket spans 2..7 days, so `diff / 86_400_000L` yields 2..6 and
+      // the ungrammatical "1 days ago" the Kotlin string would produce is
+      // unreachable in both apps.
+      expect(at(2 * day), '2 days ago');
+      expect(at(3 * day + 1000), '3 days ago');
+      expect(at(7 * day - 1), '6 days ago');
+    });
+
+    test('a future timestamp reads as Just now, as the Kotlin does', () {
+      // `diff < 60_000L` is true for any negative diff, so a clock-skewed row
+      // from the future lands in the first arm rather than falling through to
+      // the absolute date.
+      expect(at(-1), 'Just now');
+      expect(at(-30 * day), 'Just now');
+    });
+  });
+
+  group('the absolute arm beyond a week', () {
+    test(
+      'seven days exactly is an absolute date, and drops the time of day',
+      () {
+        // `MMM d, yyyy` — no time component, unlike the `yMMMd().add_jm()` the
+        // port drew for every row before this.
+        expect(at(7 * day), 'Aug 31, 2026');
+        expect(at(30 * day), 'Aug 8, 2026');
+      },
+    );
+
+    test('the absolute date is of the notification, not of now', () {
+      final created = DateTime(2025, 1, 2, 3, 4).millisecondsSinceEpoch;
+      expect(
+        notificationTimestampLabel(l10n, createdAtMillis: created, now: now),
+        'Jan 2, 2025',
+      );
+      expect(
+        notificationTimestampLabel(l10n, createdAtMillis: created, now: now),
+        DateFormat(
+          'MMM d, yyyy',
+        ).format(DateTime.fromMillisecondsSinceEpoch(created)),
+      );
+    });
+  });
+
+  group('the strings are the localized ones', () {
+    // Kotlin reads `R.string.just_now`/`minutes_ago`/`hours_ago`/`yesterday`/
+    // `days_ago`, all five of which ship a human translation in every locale.
+    // The derivation tool carried them into the `.arb`, so an Arabic device
+    // shows Arabic here in both apps.
+    final AppLocalizations ar = AppLocalizationsAr();
+
+    String arAt(int diff) =>
+        notificationTimestampLabel(ar, createdAtMillis: now - diff, now: now);
+
+    test('Arabic renders the Kotlin translations', () {
+      // The *sentences* are at parity; the **digits are not**, and this is the
+      // one place to say so rather than let the assertion read as evidence of
+      // it. Kotlin reaches these strings through `Resources.getString(id, args)`
+      // → `String.format(configLocale, …)`, which localises `%d`, so an Arabic
+      // device shows `منذ ٥ دقيقة` in Arabic-Indic digits. `gen-l10n` emits a
+      // bare `'$count'`, so the port shows ASCII. Reproducing it would mean a
+      // `NumberFormat` per placeholder — and `intl`'s own `ar` symbols carry an
+      // ASCII zero digit anyway, so it could not be reproduced faithfully even
+      // then. A number is legible in either script; the sentence around it is
+      // the part that has to be Arabic.
+      expect(arAt(0), 'الآن');
+      expect(arAt(5 * minute), 'منذ 5 دقيقة');
+      expect(arAt(2 * hour), 'منذ 2 ساعة');
+      expect(arAt(day), 'أمس');
+      expect(arAt(3 * day), 'منذ 3 أيام');
+    });
+
+    test('the absolute arm uses the locale months, and survives Somali', () {
+      // Kotlin builds its formatter with `Locale.getDefault()`, so the month
+      // name follows the language picker. `intl` has no `so` at all and throws
+      // `ArgumentError` for it — out of `build` — so that one locale falls back
+      // to English month names rather than crashing the screen.
+      String monthOf(AppLocalizations l) => notificationTimestampLabel(
+        l,
+        createdAtMillis: DateTime(2026, 8, 31).millisecondsSinceEpoch,
+        now: DateTime(2026, 12, 1).millisecondsSinceEpoch,
+      );
+
+      expect(monthOf(l10n), 'Aug 31, 2026');
+      expect(monthOf(ar), 'أغسطس 31, 2026');
+      expect(monthOf(AppLocalizationsFr()), 'août 31, 2026');
+      // Nepali month name, Nepali digits — see the group above on why the
+      // digits diverge from Kotlin's ASCII here.
+      expect(monthOf(AppLocalizationsNe()), 'अगस्ट ३१, २०२६');
+      expect(monthOf(AppLocalizationsSo()), 'Aug 31, 2026');
+    });
+  });
+
+  group('this is not relativeTimeLabel', () {
+    // The two formatters port two different Kotlin functions and the Android
+    // app renders two different sentences. `relativeTimeLabel` substitutes for
+    // `DateUtils.getRelativeTimeSpanString` ("5 minutes ago"); the notification
+    // row reads `strings.xml`'s `minutes_ago` ("5 min ago"). Collapsing them
+    // would have changed one screen's text or the other's.
+    test('the wordings differ, and both are deliberate', () {
+      expect(relativeTimeLabel(l10n, 5 * minute), '5 minutes ago');
+      expect(at(5 * minute), '5 min ago');
+    });
+
+    test('relativeTimeLabel has no Yesterday and no absolute arm', () {
+      expect(relativeTimeLabel(l10n, day), '1 day ago');
+      expect(relativeTimeLabel(l10n, 30 * day), '30 days ago');
+    });
+  });
+}

--- a/flutter/test/ui/notifications_screen_test.dart
+++ b/flutter/test/ui/notifications_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/notifications_provider.dart';
@@ -598,6 +599,112 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('No unread notifications'), findsOneWidget);
+  });
+  // ------------------------------------------------------------------
+  // The row's timestamp (Phase 127 item 1).
+  //
+  // `NotificationsAdapter.formatRelativeTime` (`:152-163`) transforms
+  // `createdAt` into one of five relative strings, or an absolute `MMM d, yyyy`
+  // beyond a week. The port drew `DateFormat.yMMMd().add_jm()` for every row —
+  // the same class of defect as the bare `7` the phase before this one fixed: a
+  // stored value drawn where Kotlin transforms it.
+  //
+  // Both offsets below are computed from the wall clock so the bucket is fixed
+  // whatever day the suite runs on; the *formatter's* own boundaries are pinned
+  // exhaustively against a fixed instant in
+  // `test/ui/notification_timestamp_test.dart`.
+  // ------------------------------------------------------------------
+
+  testWidgets('a recent row reads as a relative time, not an absolute date', (
+    tester,
+  ) async {
+    final createdAt = DateTime.now()
+        .subtract(const Duration(minutes: 5))
+        .millisecondsSinceEpoch;
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              NotificationRow(
+                id: 'reply-1',
+                userId: 'user-1',
+                message: 'bob replied to your voice',
+                type: 'replyMessage',
+                isRead: false,
+                createdAt: createdAt,
+                priority: 0,
+                isFromServer: true,
+                needsSync: false,
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('5 min ago'), findsOneWidget);
+    // The absolute rendering the row used to draw, with its time of day, is
+    // gone for anything inside the week.
+    expect(
+      find.textContaining(
+        DateFormat.yMMMd().format(
+          DateTime.fromMillisecondsSinceEpoch(createdAt),
+        ),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('a row older than a week reads as a date with no time of day', (
+    tester,
+  ) async {
+    final createdAt = DateTime.now()
+        .subtract(const Duration(days: 30))
+        .millisecondsSinceEpoch;
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              NotificationRow(
+                id: 'reply-1',
+                userId: 'user-1',
+                message: 'bob replied to your voice',
+                type: 'replyMessage',
+                isRead: false,
+                createdAt: createdAt,
+                priority: 0,
+                isFromServer: true,
+                needsSync: false,
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final created = DateTime.fromMillisecondsSinceEpoch(createdAt);
+    expect(
+      find.text(DateFormat('MMM d, yyyy').format(created)),
+      findsOneWidget,
+    );
+    // `getDateFormatter()` is `MMM d, yyyy` and nothing else — the port's
+    // `add_jm()` appended a clock time the Kotlin never shows.
+    expect(
+      find.text(DateFormat.yMMMd().add_jm().format(created)),
+      findsNothing,
+    );
   });
 }
 

--- a/flutter/test/ui/notifications_screen_test.dart
+++ b/flutter/test/ui/notifications_screen_test.dart
@@ -1008,6 +1008,41 @@ void main() {
     ]);
   });
 
+  testWidgets('the checkbox is decoration, and the row owns the tap', (
+    tester,
+  ) async {
+    // `cbSelect` is `clickable="false"` `focusable="false"`
+    // (`row_notifications.xml:41-42`) — the row's own click listener is what
+    // toggles. A Checkbox with a non-null `onChanged` would *absorb* the tap
+    // and do nothing with it, giving the one control that looks most tappable
+    // in selection mode no effect at all.
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'n-1', message: 'first', type: 'replyMessage'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'first');
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+
+    // The tap reached the row, which deselected the last item and left
+    // selection mode.
+    expect(find.text('Notifications'), findsOneWidget);
+    expect(find.byType(Checkbox), findsNothing);
+  });
+
   testWidgets('swiping is disabled while selecting', (tester) async {
     // The swipe is the port's own, and it yields rather than competing: Kotlin
     // disarms the row's long-press in selection mode for the same reason.
@@ -1032,10 +1067,25 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    // Swipe outside selection mode: the confirmation dialog opens. This is the
+    // control, and it is the whole point of the test below — `deleted` being
+    // empty proves nothing on its own, because `confirmDismiss` returning false
+    // also leaves it empty. The *dialog* is what distinguishes "the swipe was
+    // never armed" from "the swipe was armed and then declined".
+    await tester.drag(find.text('first'), const Offset(-500, 0));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(deleted, isEmpty);
+
     await enterSelection(tester, 'first');
     await tester.drag(find.text('first'), const Offset(-500, 0));
     await tester.pumpAndSettle();
 
+    // Armed, the swipe would reach `confirmDismiss` and put this dialog up
+    // over a selection the user is in the middle of making.
+    expect(find.byType(AlertDialog), findsNothing);
     expect(deleted, isEmpty);
     expect(find.text('1 selected'), findsOneWidget);
   });

--- a/flutter/test/ui/notifications_screen_test.dart
+++ b/flutter/test/ui/notifications_screen_test.dart
@@ -85,7 +85,7 @@ void main() {
 
     expect(find.text('Notifications'), findsOneWidget);
     expect(find.text('Unread (1)'), findsOneWidget);
-    expect(find.text('Mark all read'), findsOneWidget);
+    expect(find.text('Mark all as read'), findsOneWidget);
     // The unread resource group is expanded by default, so its header and the
     // notification content are both present.
     expect(find.text('4 new resources are available'), findsOneWidget);
@@ -516,7 +516,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Mark all read'), findsNothing);
+    expect(find.text('Mark all as read'), findsNothing);
   });
 
   testWidgets('Mark all read fires on a tab that has unread rows', (
@@ -543,7 +543,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Mark all read'));
+    await tester.tap(find.text('Mark all as read'));
     await tester.pump();
     expect(markedAll, [true]);
   });
@@ -706,6 +706,339 @@ void main() {
       findsNothing,
     );
   });
+  // ------------------------------------------------------------------
+  // Selection mode (Phase 127 item 2).
+  //
+  // `NotificationsAdapter.bind`'s `isSelectionMode` branch (`:129-149`),
+  // `_selectedIds` and the three actions over it in `NotificationsViewModel`
+  // (`:39,145-153,173-205`), and the bulk bar that replaces the top bar
+  // (`NotificationsFragment.kt:104-107`, `fragment_notifications.xml:44-93`).
+  //
+  // Kotlin has exactly one test for any of this
+  // (`NotificationsViewModelTest.kt:216-233`, the toggle), so there is little to
+  // mirror; everything below is read from the Kotlin source, with the quirks it
+  // has rather than the ones it ought to.
+  // ------------------------------------------------------------------
+
+  /// Long-presses the one row on screen, which is the only way into selection
+  /// mode in either app.
+  Future<void> enterSelection(WidgetTester tester, String message) async {
+    await tester.longPress(find.text(message));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a long press enters selection mode and swaps the top bar', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'n-1', message: 'first', type: 'replyMessage'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Before: the title, the filter spinner's segments, Mark all read; no
+    // checkbox.
+    expect(find.text('Notifications'), findsOneWidget);
+    expect(find.text('Mark all as read'), findsOneWidget);
+    expect(find.text('Unread (1)'), findsOneWidget);
+    expect(find.byType(Checkbox), findsNothing);
+
+    await enterSelection(tester, 'first');
+
+    // After: `tvSelectedCount`, `btnBulkMarkAsRead`, `btnBulkDelete`,
+    // `btnCancelSelection` — and `ltTopBar` gone, which takes the filter and
+    // Mark-all with it.
+    expect(find.text('1 selected'), findsOneWidget);
+    expect(find.text('Mark read'), findsOneWidget);
+    expect(find.text('Delete'), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsOneWidget);
+    expect(find.byType(Checkbox), findsOneWidget);
+    expect(find.text('Notifications'), findsNothing);
+    expect(find.text('Mark all as read'), findsNothing);
+    expect(find.text('Unread (1)'), findsNothing);
+    // The row's own Mark-as-read button is hidden in the selection branch.
+    expect(find.text('Mark as read'), findsNothing);
+  });
+
+  testWidgets('a tap toggles while selecting, and never navigates', (
+    tester,
+  ) async {
+    final read = <String>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'n-1', message: 'first', type: 'replyMessage'),
+              _row(id: 'n-2', message: 'second', type: 'replyMessage'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(2),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onRead: read.add),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'first');
+    await tester.tap(find.text('second'));
+    await tester.pumpAndSettle();
+    expect(find.text('2 selected'), findsOneWidget);
+
+    // Tapping a selected row deselects it, and the *tap* never marks anything
+    // read — `onNotificationClick` is not wired in the selection branch.
+    await tester.tap(find.text('second'));
+    await tester.pumpAndSettle();
+    expect(find.text('1 selected'), findsOneWidget);
+    expect(read, isEmpty);
+
+    // Deselecting the last row leaves selection mode: there is no separate
+    // mode flag in either app, only `_selectedIds.isNotEmpty()`.
+    await tester.tap(find.text('first'));
+    await tester.pumpAndSettle();
+    expect(find.text('Notifications'), findsOneWidget);
+    expect(find.byType(Checkbox), findsNothing);
+    expect(read, isEmpty);
+  });
+
+  testWidgets('the close button clears the selection', (tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'n-1', message: 'first', type: 'replyMessage'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'first');
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Notifications'), findsOneWidget);
+    expect(find.text('1 selected'), findsNothing);
+  });
+
+  testWidgets('Mark read acts on the whole selection and then clears it', (
+    tester,
+  ) async {
+    final marked = <Set<String>>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'n-1', message: 'first', type: 'replyMessage'),
+              _row(id: 'n-2', message: 'second', type: 'replyMessage'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(2),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onMarkSelected: marked.add),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'first');
+    await tester.tap(find.text('second'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Mark read'));
+    await tester.pumpAndSettle();
+
+    expect(marked, [
+      {'n-1', 'n-2'},
+    ]);
+    expect(find.text('Notifications'), findsOneWidget);
+  });
+
+  testWidgets('Delete acts on the whole selection, with no confirmation', (
+    tester,
+  ) async {
+    // Kotlin's `btnBulkDelete` goes straight to `deleteSelected`. The row's
+    // swipe *does* confirm, but that swipe is the port's own affordance and
+    // Kotlin has no equivalent to copy a dialog from.
+    final deleted = <Set<String>>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'n-1', message: 'first', type: 'replyMessage'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onDeleteSelected: deleted.add),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'first');
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(deleted, [
+      {'n-1'},
+    ]);
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.text('Notifications'), findsOneWidget);
+  });
+
+  testWidgets('an already-read row can be selected', (tester) async {
+    // Kotlin arms the long-press on every row, read or not
+    // (`NotificationsAdapter.kt:145`), and `markNotificationsAsRead` does not
+    // filter by `isRead`. Gating selection on unread would be an improvement,
+    // not a port.
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              // The group is resolved from the *message* for a
+              // `replyMessage` row (`resolvedNotificationType` sniffs it), so
+              // this reads as a reply rather than landing in "Other".
+              _row(
+                id: 'n-1',
+                message: 'bob replied to your voice',
+                type: 'replyMessage',
+                isRead: true,
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(0),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    // The read group is collapsed by default, so open it first.
+    await tester.tap(find.text('Voice Replies'));
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'bob replied to your voice');
+
+    expect(find.text('1 selected'), findsOneWidget);
+    expect(find.byType(Checkbox), findsOneWidget);
+  });
+
+  testWidgets('a group header still collapses while a selection is open', (
+    tester,
+  ) async {
+    // The header is not selection-aware — `NotificationListItem.Header` carries
+    // neither `isSelected` nor `isSelectionMode`, and `HeaderViewHolder.bind`
+    // wires only the expansion toggle. So a selected row can be collapsed out
+    // of sight while the bulk bar still counts it, and the bulk action still
+    // acts on it. Reproduced deliberately; it is how the Kotlin behaves.
+    final marked = <Set<String>>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(
+                id: 'n-1',
+                message: 'bob replied to your voice',
+                type: 'replyMessage',
+              ),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onMarkSelected: marked.add),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'bob replied to your voice');
+    await tester.tap(find.text('Voice Replies'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('bob replied to your voice'),
+      findsNothing,
+      reason: 'collapsed out of sight',
+    );
+    expect(find.text('1 selected'), findsOneWidget);
+
+    await tester.tap(find.text('Mark read'));
+    await tester.pumpAndSettle();
+    expect(marked, [
+      {'n-1'},
+    ]);
+  });
+
+  testWidgets('swiping is disabled while selecting', (tester) async {
+    // The swipe is the port's own, and it yields rather than competing: Kotlin
+    // disarms the row's long-press in selection mode for the same reason.
+    final deleted = <String>[];
+    await tester.pumpWidget(
+      wrapScreen(
+        const NotificationsScreen(),
+        overrides: [
+          notificationsProvider.overrideWith(
+            (ref) => Stream.value([
+              _row(id: 'n-1', message: 'first', type: 'replyMessage'),
+            ]),
+          ),
+          unreadNotificationCountProvider.overrideWith(
+            (ref) => Stream.value(1),
+          ),
+          notificationActionsProvider.overrideWithValue(
+            _RecordingActions(onDelete: deleted.add),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await enterSelection(tester, 'first');
+    await tester.drag(find.text('first'), const Offset(-500, 0));
+    await tester.pumpAndSettle();
+
+    expect(deleted, isEmpty);
+    expect(find.text('1 selected'), findsOneWidget);
+  });
 }
 
 NotificationRow _row({
@@ -733,11 +1066,19 @@ NotificationRow _row({
 /// Records the row actions instead of touching a repository, so a tap on
 /// *Mark as read*, *Mark all read* or a swipe is observable.
 class _RecordingActions implements NotificationActions {
-  _RecordingActions({this.onRead, this.onDelete, this.onMarkAll});
+  _RecordingActions({
+    this.onRead,
+    this.onDelete,
+    this.onMarkAll,
+    this.onMarkSelected,
+    this.onDeleteSelected,
+  });
 
   final void Function(String id)? onRead;
   final void Function(String id)? onDelete;
   final void Function()? onMarkAll;
+  final void Function(Set<String> ids)? onMarkSelected;
+  final void Function(Set<String> ids)? onDeleteSelected;
 
   @override
   Ref get ref => throw UnsupportedError('the fake talks to no providers');
@@ -750,4 +1091,19 @@ class _RecordingActions implements NotificationActions {
 
   @override
   Future<void> markAllAsRead() async => onMarkAll?.call();
+
+  /// Reports every id back as acted on, which is what the repository does for
+  /// ids that exist — the screen clears its selection only on a non-empty
+  /// result.
+  @override
+  Future<Set<String>> markSelectedAsRead(Set<String> ids) async {
+    onMarkSelected?.call(ids);
+    return ids;
+  }
+
+  @override
+  Future<Set<String>> deleteSelected(Set<String> ids) async {
+    onDeleteSelected?.call(ids);
+    return ids;
+  }
 }


### PR DESCRIPTION
Lane C of the Phase 127 parallel round. Closes the two items Phase 124 reported on itself:

1. **The bell row's timestamp is absolute** where Kotlin's `NotificationsAdapter.formatRelativeTime` (`:152-163`) shows "Just now / N min ago / N hr ago / Yesterday / N days ago", then `MMM d, yyyy` beyond a week.
2. **Selection mode is unported** — long-press entry, the checkbox, the bulk bar, `markSelectedAsRead` / `deleteSelected`.

Draft while in progress. Files owned: `lib/ui/notifications/`, `lib/repository/notifications_repository.dart`, `lib/ui/components/relative_time.dart`, `lib/l10n/*.arb`, `tool/arb_from_strings_xml.dart`, `test/l10n/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167AhA88bVH4kBQg9mm3amt

---
_Generated by [Claude Code](https://claude.ai/code/session_0167AhA88bVH4kBQg9mm3amt)_