### PR TITLE
Phase 129: a submission's team object (routed remainder of aca425a)

### DIFF
--- a/flutter/PHASE_129_NOTES.md
+++ b/flutter/PHASE_129_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 129 — the harvest's routed remainder: a submission's `team` object
+
+Lane B of a three-lane round. Ports the three behavioural changes Phase 126
+verified in upstream `aca425a` ("teams: smoother submissions repository
+stamping", fixes #16664) but routed rather than applied, because
+`lib/repository/submissions_repository.dart` was another lane's file.
+
+Work in progress — findings and evidence land here as they are established.

--- a/flutter/PHASE_129_NOTES.md
+++ b/flutter/PHASE_129_NOTES.md
@@ -8,6 +8,12 @@ round.
 
 PR #16919. Branch `claude/submission-team-object-w6p3`.
 
+Two `parity-auditor` passes at `effort: max` ran per the standing rule — one on
+the Kotlin ground truth, one on this lane's own finished, green code. **Both
+found real defects**, including two claims of mine that were simply false, and
+the corrections are folded in below rather than appended, so nothing here reads
+as the first draft did.
+
 ## What a submission carries, before and after
 
 The cache-miss case is the one that matters, because it is not an edge case:
@@ -19,8 +25,8 @@ the association away.
 |---|---|---|
 | adopted team survey, team document **present** | no `team` key at all | `{"_id": …, "name": …, "type": …}` |
 | adopted team survey, team document **absent** | no `team` key at all | `{"_id": …}` |
-| team exam attempt, team present | no `team` key, and no `teamId` on the row | row carries `teamId`; `{"_id", "name", "type"}` |
-| team exam attempt, team absent | no `team` key, no `teamId` | row carries `teamId`; `{"_id"}` |
+| team **survey** sheet, team present | no `team` key, and no `teamId` on the row | row carries `teamId`; `{"_id", "name", "type"}` — *once a caller passes one, see below* |
+| team **survey** sheet, team absent | no `team` key, no `teamId` | row carries `teamId`; `{"_id"}` — *same* |
 | no team | no `team` key | no `team` key |
 | blank/whitespace team id | no `team` key | no `team` key |
 
@@ -32,7 +38,11 @@ overwrite a name the server already holds.
 
 `type` is also no longer defaulted to `"team"`. The pre-change Kotlin wrote
 `team.type ?: "team"`, which mislabelled an enterprise whose own document said
-otherwise; it now travels only when the local document has one.
+otherwise; it now travels only when the local document has one. The audit
+sharpened this: `?: "team"` was already near-dead, because `MyTeam.type` comes
+from `JsonUtils.getString`, which returns `""` rather than null, and local
+creation always sets `"team"`/`"enterprise"`. **The live delta is `""` →
+omitted, where the old code sent `"type": ""`.**
 
 ## The three items, each demonstrated failing first
 
@@ -53,43 +63,84 @@ DEFECT 1: an exam attempt cannot record the team it was taken for
 ```
 
 **Item 3 is the one with effect today, so it leads.** The port's `serialize`
-emitted no `team` key at all, and its reader is already reachable: two writers
-put a value in `submissions.teamId` today — `createSurveyAdoptionSubmission`
-(a team survey's adoption marker, which is `isUpdated: true` and so a pending
-upload the moment it is written) and `upsertDocuments` (the sync-in, from
-`team._id` or `user.membershipDoc.teamId`). Both went up with the team dropped
-from the document body.
+emitted no `team` key at all, and its reader is reachable through two writers
+of `submissions.teamId`. They are not equally good evidence, and the first
+draft of these notes ran them together, which was wrong:
 
-**Item 1** is the writer half. The port's exam-session writer took no team at
-all, so the column was never written from this device; `startExamSession` now
-takes `teamId` and persists it **unconditionally when non-blank**, which is the
-upstream fix. See *Reported, not fixed* — nothing passes it yet.
+* **the sync-in** (`upsertDocuments`, from `team._id` falling back to
+  `user.membershipDoc.teamId`). A synced team submission the user re-answers
+  goes `isUpdated = 1` and is re-uploaded — through `getPendingSubmissions` in
+  Kotlin, `pendingUploads` here — and now carries the team back. **This one is
+  parity: it is live in both apps, and pre-change both lost the team.**
+* **the team-survey adoption marker** (`createSurveyAdoptionSubmission`, which
+  writes `teamId` and `isUpdated: true`). This one is reachable *in the port
+  only*, and rests on a pre-existing divergence rather than on Kotlin
+  behaviour: Kotlin's `createMappedSubmission` writes `status = ""` and sets
+  the `@Ignore`d `membershipDoc` instead of the column, and
+  `getPendingSubmissions` requires `status = 'complete'` — **so Kotlin never
+  uploads that document at all**, while the port's `pendingUploads` gates on
+  `isUpdated` and does. Verified in both trees. The divergence predates this
+  phase and is not its to fix, but a claim resting on it is not a parity
+  claim.
 
 **Item 2** is the lookup, and it is what makes item 1's "unconditionally"
 survive contact with a real device.
 
+**Item 1 is the writer half, and the first cut put it on the wrong arm.** The
+port splits Kotlin's single `createExamSubmission` into an exam writer
+(`startExamSession`) and a survey writer (`createSurveyDraft`), and I gave the
+parameter to the exam one — which is the arm **Kotlin itself cannot reach with
+a team.** Every Kotlin site that sets `isTeam = true` also sets
+`type = "survey"` (`SubmissionsAdapter.openSurvey:114-121` for the team's
+surveys tab, `PublicSurveyActivity:99-107` for a deep link), while
+`CourseStepFragment`'s exam launch passes no team argument at all, so a graded
+course exam can never carry one. Both writers now take `teamId` and persist it
+unconditionally when non-blank; `createSurveyDraft` is the one a team reaches,
+and `startExamSession` keeps it only because it is `createExamSubmission`'s
+exam arm and dropping it would leave the port's split unable to express its own
+specification. Neither has a caller yet — see *Reported, not fixed*.
+
 ## Cancellation versus exception
 
-Kotlin's `getTeamByIdOrNull` rethrows `CancellationException` and swallows
-every other `Exception`. It **has** to name that type, because in Kotlin a
-cancellation *is* an `Exception`: a bare `catch (_: Exception)` would swallow a
-cancelled coroutine and turn it into a silent null.
+**The first cut of this section was wrong, and the audit caught it.** It said
+"Dart has no cancellation exception — a `Future` is not cancellable". Drift
+ships one, `package:drift/drift.dart` exports it, and it
+`implements Exception`:
 
-Dart has no cancellation exception — a `Future` is not cancellable — so there
-is no type to rethrow. The analogous hazard is `Error`: a `TypeError` or
-`StateError` out of this lookup means a defect in this code, not a missing row,
-and reporting it as a cache miss would hide it behind a document that merely
-looks under-populated.
+```
+drift-2.34.3/lib/src/runtime/cancellation_zone.dart:82
+  final class CancellationException implements Exception {
+```
 
-So the port catches `on Exception`, not a bare `catch`:
+and the port's production executor is `NativeDatabase.createInBackground`,
+whose isolate server wraps every `ExecuteQuery` in `runCancellable`
+(`drift/src/remote/server_impl.dart:121-131`). So the precise hazard Kotlin
+names a type to avoid — a lone `catch (_: Exception)` swallowing a cancellation
+— exists here with the same shape, and `on Exception` alone swallowed it.
 
-* an `Exception` (a drift/IO failure — the thing Kotlin is absorbing) → `null`,
-  the cache-miss path, and the upload keeps its `team._id`;
+No path reaches this one-shot `getSingleOrNull` from inside a cancellation zone
+today (only `QueryStreamFetcher.fetchData` enters one), so nothing was broken.
+That is not a reason to leave it: the reasoning is what the next reader
+inherits, and a stream fetch or `computeWithDatabase` would have made the
+comment's own mistake real.
+
+Kotlin's rethrow therefore **ports literally**, not by analogy:
+
+* `CancellationException` → rethrow;
+* any other `Exception` — a drift or IO failure, the thing Kotlin absorbs →
+  `null`, the cache-miss path, and the upload keeps its `team._id`;
 * an `Error` → propagates.
 
-Both halves are pinned by tests, with a `TeamDao` whose one read fails: one
-throwing an `Exception` (the document still uploads with `{"_id": …}`) and one
-throwing a `StateError` (`serialize` rethrows it).
+The last of those is **deliberately stricter than Kotlin**, and worth stating
+because it is a divergence rather than a port. Reading a closed database throws
+Dart `StateError`, where Room throws `IllegalStateException` — an `Exception`
+Kotlin's catch absorbs. Nothing in `lib/` closes the database, so the case does
+not arise in production; when it does arise it is a defect in the caller, and
+`serialize` rethrowing aborts `SubmissionsUploader.queuePending` for the whole
+batch rather than queueing rows with a silently under-populated team. Loud
+beats silent here.
+
+All three arms are pinned by tests, with a `TeamDao` whose one read fails.
 
 ## The corrected doc comment — and a correction to Phase 126's note
 
@@ -126,9 +177,16 @@ reached from `UploadConfigs` with rows fetched through
 fallback is the branch that runs. The port's `serialize` likewise only ever
 receives a persisted `SubmissionRow`.
 
-This is also why item 1 matters as much as it does: the column is the *only*
-durable carrier, so the pre-change Kotlin's gate on a resolved team did not
-merely omit a name — it lost the attribution permanently.
+This is also why item 1 matters as much as it does — though **"the only
+durable carrier" was too strong, and the audit corrected it.** `teamObject`
+and `membershipDoc` are both `@Ignore`d, but the same gated block also wrote
+the team id into the **persisted `user` TEXT column**
+(`{"membershipDoc":{"teamId":…}}`), which is a real column. So the pre-change
+loss was partial, not total. It was still a loss: that blob is overwritten by
+the respondent profile when the user-information dialog is submitted
+(`UserInformationFragment` -> `SubmissionDao.markComplete`) and dropped on
+upload whenever the live `users` row resolves, since both serializers prefer
+`UserEntity.serialize()`. The column is the only carrier that survives both.
 
 ## What was touched, region by region
 
@@ -142,9 +200,15 @@ or changed; nothing in the file was renamed or moved.
 | constructor + fields (`:18-50`) | `required TeamDao teamDao` named parameter, `_teamDao` field |
 | `startExamSession` doc + signature | `String? teamId`, doc for it and for its missing caller |
 | `_openExamSession` | `teamId` parameter, `persistedTeamId` blank-guard, `teamId: Value(...)` on the companion |
+| `createSurveyDraft` | the same three, plus doc for why this is the arm a team reaches |
 | `serialize` | `final team = await _resolveTeamJson(row)` and `'team': ?team` after `type` |
 | `_userDocument` doc block | the stale `team`-object claim corrected |
 | new, placed after `_userDocument` | `_resolveTeamJson`, `_teamByIdOrNull` |
+
+Two citation ranges in pre-existing comments were also corrected in place:
+`serializeSubmission (:813-862)` now reads `:820-865`, because `aca425a`
+deleted comment lines above that function. The behaviour those comments
+describe is unchanged.
 
 `lib/providers/app_providers.dart` — one line, `teamDao:` on
 `submissionsRepositoryProvider`.
@@ -152,17 +216,33 @@ or changed; nothing in the file was renamed or moved.
 The dependency is a **required** named parameter rather than an optional one on
 purpose. An optional team lookup that silently degrades a document's contents
 is the exact shape this project keeps getting burned by; the compiler now makes
-every construction site say what it wants. That cost 18 one-line additions
-across 14 test files (all in `setUp`-style constructor calls, plus two
-`Fake` overrides of `startExamSession` in `test/ui/exam/take_exam_screen_test.dart`
-that the signature change forced).
+every construction site say what it wants. That cost 20 one-line additions
+across 15 test files — most in a `setUp`, six inside test bodies
+(`surveys_repository_test.dart`, `dashboard_providers_test.dart`,
+`course_progress_screen_test.dart`, `take_course_screen_test.dart`,
+`take_exam_screen_test.dart`, `submissions_sync_round_trip_test.dart`) — plus
+two `Fake` overrides of `startExamSession` in
+`test/ui/exam/take_exam_screen_test.dart` that the signature change forced.
+The provider takes `teamDaoProvider` rather than `teamsRepositoryProvider`
+deliberately: the repository transitively reaches `planetPrefsProvider`, which
+is `UnimplementedError` in the widget-test harness (the Phase 75/99 trap).
 
 ## Tests
 
-`test/repository/submission_team_object_test.dart`, 14 new tests: the resolved
-and unresolved team, blank name/type, the absent `type` (no `"team"` default),
-no team, a blank team id, `membershipDoc` surviving alongside the new key, the
-two lookup-failure halves, and four on the exam writer.
+`test/repository/submission_team_object_test.dart`, 18 new tests: the resolved
+and unresolved team, blank name/type, one key resolving where the other does
+not, the absent `type` (no `"team"` default), no team, a blank team id,
+`membershipDoc` surviving alongside the new key, the three lookup arms
+(cancellation, `Exception`, `Error`), three on the survey writer and four on
+the exam writer.
+
+**Mutation-tested.** The implementation audit injected 11 mutations and all 11
+were killed; I then mutation-tested the three behaviours added after it —
+removing the cancellation rethrow, dropping `createSurveyDraft`'s `teamId`
+write, and weakening the blank-name guard to `isEmpty` — and each fails a test
+that names it. One test the audit found *redundant* (it could not fail unless
+the exact-equality test above it failed first) was retargeted to the mixed case
+Kotlin's two independent guards allow: name resolvable, type blank.
 
 ## Reported, not fixed
 
@@ -181,19 +261,33 @@ team's surveys tab with `putBoolean("isTeam", true)` plus the team id,
 In the port, `TeamSurveysScreen` (`lib/ui/teams/team_surveys_screen.dart:67`)
 pushes `'${Routes.surveys}/${survey.id}'` and drops the team on the floor, so
 **every answer sheet the port writes is team-less where Kotlin's carries the
-team.** Closing it is three edits, all outside this lane's file set:
+team.** Closing it is four edits, all outside this lane's file set:
 
 1. `lib/ui/router.dart` — a `teamId` query parameter on the survey route;
-2. `lib/ui/surveys/take_survey_screen.dart` — accept it and pass it to the
-   submission writer (its writer is `createSurveyDraft` /
-   `getOrCreateSurveySubmission`, which need the same `teamId` treatment
-   `_openExamSession` just got — Kotlin reaches all of them through the one
-   `createExamSubmission`);
-3. `lib/ui/teams/team_surveys_screen.dart` — send it.
+2. `lib/ui/surveys/take_survey_screen.dart` — accept it and pass it on;
+3. `lib/repository/surveys_repository.dart` — `submitResponse` is the link
+   between the screen and `createSurveyDraft`, and it has no `teamId`
+   parameter;
+4. `lib/ui/teams/team_surveys_screen.dart` — send it.
 
-Whoever takes it should note that `take_survey_screen` is the port's survey
-analogue of `ExamTakingFragment`'s survey branch, and Kotlin's survey branch
-passes the team too (`:151-152`) — this is not exam-only.
+**Not exam-only — in fact not exam at all.** The port's exam route is
+`'/courses/exam/:examId'`, reached from a course step, where no team context
+exists or can; Kotlin's exam branch is dead with respect to teams for the same
+reason. `createSurveyDraft` is the writer to wire.
+
+**A second site, with the value already in hand.**
+`lib/ui/surveys/public_survey_screen.dart:245-253` calls `createSurveyDraft`
+while `widget.teamId` sits two statements away (it is passed to
+`UserInformationScreen(teamId: …)` at `:261`). Kotlin's
+`PublicSurveyActivity:99-107` launches the sheet with `isTeam = true` and the
+team id, so `createExamSubmission` stamps the column. The effect is small — the
+public POST carries the team in its URL, and the port excludes `public_%`
+owners from `pendingUploads` — but there are two Kotlin sites, not one, and the
+first cut of these notes named only the first.
+
+Found on the same trail and pre-existing: `UserInformationScreen.teamId`
+(`lib/ui/exam/user_information_screen.dart:39,45`) is declared and never read,
+while `UserInformationFragment` uses it at `:155-157` and `:296-299`.
 
 ### The stored `user` blob's `age`/`gender`
 
@@ -209,6 +303,28 @@ Planet the stored blob is only Kotlin's *fallback* — both serializers prefer
 the live `UserEntity.serialize()`. The port having no live user lookup is a
 pre-existing recorded gap (`_userDocument`'s doc block), not something this
 phase changed.
+
+### The sync-in stores `NULL` where Kotlin stores `''`, and a live query splits on it
+
+Surfaced by the ground-truth audit, verified in both trees, **pre-existing and
+not this phase's** — but it has a live caller and it is a read-path query, so
+it is reported rather than touched (Lane A's region this round).
+
+Kotlin's `upsertRoomSubmissionsFromSync` writes `teamId` from
+`JsonUtils.getString`, which returns `""` and not null, so a synced *team-less*
+submission carries `''`. `SubmissionDao.getByUserIdWithoutTeam` then tests
+`teamId IS NULL`, which **does not match `''`** — so Kotlin excludes such rows
+from a user's personal survey list. The port's `upsertDocuments` writes `NULL`
+and `SubmissionDao.byUserWithoutTeam` matches `isNull() | equals('')`, so it
+includes them. Same server document, different list. The live caller is
+`surveys_repository.dart:142-143`, the team-versus-personal survey split.
+
+The port's behaviour is arguably the better one; Kotlin is the specification,
+quirks included, so somebody should decide deliberately rather than by
+accident. Two smaller consequences of the same `''`: Kotlin uploads
+`user.membershipDoc = {"teamId": ""}` for such a row where the port omits the
+key, and Kotlin's `deletePendingSurveyOrphans`/`getUniquePendingSurveyCandidates`
+skip it too.
 
 ### Item 4 of Phase 126's routed list was not assigned to this lane
 

--- a/flutter/PHASE_129_NOTES.md
+++ b/flutter/PHASE_129_NOTES.md
@@ -1,8 +1,220 @@
-# Phase 129 — the harvest's routed remainder: a submission's `team` object
+# Phase 129 — a submission's `team` object (the harvest's routed remainder)
 
 Lane B of a three-lane round. Ports the three behavioural changes Phase 126
 verified in upstream `aca425a` ("teams: smoother submissions repository
-stamping", fixes #16664) but routed rather than applied, because
-`lib/repository/submissions_repository.dart` was another lane's file.
+stamping", fixes #16664) and routed rather than applied, because
+`lib/repository/submissions_repository.dart` was another lane's file that
+round.
 
-Work in progress — findings and evidence land here as they are established.
+PR #16919. Branch `claude/submission-team-object-w6p3`.
+
+## What a submission carries, before and after
+
+The cache-miss case is the one that matters, because it is not an edge case:
+an incomplete local `teams` table is the *normal* state of a handset that has
+not finished syncing, and it is exactly the state in which the old code threw
+the association away.
+
+| | before | after |
+|---|---|---|
+| adopted team survey, team document **present** | no `team` key at all | `{"_id": …, "name": …, "type": …}` |
+| adopted team survey, team document **absent** | no `team` key at all | `{"_id": …}` |
+| team exam attempt, team present | no `team` key, and no `teamId` on the row | row carries `teamId`; `{"_id", "name", "type"}` |
+| team exam attempt, team absent | no `team` key, no `teamId` | row carries `teamId`; `{"_id"}` |
+| no team | no `team` key | no `team` key |
+| blank/whitespace team id | no `team` key | no `team` key |
+
+`_id` alone is enough: Planet attributes a submission by `team._id`, so a
+document with the id and no name is attributable and one with neither is not.
+`name` and `type` are **omitted, never sent as null** — Kotlin guards each with
+`?.let { addProperty(…) }` (`resolveTeamJson:806-808`), and a null would
+overwrite a name the server already holds.
+
+`type` is also no longer defaulted to `"team"`. The pre-change Kotlin wrote
+`team.type ?: "team"`, which mislabelled an enterprise whose own document said
+otherwise; it now travels only when the local document has one.
+
+## The three items, each demonstrated failing first
+
+Run against the pre-fix tree (`git stash push lib/`, temporary test file,
+output kept at `prefix_evidence.txt` in the session scratchpad):
+
+```
+DEFECT 3: an adopted team survey uploads no team object
+  Expected: {'_id': 'team-1', 'name': 'Water quality group', 'type': 'enterprise'}
+    Actual: <null>
+DEFECT 3b: a team whose document is absent loses its id too
+  Expected: {'_id': 'team-missing'}
+    Actual: <null>
+DEFECT 1: an exam attempt cannot record the team it was taken for
+  Expected: 'team-1'
+    Actual: <null>
+  the attempt was started from team-1
+```
+
+**Item 3 is the one with effect today, so it leads.** The port's `serialize`
+emitted no `team` key at all, and its reader is already reachable: two writers
+put a value in `submissions.teamId` today — `createSurveyAdoptionSubmission`
+(a team survey's adoption marker, which is `isUpdated: true` and so a pending
+upload the moment it is written) and `upsertDocuments` (the sync-in, from
+`team._id` or `user.membershipDoc.teamId`). Both went up with the team dropped
+from the document body.
+
+**Item 1** is the writer half. The port's exam-session writer took no team at
+all, so the column was never written from this device; `startExamSession` now
+takes `teamId` and persists it **unconditionally when non-blank**, which is the
+upstream fix. See *Reported, not fixed* — nothing passes it yet.
+
+**Item 2** is the lookup, and it is what makes item 1's "unconditionally"
+survive contact with a real device.
+
+## Cancellation versus exception
+
+Kotlin's `getTeamByIdOrNull` rethrows `CancellationException` and swallows
+every other `Exception`. It **has** to name that type, because in Kotlin a
+cancellation *is* an `Exception`: a bare `catch (_: Exception)` would swallow a
+cancelled coroutine and turn it into a silent null.
+
+Dart has no cancellation exception — a `Future` is not cancellable — so there
+is no type to rethrow. The analogous hazard is `Error`: a `TypeError` or
+`StateError` out of this lookup means a defect in this code, not a missing row,
+and reporting it as a cache miss would hide it behind a document that merely
+looks under-populated.
+
+So the port catches `on Exception`, not a bare `catch`:
+
+* an `Exception` (a drift/IO failure — the thing Kotlin is absorbing) → `null`,
+  the cache-miss path, and the upload keeps its `team._id`;
+* an `Error` → propagates.
+
+Both halves are pinned by tests, with a `TeamDao` whose one read fails: one
+throwing an `Exception` (the document still uploads with `{"_id": …}`) and one
+throwing a `StateError` (`serialize` rethrows it).
+
+## The corrected doc comment — and a correction to Phase 126's note
+
+Phase 126 recorded that "the port's own doc comment says so
+(`serializeSubmission` emits none)". **That quotation is of the wrong comment.**
+The text it quotes is in `serialize`'s doc block at
+`submissions_repository.dart:981` and is about the **top-level `userId`** key,
+not the team — and it is still true, so it is not stale and has not been
+touched.
+
+The genuinely stale claim is in `_userDocument`'s doc block, which said
+`membershipDoc` is
+
+> where the sync-in recovers `teamId` from when the document has no `team`
+> object, so omitting it dropped a team submission's team on every round trip
+
+— i.e. it assumed the port's uploaded document never has a `team` object,
+which stops being true here. Corrected in place: `membershipDoc` is now the
+*fallback* the sync-in reads when `team` is absent, both are sent as Kotlin
+sends both, and the sync-in prefers `team._id`. The comment also now records
+why Kotlin rebuilds `membershipDoc` on every read rather than persisting it
+(`Submission.membershipDoc` is `@Ignore`d, `hydrateSubmissions:73`), which is
+the same reason the field covers rows whose `teamId` came from the server.
+
+## Kotlin's `teamObject` branch has no port counterpart, and needs none
+
+`resolveTeamJson` prefers `submission.teamObject?._id` over
+`submission.teamId`. `Submission.teamObject` is `@Ignore`d
+(`Submission.kt:20`) — never persisted — and both Kotlin serializers are
+reached from `UploadConfigs` with rows fetched through
+`getPendingExamResults`/`getPendingSubmissionsForUpload`
+(`UploadConfigs.kt:242,257`), which rehydrate `membershipDoc` and not
+`teamObject`. So the field is null on the upload path and the `teamId`
+fallback is the branch that runs. The port's `serialize` likewise only ever
+receives a persisted `SubmissionRow`.
+
+This is also why item 1 matters as much as it does: the column is the *only*
+durable carrier, so the pre-change Kotlin's gate on a resolved team did not
+merely omit a name — it lost the attribution permanently.
+
+## What was touched, region by region
+
+`lib/repository/submissions_repository.dart` is shared at section level this
+round; Lane A owns the read path (`hasSubmission` and the submission queries).
+**Every edit here is on the write side.** No read-path method was read, called
+or changed; nothing in the file was renamed or moved.
+
+| region | change |
+|---|---|
+| constructor + fields (`:18-50`) | `required TeamDao teamDao` named parameter, `_teamDao` field |
+| `startExamSession` doc + signature | `String? teamId`, doc for it and for its missing caller |
+| `_openExamSession` | `teamId` parameter, `persistedTeamId` blank-guard, `teamId: Value(...)` on the companion |
+| `serialize` | `final team = await _resolveTeamJson(row)` and `'team': ?team` after `type` |
+| `_userDocument` doc block | the stale `team`-object claim corrected |
+| new, placed after `_userDocument` | `_resolveTeamJson`, `_teamByIdOrNull` |
+
+`lib/providers/app_providers.dart` — one line, `teamDao:` on
+`submissionsRepositoryProvider`.
+
+The dependency is a **required** named parameter rather than an optional one on
+purpose. An optional team lookup that silently degrades a document's contents
+is the exact shape this project keeps getting burned by; the compiler now makes
+every construction site say what it wants. That cost 18 one-line additions
+across 14 test files (all in `setUp`-style constructor calls, plus two
+`Fake` overrides of `startExamSession` in `test/ui/exam/take_exam_screen_test.dart`
+that the signature change forced).
+
+## Tests
+
+`test/repository/submission_team_object_test.dart`, 14 new tests: the resolved
+and unresolved team, blank name/type, the absent `type` (no `"team"` default),
+no team, a blank team id, `membershipDoc` surviving alongside the new key, the
+two lookup-failure halves, and four on the exam writer.
+
+## Reported, not fixed
+
+### The port's answer sheets carry no team, because nothing plumbs one
+
+This is the reachability half of item 1 and it is a **named gap, not a finished
+feature**. `startExamSession(teamId:)` exists and is tested, and no caller
+passes it.
+
+In Kotlin the team context is fragment arguments: `TeamPagerAdapter` opens the
+team's surveys tab with `putBoolean("isTeam", true)` plus the team id,
+`BaseExamFragment` reads both (`:77-78`), and `ExamTakingFragment` passes
+`if (isTeam) teamId else null` into `CreateExamSubmissionRequest` (`:124-125`,
+`:151-152`).
+
+In the port, `TeamSurveysScreen` (`lib/ui/teams/team_surveys_screen.dart:67`)
+pushes `'${Routes.surveys}/${survey.id}'` and drops the team on the floor, so
+**every answer sheet the port writes is team-less where Kotlin's carries the
+team.** Closing it is three edits, all outside this lane's file set:
+
+1. `lib/ui/router.dart` — a `teamId` query parameter on the survey route;
+2. `lib/ui/surveys/take_survey_screen.dart` — accept it and pass it to the
+   submission writer (its writer is `createSurveyDraft` /
+   `getOrCreateSurveySubmission`, which need the same `teamId` treatment
+   `_openExamSession` just got — Kotlin reaches all of them through the one
+   `createExamSubmission`);
+3. `lib/ui/teams/team_surveys_screen.dart` — send it.
+
+Whoever takes it should note that `take_survey_screen` is the port's survey
+analogue of `ExamTakingFragment`'s survey branch, and Kotlin's survey branch
+passes the team too (`:151-152`) — this is not exam-only.
+
+### The stored `user` blob's `age`/`gender`
+
+Kotlin's `createExamSubmission` writes `user` as
+`{"age": dob, "gender": gender, "membershipDoc": {"teamId": …}}` when a team is
+present. The port writes no `user` column there, and deliberately: the
+`membershipDoc` half is already synthesized at serialize time from the row's
+`teamId` (`_userDocument`), which is a superset — it also covers rows whose
+`teamId` arrived from the server, exactly as Kotlin's `hydrateSubmissions`
+does. The `age`/`gender` half would need the profile fields the port's
+exam-session caller does not hold, and on the document that actually reaches
+Planet the stored blob is only Kotlin's *fallback* — both serializers prefer
+the live `UserEntity.serialize()`. The port having no live user lookup is a
+pre-existing recorded gap (`_userDocument`'s doc block), not something this
+phase changed.
+
+### Item 4 of Phase 126's routed list was not assigned to this lane
+
+Phase 126's "To Lane A — `aca425a`" list has a fourth item, the `27c0470`
+site: a submission's nested `parent` should carry `androidId` and `app`,
+because `StepExam.serializeExam` is shared with the `exams`-database upload,
+and the port's `examParentDocument` is `static` with no `DeviceIdentity` seam.
+This lane's brief enumerates items 1–3 only, and `examParentDocument` sits
+between the two owners' regions, so it was left alone. It is still open.

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -446,6 +446,7 @@ final submissionsRepositoryProvider = Provider<SubmissionsRepository>(
     ref.watch(submitPhotosDaoProvider),
     ref.watch(surveyDaoProvider),
     ref.watch(examDaoProvider),
+    teamDao: ref.watch(teamDaoProvider),
   ),
 );
 

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -106,14 +106,35 @@ class SubmissionsRepository {
   }
 
   /// Creates the empty answer sheet used when a user starts an offline survey.
+  ///
+  /// **This is the branch of `createExamSubmission` a team can actually reach**,
+  /// and the port splitting one Kotlin writer in two is what hid that. Every
+  /// Kotlin site that sets `isTeam = true` also sets `type = "survey"` —
+  /// `SubmissionsAdapter.openSurvey` (`:114-121`) for the team's surveys tab
+  /// and `PublicSurveyActivity` (`:99-107`) for a deep link — so
+  /// `ExamTakingFragment`'s exam branch passes a `teamId` that is always null
+  /// and a graded course exam can never carry a team. [teamId] therefore
+  /// belongs here as much as on [startExamSession], with the same
+  /// blank-guarded, unconditional write.
+  ///
+  /// **No caller passes it yet** — see [startExamSession] and
+  /// `PHASE_129_NOTES.md` for the chain that has to carry it
+  /// (`TeamSurveysScreen` -> the survey route -> `TakeSurveyScreen` ->
+  /// `SurveysRepository.submitResponse`), and for the second site,
+  /// `public_survey_screen`, which already holds the team id it does not pass.
   Future<String> createSurveyDraft({
     required SurveyRow survey,
     required List<SurveyQuestionRow> questions,
     required String userId,
     Map<String, SubmissionDraftAnswer> answers = const {},
+    String? teamId,
     DateTime? now,
   }) async {
     final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
+    // `teamId?.takeIf { it.isNotBlank() }` (`createExamSubmission:440`).
+    final persistedTeamId = (teamId == null || teamId.trim().isEmpty)
+        ? null
+        : teamId;
     final id = sha1
         .convert(utf8.encode('$userId:$timestamp:${survey.id}'))
         .toString();
@@ -130,6 +151,7 @@ class SubmissionsRepository {
           parent: Value(jsonEncode({'_id': survey.id, 'name': survey.name})),
           userId: Value(userId),
           type: const Value('survey'),
+          teamId: Value(persistedTeamId),
           startTime: Value(timestamp),
           lastUpdateTime: Value(timestamp),
           status: const Value('complete'),
@@ -257,24 +279,36 @@ class SubmissionsRepository {
   /// attempt out of `pendingUploads`; Kotlin gets the same effect from
   /// `getPendingSubmissions`' `WHERE status = 'complete'` filter.
   ///
-  /// [teamId] is the team an attempt started from a team's own surveys tab
-  /// belongs to: `ExamTakingFragment` reads `isTeam`/`teamId` from its
-  /// arguments and passes `if (isTeam) teamId else null` into the request
-  /// (`:124-125`, `:151-152`), and `createExamSubmission` persists it. It is
-  /// stored **whether or not the team document is on this handset**, which is
-  /// the `aca425a` fix: the column is the only durable carrier
-  /// (`Submission.teamObject` is `@Ignore`d), so gating the write on a
-  /// successful lookup lost the attribution for good. See [_resolveTeamJson].
+  /// [teamId] mirrors `createExamSubmission`'s own parameter, which
+  /// `ExamTakingFragment` fills from `if (isTeam) teamId else null` on both
+  /// its branches (`:124-125` exam, `:151-152` survey). It is stored
+  /// **whether or not the team document is on this handset**, which is the
+  /// `aca425a` fix. `Submission.teamObject` and `Submission.membershipDoc` are
+  /// both `@Ignore`d, so gating the write on a successful lookup left the
+  /// attribution nowhere durable except inside the `user` JSON blob the same
+  /// block wrote — and that blob is overwritten by the respondent profile
+  /// (`UserInformationFragment` -> `SubmissionDao.markComplete`) and dropped
+  /// on upload whenever the live `users` row resolves. The column is the only
+  /// carrier that survives both. See [_resolveTeamJson].
   ///
-  /// **Nothing in the port passes it yet, and that is a named gap, not a
-  /// finished feature.** `TeamSurveysScreen` pushes
+  /// **On the exam arm that parameter is dead in Kotlin too, and saying
+  /// otherwise was this phase's own mistake.** Every Kotlin site that sets
+  /// `isTeam = true` also sets `type = "survey"`
+  /// (`SubmissionsAdapter.openSurvey:114-121`, `PublicSurveyActivity:99-107`);
+  /// `CourseStepFragment`'s exam launch (`:277-289`) passes no team argument
+  /// at all, so `type` keeps `BaseExamFragment`'s `"exam"` default and a
+  /// graded course exam can never carry a team. It is kept here because this
+  /// method is `createExamSubmission`'s exam arm and dropping it would make
+  /// the port's split unable to express its own specification — but the arm a
+  /// team reaches is [createSurveyDraft], and that is where the port's gap
+  /// actually is.
+  ///
+  /// **Nothing in the port passes it on either arm yet, and that is a named
+  /// gap, not a finished feature.** `TeamSurveysScreen` pushes
   /// `'${Routes.surveys}/${survey.id}'` with no team, so the port's answer
   /// sheets are all team-less where Kotlin's carry the team. Closing it is
-  /// three edits outside this repository — a query parameter on the survey
-  /// route, `TakeSurveyScreen` accepting it, and the team surveys tab sending
-  /// it — recorded in `PHASE_129_NOTES.md`. The parameter is here because the
-  /// alternative is a write path that cannot express the thing it is being
-  /// fixed to express; it is covered by tests that call it directly.
+  /// four edits outside this repository, all recorded in
+  /// `PHASE_129_NOTES.md`.
   Future<String> startExamSession({
     required ExamRow exam,
     required List<ExamQuestionRow> questions,
@@ -1020,7 +1054,7 @@ class SubmissionsRepository {
   /// also sends remain part of the community-code parity gap.
   ///
   /// There is deliberately **no top-level `userId`**. Kotlin's
-  /// `serializeSubmission` emits none (`SubmissionsRepositoryImpl.kt:813-862`)
+  /// `serializeSubmission` emits none (`SubmissionsRepositoryImpl.kt:820-865`)
   /// and its sync-in derives the owner from `user._id`, so the key the port
   /// used to send was one only the port could read — which is exactly why the
   /// sync-in's matching read of it went unnoticed. See [_userDocument].
@@ -1315,9 +1349,16 @@ class SubmissionsRepository {
   /// `teamId`. It used to be the *only* place a team survived an upload, and
   /// this comment used to say so; [serialize] now emits a top-level `team`
   /// object as well (`aca425a`), so `membershipDoc` is the fallback the
-  /// sync-in reads when `team` is absent rather than the sole carrier. Both
-  /// are sent, as Kotlin sends both, and the sync-in prefers `team._id`
-  /// ([upsertDocuments]).
+  /// sync-in reads when `team` is absent rather than the sole carrier. The
+  /// port sends both, and the sync-in prefers `team._id` ([upsertDocuments]).
+  ///
+  /// Sending both is a **superset** on the exam arm, not a Kotlin quirk:
+  /// `serializeSubmission` merges `membershipDoc` into the user object
+  /// (`:851-856`) while `getExamUploadPayload` (`:749-790`) sends `team` and
+  /// never touches `membershipDoc`. The port has one [serialize] for both
+  /// Kotlin serializers, so an exam-typed row carries a key Kotlin's exam
+  /// path omits. Harmless — it is the same team id, in the field the port's
+  /// own sync-in already falls back to.
   ///
   /// It also covers the case the writer cannot: a row whose `teamId` came from
   /// the server rather than from this device still gets its `membershipDoc`,
@@ -1364,7 +1405,7 @@ class SubmissionsRepository {
   /// (`Submission.kt:20`) — it is never persisted, and both Kotlin serializers
   /// are reached from `UploadConfigs` with rows fetched through
   /// `getPendingExamResults`/`getPendingSubmissionsForUpload`
-  /// (`UploadConfigs.kt:242,257`), which rehydrate `membershipDoc` and not
+  /// (`UploadConfigs.kt:242,256`), which rehydrate `membershipDoc` and not
   /// `teamObject`. So the field is always null on the upload path and the
   /// `submission.teamId` fallback is the branch that runs. The port's
   /// [serialize] likewise only ever sees a persisted [SubmissionRow].
@@ -1394,19 +1435,33 @@ class SubmissionsRepository {
   /// `createExamSubmission` down and `startExamSession`'s three retries burned
   /// on an error retrying cannot fix.
   ///
-  /// **`on Exception` is the port of the `CancellationException` rethrow, not
-  /// a loosening of it.** Kotlin has to name that type because it *is* an
-  /// `Exception`, so a bare `catch (_: Exception)` would swallow a coroutine
-  /// cancellation and turn a cancelled scope into a silent null. Dart has no
-  /// cancellation exception — a `Future` is not cancellable — and the analogous
-  /// hazard is `Error`: a `TypeError` or a `StateError` here is a defect in
-  /// this code, not a missing row, and swallowing it would report a cache miss
-  /// where the truth is a bug. `on Exception` catches the expected failures
-  /// (drift/IO) and lets every `Error` through, which is why it is not a bare
-  /// `catch`.
+  /// **Drift has a `CancellationException` and it implements `Exception`**, so
+  /// the rethrow ports literally rather than by analogy. Kotlin has to name
+  /// its own `CancellationException` for exactly this reason — a cancellation
+  /// *is* an `Exception` there, so a lone `catch (_: Exception)` would swallow
+  /// a cancelled scope and turn it into a silent null. The port's production
+  /// executor is `NativeDatabase.createInBackground`, whose isolate server
+  /// wraps every query in drift's `runCancellable`, so the same type is on the
+  /// table here; no path reaches this one-shot read from inside a cancellation
+  /// zone today, and that is not a reason to leave the hazard unhandled. An
+  /// earlier revision of this comment claimed "Dart has no cancellation
+  /// exception"; it was wrong.
+  ///
+  /// Every other `Exception` — a drift or IO failure, the thing Kotlin is
+  /// absorbing — becomes a cache miss, and the upload keeps its `team._id`.
+  ///
+  /// An `Error` propagates, which is **deliberately stricter than Kotlin** in
+  /// one case: reading a closed database throws Dart `StateError` where Room
+  /// throws `IllegalStateException`, an `Exception` that Kotlin's catch
+  /// absorbs. Nothing in `lib/` ever closes the database, so in production the
+  /// case does not arise; when it does arise it is a defect in the caller, and
+  /// reporting it as a team that is merely missing would hide it behind a
+  /// document that looks under-populated.
   Future<TeamRow?> _teamByIdOrNull(String teamId) async {
     try {
       return await _teamDao.getById(teamId);
+    } on CancellationException {
+      rethrow;
     } on Exception catch (_) {
       return null;
     }
@@ -1443,7 +1498,7 @@ class SubmissionsRepository {
   /// sent:
   ///
   /// * `userId` is `normalizeSubmissionUserId(user._id)` — the owner lives in
-  ///   the nested user object, and `serializeSubmission` (`:813-862`) emits no
+  ///   the nested user object, and `serializeSubmission` (`:820-865`) emits no
   ///   top-level `userId` at all. The port's own uploader used to emit one,
   ///   which is the only reason anything ever appeared here: the pair agreed
   ///   with itself and disagreed with Planet.

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -20,8 +20,9 @@ class SubmissionsRepository {
     this._dao,
     this._photosDao,
     this._surveyDao,
-    this._examDao,
-  );
+    this._examDao, {
+    required TeamDao teamDao,
+  }) : _teamDao = teamDao;
 
   static const int initialBatchSize = 100;
 
@@ -37,6 +38,18 @@ class SubmissionsRepository {
   /// `exams` table into [Exams] and [Surveys], so the lookup needs both this
   /// and `_surveyDao`.
   final ExamDao _examDao;
+
+  /// The team a submission is attributed to, for the `team` object every
+  /// upload carries (see [_resolveTeamJson]).
+  ///
+  /// Kotlin reaches the same row through `Provider<TeamsRepository>`, whose
+  /// one use is `getTeamById(teamId)` -> `teamDao.getById(teamId)`
+  /// (`TeamsRepositoryImpl.kt:375-378`); the lazy `Provider` wrapper is a Hilt
+  /// cycle-breaker, not behaviour, so the port injects the DAO the repository
+  /// would have delegated to. `TeamDao.getById` matches it exactly — the
+  /// document's own `_id`, never the `teamId` column that memberships,
+  /// requests and reports all carry.
+  final TeamDao _teamDao;
 
   Stream<List<SubmissionRow>> watchForUser(String userId) =>
       _dao.watchForUser(userId);
@@ -243,11 +256,31 @@ class SubmissionsRepository {
   /// `pending` status plus `isUpdated: false` is what keeps a half-finished
   /// attempt out of `pendingUploads`; Kotlin gets the same effect from
   /// `getPendingSubmissions`' `WHERE status = 'complete'` filter.
+  ///
+  /// [teamId] is the team an attempt started from a team's own surveys tab
+  /// belongs to: `ExamTakingFragment` reads `isTeam`/`teamId` from its
+  /// arguments and passes `if (isTeam) teamId else null` into the request
+  /// (`:124-125`, `:151-152`), and `createExamSubmission` persists it. It is
+  /// stored **whether or not the team document is on this handset**, which is
+  /// the `aca425a` fix: the column is the only durable carrier
+  /// (`Submission.teamObject` is `@Ignore`d), so gating the write on a
+  /// successful lookup lost the attribution for good. See [_resolveTeamJson].
+  ///
+  /// **Nothing in the port passes it yet, and that is a named gap, not a
+  /// finished feature.** `TeamSurveysScreen` pushes
+  /// `'${Routes.surveys}/${survey.id}'` with no team, so the port's answer
+  /// sheets are all team-less where Kotlin's carry the team. Closing it is
+  /// three edits outside this repository — a query parameter on the survey
+  /// route, `TakeSurveyScreen` accepting it, and the team surveys tab sending
+  /// it — recorded in `PHASE_129_NOTES.md`. The parameter is here because the
+  /// alternative is a write path that cannot express the thing it is being
+  /// fixed to express; it is covered by tests that call it directly.
   Future<String> startExamSession({
     required ExamRow exam,
     required List<ExamQuestionRow> questions,
     required String userId,
     String? courseId,
+    String? teamId,
     DateTime? now,
   }) async {
     final resolvedCourseId = (courseId?.isNotEmpty ?? false)
@@ -267,6 +300,7 @@ class SubmissionsRepository {
           questions: questions,
           userId: userId,
           parentId: parentId,
+          teamId: teamId,
           now: now,
         );
       } on Exception catch (error) {
@@ -283,9 +317,16 @@ class SubmissionsRepository {
     required List<ExamQuestionRow> questions,
     required String userId,
     required String parentId,
+    String? teamId,
     DateTime? now,
   }) async {
     await _deleteExamSubmissions(parentId: parentId, userId: userId);
+    // `teamId?.takeIf { it.isNotBlank() }` (`createExamSubmission:440`), and
+    // written to the column **unconditionally** — see [_resolveTeamJson] and
+    // the doc comment above for why the team must not depend on the lookup.
+    final persistedTeamId = (teamId == null || teamId.trim().isEmpty)
+        ? null
+        : teamId;
     final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
     final id = sha1
         .convert(utf8.encode('$userId:$timestamp:${exam.id}'))
@@ -306,6 +347,7 @@ class SubmissionsRepository {
           ),
           userId: Value(userId),
           type: const Value('exam'),
+          teamId: Value(persistedTeamId),
           startTime: Value(timestamp),
           lastUpdateTime: Value(timestamp),
           // Deliberately left at 0. `createExamSubmission` never sets a
@@ -985,6 +1027,7 @@ class SubmissionsRepository {
   Future<Map<String, dynamic>> serialize(SubmissionRow row) async {
     final answers = await _dao.answersFor(row.id);
     final parent = await _parentDocument(row);
+    final team = await _resolveTeamJson(row);
     return {
       if (row.couchId != null && row.couchId!.isNotEmpty) '_id': row.couchId,
       if (row.rev != null && row.rev!.isNotEmpty) '_rev': row.rev,
@@ -992,6 +1035,9 @@ class SubmissionsRepository {
       // these unconditionally, so a null would arrive as a missing field.
       'parentId': row.parentId ?? '',
       'type': row.type ?? 'survey',
+      // Straight after `type`, where both Kotlin serializers add it
+      // (`getExamUploadPayload:764`, `serializeSubmission:836`).
+      'team': ?team,
       'status': row.status ?? 'pending',
       'startTime': row.startTime,
       'lastUpdateTime': row.lastUpdateTime,
@@ -1266,9 +1312,18 @@ class SubmissionsRepository {
   /// still a gap, recorded in the phase notes.
   ///
   /// `membershipDoc` rides along the same way Kotlin adds it, from the row's
-  /// `teamId` — it is where the sync-in recovers `teamId` from when the
-  /// document has no `team` object, so omitting it dropped a team submission's
-  /// team on every round trip.
+  /// `teamId`. It used to be the *only* place a team survived an upload, and
+  /// this comment used to say so; [serialize] now emits a top-level `team`
+  /// object as well (`aca425a`), so `membershipDoc` is the fallback the
+  /// sync-in reads when `team` is absent rather than the sole carrier. Both
+  /// are sent, as Kotlin sends both, and the sync-in prefers `team._id`
+  /// ([upsertDocuments]).
+  ///
+  /// It also covers the case the writer cannot: a row whose `teamId` came from
+  /// the server rather than from this device still gets its `membershipDoc`,
+  /// which is why Kotlin rebuilds the field on every read
+  /// (`hydrateSubmissions`, `SubmissionsRepositoryImpl.kt:73`) instead of
+  /// persisting it — `Submission.membershipDoc` is `@Ignore`d.
   static Object? _userDocument(SubmissionRow row) {
     final userId = row.userId;
     final stored = _asDocument(row.user);
@@ -1287,6 +1342,74 @@ class SubmissionsRepository {
       base['membershipDoc'] = {'teamId': teamId};
     }
     return base;
+  }
+
+  /// The `team` object the upload carries, or null when this submission has no
+  /// team to attribute — a port of `resolveTeamJson`
+  /// (`SubmissionsRepositoryImpl.kt:791-810`, new in `aca425a`).
+  ///
+  /// The id is the authority and the name and type are decoration: `_id` is
+  /// always written when there is an id at all, while `name` and `type` are
+  /// **omitted rather than sent as null** when the team document is not on
+  /// this handset. That asymmetry is the whole point of the upstream change.
+  /// Planet attributes a submission by `team._id`, so a document with the id
+  /// and no name is attributable and one with neither is not; the previous
+  /// Kotlin emitted the object only when the team resolved, which silently
+  /// dropped the association exactly when the local cache was incomplete —
+  /// the normal state of a handset that has not finished syncing.
+  ///
+  /// **Kotlin's `teamObject` branch has no port counterpart, and needs none.**
+  /// `resolveTeamJson` prefers `submission.teamObject?._id` over
+  /// `submission.teamId`, but `Submission.teamObject` is `@Ignore`d
+  /// (`Submission.kt:20`) — it is never persisted, and both Kotlin serializers
+  /// are reached from `UploadConfigs` with rows fetched through
+  /// `getPendingExamResults`/`getPendingSubmissionsForUpload`
+  /// (`UploadConfigs.kt:242,257`), which rehydrate `membershipDoc` and not
+  /// `teamObject`. So the field is always null on the upload path and the
+  /// `submission.teamId` fallback is the branch that runs. The port's
+  /// [serialize] likewise only ever sees a persisted [SubmissionRow].
+  Future<Map<String, dynamic>?> _resolveTeamJson(SubmissionRow row) async {
+    final teamId = row.teamId;
+    // `?.takeIf { it.isNotBlank() } ?: return null` (`:793-795`) — blank, not
+    // merely empty, so a whitespace column cannot produce `{"_id": " "}`.
+    if (teamId == null || teamId.trim().isEmpty) return null;
+
+    final team = await _teamByIdOrNull(teamId);
+    final name = team?.name;
+    final type = team?.type;
+    return {
+      '_id': teamId,
+      // The stored value, not the trimmed one: Kotlin's `takeIf` decides
+      // whether to write the string, it does not rewrite it.
+      if (name != null && name.trim().isNotEmpty) 'name': name,
+      if (type != null && type.trim().isNotEmpty) 'type': type,
+    };
+  }
+
+  /// Port of `getTeamByIdOrNull` (`SubmissionsRepositoryImpl.kt:812-818`): the
+  /// team if this handset has it, null if the lookup fails.
+  ///
+  /// A failed lookup must not fail the upload. Before `aca425a` the Kotlin
+  /// called `getTeamById` bare, so a throwing read took the whole
+  /// `createExamSubmission` down and `startExamSession`'s three retries burned
+  /// on an error retrying cannot fix.
+  ///
+  /// **`on Exception` is the port of the `CancellationException` rethrow, not
+  /// a loosening of it.** Kotlin has to name that type because it *is* an
+  /// `Exception`, so a bare `catch (_: Exception)` would swallow a coroutine
+  /// cancellation and turn a cancelled scope into a silent null. Dart has no
+  /// cancellation exception — a `Future` is not cancellable — and the analogous
+  /// hazard is `Error`: a `TypeError` or a `StateError` here is a defect in
+  /// this code, not a missing row, and swallowing it would report a cache miss
+  /// where the truth is a bug. `on Exception` catches the expected failures
+  /// (drift/IO) and lets every `Error` through, which is why it is not a bare
+  /// `catch`.
+  Future<TeamRow?> _teamByIdOrNull(String teamId) async {
+    try {
+      return await _teamDao.getById(teamId);
+    } on Exception catch (_) {
+      return null;
+    }
   }
 
   /// `parent` and `user` are stored locally as JSON *text*, but Kotlin uploads

--- a/flutter/test/providers/dashboard_providers_test.dart
+++ b/flutter/test/providers/dashboard_providers_test.dart
@@ -116,6 +116,7 @@ void main() {
         db.submitPhotosDao,
         db.surveyDao,
         db.examDao,
+        teamDao: db.teamDao,
       ).createBulkSurveySubmissions('survey-1', const ['user-1']);
     }
 

--- a/flutter/test/repository/exam_flow_test.dart
+++ b/flutter/test/repository/exam_flow_test.dart
@@ -34,6 +34,7 @@ void main() {
       database.submitPhotosDao,
       database.surveyDao,
       database.examDao,
+      teamDao: database.teamDao,
     );
     surveys = SurveysRepository(
       api,

--- a/flutter/test/repository/mandatory_survey_round_trip_test.dart
+++ b/flutter/test/repository/mandatory_survey_round_trip_test.dart
@@ -60,6 +60,7 @@ void main() {
       database.submitPhotosDao,
       database.surveyDao,
       database.examDao,
+      teamDao: database.teamDao,
     );
     surveys = SurveysRepository(
       api,

--- a/flutter/test/repository/public_survey_uploader_test.dart
+++ b/flutter/test/repository/public_survey_uploader_test.dart
@@ -33,6 +33,7 @@ void main() {
       database.submitPhotosDao,
       database.surveyDao,
       database.examDao,
+      teamDao: database.teamDao,
     );
     surveys = SurveysRepository(
       api,

--- a/flutter/test/repository/step_assessment_sync_test.dart
+++ b/flutter/test/repository/step_assessment_sync_test.dart
@@ -55,6 +55,7 @@ void main() {
         db.submitPhotosDao,
         db.surveyDao,
         db.examDao,
+        teamDao: db.teamDao,
       ),
     );
   });

--- a/flutter/test/repository/submission_team_object_test.dart
+++ b/flutter/test/repository/submission_team_object_test.dart
@@ -1,4 +1,4 @@
-import 'package:drift/drift.dart' show Value;
+import 'package:drift/drift.dart' show CancellationException, Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/data/api/planet_api.dart';
@@ -103,19 +103,25 @@ void main() {
     );
 
     /// `name`/`type` are **omitted**, never sent as null: Kotlin guards each
-    /// with `?.let { addProperty(...) }` (`:806-808`). A null would overwrite
+    /// with `?.let { addProperty(...) }` (`:807-808`). A null would overwrite
     /// a name Planet already holds.
+    ///
+    /// The two guards are independent, so a resolved team can contribute one
+    /// key and not the other — the case an exact-equality assertion on the
+    /// all-or-nothing inputs cannot distinguish.
     test(
-      'omits a name and type it cannot resolve rather than nulling them',
+      'omits one key while keeping the other when only one resolves',
       () async {
-        final team = await teamOf(await adoptionFor('team-missing'));
-        expect((team! as Map).containsKey('name'), isFalse);
+        await seedTeam(type: '  ');
+        final team = await teamOf(await adoptionFor('team-1'));
+        expect((team! as Map)['name'], 'Water quality group');
         expect((team as Map).containsKey('type'), isFalse);
       },
     );
 
     test('omits a blank name and type the same way', () async {
-      // `takeIf { it.isNotBlank() }` (`:805-808`) — blank, not merely empty.
+      // `takeIf { it.isNotBlank() }` (`:797-798`, `:807-808`) — blank, not
+      // merely empty, so a whitespace name cannot reach the wire.
       await seedTeam(name: '   ', type: '');
       expect(await teamOf(await adoptionFor('team-1')), {'_id': 'team-1'});
     });
@@ -172,16 +178,89 @@ void main() {
       expect(await teamOf(await adoptionFor('team-1')), {'_id': 'team-1'});
     });
 
-    /// The port of Kotlin's `CancellationException` rethrow. Dart has no
-    /// cancellation exception; the hazard `on Exception` guards against is an
-    /// `Error`, which means a defect here rather than a missing row, and
-    /// reporting it as a cache miss would hide it.
+    /// Kotlin's `CancellationException` rethrow, ported literally: drift ships
+    /// a `CancellationException` that **implements `Exception`**, and the
+    /// port's production executor wraps queries in `runCancellable`, so a lone
+    /// `on Exception` would swallow a cancelled read exactly as a lone
+    /// `catch (_: Exception)` would in Kotlin.
+    test(
+      'rethrows a cancellation rather than reporting a cache miss',
+      () async {
+        repository = build(
+          teamDao: _FailingTeamDao(const CancellationException()),
+        );
+        final row = (await repository.getById(await adoptionFor('team-1')))!;
+        await expectLater(
+          repository.serialize(row),
+          throwsA(isA<CancellationException>()),
+        );
+      },
+    );
+
+    /// An `Error` propagates too, which is deliberately **stricter** than
+    /// Kotlin: reading a closed database throws Dart `StateError` where Room
+    /// throws `IllegalStateException`, which Kotlin's catch absorbs. Nothing
+    /// in `lib/` closes the database, and a defect in the caller should not
+    /// arrive as a team that merely looks missing.
     test('rethrows an Error instead of reporting a cache miss', () async {
       repository = build(teamDao: _FailingTeamDao(StateError('bad state')));
       final id = await adoptionFor('team-1');
       final row = (await repository.getById(id))!;
       await expectLater(repository.serialize(row), throwsA(isA<StateError>()));
     });
+  });
+
+  group('a survey answer sheet started from a team', () {
+    /// The arm that matters: every Kotlin site setting `isTeam = true` also
+    /// sets `type = "survey"`, so this — not `startExamSession` — is the
+    /// branch a team reaches.
+    Future<String> draftFor(String? teamId) async {
+      await database.surveyDao.upsertAll([
+        SurveysCompanion.insert(
+          id: 'survey-1',
+          name: const Value('Water quality'),
+          courseId: const Value('course-1'),
+        ),
+      ], const {});
+      final survey = (await database.surveyDao.getById('survey-1'))!;
+      return repository.createSurveyDraft(
+        survey: survey,
+        questions: const [],
+        userId: 'ada',
+        teamId: teamId,
+      );
+    }
+
+    test('persists the team id and uploads the team', () async {
+      await seedTeam();
+      final id = await draftFor('team-1');
+      expect((await repository.getById(id))!.teamId, 'team-1');
+      expect(await teamOf(id), {
+        '_id': 'team-1',
+        'name': 'Water quality group',
+        'type': 'enterprise',
+      });
+    });
+
+    test('persists it even when the team document is missing', () async {
+      final id = await draftFor('team-1');
+      expect((await repository.getById(id))!.teamId, 'team-1');
+      expect(await teamOf(id), {'_id': 'team-1'});
+    });
+
+    test(
+      'stores no team for a blank id, and none when none is given',
+      () async {
+        expect(
+          (await repository.getById(await draftFor('  ')))!.teamId,
+          isNull,
+        );
+        expect(
+          (await repository.getById(await draftFor(null)))!.teamId,
+          isNull,
+        );
+      },
+    );
   });
 
   group('an exam attempt started from a team', () {
@@ -201,11 +280,13 @@ void main() {
       });
     });
 
-    /// The `aca425a` fix, at the writer. `Submission.teamObject` is `@Ignore`d,
-    /// so the column is the only durable carrier: gating the write on a
-    /// resolved team — as the Kotlin used to — lost the attribution
-    /// permanently, and it lost it precisely on the handsets whose cache was
-    /// incomplete.
+    /// The `aca425a` fix, at the writer. `Submission.teamObject` and
+    /// `membershipDoc` are both `@Ignore`d, and the `user` blob that carried
+    /// the team id durably is overwritten by the respondent profile and
+    /// dropped on upload when the live `users` row resolves — so the column is
+    /// the only carrier that survives. Gating its write on a resolved team, as
+    /// the Kotlin used to, lost the attribution precisely on the handsets
+    /// whose cache was incomplete.
     test('persists it even when the team document is missing', () async {
       final id = await repository.startExamSession(
         exam: await seedExam(),

--- a/flutter/test/repository/submission_team_object_test.dart
+++ b/flutter/test/repository/submission_team_object_test.dart
@@ -1,0 +1,239 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// A [TeamDao] whose one read fails, standing in for the throwing lookup
+/// `getTeamByIdOrNull` exists to absorb.
+class _FailingTeamDao extends Mock implements TeamDao {
+  _FailingTeamDao(this.error);
+  final Object error;
+
+  @override
+  Future<TeamRow?> getById(String id) => Future<TeamRow?>.error(error);
+}
+
+/// The `team` object an uploaded submission carries — `resolveTeamJson` and
+/// the unconditional `teamId` write, ported from upstream `aca425a`
+/// ("teams: smoother submissions repository stamping", fixes #16664).
+///
+/// The whole point of that change is what happens when the team document is
+/// **not** on this handset, which is the normal state of a device that has not
+/// finished syncing, so the cache-miss path is tested first-class rather than
+/// as an afterthought.
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository repository;
+
+  SubmissionsRepository build({TeamDao? teamDao}) => SubmissionsRepository(
+    MockPlanetApi(),
+    database.submissionDao,
+    database.submitPhotosDao,
+    database.surveyDao,
+    database.examDao,
+    teamDao: teamDao ?? database.teamDao,
+  );
+
+  setUp(() {
+    database = AppDatabase.memory();
+    repository = build();
+  });
+  tearDown(() => database.close());
+
+  Future<void> seedTeam({
+    String id = 'team-1',
+    String? name = 'Water quality group',
+    String? type = 'enterprise',
+  }) => database.teamDao.upsert(
+    TeamsCompanion.insert(id: id, name: Value(name), type: Value(type)),
+  );
+
+  Future<String> adoptionFor(String? teamId, {String id = 'adoption-1'}) async {
+    await repository.createSurveyAdoptionSubmission(
+      id: id,
+      surveyId: 'survey-1',
+      userId: 'ada',
+      parentJson: '{"_id":"survey-1","name":"Water quality"}',
+      userJson: '{"_id":"ada"}',
+      source: 'planet-1',
+      parentCode: 'parent-1',
+      teamId: teamId,
+    );
+    return id;
+  }
+
+  Future<Object?> teamOf(String id) async =>
+      (await repository.serialize((await repository.getById(id))!))['team'];
+
+  Future<ExamRow> seedExam() async {
+    await database.examDao.upsertAll([
+      ExamsCompanion.insert(
+        id: 'exam-1',
+        name: const Value('Week 1'),
+        courseId: const Value('course-1'),
+      ),
+    ], const {});
+    return (await database.examDao.getById('exam-1'))!;
+  }
+
+  group('the team object an upload carries', () {
+    test('is the local name and type under the row\'s team id', () async {
+      await seedTeam();
+      expect(await teamOf(await adoptionFor('team-1')), {
+        '_id': 'team-1',
+        'name': 'Water quality group',
+        'type': 'enterprise',
+      });
+    });
+
+    /// The reason `aca425a` exists. `_id` alone still attributes the
+    /// submission — Planet joins on it — where the pre-change Kotlin emitted
+    /// no `team` key at all and the association was gone for good.
+    test(
+      'keeps the id when the team document is not on this handset',
+      () async {
+        expect(await teamOf(await adoptionFor('team-missing')), {
+          '_id': 'team-missing',
+        });
+      },
+    );
+
+    /// `name`/`type` are **omitted**, never sent as null: Kotlin guards each
+    /// with `?.let { addProperty(...) }` (`:806-808`). A null would overwrite
+    /// a name Planet already holds.
+    test(
+      'omits a name and type it cannot resolve rather than nulling them',
+      () async {
+        final team = await teamOf(await adoptionFor('team-missing'));
+        expect((team! as Map).containsKey('name'), isFalse);
+        expect((team as Map).containsKey('type'), isFalse);
+      },
+    );
+
+    test('omits a blank name and type the same way', () async {
+      // `takeIf { it.isNotBlank() }` (`:805-808`) — blank, not merely empty.
+      await seedTeam(name: '   ', type: '');
+      expect(await teamOf(await adoptionFor('team-1')), {'_id': 'team-1'});
+    });
+
+    /// `type` is no longer defaulted to `"team"`. The pre-change Kotlin wrote
+    /// `team.type ?: "team"`, which mislabelled an enterprise whose own
+    /// document said otherwise; the type now travels only when the local
+    /// document has one.
+    test('does not invent a type for a team whose document omits it', () async {
+      await seedTeam(type: null);
+      expect(await teamOf(await adoptionFor('team-1')), {
+        '_id': 'team-1',
+        'name': 'Water quality group',
+      });
+    });
+
+    test('is absent entirely for a submission with no team', () async {
+      final payload = await repository.serialize(
+        (await repository.getById(await adoptionFor(null)))!,
+      );
+      expect(payload.containsKey('team'), isFalse);
+    });
+
+    test(
+      'is absent for a blank team id rather than sent as a blank id',
+      () async {
+        final payload = await repository.serialize(
+          (await repository.getById(await adoptionFor('  ')))!,
+        );
+        expect(payload.containsKey('team'), isFalse);
+      },
+    );
+
+    /// `membershipDoc` is the other half Planet and the port's own sync-in
+    /// read the team back from, and it must survive alongside the new key —
+    /// not be replaced by it.
+    test('travels alongside the user object\'s membershipDoc', () async {
+      await seedTeam();
+      final payload = await repository.serialize(
+        (await repository.getById(await adoptionFor('team-1')))!,
+      );
+      expect((payload['user'] as Map)['membershipDoc'], {'teamId': 'team-1'});
+      expect((payload['team'] as Map)['_id'], 'team-1');
+    });
+  });
+
+  group('the team lookup', () {
+    /// `getTeamByIdOrNull` swallows `Exception` so a failing read cannot cost
+    /// the upload its team id — the document still goes up attributable.
+    test('failing does not fail the upload', () async {
+      repository = build(
+        teamDao: _FailingTeamDao(Exception('database is locked')),
+      );
+      expect(await teamOf(await adoptionFor('team-1')), {'_id': 'team-1'});
+    });
+
+    /// The port of Kotlin's `CancellationException` rethrow. Dart has no
+    /// cancellation exception; the hazard `on Exception` guards against is an
+    /// `Error`, which means a defect here rather than a missing row, and
+    /// reporting it as a cache miss would hide it.
+    test('rethrows an Error instead of reporting a cache miss', () async {
+      repository = build(teamDao: _FailingTeamDao(StateError('bad state')));
+      final id = await adoptionFor('team-1');
+      final row = (await repository.getById(id))!;
+      await expectLater(repository.serialize(row), throwsA(isA<StateError>()));
+    });
+  });
+
+  group('an exam attempt started from a team', () {
+    test('persists the team id', () async {
+      await seedTeam();
+      final id = await repository.startExamSession(
+        exam: await seedExam(),
+        questions: const [],
+        userId: 'ada',
+        teamId: 'team-1',
+      );
+      expect((await repository.getById(id))!.teamId, 'team-1');
+      expect(await teamOf(id), {
+        '_id': 'team-1',
+        'name': 'Water quality group',
+        'type': 'enterprise',
+      });
+    });
+
+    /// The `aca425a` fix, at the writer. `Submission.teamObject` is `@Ignore`d,
+    /// so the column is the only durable carrier: gating the write on a
+    /// resolved team — as the Kotlin used to — lost the attribution
+    /// permanently, and it lost it precisely on the handsets whose cache was
+    /// incomplete.
+    test('persists it even when the team document is missing', () async {
+      final id = await repository.startExamSession(
+        exam: await seedExam(),
+        questions: const [],
+        userId: 'ada',
+        teamId: 'team-1',
+      );
+      expect((await repository.getById(id))!.teamId, 'team-1');
+      expect(await teamOf(id), {'_id': 'team-1'});
+    });
+
+    test('stores no team for a blank id', () async {
+      final id = await repository.startExamSession(
+        exam: await seedExam(),
+        questions: const [],
+        userId: 'ada',
+        teamId: '   ',
+      );
+      expect((await repository.getById(id))!.teamId, isNull);
+    });
+
+    test('stores no team when none is given', () async {
+      final id = await repository.startExamSession(
+        exam: await seedExam(),
+        questions: const [],
+        userId: 'ada',
+      );
+      expect((await repository.getById(id))!.teamId, isNull);
+    });
+  });
+}

--- a/flutter/test/repository/submissions_exporter_test.dart
+++ b/flutter/test/repository/submissions_exporter_test.dart
@@ -23,6 +23,7 @@ void main() {
       db.submitPhotosDao,
       db.surveyDao,
       db.examDao,
+      teamDao: db.teamDao,
     );
     exporter = SubmissionsExporter(repository);
   });

--- a/flutter/test/repository/submissions_repository_test.dart
+++ b/flutter/test/repository/submissions_repository_test.dart
@@ -32,6 +32,7 @@ void main() {
       database.submitPhotosDao,
       database.surveyDao,
       database.examDao,
+      teamDao: database.teamDao,
     );
   });
 

--- a/flutter/test/repository/submissions_sync_round_trip_test.dart
+++ b/flutter/test/repository/submissions_sync_round_trip_test.dart
@@ -44,6 +44,7 @@ void main() {
       database.submitPhotosDao,
       database.surveyDao,
       database.examDao,
+      teamDao: database.teamDao,
     );
   });
   tearDown(() => database.close());
@@ -279,6 +280,7 @@ void main() {
         secondDevice.submitPhotosDao,
         secondDevice.surveyDao,
         secondDevice.examDao,
+        teamDao: secondDevice.teamDao,
       );
     });
     tearDown(() => secondDevice.close());
@@ -810,6 +812,7 @@ void main() {
         database.submitPhotosDao,
         database.surveyDao,
         database.examDao,
+        teamDao: database.teamDao,
       );
     });
 

--- a/flutter/test/repository/submissions_uploader_test.dart
+++ b/flutter/test/repository/submissions_uploader_test.dart
@@ -36,6 +36,7 @@ void main() {
       db.submitPhotosDao,
       db.surveyDao,
       db.examDao,
+      teamDao: db.teamDao,
     );
     outbox = OutboxRepository(db.outboxDao);
     uploader = SubmissionsUploader(api, repository, outbox, testDeviceIdentity);

--- a/flutter/test/repository/submit_photos_uploader_test.dart
+++ b/flutter/test/repository/submit_photos_uploader_test.dart
@@ -39,6 +39,7 @@ void main() {
       database.submitPhotosDao,
       database.surveyDao,
       database.examDao,
+      teamDao: database.teamDao,
     );
     outbox = OutboxRepository(database.outboxDao);
     uploader = SubmitPhotosUploader(

--- a/flutter/test/repository/survey_export_test.dart
+++ b/flutter/test/repository/survey_export_test.dart
@@ -30,6 +30,7 @@ void main() {
       database.submitPhotosDao,
       database.surveyDao,
       database.examDao,
+      teamDao: database.teamDao,
     );
   });
   tearDown(() => database.close());

--- a/flutter/test/repository/surveys_repository_test.dart
+++ b/flutter/test/repository/surveys_repository_test.dart
@@ -38,6 +38,7 @@ void main() {
         database.submitPhotosDao,
         database.surveyDao,
         database.examDao,
+        teamDao: database.teamDao,
       ),
     );
   });
@@ -333,6 +334,7 @@ void main() {
           database.submitPhotosDao,
           database.surveyDao,
           database.examDao,
+          teamDao: database.teamDao,
         ),
         urlMapper: ServerUrlMapper(
           mappings: {'http://local.example': 'https://alt.example'},
@@ -423,6 +425,7 @@ void main() {
         database.submitPhotosDao,
         database.surveyDao,
         database.examDao,
+        teamDao: database.teamDao,
       ).markSubmissionComplete(id!, {'birthYear': '2000', 'gender': 'male'});
 
       Map<String, dynamic>? capturedBody;
@@ -501,6 +504,7 @@ void main() {
             database.submitPhotosDao,
             database.surveyDao,
             database.examDao,
+            teamDao: database.teamDao,
           ),
           urlMapper: ServerUrlMapper(
             mappings: {'http://local.example': 'https://alt.example'},

--- a/flutter/test/ui/courses/course_progress_screen_test.dart
+++ b/flutter/test/ui/courses/course_progress_screen_test.dart
@@ -239,6 +239,7 @@ void main() {
         database.submitPhotosDao,
         database.surveyDao,
         database.examDao,
+        teamDao: database.teamDao,
       );
 
       final submissionId = await repository.startExamSession(

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -309,6 +309,7 @@ void main() {
       db.submitPhotosDao,
       db.surveyDao,
       db.examDao,
+      teamDao: db.teamDao,
     );
     final answered = await SurveysRepository(
       api,

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -100,6 +100,7 @@ class _FlakySubmissionsRepository extends Fake
     required List<ExamQuestionRow> questions,
     required String userId,
     String? courseId,
+    String? teamId,
     DateTime? now,
   }) async {
     calls++;
@@ -109,6 +110,7 @@ class _FlakySubmissionsRepository extends Fake
       questions: questions,
       userId: userId,
       courseId: courseId,
+      teamId: teamId,
       now: now,
     );
   }
@@ -139,6 +141,7 @@ class _ThrowingSubmissionsRepository extends Fake
     required List<ExamQuestionRow> questions,
     required String userId,
     String? courseId,
+    String? teamId,
     DateTime? now,
   }) async => throw Exception('disk full');
 }
@@ -1071,6 +1074,7 @@ void main() {
         db.submitPhotosDao,
         db.surveyDao,
         db.examDao,
+        teamDao: db.teamDao,
       );
       final flaky = _FlakySubmissionsRepository(real);
 


### PR DESCRIPTION
Lane B of a three-lane round. Ports the three behavioural changes Phase 126 verified in upstream `aca425a` ("teams: smoother submissions repository stamping", fixes #16664) but routed rather than applied, because `lib/repository/submissions_repository.dart` belonged to another lane.

Full write-up in `flutter/PHASE_129_NOTES.md`. Two `parity-auditor` passes at max effort ran per the standing rule — one on the Kotlin ground truth, one on this lane's own finished, green code. **Both found real defects**, including two claims of mine that were false; the second commit is those fixes.

## What a submission carries, before and after

| | before | after |
|---|---|---|
| adopted team survey, team document **present** | no `team` key at all | `{"_id", "name", "type"}` |
| adopted team survey, team document **absent** | no `team` key at all | `{"_id"}` |
| team survey sheet, team present | no `team` key, no `teamId` on the row | row carries `teamId`; `{"_id", "name", "type"}` — *once a caller passes one* |
| no team / blank team id | no `team` key | no `team` key |

The cache-miss row is the point of the upstream change: an incomplete local `teams` table is the normal state of a handset that has not finished syncing, and Planet attributes a submission by `team._id`, so the id alone is attributable where no key at all is not. `name`/`type` are **omitted, never nulled** — a null would overwrite a name the server holds. `type` is no longer defaulted to `"team"`; the live delta is `""` → omitted, where the old code sent `"type": ""`.

## The three items

1. **The writer keeps the team on a cache miss.** Persisted unconditionally when non-blank. `Submission.teamObject` and `membershipDoc` are both `@Ignore`d, and the `user` blob that also carried it is overwritten by the respondent profile and dropped on upload when the live `users` row resolves — so the column is the only carrier that survives. *The first cut put this on the exam writer, which is the one arm Kotlin itself cannot reach with a team* (every site setting `isTeam = true` also sets `type = "survey"`); `createSurveyDraft` now carries it too. **Neither has a caller yet** — that is a named gap in the notes with the four files that close it, not a finished feature.
2. **The lookup is failure-tolerant.** Kotlin's `CancellationException` rethrow ports *literally*: drift ships one, `package:drift/drift.dart` exports it, it `implements Exception`, and the port's production executor wraps every query in `runCancellable`. `Error` still propagates — deliberately stricter than Kotlin, whose `IllegalStateException` on a closed database it absorbs.
3. **`serialize` emits the `team` object**, via a port of the new `resolveTeamJson`. Its reachable reader is a synced team submission the user re-answers — live in both apps, and pre-change both lost the team. (The adoption marker also reaches it, but only through a pre-existing port divergence: Kotlin never uploads that document at all.)

## Verification

* All three defects demonstrated **failing on the pre-fix tree** before the fix (output in the notes).
* 18 tests in `test/repository/submission_team_object_test.dart`; **2283 pass**. `dart format` and `flutter analyze` clean.
* **Mutation-tested**: the audit killed 11 of 11 mutations it injected; the three behaviours added afterwards were each mutation-tested individually.

## Reported, not fixed

* A second unclosed writer — `public_survey_screen` already holds the team id it does not pass.
* A pre-existing sync-in divergence with a live caller: Kotlin stores `''` for a team-less synced submission and `getByUserIdWithoutTeam` matches only `IS NULL`, so Kotlin **excludes** those rows from a user's personal survey list where the port includes them. That query is read-path, so it is another lane's region.
* Phase 126's routed item 4 (device identity on the nested `parent`) was not assigned to this lane.

Only the **write path** of `submissions_repository.dart` was touched. No read-path method was read, called or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pNb5QfNiQEnXvQNGzE2Bp