### PR TITLE
feat(flutter): the course step tile says Redo survey / Retake test once answered

### DIFF
--- a/flutter/PHASE_128_NOTES.md
+++ b/flutter/PHASE_128_NOTES.md
@@ -5,10 +5,10 @@ own successor (`PHASE_125_NOTES.md` §"Found, not fixed" item 1) and correctly
 so: this is **the only user-visible Kotlin reader of the composite survey
 `parentId`**, and Phase 125's writer fix is its precondition.
 
-`CourseStepFragment.hideTestIfNoQuestion` (`:241-262`) picks each assessment
+`CourseStepFragment.hideTestIfNoQuestion` (`:241-261`) picks each assessment
 button's wording off `CourseStepData.hasExam`/`hasSurvey`, which are
 `submissionsRepository.hasSubmission(stepExams[0].id, step.courseId, userId,
-"exam"/"survey")` (`CoursesRepositoryImpl.kt:536-546`). The port hardcoded
+"exam"/"survey")` (`CoursesRepositoryImpl.kt:537-546`). The port hardcoded
 `l10n.takeTest` and `l10n.recordSurvey`, so **a learner who had already sat the
 test was invited to take it for the first time, every time** — and the count
 Kotlin puts in that label was absent entirely.
@@ -149,6 +149,9 @@ else null`.
 
 `_StepContent` now takes `userId`. It watches one provider where it used to
 watch two, and the two tiles read their visibility, count and wording off it.
+Both tiles' `onTap` awaits its `context.push` and then calls a local
+`refreshAssessment` — see defect 5 below for why that is not optional, and why
+the `push` literal has to stay at the call site.
 
 ## Each defect, with failing-first evidence
 
@@ -164,12 +167,40 @@ right" cannot tell them apart.
 | 2 | **a survey's question count read `ExamQuestions`** (Kotlin's single table, copied literally) | the `type == 'survey'` table choice | `Expected: true / Actual: <false>` in the repository, and `Found 0 widgets with text "redo survey"` at the screen — 4 tests red |
 | 3 | an exam whose questions have not synced claims an attempt | the `questions == 0` guard | `Expected: false / Actual: <true>` |
 | 4 | a second exam's submission swapped the label | `exams.first` widened to "any exam" | `Expected: false / Actual: <true>` |
+| 5 | **the label could not change within a session** | `pushAndRefresh` back to a bare `context.push` | `Expected: exactly one matching candidate / Actual: Found 0 widgets with text "Retake Test [1]"` |
 
 Two tests are **guards, not failing-first evidence**, and are labelled so rather
 than counted above: "does not confuse the two types" and "is false for another
 user" pin `countByUserParentAndType`'s existing `type`/`userId` clauses, which
 predate this diff — reverting them means deleting an argument pass-through,
 which proves nothing about a decision anyone might make.
+
+Defect 5 is the one the ground-truth audit found and it is the most important
+of the five, because without it the other four guard a label the learner cannot
+watch change. **Kotlin recreates the fragment and the port does not.**
+`btnTakeTest` calls `openCallFragment` (`CourseStepFragment.kt:282`) →
+`FragmentNavigator.replaceFragment(…, addToBackStack = true)`, a `replace()`
+transaction, so popping back rebuilds `CourseStepFragment`, `onViewCreated`
+runs again and `getCourseStepData` re-queries. `context.push` leaves
+`TakeCourseScreen` mounted, so `_StepContent` keeps its listener, the
+`autoDispose` family member is never disposed and its future never re-runs — the
+label stayed on *take test [1]* until the learner left the course entirely.
+The fix awaits the pop and invalidates.
+
+**And the port's own reachability guard caught the first version of that fix.**
+Folding `await context.push(location)` into a helper made the navigation
+unreadable, and `test/ui/route_reachability_test.dart` failed with
+`[_NavSite:take_course_screen.dart:379 -> location]` — its message offers a
+`declared` exception map and that would have been the wrong door to take. The
+route literals stay at each `onTap` and only the invalidate is factored out.
+Phase 116 wrote that guard after finding four unreachable screens; this is the
+first time it has fired on a *new* navigation rather than an audit.
+
+That is the same argument `stepExamProvider`'s own doc comment already makes one
+level down ("a step opened before the sync wrote its exam answered `null` for
+the rest of the process"), unsatisfied one level up. **When a screen's state
+depends on something another screen writes, `autoDispose` is not the refresh —
+the pop is.**
 
 `test/repository/step_tile_label_test.dart` is new (13 tests) and named for the
 shape rather than the file, like `mandatory_survey_round_trip_test.dart`. Its
@@ -178,7 +209,8 @@ because the rest of the file proves nothing if they did not — Phase 113's exac
 failure. **No fixture hand-writes a `parentId`**: every submission is authored
 by `startExamSession` or `createSurveyDraft` against rows
 `ExamMapper.fromCourseDoc` / `SurveyMapper.fromCourseDoc` produced from a
-document shaped like the server's. `take_course_screen_test.dart` gains 5.
+document shaped like the server's. `take_course_screen_test.dart` gains 5, and three of its existing
+expectations move from `Take test` to `take test [1]`.
 
 ## `submissions_repository.dart` — which regions this lane touched
 
@@ -204,19 +236,69 @@ No overlap with Lane C (`lib/ui/notifications/`, the five locale files,
 `tool/arb_from_strings_xml.dart`, `test/l10n/`) except the two hand-offs named
 under the derivation section, which are reports rather than edits.
 
+## What the ground-truth audit overturned
+
+Three things I had wrong or would have got wrong, all found by a
+`parity-auditor` pass at `effort: max` before the implementation was finished.
+
+**A two-exam step is port-only, so the `[%d]` is structurally `[1]` in the
+Android app.** I justified the list-returning provider by "a step can carry
+several exams". It cannot, in Kotlin: `steps[i].exam` is read with
+`getAsJsonObject` so it is one object per step, and the standalone `exams` walk
+calls `insertCourseStepsExams("", "", jsonDoc, "")` whose `checkIdsAndInsert`
+skips blank ids, leaving `stepId` null — so nothing Planet sends produces two
+rows sharing a `stepId`. The **port** can: `ExamMapper.fromDoc` writes a
+document's own `stepId` (`_presentOrAbsent`), which is a Phase 110 deviation
+made on purpose. So the `exams.first`-decides quirk is ported for fidelity to
+what the Kotlin *says*, on a state only the port can reach, and the test that
+pins it says so rather than implying a Kotlin scenario. The list shape is still
+right — it is what `getByStepIdAndType` returns and where the `1` comes from.
+
+**`hideTestIfNoQuestion` reads no question count.** The name promises the guard
+is about questions; it hides on *list emptiness* and the only question count in
+the whole feed is inside `hasSubmission`, where it changes the label's **wording**
+and never a button's presence — the inversion of what the name says. The Dart
+provider is named for what it computes.
+
+**Kotlin's Take Test button can open a row its own label never interrogated, and
+the port is already better.** `hasExam` asks about `stepExams[0]`, selected by
+`stepId = ? AND type = 'courses'`; the button routes through
+`BaseExamFragment.initExam` → `ExamDao.getFirstByStepId`, which is
+`WHERE stepId = ? LIMIT 1` with **no type filter** — so on a step carrying both
+an exam and a survey it can open the survey row. The port pushes
+`exams.first.id`, the same row the label read, so label and destination cannot
+disagree. That property predates this phase; this diff preserves it
+deliberately rather than by accident, and it is now documented at the provider.
+
+Two more worth recording because they explain the Kotlin's odd surface:
+`type = "courses"` is **never assigned anywhere in the Kotlin tree** — it is the
+server's value copied verbatim, and the in-tree *fallbacks* are `"exam"` and
+`"survey"` singular, which no Kotlin query ever selects. And
+`CourseStepFragment.onCreateView` (`:79-80`) forces both buttons VISIBLE with
+their XML defaults, so between view creation and the data arriving Kotlin shows
+the literal string `take test [%d]` — percent-d and all — and `Take Survey`, a
+*third* string that is not part of this swap. Pre-load flicker; deliberately not
+ported.
+
 ## Found, not fixed
 
-**1. `resourcesInStep` counts a different thing from Kotlin's `btnResources`,
-and reads differently too.** Kotlin sets
-`getString(R.string.resources_size, data.resources.size)` — "Resources [%d]" on
-`myLibraryDao.getByStepId(stepId)`, the rows actually on the device. The port
-renders `l10n.resourcesInStep(step.noOfResources)`, an ICU plural ("No
-resources" / "1 resource" / "{count} resources") on the **step document's own
-declared count**. Those disagree whenever a step's resources have not all
-synced, which is the normal case on a fresh install, and the plural means the
-key can never derive a translation from the Kotlin XML (the tool skips plurals
-for good reason). Same tile, one line above the two this phase fixed;
-deliberately out of scope because it is a second feature, not this label swap.
+**1. The resources tile above the two this phase fixed is the port's own
+affordance, and it has a chevron that does nothing.** `take_course_screen.dart`
+renders `ListTile(… trailing: Icon(Icons.chevron_right))` with **no `onTap`** —
+same in `course_detail_screen.dart`. Kotlin's live analogue is
+`BaseContainerFragment.setResourceButton`, reached from
+`CourseDetailFragment`, and it opens a **download dialog**.
+`CourseStepFragment`'s own `btnResources` is **dead code** on two independent
+counts (it sits inside `legacy_buttons_container`, declared
+`android:visibility="gone"` with nothing anywhere making it visible, and
+`setListeners` sets the button GONE at `:292`), so the number Kotlin computes
+at `:121-122` is never rendered. My first draft of this item claimed the port
+diverged from a live Kotlin count; it does not, because there is no live Kotlin
+count. What remains true and worth logging: the port's
+`l10n.resourcesInStep(step.noOfResources)` is an **ICU plural**, which
+`tool/arb_from_strings_xml.dart` skips for good reason, so that key can never
+derive a translation from the Kotlin XML — and the chevron promises a
+navigation nothing implements.
 
 **2. `takeTest` is a dead ARB key.** See the l10n section — removing it needs
 Lane C's files.
@@ -229,11 +311,33 @@ is a `> 0` count — but it would double it in the list and the exporter, and th
 machinery to prevent it (`SubmissionDao.getByIdOrRemoteId`) is still sitting
 unused by the walk.
 
-**4. Nothing invalidates `stepAssessmentProvider` when an attempt is made.**
-`autoDispose` is what makes the label refresh: the learner leaves the step to
-sit the exam, the provider's last listener goes, and re-entering re-reads. That
-is the same argument `stepExamProvider`'s own doc makes and it is load-bearing
-here for a new reason — a `PageView` keeps its neighbours alive, so a learner
-who returns to the *same* step without the page being disposed could see a stale
-label. I did not reproduce it and it needs a widget test that drives the real
-exam screen, which no test in the port does yet.
+**4. `TakeCourseFragment.changeNextButtonState` is unported** — the next-step
+lock for `MANDATORY_SURVEY_COURSE_ID` (`TakeCourseFragment.kt:315-338`), which
+refuses Next with `please_complete_test`/`please_complete_survey`. It reads the
+**same** `CourseStepData` this phase now reads, but off
+`stepExams.isNotEmpty()`/`stepSurvey.isNotEmpty()` rather than
+`hasExam`/`hasSurvey`, and the port's `_NavigationBar` has no equivalent. A
+separate gap, not made worse by this diff — but the next lane to touch this
+screen has the provider it would need already in place.
+
+**5. Kotlin's Take Test button can open a row its own label never asked about,
+and none of the port's type-routing deviations are in
+`docs/kotlin-to-flutter-migration.md`.** Both are recorded in the code (see the
+`stepAssessmentProvider` doc); neither is in the migration doc's *Faithful
+quirks / deliberate deviations* list, which still carries four quirks and six
+deviations, none of them Phase 113's `exam`/`survey` table routing. This phase's
+count, the buttons' presence and the take-vs-retake wording all rest on that
+routing. **Integrator: that list is the place for it, and this file is not the
+lane's to edit.** The text is the "What the ground-truth audit overturned"
+section above.
+
+**6. Stale Kotlin line citations are widespread, and I fixed only my own
+region.** The ground-truth audit found them in `exam_mapper.dart` (three),
+`survey_mapper.dart` (one), `app_database.dart` (one, an
+`ExamDao.getByStepIdAndType(stepId, "survey")` that is actually the plural) and
+in `examParentId`'s doc (`createExamSubmission` is `:446-453`, not `:449-456`).
+I corrected the citations inside `hasUnfinishedSurveys`' doc, since leaving them
+wrong next to the function I had just ported correctly would be worse; the rest
+belong to other lanes' files or to the write path. Given that misreading a
+correctly-named function is this project's most expensive recurring failure, a
+pass that just fixes citations would be cheap and worth a lane.

--- a/flutter/PHASE_128_NOTES.md
+++ b/flutter/PHASE_128_NOTES.md
@@ -1,11 +1,27 @@
 # Phase 128 — the step tile's *Redo survey* / *Retake test* labels
 
+> ## Integrator: one action is required before this merges
+>
+> **Run `dart tool/arb_from_strings_xml.dart` (Lane C's file) and bump
+> `humanReviewed` in `test/l10n/placeholder_integrity_test.dart` by +5 per
+> locale: ar 410→415, es 462→467, fr 409→414, ne 411→416, so 411→416.**
+>
+> This diff adds three user-facing strings to `app_en.arb` and, as merged,
+> **an Arabic, Spanish, French, Nepali or Somali learner sees `redo survey`
+> and `take test [1]` in English** on a screen where the Android app has
+> always shown their own language. The 15 human translations already exist in
+> `values-*/strings.xml`; I verified the derivation picks up all of them and
+> then reverted the five locale files, because Lane C owns them and is editing
+> them this round. This is the only respect in which the branch is *worse*
+> than the Kotlin app, and it is one command. The run also delivers two keys
+> that are not mine — see the l10n section.
+
 Lane A of a three-lane round. One missing feature, named by Phase 125 as its
 own successor (`PHASE_125_NOTES.md` §"Found, not fixed" item 1) and correctly
 so: this is **the only user-visible Kotlin reader of the composite survey
 `parentId`**, and Phase 125's writer fix is its precondition.
 
-`CourseStepFragment.hideTestIfNoQuestion` (`:241-261`) picks each assessment
+`CourseStepFragment.hideTestIfNoQuestion` (`:241-260`) picks each assessment
 button's wording off `CourseStepData.hasExam`/`hasSurvey`, which are
 `submissionsRepository.hasSubmission(stepExams[0].id, step.courseId, userId,
 "exam"/"survey")` (`CoursesRepositoryImpl.kt:537-546`). The port hardcoded
@@ -26,6 +42,7 @@ parity, not internal consistency.
 |---|---|
 | exam on the step, no attempt by this user | **take test [N]** |
 | exam on the step, an attempt exists for `stepExams[0]` | **Retake Test [N]** |
+| exam opened and abandoned with **no answer given** | **take test [N]** in the port, `Retake Test [N]` in Kotlin — see below |
 | exam on the step, its questions have not synced yet | **take test [N]** — the `countByExamId == 0` guard |
 | exam present, attempt belongs to another user | **take test [N]** |
 | survey on the step, no answer sheet | **Record survey** |
@@ -47,9 +64,23 @@ read as untaken rather than blocking anything. That is why the
 deliberately is **not** ported in `hasUnfinishedSurveys`, where it would invert
 into "a question-less survey blocks the course forever".
 
-The label is also status-blind, as Kotlin's `countByUserParentAndType` is
-(`SubmissionDao.kt:23`): merely *opening* an exam attempt makes the tile read
-"Retake". Faithful.
+The label is status-blind, as Kotlin's `countByUserParentAndType` is
+(`SubmissionDao.kt:23`): a submission of **any** status satisfies it, graded or
+not, uploaded or not. Faithful.
+
+**What is not faithful — and my first draft of this file claimed it was — is
+"merely opening an exam makes the tile read Retake".** That is true of Kotlin,
+whose `createExamSubmission` writes a `pending` row from `initializeExamData`
+before the first question is drawn. The port's `_ensureSession` is called from
+one place, `_saveCurrentAnswer`, so the row appears on the learner's **first
+answer**. `take_exam_screen.dart` documents that deviation deliberately —
+"abandoning an exam without answering anything leaves no row behind" — so the
+divergence is pre-existing and intended, not new here. But it changes the
+label: a learner who opens the test, answers nothing and backs out sees
+*Retake Test [1]* on Kotlin and *take test [1]* in the port. Only the first
+open differs; after any answered attempt the two agree. Nothing tests it,
+because both test files call `startExamSession` directly rather than driving
+the screen. Found by the implementation audit.
 
 ## The `%d` count keys derived their translations — all three, all five locales
 
@@ -98,7 +129,12 @@ Three consequences I did **not** act on:
 * **`takeTest` could not simply have grown a `{count}`.** ar/es/fr carry values
   for it with no placeholder, so declaring one would generate a getter taking an
   argument those three locales silently drop — the Phase 109 defect class, and
-  `placeholder_integrity_test`'s second test would fail on it.
+  `placeholder_integrity_test`'s second test would fail on it. One correction
+  to my own framing: all three of those values are flagged `x-mt`, unreviewed
+  machine translation, so the cost of *deleting* the key is lower than the
+  paragraph above implies — three machine strings and their flags, not three
+  human translations. `recordSurvey`'s five values are unflagged and genuinely
+  are human.
 * **`recordSurvey` is "Record survey" where Kotlin is "Record Survey"**, which
   is why it derived by *shared English* rather than by name in the first place.
   It already has five human translations and I left it alone: replacing one
@@ -161,7 +197,7 @@ right" cannot tell them apart.
 
 | # | defect | revert replayed | pre-fix failure |
 |---|---|---|---|
-| 1 | **a learner who has taken the test is still told to take it** | both tiles' labels back to `l10n.takeTest` / `l10n.recordSurvey` | `Expected: exactly one matching candidate / Actual: Found 0 widgets with text "Retake Test [1]"` — 5 tests red |
+| 1 | **a learner who has taken the test is still told to take it** | both tiles' labels back to `l10n.takeTest` / `l10n.recordSurvey` | `Expected: exactly one matching candidate / Actual: Found 0 widgets with text "Retake Test [1]"` — **6** tests red |
 | 1b | the same for the survey half | as above | `Found 0 widgets with text "redo survey"` |
 | 1c | the label carried no count | as above | `Found 0 widgets with text "take test [1]"` |
 | 2 | **a survey's question count read `ExamQuestions`** (Kotlin's single table, copied literally) | the `type == 'survey'` table choice | `Expected: true / Actual: <false>` in the repository, and `Found 0 widgets with text "redo survey"` at the screen — 4 tests red |
@@ -169,11 +205,42 @@ right" cannot tell them apart.
 | 4 | a second exam's submission swapped the label | `exams.first` widened to "any exam" | `Expected: false / Actual: <true>` |
 | 5 | **the label could not change within a session** | `pushAndRefresh` back to a bare `context.push` | `Expected: exactly one matching candidate / Actual: Found 0 widgets with text "Retake Test [1]"` |
 
-Two tests are **guards, not failing-first evidence**, and are labelled so rather
-than counted above: "does not confuse the two types" and "is false for another
-user" pin `countByUserParentAndType`'s existing `type`/`userId` clauses, which
-predate this diff — reverting them means deleting an argument pass-through,
-which proves nothing about a decision anyone might make.
+**Three more rows the implementation audit added, two of which were tests of
+mine that read as coverage and were not.** It replayed the reverts itself; I
+reproduced each before and after fixing.
+
+| # | defect | revert replayed | pre-fix failure |
+|---|---|---|---|
+| 6 | the `type` clause in `countByUserParentAndType` was **unpinned** | `submissions.type.equals(type)` deleted | was `All tests passed`; now `Expected: false` |
+| 7 | the blank-**course** guard was unpinned *semantically* | `course.isEmpty` dropped from the guard | was a `Null check operator used on a null value` from `userId!`; now `Expected: false` |
+
+Row 6: "does not confuse the two types" asked about `'exam-1'` with
+`type: 'survey'`, which short-circuits on `surveyQuestions` being empty and
+never issues the count — so deleting the `type` clause left all 13 tests green.
+Its own comment named the shared-id case and did not build it. It now seeds a
+document whose `steps[0].exam._id` and `steps[0].survey._id` are the same
+string, so both question tables answer non-zero and the `type` clause is the
+only thing left deciding.
+
+Row 7: the blank-guard test detected the guard's deletion as a *crash*, from
+`userId!`, not as a wrong answer — so it pinned the `!` and not the semantics.
+The guard now binds all three arguments to locals (no `!`), and a new test
+seeds a survey with **no `courseId`**, whose writer stores the bare id, so a
+blank `courseId` argument produces a `parentId` that *does* match a real row —
+the one case where dropping the guard changes the answer. The same change makes
+the guard `isNullOrBlank` rather than `isEmpty`, which is what its own doc
+comment had claimed all along; whitespace is now pinned too.
+
+One test remains a **guard, not evidence**, and is labelled so: the original
+blank-id sweep, which without the guard still answers false by other routes.
+Conversely "is false for another user" *is* failing-first evidence — deleting
+`submissions.userId.equals(userId)` reds it and reds the screen test beside it
+— so the previous draft of this file under-claimed it while over-claiming its
+neighbour.
+
+"Redo survey still opens the survey screen" adds little over its sibling plus
+the pre-existing route test: with one survey on the step it cannot distinguish
+`surveys.first` from any other selector.
 
 Defect 5 is the one the ground-truth audit found and it is the most important
 of the five, because without it the other four guard a label the learner cannot
@@ -220,8 +287,13 @@ expectations move from `Take test` to `take test [1]`.
 |---|---|
 | between `_repairSurveyParentId` and `hasUnfinishedSurveys` | **added** `hasSubmission` (+ its doc comment). Nothing else in the file is modified — no line of `createExamSubmission`, `serializeSubmission`, the team-object block, or any other write-path method is touched. |
 
-Lane B owns the write path in the same file. `git diff` on it shows exactly one
-insertion hunk.
+Lane B owns the write path in the same file. **`git diff` on it shows five
+hunks, not one** — the 100-line insertion plus four one-line comment edits
+(the stale-citation corrections in the neighbouring `examParentId` and
+`hasUnfinishedSurveys` docs). An earlier draft of this section said "exactly
+one insertion hunk", which told the integrator there were no other conflict
+surfaces in a file partitioned between two lanes. There are four, each one
+line of comment.
 
 ## Files touched outside the read path
 
@@ -247,12 +319,23 @@ several exams". It cannot, in Kotlin: `steps[i].exam` is read with
 `getAsJsonObject` so it is one object per step, and the standalone `exams` walk
 calls `insertCourseStepsExams("", "", jsonDoc, "")` whose `checkIdsAndInsert`
 skips blank ids, leaving `stepId` null — so nothing Planet sends produces two
-rows sharing a `stepId`. The **port** can: `ExamMapper.fromDoc` writes a
-document's own `stepId` (`_presentOrAbsent`), which is a Phase 110 deviation
-made on purpose. So the `exams.first`-decides quirk is ported for fidelity to
-what the Kotlin *says*, on a state only the port can reach, and the test that
-pins it says so rather than implying a Kotlin scenario. The list shape is still
-right — it is what `getByStepIdAndType` returns and where the `1` comes from.
+rows sharing a `stepId`.
+
+**And the implementation audit went one further: no server can reach it in the
+port either.** I had written that `ExamMapper.fromDoc` writes a document's own
+`stepId`, which is true — but the value my fixture puts there is
+`CourseMapper.stepIdFor`'s `'$courseId:$stepIndex'`, the port's **local
+positional key**, recorded in the migration doc as a deliberate deviation
+precisely because it is never a server value. No CouchDB `exams` document can
+carry it. So the two-exam state is unreachable in both apps, and my fixture is
+a document shaped like nothing Planet sends — the Phase 113/125 fabricated-join
+shape, moved from `parentId` to `exams.stepId`.
+
+The test stays, with its comment corrected to say that: it pins `exams.first`
+against the tempting "any exam counts" reading, which is what a reimplementer
+would choose and what the revert reds. It is not evidence a learner can meet
+the state. The list shape is still right — it is what `getByStepIdAndType`
+returns and where the `1` comes from.
 
 **`hideTestIfNoQuestion` reads no question count.** The name promises the guard
 is about questions; it hides on *list emptiness* and the only question count in
@@ -331,13 +414,61 @@ routing. **Integrator: that list is the place for it, and this file is not the
 lane's to edit.** The text is the "What the ground-truth audit overturned"
 section above.
 
-**6. Stale Kotlin line citations are widespread, and I fixed only my own
+**6. A course-step survey does not return the learner to the step, so half of
+the refresh fix is dead.** `TakeSurveyScreen`'s submit ends with
+`context.go('${Routes.submissions}/<id>')` — `go`, not `pop` — so answering the
+survey unmounts `TakeCourseScreen`, the tile's `await context.push(…)` never
+resolves into a live element, and `refreshAssessment` short-circuits on
+`context.mounted`. The label is correct once the learner navigates back into
+the course (the screen is rebuilt), but Kotlin puts them back on the step:
+`openSurvey` → `BaseExamFragment.continueExam` takes the `isTeam == false`
+branch, shows the thank-you dialog, and its Finish calls
+`FragmentNavigator.popBackStack`. The exam path already matches
+(`take_exam_screen.dart` pops). **The commit message for `140704d` said
+"returning from the exam *or survey* re-reads the assessment"; the survey half
+was false and is now stated honestly at the code.** Fixing it means changing
+`take_survey_screen.dart`'s exit, which four other entry points share — outside
+this lane's file set and a much larger behavioural call than a label. The
+`refreshAssessment` call stays on the survey tile because it is correct for the
+back-out case and a no-op otherwise. No test covers the survey refresh path;
+the one that looks like it does stubs the route with a `Text` widget, so the
+real screen's `context.go` is never exercised.
+
+**7. The two entry points into the same step exam now disagree.**
+`course_detail_screen.dart` renders `l10n.takeExam` — "Take exam", no count, no
+retake — for the same step this tile now renders as `take test [1]` /
+`Retake Test [1]`. That screen's own comment already says it "carries none of
+`CourseStepFragment`'s gating"; this diff *widens* a gap it did not create.
+Closing it means giving that screen the whole assessment read, which is a new
+feature for a screen whose Kotlin counterpart shows a download dialog rather
+than a test button — so it is a phase, not a follow-up line.
+
+**8. Stale Kotlin line citations are widespread, and I fixed only my own
 region.** The ground-truth audit found them in `exam_mapper.dart` (three),
 `survey_mapper.dart` (one), `app_database.dart` (one, an
 `ExamDao.getByStepIdAndType(stepId, "survey")` that is actually the plural) and
 in `examParentId`'s doc (`createExamSubmission` is `:446-453`, not `:449-456`).
 I corrected the citations inside `hasUnfinishedSurveys`' doc, since leaving them
 wrong next to the function I had just ported correctly would be worse; the rest
-belong to other lanes' files or to the write path. Given that misreading a
-correctly-named function is this project's most expensive recurring failure, a
-pass that just fixes citations would be cheap and worth a lane.
+belong to other lanes' files or to the write path. The implementation audit
+added `normalizeSubmissionUserId` (`:727-734`, cited `:741-748`),
+`serializeSubmission` (`:820`, cited `:813-862`) and
+`mandatory_survey_round_trip_test.dart:433`'s `:181-183`, and caught **three
+that this phase itself wrote wrong**: `hideTestIfNoQuestion` is `:241-260`, not
+`:241-261` (`:261` is blank, `:262` starts the next method) — I had made that
+off-by-one twice, once from the brief and once by miscounting an `awk` window —
+the survey block is `:252-259`, and `createBulkSurveySubmissions`' key is
+`:203-208`. All fixed. Given that misreading a correctly-named function is this
+project's most expensive recurring failure, a pass that just fixes citations
+would be cheap and worth a lane.
+
+**9. I pushed `140704d` without running the full suite after the last code
+change, and it was red.** I ran the whole suite, then added the refresh fix,
+then ran only the two files I had touched, then pushed. `route_reachability_test`
+was failing the entire time — the port's own guard, on my own new navigation —
+and CI told me rather than my own gate. The brief says run the full gate before
+every push, and "the two files I touched" is not that: a static-analysis guard
+lives in a file no feature change ever touches. Recorded because the failure
+mode is structural, not a slip: **the tests most likely to catch a new
+navigation, a new ARB key or a new provider are precisely the ones outside the
+diff.**

--- a/flutter/PHASE_128_NOTES.md
+++ b/flutter/PHASE_128_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 128 — the step tile's Redo survey / Retake test labels
+
+Lane A of a three-lane round. Work in progress.
+
+Ported from `CourseStepFragment.hideTestIfNoQuestion` (`:241-262`), whose
+label swap reads `getCourseStepData`'s `hasExam`/`hasSurvey` —
+`submissionsRepository.hasSubmission(stepExams[0].id, step.courseId, userId,
+"exam"/"survey")` (`CoursesRepositoryImpl.kt:529-556`).

--- a/flutter/PHASE_128_NOTES.md
+++ b/flutter/PHASE_128_NOTES.md
@@ -1,8 +1,239 @@
-# Phase 128 — the step tile's Redo survey / Retake test labels
+# Phase 128 — the step tile's *Redo survey* / *Retake test* labels
 
-Lane A of a three-lane round. Work in progress.
+Lane A of a three-lane round. One missing feature, named by Phase 125 as its
+own successor (`PHASE_125_NOTES.md` §"Found, not fixed" item 1) and correctly
+so: this is **the only user-visible Kotlin reader of the composite survey
+`parentId`**, and Phase 125's writer fix is its precondition.
 
-Ported from `CourseStepFragment.hideTestIfNoQuestion` (`:241-262`), whose
-label swap reads `getCourseStepData`'s `hasExam`/`hasSurvey` —
+`CourseStepFragment.hideTestIfNoQuestion` (`:241-262`) picks each assessment
+button's wording off `CourseStepData.hasExam`/`hasSurvey`, which are
 `submissionsRepository.hasSubmission(stepExams[0].id, step.courseId, userId,
-"exam"/"survey")` (`CoursesRepositoryImpl.kt:529-556`).
+"exam"/"survey")` (`CoursesRepositoryImpl.kt:536-546`). The port hardcoded
+`l10n.takeTest` and `l10n.recordSurvey`, so **a learner who had already sat the
+test was invited to take it for the first time, every time** — and the count
+Kotlin puts in that label was absent entirely.
+
+Unlike the mandatory-survey gate Phase 125 fixed, **this reader works in the
+shipping Android app**: `getCourseStepData` reads the *plural*-typed rows
+(`getByStepIdAndType(stepId, "surveys")`, `:534`), which is what a survey
+document actually carries, where `hasUnfinishedSurveys`' Kotlin original reads
+the singular `"survey"` and therefore matches nothing. So this is restored
+parity, not internal consistency.
+
+## What the tile says in each state
+
+| state | label |
+|---|---|
+| exam on the step, no attempt by this user | **take test [N]** |
+| exam on the step, an attempt exists for `stepExams[0]` | **Retake Test [N]** |
+| exam on the step, its questions have not synced yet | **take test [N]** — the `countByExamId == 0` guard |
+| exam present, attempt belongs to another user | **take test [N]** |
+| survey on the step, no answer sheet | **Record survey** |
+| survey on the step, a sheet exists (any status) | **redo survey** |
+| course the learner has not joined, or a guest | neither tile |
+
+`N` is `exams.length`, the whole list, while the boolean reads only
+`exams.first` — Kotlin's quirk (`getString(R.string.take_test, exams.size)`
+against `hasSubmission(stepExams[0].id, …)`), ported rather than corrected and
+pinned by a test.
+
+Two states are worth stating because the `false` branch means something
+different here than it does at `hasUnfinishedSurveys`' call site. There, `false`
+means *finished*; here it means *not yet taken*. So every guard in
+`hasSubmission` inverts into "offer a first attempt": a blank user id, a step
+whose `courseId` never synced, and an exam whose questions have not arrived all
+read as untaken rather than blocking anything. That is why the
+`questionDao.countByExamId(stepExamId) == 0 → false` rule **is** ported here and
+deliberately is **not** ported in `hasUnfinishedSurveys`, where it would invert
+into "a question-less survey blocks the course forever".
+
+The label is also status-blind, as Kotlin's `countByUserParentAndType` is
+(`SubmissionDao.kt:23`): merely *opening* an exam attempt makes the tile read
+"Retake". Faithful.
+
+## The `%d` count keys derived their translations — all three, all five locales
+
+**Yes, and this is worth recording because it is the first time the Phase 121
+placeholder conversion has paid off on a new key.** Three keys were added to
+`app_en.arb`, worded to match the Kotlin English exactly:
+
+| key | English | Kotlin source |
+|---|---|---|
+| `takeTestCount` | `take test [{count}]` | `take_test` = `take test [%d]` |
+| `retakeTestCount` | `Retake Test [{count}]` | `retake_test` = `Retake Test [%d]` |
+| `redoSurvey` | `redo survey` | `redo_survey` = `redo survey` |
+
+Running `dart tool/arb_from_strings_xml.dart` derives a human translation for
+**all three in all five locales** — ar/es/fr/ne/so, 15 values, every one already
+shipping in the Android app. I ran it to check and then reverted the five locale
+files, because they and the tool belong to Lane C. `app_en.arb` is the only l10n
+file this diff touches.
+
+**Integrator: a derivation run is wanted, and it adds 5 keys per locale, not 3.**
+The other two are `playbackSpeed` and `playbackSpeedValue`, template keys that
+arrived with the Phase 126/127 harvest merge (`6b6e9c8`) and have never been
+derived; the run picks them up as well. All five are human translations from the
+XML and therefore unflagged, so
+`test/l10n/placeholder_integrity_test.dart`'s `humanReviewed` map moves by +5 in
+every locale: ar 410→415, es 462→467, fr 409→414, ne 411→416, so 411→416. That
+test file is Lane C's too.
+
+The exact literal English is why it worked, and it is a real trade-off rather
+than a free win: **`Take test [{count}]` would have derived nothing.** The tool
+matches a format string on its literal with the holes removed, exactly and
+case-sensitively (`arb_from_strings_xml.dart` header, "Matching is exact literal
+only"), so one capital letter forfeits five human translations. `take test [3]`
+reads worse in English than `Take test [3]`; five reviewed translations beat one
+capital, and Kotlin's own lowercase is the specification. Same reasoning for
+`redo survey`. If anyone prefers the capital later, the price is named here.
+
+Three consequences I did **not** act on:
+
+* **`takeTest` is now dead** — its only caller was the line this phase replaced.
+  Deleting it from `app_en.arb` would orphan its value *and* its `x-mt`
+  metadata block in ar/es/fr, which `test/l10n/placeholder_integrity_test.dart`
+  ("no x-mt flag outlives the string it marks") checks; both are Lane C's files.
+  Left in place, unused, for whoever does the next l10n pass. It is the only key
+  I know of in that state.
+* **`takeTest` could not simply have grown a `{count}`.** ar/es/fr carry values
+  for it with no placeholder, so declaring one would generate a getter taking an
+  argument those three locales silently drop — the Phase 109 defect class, and
+  `placeholder_integrity_test`'s second test would fail on it.
+* **`recordSurvey` is "Record survey" where Kotlin is "Record Survey"**, which
+  is why it derived by *shared English* rather than by name in the first place.
+  It already has five human translations and I left it alone: replacing one
+  valid translation with another is not a repair.
+
+## The `hasSubmission` port, and where the port cannot copy the Kotlin
+
+`SubmissionsRepository.hasSubmission` (`submissions_repository.dart`, in the
+read-path region beside `hasUnfinishedSurveys`) is a straight port of
+`SubmissionsRepositoryImpl.hasSubmission` (`:176-192`) with one unavoidable
+divergence.
+
+**Kotlin keeps every question, exam and survey alike, in one `exam_questions`
+table keyed by `examId`** (`QuestionDao.kt:13`), because it keeps every exam and
+survey in one `exams` table distinguished by `type`. The port split both pairs
+— `Exams`/`Surveys` and `ExamQuestions`/`SurveyQuestions` — so the count has to
+pick its table from the `type` argument, the same value Kotlin would have read
+off the `exams` row. Copying the Kotlin literally (always `ExamQuestions`) is a
+live defect, not a harmless simplification: it finds nothing for a survey, the
+guard short-circuits, and **every answered survey reads as unanswered**.
+Demonstrated failing.
+
+Phase 52 ported `hasSubmission` once already, as `hasUnfinishedSurveys`, and
+neither is reusable for the other — the brief was right to warn. They differ on
+the question-count guard (above), on the blank-user guard's meaning, and on
+direction: `hasUnfinishedSurveys` loops a course's surveys asking "is any one
+missing", this asks about one named exam. They now sit next to each other with
+each divergence documented at the code.
+
+No DAO change and no schema change. `SubmissionDao.countByUserParentAndType`
+already existed (Phase 125), and the question counts reuse
+`ExamDao.questionsFor` / `SurveyDao.questionsFor`. `schemaVersion` stays **46**
+and no generated output moved, so no `build_runner` run was needed.
+
+## The provider
+
+`courses_providers.dart` gains `stepAssessmentProvider`, a `FutureProvider
+.autoDispose.family` keyed on `({stepId, courseId, userId})` returning
+`({exams, surveys, hasExam, hasSurvey})` — the assessment half of Kotlin's
+`CourseStepData`, computed the way `getCourseStepData` computes it.
+
+`stepExamProvider` (nullable single row) is kept for `course_detail_screen` and
+now derives from a new **`stepExamsProvider`** (the list), because
+`getByStepIdAndType(stepId, "courses")` is a list and its *size* is what the
+label carries. `take_course_screen`'s `_recordProgress` moved to the list too,
+so its `passed` argument is literally Kotlin's `if (stepExams.isEmpty()) true
+else null`.
+
+`_StepContent` now takes `userId`. It watches one provider where it used to
+watch two, and the two tiles read their visibility, count and wording off it.
+
+## Each defect, with failing-first evidence
+
+Each row names the exact revert it was replayed against, because two of the four
+are decisions rather than omissions and a test that only asserts "the label is
+right" cannot tell them apart.
+
+| # | defect | revert replayed | pre-fix failure |
+|---|---|---|---|
+| 1 | **a learner who has taken the test is still told to take it** | both tiles' labels back to `l10n.takeTest` / `l10n.recordSurvey` | `Expected: exactly one matching candidate / Actual: Found 0 widgets with text "Retake Test [1]"` — 5 tests red |
+| 1b | the same for the survey half | as above | `Found 0 widgets with text "redo survey"` |
+| 1c | the label carried no count | as above | `Found 0 widgets with text "take test [1]"` |
+| 2 | **a survey's question count read `ExamQuestions`** (Kotlin's single table, copied literally) | the `type == 'survey'` table choice | `Expected: true / Actual: <false>` in the repository, and `Found 0 widgets with text "redo survey"` at the screen — 4 tests red |
+| 3 | an exam whose questions have not synced claims an attempt | the `questions == 0` guard | `Expected: false / Actual: <true>` |
+| 4 | a second exam's submission swapped the label | `exams.first` widened to "any exam" | `Expected: false / Actual: <true>` |
+
+Two tests are **guards, not failing-first evidence**, and are labelled so rather
+than counted above: "does not confuse the two types" and "is false for another
+user" pin `countByUserParentAndType`'s existing `type`/`userId` clauses, which
+predate this diff — reverting them means deleting an argument pass-through,
+which proves nothing about a decision anyone might make.
+
+`test/repository/step_tile_label_test.dart` is new (13 tests) and named for the
+shape rather than the file, like `mandatory_survey_round_trip_test.dart`. Its
+first test asserts the mappers really set `courseId` on the exam and the survey,
+because the rest of the file proves nothing if they did not — Phase 113's exact
+failure. **No fixture hand-writes a `parentId`**: every submission is authored
+by `startExamSession` or `createSurveyDraft` against rows
+`ExamMapper.fromCourseDoc` / `SurveyMapper.fromCourseDoc` produced from a
+document shaped like the server's. `take_course_screen_test.dart` gains 5.
+
+## `submissions_repository.dart` — which regions this lane touched
+
+**Read path only, one addition, no edits to anything that existed.**
+
+| region | change |
+|---|---|
+| between `_repairSurveyParentId` and `hasUnfinishedSurveys` | **added** `hasSubmission` (+ its doc comment). Nothing else in the file is modified — no line of `createExamSubmission`, `serializeSubmission`, the team-object block, or any other write-path method is touched. |
+
+Lane B owns the write path in the same file. `git diff` on it shows exactly one
+insertion hunk.
+
+## Files touched outside the read path
+
+| file | why |
+|---|---|
+| `lib/l10n/app_en.arb` | the three keys above; additions only |
+| `lib/providers/courses_providers.dart` | `stepExamsProvider`, `stepAssessmentProvider`, and `stepExamProvider` re-expressed as the list's head |
+| `lib/ui/courses/take_course_screen.dart` | the two tiles, `_StepContent.userId`, `_recordProgress` on the list |
+| `test/ui/courses/take_course_screen_test.dart`, `test/repository/step_tile_label_test.dart` | the tests |
+
+No overlap with Lane C (`lib/ui/notifications/`, the five locale files,
+`tool/arb_from_strings_xml.dart`, `test/l10n/`) except the two hand-offs named
+under the derivation section, which are reports rather than edits.
+
+## Found, not fixed
+
+**1. `resourcesInStep` counts a different thing from Kotlin's `btnResources`,
+and reads differently too.** Kotlin sets
+`getString(R.string.resources_size, data.resources.size)` — "Resources [%d]" on
+`myLibraryDao.getByStepId(stepId)`, the rows actually on the device. The port
+renders `l10n.resourcesInStep(step.noOfResources)`, an ICU plural ("No
+resources" / "1 resource" / "{count} resources") on the **step document's own
+declared count**. Those disagree whenever a step's resources have not all
+synced, which is the normal case on a fresh install, and the plural means the
+key can never derive a translation from the Kotlin XML (the tool skips plurals
+for good reason). Same tile, one line above the two this phase fixed;
+deliberately out of scope because it is a second feature, not this label swap.
+
+**2. `takeTest` is a dead ARB key.** See the l10n section — removing it needs
+Lane C's files.
+
+**3. Phase 125's items 2–6 are all still open**, and item 2 (a locally-authored
+submission duplicating when pulled back, because `upsertDocuments` keys on the
+document `_id` while the local row's key is a sha1) now bears on this phase too:
+a duplicated submission row would not change the label — `countByUserParentAndType`
+is a `> 0` count — but it would double it in the list and the exporter, and the
+machinery to prevent it (`SubmissionDao.getByIdOrRemoteId`) is still sitting
+unused by the walk.
+
+**4. Nothing invalidates `stepAssessmentProvider` when an attempt is made.**
+`autoDispose` is what makes the label refresh: the learner leaves the step to
+sit the exam, the provider's last listener goes, and re-entering re-reads. That
+is the same argument `stepExamProvider`'s own doc makes and it is load-bearing
+here for a new reason — a `PageView` keeps its neighbours alive, so a learner
+who returns to the *same* step without the page being disposed could see a stale
+label. I did not reproduce it and it needs a widget test that drives the real
+exam screen, which no test in the port does yet.

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -905,7 +905,16 @@
   "no": "No",
   "submit": "Submit",
   "takeTest": "Take test",
+  "takeTestCount": "take test [{count}]",
+  "@takeTestCount": {
+    "placeholders": { "count": {"type": "int"} }
+  },
+  "retakeTestCount": "Retake Test [{count}]",
+  "@retakeTestCount": {
+    "placeholders": { "count": {"type": "int"} }
+  },
   "recordSurvey": "Record survey",
+  "redoSurvey": "redo survey",
   "react": "React",
   "pickReaction": "Pick a reaction",
   "comments": "Comments",

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -304,16 +304,108 @@ final stepExamProvider = FutureProvider.autoDispose.family<ExamRow?, String>((
   ref,
   stepId,
 ) async {
-  final db = ref.watch(appDatabaseProvider);
-  final rows = await db.examDao.getByStepIds([stepId]);
+  final rows = await ref.watch(stepExamsProvider(stepId).future);
   return rows.isEmpty ? null : rows.first;
 });
+
+/// Every exam attached to a course step — the port of `getCourseStepData`'s
+/// `stepExams`, which is `examDao.getByStepIdAndType(stepId, "courses")`
+/// (`CoursesRepositoryImpl.kt:533`).
+///
+/// [stepExamProvider] is this list's head, and it is what most callers want;
+/// the *list* exists because the step tile's label carries `exams.size`
+/// (`CourseStepFragment.kt:244-250`, `getString(R.string.take_test,
+/// exams.size)`). Kotlin's `type = "courses"` filter is the port's choice of
+/// table: `ExamMapper.fromDoc` reads a document's `type` to decide whether the
+/// row lands in [Exams] or [Surveys] and then discards it, so `examDao` is
+/// already the `"courses"`-typed half.
+final stepExamsProvider = FutureProvider.autoDispose
+    .family<List<ExamRow>, String>((ref, stepId) async {
+      final db = ref.watch(appDatabaseProvider);
+      return db.examDao.getByStepIds([stepId]);
+    });
 
 /// The surveys attached to a course step. Drives the "Take survey" button.
 final stepSurveysProvider = FutureProvider.autoDispose
     .family<List<SurveyRow>, String>((ref, stepId) async {
       final db = ref.watch(appDatabaseProvider);
       return db.surveyDao.getByStepId(stepId);
+    });
+
+/// What [stepAssessmentProvider] is keyed on — `getCourseStepData`'s two
+/// arguments plus the step's own course, which Kotlin reads off the step row it
+/// has already loaded (`CoursesRepositoryImpl.kt:530`, `:538`).
+typedef StepAssessmentKey = ({String stepId, String? courseId, String? userId});
+
+/// The assessment half of Kotlin's `CourseStepData`: both lists, plus the two
+/// booleans that decide whether the step tile says *take* or *retake*.
+typedef StepAssessment = ({
+  List<ExamRow> exams,
+  List<SurveyRow> surveys,
+  bool hasExam,
+  bool hasSurvey,
+});
+
+/// Port of the assessment fields `CoursesRepositoryImpl.getCourseStepData`
+/// computes (`:529-556`), feeding `CourseStepFragment.hideTestIfNoQuestion`
+/// (`:241-261`).
+///
+/// The lists drive **visibility** and the count in the label; the booleans
+/// drive the label's *wording*. Nothing here reads a question count, despite
+/// `hideTestIfNoQuestion`'s name: that count lives inside
+/// [SubmissionsRepository.hasSubmission] and decides the *wording*, never
+/// whether a button appears. The name is a fossil.
+///
+/// Kotlin's two booleans are
+/// `hasSubmission(stepExams[0].id, step.courseId, userId, "exam")` and the same
+/// for `stepSurvey[0].id` with `"survey"` — so with two exams on one step the
+/// label counts both and only the **first** one's submission decides whether it
+/// reads "Retake". That is Kotlin's quirk, ported rather than corrected, and
+/// the state it applies to is **port-only**: Kotlin cannot produce a step with
+/// two exams (one `steps[i].exam` object per step, read with `getAsJsonObject`,
+/// and the standalone `exams` walk passes `("", "", doc, "")` so it never sets
+/// `stepId`), while `ExamMapper.fromDoc` does write a document's own `stepId`.
+/// So this is fidelity to what the Kotlin *says*, not to a state it reaches.
+///
+/// One deliberate improvement on the Kotlin, preserved here rather than
+/// introduced: the exam tile opens `exams.first.id`, the same row `hasExam`
+/// interrogated. Kotlin's `btnTakeTest` routes through
+/// `BaseExamFragment.initExam` → `ExamDao.getFirstByStepId`, which is
+/// `WHERE stepId = ? LIMIT 1` with **no type filter**, so on a step carrying
+/// both an exam and a survey it can open the survey row the label never asked
+/// about. Label and destination cannot disagree in the port.
+///
+/// A step with no exams (or no surveys) short-circuits to `false` without a
+/// query, as `getCourseStepData` does (`:537`, `:542`) — which matters because
+/// `hasSubmission`'s guards would answer `false` anyway and this keeps the
+/// reason legible.
+final stepAssessmentProvider = FutureProvider.autoDispose
+    .family<StepAssessment, StepAssessmentKey>((ref, key) async {
+      final exams = await ref.watch(stepExamsProvider(key.stepId).future);
+      final surveys = await ref.watch(stepSurveysProvider(key.stepId).future);
+      final submissions = ref.watch(submissionsRepositoryProvider);
+      final hasExam =
+          exams.isNotEmpty &&
+          await submissions.hasSubmission(
+            stepExamId: exams.first.id,
+            courseId: key.courseId,
+            userId: key.userId,
+            type: 'exam',
+          );
+      final hasSurvey =
+          surveys.isNotEmpty &&
+          await submissions.hasSubmission(
+            stepExamId: surveys.first.id,
+            courseId: key.courseId,
+            userId: key.userId,
+            type: 'survey',
+          );
+      return (
+        exams: exams,
+        surveys: surveys,
+        hasExam: hasExam,
+        hasSurvey: hasSurvey,
+      );
     });
 
 /// Distinct grade levels present locally, for the filter spinner.

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -315,10 +315,18 @@ final stepExamProvider = FutureProvider.autoDispose.family<ExamRow?, String>((
 /// [stepExamProvider] is this list's head, and it is what most callers want;
 /// the *list* exists because the step tile's label carries `exams.size`
 /// (`CourseStepFragment.kt:244-250`, `getString(R.string.take_test,
-/// exams.size)`). Kotlin's `type = "courses"` filter is the port's choice of
-/// table: `ExamMapper.fromDoc` reads a document's `type` to decide whether the
-/// row lands in [Exams] or [Surveys] and then discards it, so `examDao` is
-/// already the `"courses"`-typed half.
+/// exams.size)`).
+///
+/// **[Exams] is not the `type = "courses"` half — it is the
+/// not-`"surveys"` half**, and the difference is a real one this doc used to
+/// get wrong. `ExamMapper.fromDoc` routes on `type == 'surveys'` and files
+/// *everything else* as an exam (`exam_mapper.dart`, "everything else is an
+/// exam"), so `examDao` is a **superset** of Kotlin's `"courses"`: a
+/// `steps[i].exam` carrying no `type` at all lands here and gets a button,
+/// where Kotlin files it as `"exam"` — a value no Kotlin query selects — and
+/// shows nothing. That is Phase 113's deliberate deviation, and since this
+/// list's `length` is now rendered to the learner and its `first` decides the
+/// wording, it is the assumption both rest on.
 final stepExamsProvider = FutureProvider.autoDispose
     .family<List<ExamRow>, String>((ref, stepId) async {
       final db = ref.watch(appDatabaseProvider);
@@ -348,7 +356,7 @@ typedef StepAssessment = ({
 
 /// Port of the assessment fields `CoursesRepositoryImpl.getCourseStepData`
 /// computes (`:529-556`), feeding `CourseStepFragment.hideTestIfNoQuestion`
-/// (`:241-261`).
+/// (`:241-260`).
 ///
 /// The lists drive **visibility** and the count in the label; the booleans
 /// drive the label's *wording*. Nothing here reads a question count, despite

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -757,7 +757,7 @@ class SubmissionsRepository {
   /// (`:537-546`), which calls it twice — once with `"exam"` and once with
   /// `"survey"` — to produce `CourseStepData.hasExam`/`hasSurvey`. Those two
   /// booleans have exactly one use: `CourseStepFragment.hideTestIfNoQuestion`
-  /// (`:241-261`) swaps the step tile's button labels off them, `take_test` →
+  /// (`:241-260`) swaps the step tile's button labels off them, `take_test` →
   /// `retake_test` and `record_survey` → `redo_survey`. So this is the only
   /// **user-visible** reader in either tree whose predicate is the whole
   /// composite `parentId` — and unlike [hasUnfinishedSurveys], whose Kotlin
@@ -789,10 +789,15 @@ class SubmissionsRepository {
   /// keeps every exam and survey in one `exams` table distinguished by `type`.
   /// The port split both pairs — [Exams]/[Surveys] and
   /// [ExamQuestions]/[SurveyQuestions] — so the count has to pick its table
-  /// from [type], the same value Kotlin would have found in the `exams` row's
-  /// `type` column. `"survey"` reads [SurveyQuestions]; anything else reads
-  /// [ExamQuestions], since `"exam"` is the only other type this method is
-  /// ever called with.
+  /// from [type]. **No Kotlin line authorises that branch**: it is a forced
+  /// deviation, and copying the Kotlin literally (always [ExamQuestions])
+  /// reads as *not taken* on every survey ever answered.
+  ///
+  /// The discriminator is the **submission**'s type, `'survey'` singular —
+  /// what both callers pass and what the `submissions.type` column holds. It
+  /// is deliberately not the *exam row's* type, which for a survey document is
+  /// `'surveys'` plural; a future caller forwarding a document's own type
+  /// would fall through to [ExamQuestions] silently.
   ///
   /// The `parentId` is [examParentId]'s, i.e. Kotlin's
   /// `"$stepExamId@$courseId"` (`:190`) — the composite key Phase 125 made
@@ -804,20 +809,57 @@ class SubmissionsRepository {
     required String? userId,
     required String type,
   }) async {
-    final examId = stepExamId ?? '';
-    if (examId.isEmpty || (courseId ?? '').isEmpty || (userId ?? '').isEmpty) {
-      return false;
-    }
-    final questions = type == 'survey'
-        ? (await _surveyDao.questionsFor(examId)).length
-        : (await _examDao.questionsFor(examId)).length;
-    if (questions == 0) return false;
+    // `isNullOrBlank`, not `isEmpty`: Kotlin's guard rejects a whitespace-only
+    // argument too (`:182-184`), and the first cut of this diverged from its
+    // own doc comment on exactly that. Binding all three to locals also keeps
+    // the `!` out of the count call, so deleting the guard changes the
+    // *answer* rather than throwing a null-check error — which is what makes
+    // the guard testable.
+    final examId = (stepExamId ?? '').trim();
+    final course = (courseId ?? '').trim();
+    final user = (userId ?? '').trim();
+    if (examId.isEmpty || course.isEmpty || user.isEmpty) return false;
+    if (await _questionCount(examId, type) == 0) return false;
     final count = await _dao.countByUserParentAndType(
-      userId!,
-      examParentId(examId: examId, courseId: courseId),
+      user,
+      examParentId(examId: examId, courseId: course),
       type,
     );
     return count > 0;
+  }
+
+  /// `SELECT COUNT(*)`, the shape of Kotlin's `QuestionDao.countByExamId`
+  /// (`QuestionDao.kt:13`) — deliberately not `questionsFor(id).length`.
+  ///
+  /// Fetching the rows in order to count them decodes every question's
+  /// `choices` blob through `ExamChoiceListConverter`, whose `jsonDecode` is
+  /// unguarded, so one malformed blob would throw out of a **label** read.
+  /// [hasSubmission] feeds a single `AsyncValue` covering both step tiles, so
+  /// that throw would take the survey tile down with the exam one — a bad row
+  /// on one question hiding the buttons. A `COUNT(*)` decodes nothing.
+  ///
+  /// Built here rather than on the DAOs for the same reason
+  /// [_repairSurveyParentId]'s `UPDATE` is: `app_database.dart` belongs to
+  /// another lane this round. Both should move there.
+  Future<int> _questionCount(String examId, String type) async {
+    if (type == 'survey') {
+      final table = _surveyDao.surveyQuestions;
+      final total = table.id.count();
+      final row =
+          await (_surveyDao.selectOnly(table)
+                ..addColumns([total])
+                ..where(table.surveyId.equals(examId)))
+              .getSingle();
+      return row.read(total) ?? 0;
+    }
+    final table = _examDao.examQuestions;
+    final total = table.id.count();
+    final row =
+        await (_examDao.selectOnly(table)
+              ..addColumns([total])
+              ..where(table.examId.equals(examId)))
+            .getSingle();
+    return row.read(total) ?? 0;
   }
 
   /// Port of `SubmissionsRepositoryImpl.hasUnfinishedSurveys`. Returns true

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -354,7 +354,7 @@ class SubmissionsRepository {
   /// `ExamTakingFragment` reaches for whether the step carries an exam or a
   /// survey (`type` is the only difference), and `createBulkSurveySubmissions`
   /// (`:201-206`) resolves `examDao.getById(examId)?.courseId` to build the
-  /// same string. `hasSubmission` (`:174-190`) then queries exactly it. The
+  /// same string. `hasSubmission` (`:176-192`) then queries exactly it. The
   /// port had split the two apart: every survey writer stored the bare id
   /// while [hasUnfinishedSurveys] looked for the composite, so a learner who
   /// *had* answered a course-attached survey was still told they had not — and
@@ -748,6 +748,78 @@ class SubmissionsRepository {
         .write(SubmissionsCompanion(parentId: Value(target)));
   }
 
+  /// Port of `SubmissionsRepositoryImpl.hasSubmission`
+  /// (`SubmissionsRepositoryImpl.kt:176-192`) — whether [userId] has any
+  /// submission of [type] for the exam or survey [stepExamId] within
+  /// [courseId].
+  ///
+  /// Its one Kotlin caller is `CoursesRepositoryImpl.getCourseStepData`
+  /// (`:537-546`), which calls it twice — once with `"exam"` and once with
+  /// `"survey"` — to produce `CourseStepData.hasExam`/`hasSurvey`. Those two
+  /// booleans have exactly one use: `CourseStepFragment.hideTestIfNoQuestion`
+  /// (`:241-261`) swaps the step tile's button labels off them, `take_test` →
+  /// `retake_test` and `record_survey` → `redo_survey`. So this is the only
+  /// **user-visible** reader in either tree whose predicate is the whole
+  /// composite `parentId` — and unlike [hasUnfinishedSurveys], whose Kotlin
+  /// original is almost certainly dead (see its doc), this one works in the
+  /// shipping Android app: `getCourseStepData` reads the *plural*-typed rows
+  /// (`getByStepIdAndType(stepId, "surveys")`, `:534`), which is what a survey
+  /// document actually carries.
+  ///
+  /// **Every guard inverts into a label here**, which is the opposite of how
+  /// the same guards read at [hasUnfinishedSurveys]' call site, so they are
+  /// worth stating one at a time:
+  ///
+  /// * a blank exam id, course id or user id returns false → the tile says
+  ///   *take* / *record*. A guest browsing a joined course therefore never
+  ///   sees "Retake", and a step whose `courseId` never synced never does
+  ///   either. Kotlin's guard is `isNullOrBlank` on all three (`:182-184`).
+  /// * **`questionDao.countByExamId(stepExamId) == 0` returns false**
+  ///   (`:186-188`) — an exam whose questions have not synced yet reads as
+  ///   *not taken* however many submissions the learner has. Kotlin's comment
+  ///   for this is `getCourseStepData`'s own sibling rule (`:97`: a step with
+  ///   no exam is passed by reaching it), and here it reads sanely: do not
+  ///   claim an attempt for an exam we cannot show. This is the one guard
+  ///   [hasUnfinishedSurveys] deliberately does **not** port, because there it
+  ///   inverts into "a question-less survey blocks the course forever".
+  ///
+  /// **The question count is the one place the port cannot copy the Kotlin
+  /// literally.** Kotlin keeps every question, exam and survey alike, in one
+  /// `exam_questions` table keyed by `examId` (`QuestionDao.kt:13`), because it
+  /// keeps every exam and survey in one `exams` table distinguished by `type`.
+  /// The port split both pairs — [Exams]/[Surveys] and
+  /// [ExamQuestions]/[SurveyQuestions] — so the count has to pick its table
+  /// from [type], the same value Kotlin would have found in the `exams` row's
+  /// `type` column. `"survey"` reads [SurveyQuestions]; anything else reads
+  /// [ExamQuestions], since `"exam"` is the only other type this method is
+  /// ever called with.
+  ///
+  /// The `parentId` is [examParentId]'s, i.e. Kotlin's
+  /// `"$stepExamId@$courseId"` (`:190`) — the composite key Phase 125 made
+  /// every port writer agree on, and the reason this label swap could not have
+  /// been ported before it.
+  Future<bool> hasSubmission({
+    required String? stepExamId,
+    required String? courseId,
+    required String? userId,
+    required String type,
+  }) async {
+    final examId = stepExamId ?? '';
+    if (examId.isEmpty || (courseId ?? '').isEmpty || (userId ?? '').isEmpty) {
+      return false;
+    }
+    final questions = type == 'survey'
+        ? (await _surveyDao.questionsFor(examId)).length
+        : (await _examDao.questionsFor(examId)).length;
+    if (questions == 0) return false;
+    final count = await _dao.countByUserParentAndType(
+      userId!,
+      examParentId(examId: examId, courseId: courseId),
+      type,
+    );
+    return count > 0;
+  }
+
   /// Port of `SubmissionsRepositoryImpl.hasUnfinishedSurveys`. Returns true
   /// if the course has any attached survey the user has not yet submitted.
   ///
@@ -768,7 +840,7 @@ class SubmissionsRepository {
   /// document's own `type` (`CoursesRepositoryImpl.kt:744`:
   /// `if (examJson.has("type")) … else examKey`), which for a survey is
   /// `"surveys"`. Every other Kotlin reader uses the plural: the Take Survey
-  /// button itself is `getByStepIdAndType(stepId, "surveys")` (`:531`), the
+  /// button itself is `getByStepIdAndType(stepId, "surveys")` (`:534`), the
   /// surveys list is `getByType("surveys")`, and `ExamDao`'s defaults are
   /// `"surveys"`. So the two queries are mutually exclusive and at most one of
   /// the button and this block can ever see a given survey: a document carrying
@@ -812,7 +884,7 @@ class SubmissionsRepository {
   /// **Two further deviations from `hasSubmission`, both deliberate.**
   ///
   /// 1. The blank-user guard below returns `false`. Kotlin has no guard in
-  ///    `hasUnfinishedSurveys`; it lives in `hasSubmission` (`:181-183`), which
+  ///    `hasUnfinishedSurveys`; it lives in `hasSubmission` (`:182-184`), which
   ///    returns `false` for a blank `userId` and so inverts to *unfinished* —
   ///    Kotlin **blocks** a null user on a course that has surveys. Reachable
   ///    here through `challenge_provider`, which passes a nullable id. Blocking
@@ -820,7 +892,7 @@ class SubmissionsRepository {
   ///    the Kotlin behaviour is unobservable anyway (its survey list is always
   ///    empty, above). The blank-*course* half is not a divergence at all:
   ///    `getByCourseIdAndType("", …)` matches nothing either.
-  /// 2. `questionDao.countByExamId(stepExamId) == 0 → false` (`:185-187`) is
+  /// 2. `questionDao.countByExamId(stepExamId) == 0 → false` (`:186-188`) is
   ///    **not** ported. In `getCourseStepData` that rule reads sanely — do not
   ///    claim a submission exists for an exam whose questions have not synced.
   ///    Here it inverts into "a question-less survey blocks the course

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -466,7 +466,7 @@ class _StepContent extends ConsumerWidget {
               child: ListTile(
                 leading: const Icon(Icons.assignment_outlined),
                 // `redo_survey` once answered, `record_survey` otherwise
-                // (`CourseStepFragment.kt:252-260`). Unlike the test label
+                // (`CourseStepFragment.kt:252-259`). Unlike the test label
                 // this one carries no count, though Kotlin shows the button
                 // off the same non-empty list.
                 title: Text(
@@ -481,6 +481,20 @@ class _StepContent extends ConsumerWidget {
                 // being a pattern rather than a base, an unmatchable route: a
                 // course-step survey has no `teamId`, so the interpolation
                 // left an empty segment too.
+                // **The refresh here only fires on a back-out, and that is a
+                // gap rather than a design.** `TakeSurveyScreen`'s submit ends
+                // with `context.go('${Routes.submissions}/<id>')`, not a pop,
+                // so answering the survey unmounts this screen and the `await`
+                // never resolves into a live element — `refreshAssessment`
+                // short-circuits on `context.mounted`. Kotlin *does* return:
+                // `openSurvey` → `BaseExamFragment.continueExam` shows the
+                // thank-you dialog and its Finish calls
+                // `FragmentNavigator.popBackStack`, landing back on the step
+                // with the label now reading *redo survey*. Making the port
+                // match means changing that screen's exit, which four other
+                // entry points share — outside this phase's diff, recorded in
+                // PHASE_128_NOTES.md. The call stays because it is correct for
+                // the back-out case and a no-op otherwise.
                 onTap: () async {
                   await context.push('${Routes.surveys}/${surveys.first.id}');
                   refreshAssessment();

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -148,6 +148,7 @@ class _CourseContent extends ConsumerWidget {
               stepNumber: index + 1,
               totalSteps: steps.length,
               isMyCourse: isMyCourse,
+              userId: userId,
             ),
           ),
         ),
@@ -173,7 +174,7 @@ class _CourseContent extends ConsumerWidget {
   /// than creating duplicates.
   ///
   /// `passed` is `if (stepExams.isEmpty()) true else null`
-  /// (`CourseStepFragment.kt:97`): a step with no test is passed by reaching
+  /// (`CourseStepFragment.kt:96`): a step with no test is passed by reaching
   /// it, and a step with one waits for the exam to grade it. The port passed
   /// `null` unconditionally, because until Phase 113 nothing could tell the two
   /// apart — `stepExams` is `getByStepIdAndType(stepId, "courses")`, the join
@@ -184,7 +185,7 @@ class _CourseContent extends ConsumerWidget {
     final userId = this.userId;
     if (userId == null) return;
 
-    final exam = await ref.read(stepExamProvider(steps[index].id).future);
+    final exams = await ref.read(stepExamsProvider(steps[index].id).future);
 
     await ref
         .read(progressRepositoryProvider)
@@ -193,7 +194,7 @@ class _CourseContent extends ConsumerWidget {
           courseId: course.id,
           userId: userId,
           stepNum: index + 1,
-          passed: exam == null ? true : null,
+          passed: exams.isEmpty ? true : null,
         );
     final config = ref.read(serverConfigProvider);
     if (config != null) {
@@ -327,6 +328,7 @@ class _StepContent extends ConsumerWidget {
     required this.stepNumber,
     required this.totalSteps,
     required this.isMyCourse,
+    required this.userId,
   });
 
   final CourseStepRow step;
@@ -339,16 +341,48 @@ class _StepContent extends ConsumerWidget {
   /// browsing.
   final bool isMyCourse;
 
+  /// The signed-in user, or null for a guest. `getCourseStepData` takes
+  /// `user?.id` and hands it to `hasSubmission`, which answers `false` — i.e.
+  /// *not yet taken* — for a blank one.
+  final String? userId;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final exam = isMyCourse
-        ? ref.watch(stepExamProvider(step.id)).valueOrNull
+    // One read for both buttons' visibility, counts and labels — the port of
+    // `getCourseStepData` feeding `hideTestIfNoQuestion`.
+    final assessmentKey = (
+      stepId: step.id,
+      courseId: step.courseId,
+      userId: userId,
+    );
+    final assessment = isMyCourse
+        ? ref.watch(stepAssessmentProvider(assessmentKey)).valueOrNull
         : null;
-    final surveys = isMyCourse
-        ? ref.watch(stepSurveysProvider(step.id)).valueOrNull
-        : null;
+
+    /// Re-reads the step's assessment state after the learner comes back from
+    /// an exam or a survey, which is the only thing that can change either
+    /// label.
+    ///
+    /// **Kotlin gets this for free and the port does not.** `btnTakeTest`
+    /// calls `openCallFragment` (`CourseStepFragment.kt:282`), which is
+    /// `FragmentNavigator.replaceFragment(…, addToBackStack = true)` — a
+    /// `replace()`, so popping back **recreates** `CourseStepFragment`,
+    /// `onViewCreated` runs again and `getCourseStepData` re-queries. A
+    /// `context.push` leaves this screen mounted: the widget keeps its
+    /// listener, so the `autoDispose` family member is never disposed and its
+    /// future never re-runs. Without this the label could not change until the
+    /// learner left the course entirely and came back — a swap whose only
+    /// trigger is a submission made on the screen it pushes.
+    Future<void> pushAndRefresh(String location) async {
+      await context.push(location);
+      if (!context.mounted) return;
+      ref.invalidate(stepAssessmentProvider(assessmentKey));
+    }
+
+    final exams = assessment?.exams ?? const <ExamRow>[];
+    final surveys = assessment?.surveys ?? const <SurveyRow>[];
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -388,11 +422,21 @@ class _StepContent extends ConsumerWidget {
             const SizedBox(height: 8),
           ],
           // Take Test button — port of CourseStepFragment's btnTakeTest
-          if (exam != null) ...[
+          if (assessment != null && exams.isNotEmpty) ...[
             Card(
               child: ListTile(
                 leading: const Icon(Icons.quiz_outlined),
-                title: Text(l10n.takeTest),
+                // `hideTestIfNoQuestion` (`CourseStepFragment.kt:244-250`):
+                // `retake_test` once the learner has a submission for
+                // `stepExams[0]`, `take_test` otherwise — and both carry
+                // `exams.size`, the whole list, not the one exam the button
+                // opens. The port had hardcoded the count-less `take test`,
+                // so a step already passed still invited a first attempt.
+                title: Text(
+                  assessment.hasExam
+                      ? l10n.retakeTestCount(exams.length)
+                      : l10n.takeTestCount(exams.length),
+                ),
                 trailing: const Icon(Icons.chevron_right),
                 // `Routes.exam` is the *pattern* `/courses/exam/:examId`;
                 // appending the id to it produced
@@ -400,8 +444,8 @@ class _StepContent extends ConsumerWidget {
                 // dropped the learner on go_router's error page. The exam
                 // screen wants the step and course as query parameters, as
                 // `CourseStepFragment` passes `stepId`/`stepNum`.
-                onTap: () => context.push(
-                  '/courses/exam/${exam.id}'
+                onTap: () => pushAndRefresh(
+                  '/courses/exam/${exams.first.id}'
                   '?stepId=${step.id}&courseId=${step.courseId ?? ''}',
                 ),
               ),
@@ -409,11 +453,17 @@ class _StepContent extends ConsumerWidget {
             const SizedBox(height: 8),
           ],
           // Take Survey button — port of CourseStepFragment's btnTakeSurvey
-          if (surveys != null && surveys.isNotEmpty) ...[
+          if (assessment != null && surveys.isNotEmpty) ...[
             Card(
               child: ListTile(
                 leading: const Icon(Icons.assignment_outlined),
-                title: Text(l10n.recordSurvey),
+                // `redo_survey` once answered, `record_survey` otherwise
+                // (`CourseStepFragment.kt:252-260`). Unlike the test label
+                // this one carries no count, though Kotlin shows the button
+                // off the same non-empty list.
+                title: Text(
+                  assessment.hasSurvey ? l10n.redoSurvey : l10n.recordSurvey,
+                ),
                 trailing: const Icon(Icons.chevron_right),
                 // Kotlin's `btnTakeSurvey` calls
                 // `SubmissionsAdapter.openSurvey(…, stepSurvey[0].id, …)`,
@@ -424,7 +474,7 @@ class _StepContent extends ConsumerWidget {
                 // course-step survey has no `teamId`, so the interpolation
                 // left an empty segment too.
                 onTap: () =>
-                    context.push('${Routes.surveys}/${surveys.first.id}'),
+                    pushAndRefresh('${Routes.surveys}/${surveys.first.id}'),
               ),
             ),
           ],

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -361,9 +361,9 @@ class _StepContent extends ConsumerWidget {
         ? ref.watch(stepAssessmentProvider(assessmentKey)).valueOrNull
         : null;
 
-    /// Re-reads the step's assessment state after the learner comes back from
-    /// an exam or a survey, which is the only thing that can change either
-    /// label.
+    /// Re-reads the step's assessment state, which each tile calls after the
+    /// screen it pushed has popped — the only thing that can change either
+    /// label is a submission made over there.
     ///
     /// **Kotlin gets this for free and the port does not.** `btnTakeTest`
     /// calls `openCallFragment` (`CourseStepFragment.kt:282`), which is
@@ -375,8 +375,13 @@ class _StepContent extends ConsumerWidget {
     /// future never re-runs. Without this the label could not change until the
     /// learner left the course entirely and came back — a swap whose only
     /// trigger is a submission made on the screen it pushes.
-    Future<void> pushAndRefresh(String location) async {
-      await context.push(location);
+    ///
+    /// The `await context.push(…)` deliberately stays at each `onTap` with its
+    /// route written out, rather than being folded in here behind a `location`
+    /// parameter: `test/ui/route_reachability_test.dart` scans these call sites
+    /// statically and a variable target is a navigation it cannot read. It
+    /// caught exactly that when this was written the other way round.
+    void refreshAssessment() {
       if (!context.mounted) return;
       ref.invalidate(stepAssessmentProvider(assessmentKey));
     }
@@ -444,10 +449,13 @@ class _StepContent extends ConsumerWidget {
                 // dropped the learner on go_router's error page. The exam
                 // screen wants the step and course as query parameters, as
                 // `CourseStepFragment` passes `stepId`/`stepNum`.
-                onTap: () => pushAndRefresh(
-                  '/courses/exam/${exams.first.id}'
-                  '?stepId=${step.id}&courseId=${step.courseId ?? ''}',
-                ),
+                onTap: () async {
+                  await context.push(
+                    '/courses/exam/${exams.first.id}'
+                    '?stepId=${step.id}&courseId=${step.courseId ?? ''}',
+                  );
+                  refreshAssessment();
+                },
               ),
             ),
             const SizedBox(height: 8),
@@ -473,8 +481,10 @@ class _StepContent extends ConsumerWidget {
                 // being a pattern rather than a base, an unmatchable route: a
                 // course-step survey has no `teamId`, so the interpolation
                 // left an empty segment too.
-                onTap: () =>
-                    pushAndRefresh('${Routes.surveys}/${surveys.first.id}'),
+                onTap: () async {
+                  await context.push('${Routes.surveys}/${surveys.first.id}');
+                  refreshAssessment();
+                },
               ),
             ),
           ],

--- a/flutter/test/repository/step_tile_label_test.dart
+++ b/flutter/test/repository/step_tile_label_test.dart
@@ -12,7 +12,7 @@ import 'package:myplanet/repository/submissions_repository.dart';
 
 class MockPlanetApi extends Mock implements PlanetApi {}
 
-/// Phase 128 — `CourseStepFragment.hideTestIfNoQuestion` (`:241-262`) and the
+/// Phase 128 — `CourseStepFragment.hideTestIfNoQuestion` (`:241-260`) and the
 /// read it hangs off, `SubmissionsRepositoryImpl.hasSubmission` (`:176-192`).
 ///
 /// This is the only **user-visible** reader in either tree whose predicate is
@@ -182,21 +182,76 @@ void main() {
       );
     });
 
-    test('does not confuse the two types', () async {
+    test('does not confuse the two types when they share an id', () async {
       // Kotlin scopes the count by `type` as well as `parentId`
-      // (`SubmissionDao.kt:23`). The exam and the survey on this step have
-      // different ids, but a step whose exam and survey share an id is
-      // reachable — `_liveParentDocument`'s comment says the two id spaces are
-      // not disjoint — so the type clause is load-bearing, not decoration.
-      await takeExam();
+      // (`SubmissionDao.kt:23`), and that clause only *matters* where the two
+      // id spaces overlap — which they do: `_liveParentDocument`'s comment
+      // says so, and `collectRoomExam` mints an embedded assessment's id from
+      // the document's own `_id`, so one document can name both.
+      //
+      // **The first cut of this test asked about `'exam-1'` with
+      // `type: 'survey'` and was vacuous**: `hasSubmission` short-circuits on
+      // `surveyQuestions` being empty for an exam id and never issues the
+      // count, so deleting `submissions.type.equals(type)` from
+      // `countByUserParentAndType` left all 13 tests green. Its own comment
+      // named the shared-id case and then did not build it. This one does, so
+      // both question tables answer non-zero and the `type` clause is the only
+      // thing left deciding.
+      await seed({
+        '_id': 'course-2',
+        'courseTitle': 'Shared ids',
+        'steps': [
+          {
+            'stepTitle': 'Only',
+            'exam': {
+              '_id': 'both-1',
+              'type': 'courses',
+              'name': 'Test',
+              'questions': [
+                {'id': 'q1', 'title': 'One?', 'type': 'input'},
+              ],
+            },
+            'survey': {
+              '_id': 'both-1',
+              'type': 'surveys',
+              'name': 'Survey',
+              'questions': [
+                {'id': 's1', 'title': 'How?', 'type': 'input'},
+              ],
+            },
+          },
+        ],
+      });
+      final exam = (await database.examDao.getById('both-1'))!;
+      await submissions.startExamSession(
+        exam: exam,
+        questions: await database.examDao.questionsFor('both-1'),
+        userId: 'user-1',
+        courseId: 'course-2',
+      );
+
+      // Both tables have a question for this id, so neither call short-circuits.
+      expect(await database.examDao.questionsFor('both-1'), isNotEmpty);
+      expect(await database.surveyDao.questionsFor('both-1'), isNotEmpty);
+
       expect(
         await submissions.hasSubmission(
-          stepExamId: 'exam-1',
-          courseId: 'course-1',
+          stepExamId: 'both-1',
+          courseId: 'course-2',
+          userId: 'user-1',
+          type: 'exam',
+        ),
+        isTrue,
+      );
+      expect(
+        await submissions.hasSubmission(
+          stepExamId: 'both-1',
+          courseId: 'course-2',
           userId: 'user-1',
           type: 'survey',
         ),
         isFalse,
+        reason: 'an exam attempt is not an answered survey',
       );
     });
 
@@ -219,6 +274,13 @@ void main() {
       // tile reads *take* rather than *retake*, so a guest browsing a joined
       // course, or a step whose `courseId` never synced, is offered a first
       // attempt.
+      //
+      // **This test alone does not pin the guard**, and saying so is the
+      // point: with the guard deleted every branch below still answers false
+      // by another route (an empty id matches no question row, and
+      // `examParentId(examId: 'exam-1', courseId: '')` is the bare id, which
+      // no submission here carries). The test that *does* pin it is the next
+      // one.
       for (final blank in [null, '']) {
         expect(
           await submissions.hasSubmission(
@@ -249,6 +311,58 @@ void main() {
         );
       }
     });
+
+    test(
+      'a blank course id is false even where the bare key would match',
+      () async {
+        // **The guard's semantics, not its null-safety.** A survey with no
+        // `courseId` keys its submissions on the bare id ([examParentId]), so a
+        // blank `courseId` argument produces a `parentId` that *does* match a
+        // real row — the one case where dropping the blank-course guard changes
+        // the answer rather than throwing. Kotlin answers false (`:182-184`)
+        // before it can build any key at all.
+        final mapped = SurveyMapper.fromDoc({
+          '_id': 'loose-1',
+          'type': 'surveys',
+          'name': 'Loose',
+          'questions': [
+            {'id': 's1', 'title': 'How?', 'type': 'input'},
+          ],
+        })!;
+        await database.surveyDao.upsertAll(
+          [mapped.survey],
+          {mapped.survey.id.value: mapped.questions},
+        );
+        final survey = (await database.surveyDao.getById('loose-1'))!;
+        expect(survey.courseId, isNull);
+        await submissions.createSurveyDraft(
+          survey: survey,
+          questions: await database.surveyDao.questionsFor('loose-1'),
+          userId: 'user-1',
+        );
+        // The writer stored the bare id, which is what makes a blank-course
+        // argument dangerous rather than merely useless.
+        expect(
+          (await database.submissionDao.getSurveySubmissionsByUser(
+            'user-1',
+          )).single.parentId,
+          'loose-1',
+        );
+
+        for (final blank in ['', '   ']) {
+          expect(
+            await submissions.hasSubmission(
+              stepExamId: 'loose-1',
+              courseId: blank,
+              userId: 'user-1',
+              type: 'survey',
+            ),
+            isFalse,
+            reason: 'Kotlin is isNullOrBlank, not isEmpty',
+          );
+        }
+      },
+    );
 
     test(
       'is false while the exam has no questions, submission or not',
@@ -344,15 +458,27 @@ void main() {
         // `hasSubmission(stepExams[0].id, …)` against
         // `getString(R.string.take_test, exams.size)`.
         //
-        // **The state is port-only, and the test says so rather than
-        // pretending otherwise.** Kotlin cannot reach a two-exam step: a step
-        // document carries one `exam` object, read with `getAsJsonObject`, and
-        // `bulkInsertExamsFromSync` calls `insertCourseStepsExams("", "", doc,
-        // "")` so the standalone walk leaves `stepId` null. `ExamMapper.fromDoc`
-        // *does* write a document's own `stepId`, which is the route below. So
-        // this pins fidelity to what the Kotlin says, on a shape only the port
-        // can produce — worth having, because the alternative reading ("any
-        // exam counts") is the one a reimplementer would choose.
+        // **No server can send the document below, and the test says so
+        // rather than implying otherwise.** Kotlin cannot reach a two-exam
+        // step: a step document carries one `exam` object, read with
+        // `getAsJsonObject`, and `bulkInsertExamsFromSync` calls
+        // `insertCourseStepsExams("", "", doc, "")`, so the standalone walk
+        // leaves `stepId` null. `ExamMapper.fromDoc` *does* write a document's
+        // own `stepId` — but the value this fixture puts there is
+        // `CourseMapper.stepIdFor`'s `'$courseId:$stepIndex'`, the port's own
+        // **local positional key**, which the migration doc records as a
+        // deliberate deviation precisely because it is never a server value.
+        // So no CouchDB `exams` document can carry it, and the state is
+        // unreachable in both apps.
+        //
+        // The test is kept anyway, and this comment is why: it pins
+        // `exams.first` against the tempting "any exam counts" reading — which
+        // is what a reimplementer would choose, and what the revert of this
+        // rule reds. What it is *not* is evidence that a learner can meet this
+        // state. The first draft of this comment claimed the port could reach
+        // it; the implementation audit caught that, and it is the Phase
+        // 113/125 fabricated-join shape moved from `parentId` to
+        // `exams.stepId`.
         final stepId = CourseMapper.stepIdFor('course-1', 0);
         final second = ExamMapper.fromDoc({
           '_id': 'exam-2',

--- a/flutter/test/repository/step_tile_label_test.dart
+++ b/flutter/test/repository/step_tile_label_test.dart
@@ -1,0 +1,381 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/courses_providers.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Phase 128 — `CourseStepFragment.hideTestIfNoQuestion` (`:241-262`) and the
+/// read it hangs off, `SubmissionsRepositoryImpl.hasSubmission` (`:176-192`).
+///
+/// This is the only **user-visible** reader in either tree whose predicate is
+/// the whole composite `parentId`, and unlike the mandatory-survey gate it
+/// works in the shipping Android app: `getCourseStepData` reads the
+/// *plural*-typed rows. Phase 125 made every port writer agree on that key, so
+/// the survey half of the swap is only portable now.
+///
+/// Every submission below is authored by the production writer
+/// ([SubmissionsRepository.startExamSession] /
+/// [SubmissionsRepository.createSurveyDraft]) and every exam and survey row
+/// comes out of a mapper reading a document shaped like the server's. Nothing
+/// hand-writes a `parentId` — that fixture shape is exactly what let the key
+/// disagree for four phases.
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository submissions;
+
+  /// One step carrying one exam and one survey, both with a question, as the
+  /// `courses` walk writes them.
+  const courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'Algebra',
+    'steps': [
+      {
+        'stepTitle': 'First',
+        'exam': {
+          '_id': 'exam-1',
+          'type': 'courses',
+          'name': 'Step test',
+          'questions': [
+            {'id': 'q1', 'title': 'One?', 'type': 'input'},
+          ],
+        },
+        'survey': {
+          '_id': 'survey-1',
+          'type': 'surveys',
+          'name': 'Step survey',
+          'questions': [
+            {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+          ],
+        },
+      },
+    ],
+  };
+
+  Future<void> seed(Map<String, Object?> doc) async {
+    final parsed = CourseMapper.fromDoc(doc)!;
+    await database.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in ExamMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.examDao.upsertAll(
+        [mapping.exam],
+        {mapping.exam.id.value: mapping.questions},
+      );
+    }
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+  }
+
+  /// Opens an attempt at the step's exam the way `TakeExamScreen` does.
+  Future<void> takeExam({String examId = 'exam-1'}) async {
+    final exam = (await database.examDao.getById(examId))!;
+    await submissions.startExamSession(
+      exam: exam,
+      questions: await database.examDao.questionsFor(examId),
+      userId: 'user-1',
+      courseId: 'course-1',
+    );
+  }
+
+  /// Answers the step's survey the way `TakeSurveyScreen` does.
+  Future<void> answerSurvey({String surveyId = 'survey-1'}) async {
+    final survey = (await database.surveyDao.getByCourseId(
+      'course-1',
+    )).firstWhere((row) => row.id == surveyId);
+    await submissions.createSurveyDraft(
+      survey: survey,
+      questions: await database.surveyDao.questionsFor(surveyId),
+      userId: 'user-1',
+    );
+  }
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    submissions = SubmissionsRepository(
+      MockPlanetApi(),
+      database.submissionDao,
+      database.submitPhotosDao,
+      database.surveyDao,
+      database.examDao,
+    );
+    await seed(courseDoc);
+  });
+
+  tearDown(() => database.close());
+
+  test(
+    'the mapped exam and survey really are attached to the course',
+    () async {
+      // If this fails nothing below proves anything: `hasSubmission` builds
+      // `"$examId@$courseId"`, so a mapper that dropped `courseId` would make
+      // every assertion vacuous — and it is a mapper defect the port has had
+      // before (Phase 113's unreachable exam screen).
+      final stepId = CourseMapper.stepIdFor('course-1', 0);
+      final exams = await database.examDao.getByStepIds([stepId]);
+      expect(exams.single.courseId, 'course-1');
+      final surveys = await database.surveyDao.getByStepId(stepId);
+      expect(surveys.single.courseId, 'course-1');
+    },
+  );
+
+  group('hasSubmission', () {
+    test('is false before the learner has taken the exam', () async {
+      expect(
+        await submissions.hasSubmission(
+          stepExamId: 'exam-1',
+          courseId: 'course-1',
+          userId: 'user-1',
+          type: 'exam',
+        ),
+        isFalse,
+      );
+    });
+
+    test('is true once the production writer has opened an attempt', () async {
+      // The tile's whole purpose. Pre-Phase-125 this could not have worked for
+      // a survey at all; for an exam the port simply never asked.
+      await takeExam();
+      expect(
+        await submissions.hasSubmission(
+          stepExamId: 'exam-1',
+          courseId: 'course-1',
+          userId: 'user-1',
+          type: 'exam',
+        ),
+        isTrue,
+      );
+    });
+
+    test('is true once the survey sheet exists, on the composite key', () async {
+      await answerSurvey();
+      // The row the writer authored carries the composite key, which is what
+      // makes this reader's predicate matchable. Asserted directly so a writer
+      // regression fails here rather than only at the label.
+      final row = (await database.submissionDao.getSurveySubmissionsByUser(
+        'user-1',
+      )).single;
+      expect(row.parentId, 'survey-1@course-1');
+      expect(
+        await submissions.hasSubmission(
+          stepExamId: 'survey-1',
+          courseId: 'course-1',
+          userId: 'user-1',
+          type: 'survey',
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not confuse the two types', () async {
+      // Kotlin scopes the count by `type` as well as `parentId`
+      // (`SubmissionDao.kt:23`). The exam and the survey on this step have
+      // different ids, but a step whose exam and survey share an id is
+      // reachable — `_liveParentDocument`'s comment says the two id spaces are
+      // not disjoint — so the type clause is load-bearing, not decoration.
+      await takeExam();
+      expect(
+        await submissions.hasSubmission(
+          stepExamId: 'exam-1',
+          courseId: 'course-1',
+          userId: 'user-1',
+          type: 'survey',
+        ),
+        isFalse,
+      );
+    });
+
+    test('is false for another user', () async {
+      await takeExam();
+      expect(
+        await submissions.hasSubmission(
+          stepExamId: 'exam-1',
+          courseId: 'course-1',
+          userId: 'user-2',
+          type: 'exam',
+        ),
+        isFalse,
+      );
+    });
+
+    test('is false for a blank exam id, course id or user id', () async {
+      await takeExam();
+      // Kotlin's `isNullOrBlank` triple (`:182-184`). Here `false` means the
+      // tile reads *take* rather than *retake*, so a guest browsing a joined
+      // course, or a step whose `courseId` never synced, is offered a first
+      // attempt.
+      for (final blank in [null, '']) {
+        expect(
+          await submissions.hasSubmission(
+            stepExamId: blank,
+            courseId: 'course-1',
+            userId: 'user-1',
+            type: 'exam',
+          ),
+          isFalse,
+        );
+        expect(
+          await submissions.hasSubmission(
+            stepExamId: 'exam-1',
+            courseId: blank,
+            userId: 'user-1',
+            type: 'exam',
+          ),
+          isFalse,
+        );
+        expect(
+          await submissions.hasSubmission(
+            stepExamId: 'exam-1',
+            courseId: 'course-1',
+            userId: blank,
+            type: 'exam',
+          ),
+          isFalse,
+        );
+      }
+    });
+
+    test(
+      'is false while the exam has no questions, submission or not',
+      () async {
+        // `questionDao.countByExamId(stepExamId) == 0 → false` (`:186-188`).
+        // Ported here and deliberately *not* ported in `hasUnfinishedSurveys`,
+        // where the same rule inverts into "a question-less survey blocks the
+        // course forever". Reachable: the `exams` and `courses` walks run in the
+        // same batch, so a step's exam can be on disk before its questions are.
+        await takeExam();
+        await database.delete(database.examQuestions).go();
+        expect(
+          await submissions.hasSubmission(
+            stepExamId: 'exam-1',
+            courseId: 'course-1',
+            userId: 'user-1',
+            type: 'exam',
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('counts a survey question from the surveys table, not exams', () async {
+      // Kotlin keeps every question in one `exam_questions` table
+      // (`QuestionDao.kt:13`) because it keeps every exam and survey in one
+      // `exams` table. The port split both pairs, so the count has to pick its
+      // table from `type`. Reading `ExamQuestions` for a survey would have
+      // found nothing and answered *not taken* on every survey ever answered.
+      await answerSurvey();
+      expect(await database.examDao.questionsFor('survey-1'), isEmpty);
+      expect(await database.surveyDao.questionsFor('survey-1'), isNotEmpty);
+      expect(
+        await submissions.hasSubmission(
+          stepExamId: 'survey-1',
+          courseId: 'course-1',
+          userId: 'user-1',
+          type: 'survey',
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('stepAssessmentProvider', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer(
+        overrides: [appDatabaseProvider.overrideWithValue(database)],
+      );
+      addTearDown(container.dispose);
+    });
+
+    Future<StepAssessment> read({String? userId = 'user-1'}) => container.read(
+      stepAssessmentProvider((
+        stepId: CourseMapper.stepIdFor('course-1', 0),
+        courseId: 'course-1',
+        userId: userId,
+      )).future,
+    );
+
+    test('reports both lists and both booleans', () async {
+      final before = await read();
+      expect(before.exams.map((row) => row.id), ['exam-1']);
+      expect(before.surveys.map((row) => row.id), ['survey-1']);
+      expect(before.hasExam, isFalse);
+      expect(before.hasSurvey, isFalse);
+    });
+
+    test('flips each boolean independently', () async {
+      await takeExam();
+      final afterExam = await read();
+      expect(afterExam.hasExam, isTrue);
+      expect(afterExam.hasSurvey, isFalse);
+    });
+
+    test('a guest sees the lists but never a retake', () async {
+      // `getCourseStepData(stepId, user?.id)` passes a nullable id straight
+      // through to `hasSubmission`, whose blank-user guard answers false.
+      await takeExam();
+      await answerSurvey();
+      final assessment = await read(userId: null);
+      expect(assessment.exams, isNotEmpty);
+      expect(assessment.hasExam, isFalse);
+      expect(assessment.hasSurvey, isFalse);
+    });
+
+    test(
+      'only the first exam decides the label, though the count is the whole list',
+      () async {
+        // Kotlin's quirk, ported rather than corrected:
+        // `hasSubmission(stepExams[0].id, …)` against
+        // `getString(R.string.take_test, exams.size)`.
+        //
+        // **The state is port-only, and the test says so rather than
+        // pretending otherwise.** Kotlin cannot reach a two-exam step: a step
+        // document carries one `exam` object, read with `getAsJsonObject`, and
+        // `bulkInsertExamsFromSync` calls `insertCourseStepsExams("", "", doc,
+        // "")` so the standalone walk leaves `stepId` null. `ExamMapper.fromDoc`
+        // *does* write a document's own `stepId`, which is the route below. So
+        // this pins fidelity to what the Kotlin says, on a shape only the port
+        // can produce — worth having, because the alternative reading ("any
+        // exam counts") is the one a reimplementer would choose.
+        final stepId = CourseMapper.stepIdFor('course-1', 0);
+        final second = ExamMapper.fromDoc({
+          '_id': 'exam-2',
+          'type': 'courses',
+          'name': 'Second test',
+          'stepId': stepId,
+          'courseId': 'course-1',
+          'questions': [
+            {'id': 'q2', 'title': 'Two?', 'type': 'input'},
+          ],
+        })!;
+        await database.examDao.upsertAll(
+          [second.exam],
+          {second.exam.id.value: second.questions},
+        );
+
+        // Answering only the *second* exam leaves the label saying "take":
+        // the boolean reads `stepExams[0]`.
+        await takeExam(examId: 'exam-2');
+        final assessment = await read();
+        expect(assessment.exams.length, 2);
+        expect(assessment.hasExam, isFalse);
+      },
+    );
+  });
+}

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -435,9 +435,23 @@ void main() {
   Future<void> pumpSeededStep(
     WidgetTester tester, {
     required bool joined,
+    Future<void> Function(AppDatabase db, SubmissionsRepository submissions)?
+    afterSeed,
   }) async {
     final db = await seedStepAssessments();
     addTearDown(db.close);
+    if (afterSeed != null) {
+      await afterSeed(
+        db,
+        SubmissionsRepository(
+          MockPlanetApi(),
+          db.submissionDao,
+          db.submitPhotosDao,
+          db.surveyDao,
+          db.examDao,
+        ),
+      );
+    }
     final steps = await db.courseDao.getSteps('course-1');
     await pumpScreen(
       tester,
@@ -484,7 +498,10 @@ void main() {
       // a database filled by the mappers the courses walk now runs.
       await pumpSeededStep(tester, joined: true);
 
-      expect(find.text('Take test'), findsOneWidget);
+      // The label is Kotlin's `take_test`, "take test [%d]", where `%d` is
+      // `exams.size` — not the count-less "Take test" the port used to
+      // hardcode. Phase 128.
+      expect(find.text('take test [1]'), findsOneWidget);
       expect(find.text('Record survey'), findsOneWidget);
 
       // **Rendering is not reachability**, which is what the first cut of this
@@ -492,7 +509,7 @@ void main() {
       // *pattern* — `Routes.exam` is `/courses/exam/:examId`, so the push was
       // `/courses/exam/:examId/exam-1` — which matches no route and drops the
       // learner on go_router's error page.
-      await tester.tap(find.text('Take test'));
+      await tester.tap(find.text('take test [1]'));
       await tester.pumpAndSettle();
       expect(find.text('EXAM_ROUTE exam-1'), findsOneWidget);
     },
@@ -516,7 +533,167 @@ void main() {
     // `CourseStepFragment.onViewCreated` hides both after
     // `hideTestIfNoQuestion` has shown them, when `!userHasCourse`.
     await pumpSeededStep(tester, joined: false);
-    expect(find.text('Take test'), findsNothing);
+    expect(find.text('take test [1]'), findsNothing);
     expect(find.text('Record survey'), findsNothing);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Phase 128 — `hideTestIfNoQuestion`'s label swap
+  // ---------------------------------------------------------------------------
+  //
+  // `CourseStepFragment.hideTestIfNoQuestion` (`:241-262`) picks each button's
+  // wording off `getCourseStepData`'s `hasExam`/`hasSurvey`, which are
+  // `hasSubmission(stepExams[0].id, step.courseId, userId, "exam"/"survey")`
+  // on the composite `parentId`. The port hardcoded `l10n.takeTest` and
+  // `l10n.recordSurvey`, so a learner who had already sat the test was invited
+  // to take it for the first time, every time.
+  //
+  // Both submissions here are authored by the production writer against rows
+  // the mappers produced from a document shaped like the server's, so the key
+  // the writer stores and the key this reader asks for are the same value for
+  // the same reason they are in the field.
+
+  testWidgets('the test tile says Retake once the learner has an attempt', (
+    tester,
+  ) async {
+    // Pre-fix: `Expected: exactly one matching candidate / Actual: zero` for
+    // "Retake Test [1]", with "Take test" on screen instead.
+    await pumpSeededStep(
+      tester,
+      joined: true,
+      afterSeed: (db, submissions) async {
+        final exam = (await db.examDao.getById('exam-1'))!;
+        await submissions.startExamSession(
+          exam: exam,
+          questions: await db.examDao.questionsFor('exam-1'),
+          userId: 'user-1',
+          courseId: 'course-1',
+        );
+      },
+    );
+
+    expect(find.text('Retake Test [1]'), findsOneWidget);
+    expect(find.text('take test [1]'), findsNothing);
+    // The survey is untouched, so its own label must not have moved with it.
+    expect(find.text('Record survey'), findsOneWidget);
+  });
+
+  testWidgets('the survey tile says Redo once the sheet exists', (
+    tester,
+  ) async {
+    // The half that Phase 125's writer fix is the precondition for: before it
+    // the sheet carried the bare `survey-1` and this reader's
+    // `survey-1@course-1` could never match, so the label could not have
+    // swapped however many times the learner answered.
+    await pumpSeededStep(
+      tester,
+      joined: true,
+      afterSeed: (db, submissions) async {
+        final survey = (await db.surveyDao.getByCourseId('course-1')).single;
+        await submissions.createSurveyDraft(
+          survey: survey,
+          questions: await db.surveyDao.questionsFor('survey-1'),
+          userId: 'user-1',
+        );
+      },
+    );
+
+    expect(find.text('redo survey'), findsOneWidget);
+    expect(find.text('Record survey'), findsNothing);
+    expect(find.text('take test [1]'), findsOneWidget);
+  });
+
+  testWidgets('Redo survey still opens the survey screen', (tester) async {
+    // A swapped label is not a swapped destination. `btnTakeSurvey`'s listener
+    // is set once and reads `stepSurvey[0].id` either way.
+    await pumpSeededStep(
+      tester,
+      joined: true,
+      afterSeed: (db, submissions) async {
+        final survey = (await db.surveyDao.getByCourseId('course-1')).single;
+        await submissions.createSurveyDraft(
+          survey: survey,
+          questions: await db.surveyDao.questionsFor('survey-1'),
+          userId: 'user-1',
+        );
+      },
+    );
+
+    await tester.tap(find.text('redo survey'));
+    await tester.pumpAndSettle();
+    expect(find.text('SURVEY_ROUTE survey-1'), findsOneWidget);
+  });
+
+  testWidgets('the label refreshes when the learner returns from the exam', (
+    tester,
+  ) async {
+    // **The reachability question, for a label whose only trigger is a
+    // submission made on another screen.** Kotlin recomputes on every view
+    // creation: `btnTakeTest` → `openCallFragment` →
+    // `FragmentNavigator.replaceFragment(addToBackStack = true)` is a
+    // `replace()`, so popping back recreates `CourseStepFragment`,
+    // `onViewCreated` runs again and `getCourseStepData` re-queries.
+    //
+    // `context.push` does not: it leaves `TakeCourseScreen` mounted, so
+    // `_StepContent` keeps its listener, the `autoDispose` family member is
+    // never disposed and its future never re-runs. Pre-fix this was
+    // `Expected: exactly one matching candidate / Actual: Found 0 widgets with
+    // text "Retake Test [1]"` — the swap this whole phase exists for could not
+    // be observed without leaving the course and re-entering it.
+    late AppDatabase database;
+    late SubmissionsRepository submissions;
+    await pumpSeededStep(
+      tester,
+      joined: true,
+      afterSeed: (db, repo) async {
+        database = db;
+        submissions = repo;
+      },
+    );
+
+    expect(find.text('take test [1]'), findsOneWidget);
+    await tester.tap(find.text('take test [1]'));
+    await tester.pumpAndSettle();
+    expect(find.text('EXAM_ROUTE exam-1'), findsOneWidget);
+
+    // The learner sits the exam on the pushed screen.
+    final exam = (await database.examDao.getById('exam-1'))!;
+    await submissions.startExamSession(
+      exam: exam,
+      questions: await database.examDao.questionsFor('exam-1'),
+      userId: 'user-1',
+      courseId: 'course-1',
+    );
+
+    // …and comes back to the step.
+    GoRouter.of(tester.element(find.text('EXAM_ROUTE exam-1'))).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Retake Test [1]'), findsOneWidget);
+    expect(find.text('take test [1]'), findsNothing);
+  });
+
+  testWidgets('an attempt by another learner does not swap the label', (
+    tester,
+  ) async {
+    // `countByUserParentAndType` is user-scoped (`SubmissionDao.kt:23`), so a
+    // shared handset must not tell the signed-in learner they have already
+    // sat a test somebody else sat.
+    await pumpSeededStep(
+      tester,
+      joined: true,
+      afterSeed: (db, submissions) async {
+        final exam = (await db.examDao.getById('exam-1'))!;
+        await submissions.startExamSession(
+          exam: exam,
+          questions: await db.examDao.questionsFor('exam-1'),
+          userId: 'someone-else',
+          courseId: 'course-1',
+        );
+      },
+    );
+
+    expect(find.text('take test [1]'), findsOneWidget);
+    expect(find.text('Retake Test [1]'), findsNothing);
   });
 }


### PR DESCRIPTION
Lane A of a three-lane Flutter-port round. **Phase 128**, named by Phase 125 as its own successor
(`flutter/PHASE_125_NOTES.md` §"Found, not fixed" item 1). Full write-up in
`flutter/PHASE_128_NOTES.md`.

Ports `CourseStepFragment.hideTestIfNoQuestion` (`:241-260`): the step tile swaps
`record_survey` → `redo_survey` and `take_test` → `retake_test` off `getCourseStepData`'s
`hasExam`/`hasSurvey`, which are `hasSubmission(stepExams[0].id, step.courseId, userId,
"exam"/"survey")` — the composite `parentId` on the plural-typed rows. Phase 125's writer fix is
the precondition. The port hardcoded `l10n.takeTest`/`l10n.recordSurvey`, so **a learner who had
already sat the test was invited to take it for the first time, every time**, and the count Kotlin
puts in that label was absent.

## ⚠️ Integrator: one action is required before this merges

**Run `dart tool/arb_from_strings_xml.dart` and bump `humanReviewed` in
`test/l10n/placeholder_integrity_test.dart` by +5 per locale** — ar 410→415, es 462→467,
fr 409→414, ne 411→416, so 411→416.

This diff adds three user-facing strings to `app_en.arb`. As merged, an ar/es/fr/ne/so learner
sees `redo survey` and `take test [1]` **in English**, on a screen where the Android app has
always shown their own language. The 15 human translations already exist in `values-*/strings.xml`;
I verified the derivation picks up all of them and then reverted the five locale files, because
Lane C owns them and is editing them this round. It is the only respect in which this branch is
worse than the Kotlin app, and it is one command. The run also delivers `playbackSpeed` and
`playbackSpeedValue`, undelivered since the Phase 126/127 harvest — hence +5 rather than +3.

## The three ARB keys derived their translations

Worded to match the Kotlin English exactly, which is what made it work — `Take test [{count}]`
with a capital would have derived nothing, since the tool matches literals case-sensitively.

| key | English | Kotlin source |
|---|---|---|
| `takeTestCount` | `take test [{count}]` | `take_test` = `take test [%d]` |
| `retakeTestCount` | `Retake Test [{count}]` | `retake_test` = `Retake Test [%d]` |
| `redoSurvey` | `redo survey` | `redo_survey` = `redo survey` |

## Lane hygiene

`flutter/lib/repository/submissions_repository.dart` is shared with Lane B at section level.
**Read path only**: one 100-line insertion (`hasSubmission` + `_questionCount`) plus four one-line
comment edits correcting stale Kotlin citations in the adjacent `examParentId` /
`hasUnfinishedSurveys` docs. No line of `createExamSubmission`, `serializeSubmission` or the
team-object block is touched. Otherwise: `lib/ui/courses/`, `lib/providers/courses_providers.dart`,
`lib/l10n/app_en.arb` (additions only), and the tests. No schema bump — `schemaVersion` stays 46,
no DAO change, no codegen.

## Verification

Two `parity-auditor` passes at `effort: max` — one on the Kotlin ground truth, one on the finished
implementation. The second found eight things, five of them code or test; all fixed in `2752f2f`,
including two of my own tests that read as coverage and were not. Every defect was demonstrated
failing on the exact revert it guards; the table is in the notes. 19 new tests, 2284 total.

Also recorded there, because it is structural: I pushed `140704d` without a full-suite run after
the last code change and the port's own `route_reachability_test` was red — a guard no feature
change ever touches is exactly the test most likely to catch a new navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ajyGe6RB4Pb5fheEsW4fJ