### PR TITLE
feat(flutter): port the system-tray notification tap entry points (Phase 130, Lane C)

### DIFF
--- a/flutter/PHASE_130_NOTES.md
+++ b/flutter/PHASE_130_NOTES.md
@@ -1,11 +1,433 @@
 # Phase 130 — the tray tap, and a trailing space the derivation ate
 
-Work in progress. Two items:
+Lane C. Two items, both handed over by Phase 127's *Reported, not fixed* list:
+a correct handler nothing could reach, and one character the ARB derivation
+threw away.
 
-1. **A correct handler nothing can reach.** Phase 127 left
-   `NotificationsRepository.markNotificationAsRead` with no caller, because
-   `NotificationActionReceiver` and `DashboardActivity.handleNotificationIntent`
-   are unported: the port raises system notifications and tapping one does
-   nothing. Porting the entry points.
-2. **`tool/arb_from_strings_xml.dart` drops a deliberate trailing space** on the
-   plain-text by-name path.
+Two `parity-auditor` passes at `effort: max` were run, one on the Kotlin before
+any Dart and one on the finished diff. **The first overturned three of the eight
+claims this lane had written down**, and one of the three changed the design:
+see *What the ground-truth audit corrected*. That is the fourth round running
+where a lane's own reading of the Kotlin was wrong in a way only the audit
+caught.
+
+---
+
+## Item 1 — the tray tap
+
+### What the port actually raises
+
+One thing. `TaskDeadlineNotifier` (Phase 42) is the port's only producer of an
+OS notification, through `NotificationConfig.task`:
+
+```
+id        = task.id          type = "task"
+relatedId = task.id          actionable = true   (from this phase)
+title     = "✅ New Task Assigned"
+message   = "<title>\nDue: <EEE dd, MMMM yyyy>"
+```
+
+That matches `TaskNotificationWorker` → `NotificationUtils.createTaskNotification`,
+and — with one refinement the audit supplied — it is the **only** Kotlin producer
+that routes through `NotificationUtils.NotificationManager` and therefore the
+only one that carries extras or action buttons. The other five factories
+(`createSurveyNotification`, `createJoinRequestNotification`,
+`createStorageWarningNotification`, `createResourceNotification`,
+`createSummaryNotification`) are called only from `DashboardActivity.kt:214`'s
+`state.newNotifications.forEach { showNotification(it) }`, and
+`DashboardUiState.newNotifications` has exactly two writers: its own
+`emptyList()` default and `clearNewNotifications`. Nothing populates it. So
+those five have no live caller, and **`summary_`-prefixed notification ids are
+never minted at runtime.**
+
+### What each notification type does on tap
+
+There are three gestures, not one, and the Kotlin gives each a different
+behaviour. This is the table the brief asked for; every row is reachable in the
+port today.
+
+| gesture | Kotlin path | read-marking | navigates to |
+|---|---|---|---|
+| the notification **body** | `setContentIntent` → `DashboardActivity` with `from_notification=true` → `handleNotificationIntent`'s first branch | `markNotificationAsRead(id, userId)` — **does not** stamp `createdAt`; `summary_`-aware | the destination for its type |
+| **Mark as Read** button | `NotificationActionReceiver` `ACTION_MARK_AS_READ` (`:34-39`) | `markNotificationsAsRead({id})` — **stamps** | nowhere (but see below) |
+| **View Task** button | `NotificationActionReceiver` `ACTION_OPEN_NOTIFICATION` (`:51-66`) → `DashboardActivity` with `auto_navigate=true` → the second branch | `markNotificationsAsRead({id})` — **stamps** | the destination for its type |
+
+And the destinations, by type, which is the other half of the question. The port
+resolves all of them through the one shared resolver, so this table is
+`NotificationDestinationResolver` plus `notificationDestinationLocation`:
+
+| type | port location | Kotlin |
+|---|---|---|
+| `task` | `/life/teams/<teamId>/tasks` | `TeamDetailFragment(navigateToPage = TasksPage)`, team id from the cached task's `link.teams` |
+| `join_request` | `/life/teams/<teamId>/members?tab=requests` | `TeamDetailFragment(JoinRequestsPage)`, after stripping a `join_request_` prefix |
+| `team_join` | `/life/teams/<teamId>` | `TeamDetailFragment`, no page |
+| `chat` | `/life/teams/<teamId>` | `TeamDetailFragment(ChatPage)` — the port has no team-chat tab, a pre-existing divergence |
+| `voice_reply` | `/life/voices/<voiceId>` | `ReplyActivity` |
+| `resource` | `/resources` | `ResourcesFragment` |
+| `storage` | `/profile/settings/storage` | `ACTION_INTERNAL_STORAGE_SETTINGS`, the OS screen — pre-existing divergence, the port has its own |
+| anything else | nowhere | `openNotificationsList(...)` |
+
+Only `task` has a producer. The rest are reachable from the bell row, which is
+the path Phase 49 ported and this phase now shares.
+
+### Yes, the resolver was reused — and so was the location mapping
+
+The brief asked for the resolver rather than a second mapping. Two changes make
+that literal:
+
+* `NotificationDestinationResolver.resolveFor({type, relatedId})` is split out
+  of `resolve(NotificationRow)`, which now delegates to it. A tray tap has no
+  row — Kotlin's `auto_navigate` branch switches on the two intent extras alone
+  — and the type it carries (`NotificationUtils.TYPE_*`) is already the same
+  *resolved* spelling `resolvedNotificationType` produces, so one switch serves
+  both callers with nothing translated between them.
+* `notificationDestinationLocation` moved out of `notifications_screen.dart`,
+  where it was a `switch` inside a private widget method. Phase 124 built the
+  row formatter on this same enum for the same reason.
+
+The second move bought something beyond de-duplication: the mapping is now
+**enumerable**, which is what lets the reachability guard walk it exhaustively.
+See below.
+
+### The three plugin links, and why one design decision changed
+
+`flutter_local_notifications` splits what Android hands to one Activity:
+
+| Kotlin | port |
+|---|---|
+| `createNotificationIntent`'s three extras | one `payload` string, JSON, using the Kotlin's own extra names (`notification_type`/`notification_id`/`related_id`) so a reviewer can read them side by side |
+| `DashboardActivity.onCreate` → `handleNotificationIntent(intent)` | `NotificationTapSource.launchTap()` → `getNotificationAppLaunchDetails` |
+| `onNewIntent` → `handleNotificationIntent(intent)` (`:1106`) | `NotificationTapSource.taps()`, from the `initialize` response callback |
+| `PendingIntent.getBroadcast` → `NotificationActionReceiver` | `AndroidNotificationAction` + `actionId` on the response |
+
+**The design decision the audit changed.** This lane had read Kotlin's action
+buttons as background handlers — they are `PendingIntent.getBroadcast` into a
+`BroadcastReceiver`, and *Mark as Read* obviously should not launch an app — and
+had planned `showsUserInterface: false` plus a `@pragma('vm:entry-point')`
+background response handler with its own `ProviderContainer`, on the model of
+`background_entrypoint.dart`. That was wrong.
+
+Every one of the receiver's three arms calls its own
+`markNotificationAsRead(context, notificationId)`, and that helper's tail is
+unconditional:
+
+```kotlin
+val dashboardIntent = Intent(context, DashboardActivity::class.java)
+dashboardIntent.action = "REFRESH_NOTIFICATION_BADGE"
+dashboardIntent.flags = FLAG_ACTIVITY_SINGLE_TOP or FLAG_ACTIVITY_NEW_TASK
+context.startActivity(dashboardIntent)              // :104-112
+```
+
+So tapping *Mark as Read* on a task reminder brings myPlanet's dashboard to the
+foreground in the Android app, cold-starting it if the process is dead. The
+Kotlin's own test concedes it: `NotificationActionReceiverTest.kt:130-132`
+captures a *list* of intents and searches it, because `startActivity` is called
+twice on the open path.
+
+Both actions are therefore `showsUserInterface: true`, which routes them through
+the ordinary response callback in the UI isolate — where the Riverpod graph and
+the session already exist. **The background isolate, the second entry point and
+the container it would have needed are all unnecessary**, and the simpler design
+is the more faithful one. The one thing the port does not reproduce is the
+`REFRESH_NOTIFICATION_BADGE` intent itself: the port's bell is a live drift
+stream, so there is nothing to refresh.
+
+`cancelNotification: true` on both actions ports the receiver's
+`clearNotification(it)`. `autoCancel` covers the body tap only, so without it an
+action would mark the notification read and leave it in the tray.
+
+### At parity, and this is the part worth remembering: no tray gesture marks anything read
+
+The read-marking half of all three gestures is inert on real data, in **both**
+apps.
+
+`TaskDeadlineNotifier` mints the notification with `id = task.id`, exactly as
+`TaskNotificationWorker.kt:48-53` does. But a `task` notification *row* is a
+synced CouchDB notification document: its primary key is that document's own
+`_id`, and the task id lands in `relatedId`. Concretely — notification doc
+`{_id: "n-77", type: "newTask", link: "/teams/view/team-9", …}` beside task doc
+`{_id: "t-42", …}` — the tray notification's id is `t-42` and the unread row is
+`n-77`. So `markOneAsRead("t-42")` updates zero rows, and `markAsRead({"t-42"})`
+early-returns on an empty `getByIds` before it writes anything. The bell badge
+does not move.
+
+Resolving `relatedId` back to a notification row would fix it. **That would be
+an improvement the Android app does not have**, which makes it a divergence
+rather than a repair, so it is reproduced and written down instead — with a test
+that asserts the no-op and says why (`at parity: the tray marks nothing read on
+real data`). The navigation half works precisely because it reads `relatedId`,
+which is why the tap is worth wiring regardless.
+
+Two related dead ends the audit established, both now unreachable rather than
+merely uncalled: **nothing stores a row with `type = "task"`** at all
+(`parseNotification` writes the server's raw `"newTask"` and `resolveType` maps
+it at read time), so `markSummaryAsRead(userId, "task")` could not match a row
+even if a `summary_task` id were minted — and none is. The `summary_` branch is
+doubly dead. It is still pinned by a test, because it is the one behaviour the
+body-tap path has that the action path does not.
+
+### Deliberate divergences, all four of them
+
+1. **The body tap goes where the button goes.** Kotlin's `from_notification`
+   branch opens the plain team *list* for a task, because it passes `taskId` to
+   `TeamFragment`, which reads only `fromDashboard` and `type` and discards it.
+   The same hole is in its survey arm (`SurveyFragment` reads only `isTeam` and
+   `teamId`). So Kotlin's branch-1 refinement is non-functional across the
+   board, while its `auto_navigate` branch and its in-app row tap both open the
+   team's tasks page. Two of three agree and the third disagrees by way of an
+   argument nothing reads; the port puts all three in one place. This is the
+   brief's instruction and it is also the better reading.
+2. **The shared resolver is the forgiving one.** Kotlin's button path
+   (`getTaskTeamInfo`) does `teamDao.getById(teamId) ?: return null` and emits
+   nothing when the team row is absent, so the tap silently does nothing; the
+   row path (`getTaskDetails` + `resolveAndOpenTeam`'s `?: relatedId`) still
+   opens something. Sharing one resolver means the tray navigates in a case
+   where the Android app does not. Deliberate, and the cheaper failure.
+3. **`ACTION_STORAGE_SETTINGS` and the four non-task action arms are not
+   ported.** Their factories have no live caller, so porting them adds library
+   code with no producer — the rule `notification_config.dart` already states in
+   its header. One line each when a producer appears.
+4. **An unresolvable type stays where it is** rather than opening the
+   notifications list. Same reasoning `deepLinkRoute` gives for its own
+   fall-through: yanking the user off the screen they are on is worse than doing
+   nothing. Unreachable anyway — the only live producer always sets
+   `notification_type = "task"`.
+
+Two Kotlin quirks that need no port because Flutter cannot have them:
+`openCallFragment`'s tag semantics can swallow the navigation entirely (looking
+at Team A's detail, tap a notification for Team B's task → nothing happens,
+because both use the bare `TeamDetailFragment` tag), and the whole slice is
+gated on `initializeDashboard()`, so an inactive user's notification tap is
+silently ignored in the Android app. The port's scope wraps the navigator and
+has neither problem.
+
+### Can the reachability guard cover a tray entry point? Yes — three ways
+
+The brief asked. `test/ui/route_reachability_test.dart` gains three rules,
+because a tray tap fails in three independent places and the existing scanner
+could see none of them: there is no `context.go` call site to scan for.
+
+1. **`every notification destination resolves to a registered route`** — walks
+   `NotificationDestinationKind.values` through `notificationDestinationLocation`
+   and checks each against the real route table. Exhaustive over the enum, so a
+   new kind cannot be added without an arm (that would not compile) and an arm
+   cannot name a path the router does not serve. This is strictly stronger than
+   what was there: `notifications_screen.dart` sits in the test's `declared`
+   blind-spot map, and while the mapping was a switch inside a private widget
+   method the only rule that could reach its arms was "a `Routes.x` mentioned
+   anywhere in this file counts as reached", which cannot tell a live arm from a
+   dead one. The file stays declared (the argument is still not a literal) with
+   its reason repointed at the new rule.
+2. **`a system-tray tap on the notification the port raises navigates`** — takes
+   the config `TaskDeadlineNotifier` itself builds, runs it through the real
+   payload codec and the real handler, and asserts the location resolves. The
+   payload is *not* hand-built: Phase 113's lesson is that every fixture
+   fabricated the join and that was the symptom, so it comes from
+   `NotificationTapPayload.forConfig`.
+3. **`every action the notification offers is one the handler knows`** — the
+   button ids cross a process boundary (the OS holds them while the app is
+   dead), so a rename on one side and not the other is silent, and
+   `notificationTapFrom` drops an unknown id rather than crashing. The failure
+   mode is a button that does nothing.
+
+Plus a fourth, `the platform wiring a tap depends on is present`, which is a
+**source-text** assertion and says so. Three links in the chain are arguments to
+a plugin call, and `FlutterLocalNotificationsPlugin` has a private constructor —
+it cannot be faked or subclassed from a test. Each of the three (`payload:`,
+`onDidReceiveNotificationResponse:`, `NotificationTapScope` mounted in
+`app.dart`) was missing before this phase and each alone is enough to make a tap
+do nothing. `DeepLinkScope` is checked alongside it: same exposure, and nothing
+guarded it.
+
+---
+
+## What the ground-truth audit corrected
+
+Recorded because three of eight were wrong, and the pattern is the one
+`CLAUDE.md` keeps warning about.
+
+| this lane's claim | verdict |
+|---|---|
+| `TaskNotificationWorker` is the **only** live tray producer | **refined.** Three more post notifications: `ServerReachabilityWorker.showServerNotification` (live via `NetworkMonitorWorker`, and tappable — a bare `contentIntent` with no extras, so the tap falls through both branches of `handleNotificationIntent` and is a plain app launch), `DownloadService`/`DownloadWorker` via `DownloadUtils`, and `ResourceViewerFragment`'s "Recording Audio" notification. The defensible claim is the narrower one used above: only `TaskNotificationWorker` goes through `NotificationUtils.NotificationManager`, and so only it carries extras or actions. |
+| *Mark as Read* does not launch the app | **overturned.** It does, unconditionally. This changed the design — see above. |
+| `parseNotification` writes a `type = "task"` row | **overturned.** It writes the raw `"newTask"`; `resolveType` maps at read time. And the read-marking no-op is broader than this lane had it: not just the body tap, but all three gestures. |
+| the body tap's `clearNotification` runs | **refined.** It is always a null-receiver no-op — `notificationManager` is assigned *after* `initializeDashboard()` returns, and `initializeDashboard()` is what calls `handleNotificationIntent`. The notification still disappears, via `autoCancel`. The port matches by having no explicit cancel on that path. |
+
+Four claims were confirmed as written, including the two-branch mutual
+exclusivity and that branch 1's extras are read by nothing.
+
+---
+
+## Item 2 — the trailing space, and the key that demonstrates it
+
+Phase 124 reported it and declined on ownership; Phase 127 owned `tool/` and
+declined for a better reason — no key it was adding went through that path with
+a trailing space, so a fix would have been untested. **The key that demonstrates
+it already existed, and was already wrong.**
+
+`app_en.arb` has exactly four values ending in a space, and every one is a label
+a value is drawn straight after: `storageRunningLow`, `storageAvailable`,
+`selected`, `selectResources`. Android's quoting is how that space survives in
+`strings.xml` (`<string name="storage_running_low">"Storage running low: "</string>`),
+and all five translated locales carry it.
+
+The two plain-text derivation rules wrote `translated[name]?.trim()`. The
+recovery path (`--adopt` → `_proposal`) calls `_mirrorTrailingSpace`. So the two
+keys repaired by hand kept their space and the two the tool derived lost it —
+**in all five locales, ten values**:
+
+```
+ar/storageRunningLow = "التخزين قليل:"          fr/storageAvailable = "Espace de stockage disponible:"
+es/storageRunningLow = "Almacenamiento bajo:"   ne/storageAvailable = "स्टोरेज उपलब्ध:"        (…and six more)
+```
+
+Both plain-text rules now go through one exported `derivePlainTextValue`, so a
+third rule cannot disagree again, and the two keys were deleted and re-derived
+with the space intact. The mirror is deliberately **one-directional**: it never
+removes whitespace the template does not ask for (which would start writing
+trailing spaces into 890 ordinary strings), and it takes the *template's*
+decision rather than trusting each translator — `values-ar/select_resources` is
+unquoted and carries no trailing space at all, so the mirror supplies it.
+
+**Where the loss is visible, and where it is not.** `formatStorageNotification`
+interpolates `'$runningLow $percent%'` — the Kotlin template adds a space of its
+own — so its own separator masks the missing one, and `renderNotificationHtml`
+collapses the double space the Kotlin ends up with. The guard is therefore on the
+derivation's *output* across the shipped locale files, not on one caller: the
+next consumer that concatenates without a separator would render
+`Almacenamiento bajo:10%`, in a string a translator cannot see is wrong.
+
+The same run picked up two more keys, both real: `playbackSpeed` and
+`playbackSpeedValue` derive from the Kotlin `playback_speed` /
+`playback_speed_format` and had simply never been through the tool — the phase
+that added the English keys did not re-run it. `playbackSpeedValue` is `{speed}x`
+in all five locales because the Kotlin string is `%1$sx` in all five: a
+multiplier suffix nobody translates. That is the translation, not a missing one.
+`placeholder_integrity_test.dart`'s pinned counts move +2 per locale: ar 412,
+es 464, fr 411, ne 413, so 413.
+
+---
+
+## Failing-first evidence
+
+**Item 2** was red on the shipped data before a line changed. The guard reads
+`app_en.arb` for values ending in a space and checks all five locales:
+
+```
+these locale values lost the template's trailing space, so the label runs into
+the value it prefixes:
+  ar/storageRunningLow = "التخزين قليل:"
+  ar/storageAvailable = "التخزين المتاح:"
+  es/storageRunningLow = "Almacenamiento bajo:"
+  … 10 in total, five locales × two keys
+```
+
+**Item 1** is a missing feature, so the pre-fix probe is what a source scan can
+prove, and it proved three of four:
+
+```
+the notification the port shows carries a payload            RED
+the notification the port shows offers its Kotlin actions    RED  (no AndroidNotificationAction anywhere in lib/)
+something in lib/ receives a notification response           RED  (nothing hears a tray tap)
+markNotificationAsRead has a caller in lib/                  passed — falsely
+```
+
+The fourth is worth keeping: it passed because the probe matched a **prose
+mention in a comment**, `notifications_provider.dart:47`. Grepped for a real
+call, `markNotificationAsRead(` appears only in the repository that defines it.
+Phase 127's report was right and the naive probe was not — the same shape as the
+`<basename>_test.dart` heuristic `CLAUDE.md` warns about. **Grep for the call,
+not the name.** The shipped guard strips comments.
+
+Then every new guard was checked by injecting the defect it claims to catch.
+Thirteen injections, thirteen red:
+
+| injection | red |
+|---|---|
+| a destination arm names a path the router does not serve | 3 (including a rule that already existed) |
+| the *View Task* button's id drifts from the handler's | 1 |
+| `createTaskNotification` stops being `actionable` | 3 |
+| the shown notification carries no payload | 1 (the source-text rule) |
+| `NotificationTapScope` dropped from `app.dart` | 1 (the source-text rule) |
+| the body tap uses the stamping path | 3 |
+| the action buttons use the non-stamping path | 2 |
+| *Mark as Read* navigates like the other two | 1 |
+| the session is read unwatched instead of awaited | 2 |
+| a swipe-away is treated as a tap | 1 |
+| an unknown action id is accepted | 1 |
+| an empty action id is read as an unknown action | 1 |
+| the resolver is fed the notification id instead of `relatedId` | **0 at first** — see below |
+
+**The one that found a gap.** Feeding the resolver `notificationId` instead of
+`relatedId` left the whole suite green, because the task factory sets both to
+the same string and it is the only producer. The two are not interchangeable:
+`handleNotificationIntent`'s `auto_navigate` branch reads `related_id`, and
+`createStorageWarningNotification(percent, customId)` sets `id = customId` with
+`relatedId = "storage"`. A test with a `voice_reply` payload whose two fields
+differ now separates them, and the injection goes red.
+
+Also demonstrated red for item 2: the unit tests on `derivePlainTextValue` with
+`_mirrorTrailingSpace` removed, and the file-level guard after re-deriving with
+the defect in place.
+
+---
+
+## Crossings
+
+One, listed as the rule requires. `lib/data/local/app_database.dart`'s
+`markAsRead` dartdoc said "Selection mode's *mark selected as read* is its one
+caller"; the tray action buttons are now a second caller and the comment would
+have misled the next reader about which of the two statements the tray uses.
+Comment-only, inside the notifications DAO region, no code touched.
+
+---
+
+## Reported, not fixed
+
+1. **No tray gesture marks anything read**, in either app, because the
+   notification's id and the notification row's id are different documents.
+   Explained above, tested, and deliberately not repaired — the fix would be an
+   improvement the Android app lacks. If it is ever wanted, the change is one
+   line in `NotificationTapHandler`: resolve `relatedId` to a row id before
+   marking. It should be taken *together* with the Kotlin, not in the port
+   alone, or the two apps' bell badges will disagree.
+2. **The Kotlin's `isNotified` is reset by every tasks sync-in, and the port
+   already diverges.** `TeamTask.fromJson` never sets the flag, so
+   `bulkInsertTasksFromSync`'s `upsertAll` writes the default `false` over a
+   locally-set `true` — the "sync-in rewriting a locally-authored column" class,
+   in the Android app. Consequence there: dismiss a deadline reminder, let the
+   process die, sync, and the same task notifies again. **The port does not have
+   it** — `TeamTasksRepository.insertTasksFromSync` never writes `isNotified`,
+   deliberately, and its dartdoc says why. Recorded here because the difference
+   is easy to mistake for a port bug when comparing the two apps' reminders, and
+   because it is the one place this slice is *better* than the Kotlin rather than
+   merely different. Nothing to do.
+3. **`TaskDeadlineNotifier` discards `show`'s boolean**, so a task suppressed by
+   a disabled channel is still marked notified and never notifies again. At
+   parity (`TaskNotificationWorker.kt:54` discards it too) and left alone.
+4. **`canShowNotification` is not ported at all.** Kotlin gates on
+   `areNotificationsEnabled()` plus five `SharedPreferences` flags under
+   `"notification_preferences"` — and nothing in the app ever writes those
+   flags, so they are permanently their `true` defaults and there is no settings
+   surface for them. Porting them would add five dead preferences. The
+   app-level gate is what `flutter_local_notifications` enforces anyway. Neither
+   app checks per-*channel* disablement, which is the case that actually
+   silently drops a notification.
+5. **A tap taken while signed out is lost**, where `DeepLinkScope` persists a
+   pending section link across the sign-in it triggers. The router's redirect is
+   `if (!isSignedIn) return Routes.login` (`router.dart:211-213`), so the
+   handler's `go(location)` is overridden. The window is narrow — the body-tap
+   arm awaits `sessionProvider.future` before navigating, so a *restoring*
+   session is waited out rather than raced, and only a genuinely signed-out user
+   loses the tap — and Kotlin loses it too, by hanging the whole slice off
+   `initializeDashboard()`. Reachable only for a user who signed out between the
+   reminder being raised and being tapped, which needs a signed-in user for the
+   reminder to exist at all. Persisting it would mean a `pendingNotificationTap`
+   preference on the `DeepLinkHandler.takePendingLocation` model.
+6. **`markSummaryAsRead` remains unreachable in production** — it now has a
+   caller (the body-tap arm) but no producer mints a `summary_` id, and no row
+   carries a resolved `type` that a summary id could name. Pinned by a test as
+   the one behaviour distinguishing the two read paths.
+7. **Somali and Nepali still carry no value for the two repaired keys' 459
+   siblings.** Unrelated to this phase, and the l10n row of the migration table
+   is the one that most needs a human pass rather than another derivation run.

--- a/flutter/PHASE_130_NOTES.md
+++ b/flutter/PHASE_130_NOTES.md
@@ -382,6 +382,50 @@ Comment-only, inside the notifications DAO region, no code touched.
 
 ---
 
+## A second dead row, found by sweeping this lane's own files
+
+The phase's own theme, applied to the rest of the file it was working in: every
+public member of `NotificationsRepository` was grepped for a **call** in `lib/`
+(not a mention — see the false pass in *Failing-first evidence*). Thirteen have
+callers. One does not.
+
+**`updateResourceNotification` has no production caller, and cannot get one.**
+Six tests call it, including a round-trip test and a screen test, so it is
+ported, tested, green and dead — the exact row this phase was opened to close,
+one method further down the same file.
+
+In the Android app it is live. `DashboardViewModel.updateResourceNotification`
+(`:134-137`) reads `resourcesRepository.countLibrariesNeedingUpdate(userId)` and
+hands the count over; `checkAndCreateNewNotifications` (`:354-362`) calls it, and
+that is reached from `DashboardActivity` on dashboard load
+(`checkIfShouldShowNotifications`, `:690-698`) and again on the throttled
+focus path (`:623-630`). So the Android bell carries a *"You have N
+undownloaded resources"* row and the port's never does.
+
+It is not one missing call site. **The count has no port at all**:
+`countLibrariesNeedingUpdate` → `MyLibraryDao.countPublicNeedingUpdateForUserPattern`
+(`MyLibraryDao.kt:124`) is `isPrivate = 0 AND (userId IS NULL OR userId NOT LIKE
+:userPattern)` — the catalog predicate Phase 97 already ported for
+`watchResources`, counted rather than listed — and nothing in `flutter/lib`
+computes it under any name.
+
+Two consequences beyond the missing row. `notification_format.dart`'s `resource`
+arm reads `kotlinToIntOrNull(message)`, which only succeeds on the bare count
+this writer stores; a server-sent `newresource` notification resolves onto the
+same type but carries prose, so it falls through to the message verbatim. That
+branch — and `resourceNotificationMessage` with it — is therefore dead in
+production too, and its tests pass because they build the row directly. And the
+bell's unread count differs from the Android app's by however many resources
+need updating.
+
+Not fixed here, and deliberately: the fix needs a `resourcesRepository` count
+plus a dashboard-load hook, which lands in `lib/providers/dashboard_providers.dart`
+and `lib/repository/resources_repository.dart` — neither in this lane's file set,
+and the dashboard is a collision surface. It is a small vertical slice for
+whoever takes it, and the three pieces are named above.
+
+---
+
 ## Reported, not fixed
 
 1. **No tray gesture marks anything read**, in either app, because the

--- a/flutter/PHASE_130_NOTES.md
+++ b/flutter/PHASE_130_NOTES.md
@@ -304,7 +304,13 @@ that added the English keys did not re-run it. `playbackSpeedValue` is `{speed}x
 in all five locales because the Kotlin string is `%1$sx` in all five: a
 multiplier suffix nobody translates. That is the translation, not a missing one.
 `placeholder_integrity_test.dart`'s pinned counts move +2 per locale: ar 412,
-es 464, fr 411, ne 413, so 413.
+es 464, fr 411, ne 413, so 413. So the ARB diff is **six** keys per locale, not
+four: two re-derived and two newly added. One caveat, since this document has
+been wrong about l10n measurement before: `playbackSpeedValue` raises the
+"human reviewed" count without adding any translated *text*, because the value
+is identical in all six files. It is a real translation of a string nobody
+translates, and it is also exactly the kind of number that makes a coverage
+figure look better than it is.
 
 ---
 
@@ -357,14 +363,25 @@ Thirteen injections, thirteen red:
 | an unknown action id is accepted | 1 |
 | an empty action id is read as an unknown action | 1 |
 | the resolver is fed the notification id instead of `relatedId` | **0 at first** — see below |
+| the two entry points made to disagree about a destination | 4 |
+| the cold-start tap is never asked for (**shipped by accident, see above**) | 3 |
+| the resolved location is computed and thrown away (**shipped**) | 3 |
+| the tap stream is never subscribed to | 3 |
+| the launch tap is awaited before the subscription is taken | 1 |
+| the response handler is nulled (green before the fix) | 1 |
+| the permission request leaves `main()` (green before the fix, twice) | 1 |
+| a `NotificationTypes` constant with no resolver arm | 1 |
+| the format path stops mirroring the trailing space | 1 |
 
-**The one that found a gap.** Feeding the resolver `notificationId` instead of
-`relatedId` left the whole suite green, because the task factory sets both to
-the same string and it is the only producer. The two are not interchangeable:
-`handleNotificationIntent`'s `auto_navigate` branch reads `related_id`, and
-`createStorageWarningNotification(percent, customId)` sets `id = customId` with
-`relatedId = "storage"`. A test with a `voice_reply` payload whose two fields
-differ now separates them, and the injection goes red.
+**Three found gaps rather than confirming guards**, which is the point of doing
+them. Feeding the resolver `notificationId` instead of `relatedId` left the
+whole suite green, because the task factory sets both to the same string and it
+is the only producer; the two are not interchangeable
+(`createStorageWarningNotification(percent, customId)` sets `id = customId` with
+`relatedId = "storage"`), so a `voice_reply` payload whose fields differ now
+separates them. And the response-handler and permission-request assertions were
+each green under their own defect until narrowed from a *name* to a *value* —
+the second one twice. See *What the second audit pass found* above.
 
 Also demonstrated red for item 2: the unit tests on `derivePlainTextValue` with
 `_mirrorTrailingSpace` removed, and the file-level guard after re-deriving with
@@ -379,6 +396,112 @@ One, listed as the rule requires. `lib/data/local/app_database.dart`'s
 caller"; the tray action buttons are now a second caller and the comment would
 have misled the next reader about which of the two statements the tray uses.
 Comment-only, inside the notifications DAO region, no code touched.
+
+---
+
+## What the second audit pass found in this phase's own green code
+
+Seven items, and the pattern `CLAUDE.md` records held again: **an audit of the
+ground truth does not audit the implementation.** Everything below was green,
+formatted and analyzed when the pass started.
+
+**The one that matters, and it arrived by accident.** The pass mutation-tested
+`notification_tap_scope.dart` — deleting the `launchTap()` call, then the
+`go(location)` call — and **all 2301 tests stayed green.** Nothing mounted
+`NotificationTapScope`, so the two lines that connect the whole chain to the app
+were the one part of it with no guard: every other link had one, including a
+source-text rule asserting the scope is *mounted* in `app.dart`. What the
+mounted widget then does was unchecked. With the first mutation a learner taps a
+deadline reminder on a closed app and lands on `/` — the cold-start case is the
+*only* one that matters for a reminder raised by a headless worker — and CI is
+green.
+
+That is this phase's own subject one layer up, and it cost something to learn:
+the mutations were in the working tree when a `git add -A` ran, so `452b9b6`
+shipped them and `11d19d9` restored them. **Do not `git add -A` while a
+background agent has the tree.** `test/ui/notification_tap_scope_test.dart` now
+covers the scope with six tests, following `deep_link_scope_test.dart` (mounted
+inside `MaterialApp.router`'s `builder`, because that context is above the
+`InheritedGoRouter` and `GoRouter.of` would throw there). Both shipped mutations
+go red, as do "never subscribes" and "awaits the launch tap before
+subscribing".
+
+**Two guards that passed for the wrong reason**, both in the source-text rule,
+both now fixed and re-injected:
+
+* `contains('onDidReceiveNotificationResponse:')` matched the parameter *name*,
+  so `onDidReceiveNotificationResponse: null` — which drops every tap that
+  arrives while the app is running — left it green. It asserts the value now.
+* Nothing checked that anything calls the presenter in the UI isolate. The
+  response handler is registered by `initialize`, and the only thing that
+  reaches it is `main.dart` asking for the notification permission — move that
+  request to a screen, a plausible refactor, and `taps()` is dead for the whole
+  process while `launchTap()` keeps working (Android registers *that* handler in
+  `onAttachedToEngine`, independent of Dart's `initialize`). A rule now pins the
+  call. Its first cut matched the function's own *declaration*, which survives
+  the call's removal, so the injection stayed green until it was narrowed to
+  `unawaited(_requestNotificationPermission());`. **Two of this phase's
+  source-text assertions matched a name where they meant a value** — that is the
+  failure mode of the technique, and the reason each one has to be injected
+  against.
+
+**A type nothing can reach.** `resolveFor` has no `survey` or `course` arm —
+they are two of Kotlin's six `TYPE_*` values and the bell-row handler this
+resolver was ported from has neither. Add a survey tray notification and its
+payload decodes cleanly, its type is `'survey'`, and `default: return null`
+swallows it, with the tray-tap test still green because it drives only
+`NotificationConfig.task`. A rule now walks every `NotificationTypes` constant
+through `resolveFor` and requires a destination, reconciling its list against
+the source file so a constant added there and not here fails first.
+
+**Three comments that stated something false**, each corrected in place rather
+than deleted, because each will otherwise be cited:
+
+* *The two Kotlin intents do not carry the same extras.* This lane's comment
+  said they did. `createNotificationIntent` (the body tap) puts
+  `notification_type`, `notification_id`, `from_notification` and
+  `config.extras`; only `createOpenPendingIntent` carries `related_id` at all,
+  and the body branch reads the extras instead. Benign for the task factory,
+  where `extras["taskId"]` and `relatedId` are the same string, and not in
+  general — `createStorageWarningNotification` sets `relatedId = "storage"` and
+  no extras.
+* *"The plugin does not double-deliver" is true, but not for the reason given.*
+  Android's `onNewIntent` both invokes the callback *and* calls
+  `setIntent`, and `getNotificationAppLaunchDetails` re-reads that intent every
+  time — so a tap already delivered is reported as a launch tap for the rest of
+  the process. What makes the port safe is narrower: `_start` runs once, from
+  `initState`. That is a live trap, because `OutboxDrainScope` in the same
+  directory re-runs on `AppLifecycleState.resumed`; adding the same hook here
+  would replay the last tap on every foreground, restamp included. Now
+  documented as such, with "de-duplicate on the payload first" attached.
+* *A background isolate can localise.* The hardcoded English action titles are
+  right because `addNotificationActions` passes literals, not `getString` — but
+  the second half of the rationale, "no `BuildContext` for an `.arb` lookup",
+  is false: `AppLocalizations.delegate.load(locale)` needs none. Worth
+  correcting because the port *does* carry a translated `markAsRead` for the
+  bell screen and the next reader will reach for it.
+
+**A fourth derivation path the trailing-space fix missed.** `derivePlainTextValue`
+unified the two *plain-text* rules, and its dartdoc claimed no third rule could
+disagree. True of a third plain-text rule; the ICU path is a fourth, and
+`convertAndroidFormat` still did `_parseAndroidFormat(translation.trim())`.
+Unreachable today — no `app_en.arb` value containing a `{` ends in a space — and
+closed anyway, because the guard that *would* catch it scans every
+trailing-space template key, so the red would have pointed at the test rather
+than at the missing mirror. `convertAndroidFormat` mirrors now, with a test on
+the shape rather than on live data.
+
+**And one thing the pass confirmed rather than overturned**, which is worth
+recording because it was the design's biggest unknown: `notificationTapFrom`
+drops nothing Android actually delivers. `extractNotificationResponseMap` reads
+`actionId` from an intent extra the content intent never sets, so a body tap's
+`actionId` is genuinely null and never empty; the three response types are as
+assumed. The dismissal arm is unreachable for a different reason than the
+comment claimed — the plugin only attaches a delete intent when
+`dismissIsolate` is set, which the presenter never does — so the guard is
+defensive, and kept, with the sentence fixed.
+
+All six divergences this lane claimed were challenged and all six held.
 
 ---
 

--- a/flutter/PHASE_130_NOTES.md
+++ b/flutter/PHASE_130_NOTES.md
@@ -1,0 +1,11 @@
+# Phase 130 — the tray tap, and a trailing space the derivation ate
+
+Work in progress. Two items:
+
+1. **A correct handler nothing can reach.** Phase 127 left
+   `NotificationsRepository.markNotificationAsRead` with no caller, because
+   `NotificationActionReceiver` and `DashboardActivity.handleNotificationIntent`
+   are unported: the port raises system notifications and tapping one does
+   nothing. Porting the entry points.
+2. **`tool/arb_from_strings_xml.dart` drops a deliberate trailing space** on the
+   plain-text by-name path.

--- a/flutter/lib/app.dart
+++ b/flutter/lib/app.dart
@@ -6,6 +6,7 @@ import 'l10n/app_localizations.dart';
 import 'l10n/framework_fallback_delegates.dart';
 import 'providers/settings_provider.dart';
 import 'ui/deep_link_scope.dart';
+import 'ui/notification_tap_scope.dart';
 import 'ui/outbox_drain_scope.dart';
 import 'ui/router.dart';
 
@@ -49,9 +50,10 @@ class MyPlanetApp extends ConsumerWidget {
         ),
       ),
       themeMode: themeMode,
-      // Both wrap the whole navigator so they follow the app's lifecycle
-      // rather than any one screen's: the drain on resume, and the deep-link
-      // listener for the launch link and anything that arrives afterwards.
+      // All three wrap the whole navigator so they follow the app's lifecycle
+      // rather than any one screen's: the drain on resume, the deep-link
+      // listener for the launch link and anything that arrives afterwards, and
+      // the same pair of cases for a tap on a system notification.
       // The `MediaQuery` override applies `LocaleUtils.setTextScale` — the
       // Kotlin recreates the activity to re-`Configuration.fontScale`; here
       // rebuilding this builder on a `textScaleProvider` change does the same.
@@ -60,7 +62,11 @@ class MyPlanetApp extends ConsumerWidget {
           context,
         ).copyWith(textScaler: TextScaler.linear(textScale)),
         child: OutboxDrainScope(
-          child: DeepLinkScope(child: child ?? const SizedBox.shrink()),
+          child: DeepLinkScope(
+            child: NotificationTapScope(
+              child: child ?? const SizedBox.shrink(),
+            ),
+          ),
         ),
       ),
     );

--- a/flutter/lib/core/notifications/notification_config.dart
+++ b/flutter/lib/core/notifications/notification_config.dart
@@ -33,10 +33,10 @@ enum NotificationPriority { defaultPriority, high }
 /// One notification to show, independent of the plugin that shows it.
 ///
 /// Field-for-field the subset of Kotlin's `NotificationConfig` that the task
-/// path sets. `bigTextStyle`, `autoCancel` and `category` are carried because
-/// the Kotlin builder applies them and they change what the user sees; the
-/// unported `silent`/`targetActivity` fields are omitted rather than carried
-/// unused.
+/// path sets. `bigTextStyle`, `autoCancel`, `actionable` and `category` are
+/// carried because the Kotlin builder applies them and they change what the
+/// user sees; the unported `silent`/`targetActivity` fields are omitted rather
+/// than carried unused.
 class NotificationConfig {
   const NotificationConfig({
     required this.id,
@@ -44,6 +44,7 @@ class NotificationConfig {
     required this.title,
     required this.message,
     required this.priority,
+    this.actionable = false,
     this.bigTextStyle = true,
     this.autoCancel = true,
     this.relatedId,
@@ -57,6 +58,11 @@ class NotificationConfig {
   final String title;
   final String message;
   final NotificationPriority priority;
+
+  /// `buildNotification`'s `if (config.actionable) addNotificationActions(…)`
+  /// (`:357-359`). Kotlin defaults it false and every `create*Notification`
+  /// factory that a user is meant to act on sets it true.
+  final bool actionable;
   final bool bigTextStyle;
   final bool autoCancel;
   final String? relatedId;
@@ -81,6 +87,10 @@ class NotificationConfig {
     priority: urgent
         ? NotificationPriority.high
         : NotificationPriority.defaultPriority,
+    // `createTaskNotification` sets `actionable = true`, so the notification
+    // carries *Mark as Read* and *View Task*. The port dropped both until
+    // Phase 130 — see `notificationActionsFor`.
+    actionable: true,
     relatedId: taskId,
   );
 }

--- a/flutter/lib/core/notifications/notification_config.dart
+++ b/flutter/lib/core/notifications/notification_config.dart
@@ -22,6 +22,13 @@ abstract final class NotificationChannels {
 }
 
 /// `NotificationUtils.TYPE_*`. Only `task` has a ported producer.
+///
+/// `route_reachability_test.dart` drives **every** constant here through
+/// `NotificationDestinationResolver.resolveFor` and requires a destination, so
+/// a new type cannot be added without an arm and fall silently to the
+/// resolver's `default`. That is a live risk rather than a theoretical one: the
+/// resolver is a port of the bell row's click handler, which has no `survey` or
+/// `course` arm at all, and those are two of Kotlin's six `TYPE_*` values.
 abstract final class NotificationTypes {
   static const task = 'task';
 }

--- a/flutter/lib/core/notifications/notification_presenter.dart
+++ b/flutter/lib/core/notifications/notification_presenter.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import 'notification_config.dart';
+import 'notification_tap.dart';
 
 /// Shows an OS notification. Port of the surface
 /// `NotificationUtils.NotificationManager.showNotification` exposes.
@@ -30,6 +33,28 @@ class LocalNotificationsPresenter implements NotificationPresenter {
   final FlutterLocalNotificationsPlugin _plugin;
   bool _initialized = false;
 
+  /// Every tap the plugin delivers while the app is running, from whichever
+  /// presenter happened to initialize the plugin.
+  ///
+  /// A library-level broadcast sink rather than a callback passed in at
+  /// construction, because `initialize` is the *only* place the plugin accepts
+  /// a response handler and it is called lazily by whichever presenter shows or
+  /// requests first — `main.dart` builds one to ask for the permission, and
+  /// `notificationPresenterProvider` builds another. Passing the handler per
+  /// instance meant whichever initialized second silently overwrote the first
+  /// with null. Registering the same sink from every instance has no such
+  /// ordering.
+  ///
+  /// Process-lifetime, so never closed. Broadcast, so a tap with no listener is
+  /// dropped — which is correct: the tap that *launched* the app does not come
+  /// through here at all but through `getNotificationAppLaunchDetails`, which is
+  /// the plugin's documented split (see `initialize`'s dartdoc: the callback
+  /// "is fired when the user selects a notification … [while the] application
+  /// was running").
+  static final _responses = StreamController<NotificationResponse>.broadcast();
+
+  static Stream<NotificationResponse> get responses => _responses.stream;
+
   /// `NotificationUtils.getInstance` + `createNotificationChannels`, minus the
   /// channels no ported path produces.
   Future<void> _ensureInitialized() async {
@@ -38,6 +63,19 @@ class LocalNotificationsPresenter implements NotificationPresenter {
       settings: const InitializationSettings(
         android: AndroidInitializationSettings('@mipmap/ic_launcher'),
       ),
+      onDidReceiveNotificationResponse: _responses.add,
+      // No `onDidReceiveBackgroundNotificationResponse`, and that is a
+      // *faithfulness* decision rather than an omission. Kotlin's action
+      // buttons are `PendingIntent.getBroadcast` into
+      // `NotificationActionReceiver`, which looks like a background handler —
+      // but every one of its three arms calls `markNotificationAsRead`, whose
+      // tail unconditionally does
+      // `startActivity(DashboardActivity, action = REFRESH_NOTIFICATION_BADGE)`
+      // (`NotificationActionReceiver.kt:104-112`). So *Mark as Read* brings the
+      // dashboard to the foreground in the Android app too, and every action
+      // here is `showsUserInterface: true` — which routes it to the callback
+      // above, in this isolate, with the Riverpod graph and the session already
+      // built.
     );
     await _plugin
         .resolvePlatformSpecificImplementation<
@@ -71,6 +109,11 @@ class LocalNotificationsPresenter implements NotificationPresenter {
         id: config.id.hashCode,
         title: config.title,
         body: config.message,
+        // Kotlin's three intent extras, in one string. Without it a tap can
+        // say *that* a notification was tapped and nothing about which one, so
+        // neither the read-marking nor the navigation has an id to work with —
+        // which is exactly the state the port shipped in until Phase 130.
+        payload: NotificationTapPayload.forConfig(config).encode(),
         notificationDetails: NotificationDetails(
           android: AndroidNotificationDetails(
             NotificationChannels.tasks,
@@ -86,6 +129,21 @@ class LocalNotificationsPresenter implements NotificationPresenter {
             styleInformation: config.bigTextStyle
                 ? BigTextStyleInformation(config.message)
                 : null,
+            actions: [
+              for (final action in notificationActionsFor(config))
+                AndroidNotificationAction(
+                  action.id,
+                  action.title,
+                  // See `_ensureInitialized`: both of Kotlin's actions end up
+                  // launching the dashboard, so both belong in this isolate.
+                  showsUserInterface: true,
+                  // `NotificationActionReceiver` calls `clearNotification(it)`
+                  // on every arm (`:38,47,65`). `autoCancel` covers the *body*
+                  // tap only, so without this an action would mark the
+                  // notification read and leave it sitting in the tray.
+                  cancelNotification: true,
+                ),
+            ],
           ),
         ),
       );

--- a/flutter/lib/core/notifications/notification_tap.dart
+++ b/flutter/lib/core/notifications/notification_tap.dart
@@ -1,0 +1,198 @@
+/// Port of the tray-side of `utils/NotificationUtils.kt` and of
+/// `services/NotificationActionReceiver.kt` — what a tap on a system
+/// notification carries back into the app, and what buttons the notification
+/// offers.
+///
+/// Pure Dart on purpose. The routing decision this feeds (which screen a tap
+/// opens, and which of the two read-marking paths runs) is the part worth
+/// testing, and none of it needs a platform channel. The plugin side is in
+/// `providers/notification_tap_provider.dart`, the same split
+/// `core/deeplinks/deep_link.dart` uses.
+library;
+
+import 'dart:convert';
+
+import 'notification_config.dart';
+
+/// `NotificationUtils.ACTION_*` (`:57-59`), verbatim.
+///
+/// These strings cross a process boundary — the OS holds them while the app is
+/// dead — so they are the Kotlin's own, not renamed. A handset carrying both
+/// apps during the migration is a real case.
+///
+/// `ACTION_STORAGE_SETTINGS` is deliberately absent: it is only ever attached
+/// to a `storage` notification, and nothing in either app raises one in the
+/// tray (`createStorageWarningNotification` has no live caller in the Kotlin
+/// either — the storage row is written straight to the `notifications` table by
+/// `TaskDeadlineNotifier`). See the header of `notification_config.dart` for the
+/// standing rule this follows.
+abstract final class NotificationTapActions {
+  /// `ACTION_MARK_AS_READ`. Marks read and does not navigate.
+  static const markAsRead = 'mark_as_read';
+
+  /// `ACTION_OPEN_NOTIFICATION`. Marks read and opens the notification's
+  /// destination.
+  static const open = 'open_notification';
+}
+
+/// What the OS hands back when a notification is tapped.
+///
+/// Kotlin puts three extras on both of its intents — `notification_type`,
+/// `notification_id`, `related_id` (`NotificationUtils.kt:60-62`,
+/// `:401-406`, `:413-424`) — where the plugin gives one opaque `payload`
+/// string. The JSON below uses the Kotlin's own extra names so the two are
+/// readable side by side.
+class NotificationTapPayload {
+  const NotificationTapPayload({
+    required this.type,
+    required this.notificationId,
+    this.relatedId,
+  });
+
+  /// `NotificationUtils.TYPE_*`, i.e. `config.type`. This is the *raw* tray
+  /// type, which for the one producer is already `task` — the value
+  /// `NotificationDestinationResolver` switches on.
+  final String type;
+
+  /// `config.id`. For the one live producer this is the **task** id, not the
+  /// id of any row in the `notifications` table — see
+  /// `NotificationTapHandler` for what that costs.
+  final String notificationId;
+
+  /// `config.relatedId`.
+  final String? relatedId;
+
+  String encode() => jsonEncode({
+    'notification_type': type,
+    'notification_id': notificationId,
+    if (relatedId != null) 'related_id': relatedId,
+  });
+
+  /// The inverse, returning null for anything this app did not write.
+  ///
+  /// A payload can be absent (a notification an older build of the app posted,
+  /// still sitting in the tray after an upgrade) or unparseable, and neither is
+  /// worth an exception on the launch path — the tap simply opens the app, which
+  /// is what Kotlin's own extra-less notifications do
+  /// (`ServerReachabilityWorker.kt:132-138` posts a tappable notification with
+  /// no extras at all, and `handleNotificationIntent` then does nothing).
+  static NotificationTapPayload? decode(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return null;
+      final type = decoded['notification_type'];
+      final id = decoded['notification_id'];
+      if (type is! String || id is! String || id.isEmpty) return null;
+      final related = decoded['related_id'];
+      return NotificationTapPayload(
+        type: type,
+        notificationId: id,
+        relatedId: related is String && related.isNotEmpty ? related : null,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The payload for a notification about to be shown.
+  factory NotificationTapPayload.forConfig(NotificationConfig config) =>
+      NotificationTapPayload(
+        type: config.type,
+        notificationId: config.id,
+        relatedId: config.relatedId,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is NotificationTapPayload &&
+      other.type == type &&
+      other.notificationId == notificationId &&
+      other.relatedId == relatedId;
+
+  @override
+  int get hashCode => Object.hash(type, notificationId, relatedId);
+
+  @override
+  String toString() =>
+      'NotificationTapPayload($type, $notificationId, $relatedId)';
+}
+
+/// One tap. [actionId] is null when the notification's **body** was tapped,
+/// which is the distinction the whole of `handleNotificationIntent` turns on:
+/// the body reaches `DashboardActivity` directly with `from_notification`, and
+/// an action button reaches `NotificationActionReceiver` first.
+class NotificationTap {
+  const NotificationTap({required this.payload, this.actionId});
+
+  final NotificationTapPayload payload;
+  final String? actionId;
+
+  bool get isBodyTap => actionId == null;
+
+  @override
+  bool operator ==(Object other) =>
+      other is NotificationTap &&
+      other.payload == payload &&
+      other.actionId == actionId;
+
+  @override
+  int get hashCode => Object.hash(payload, actionId);
+
+  @override
+  String toString() => 'NotificationTap($actionId, $payload)';
+}
+
+/// One action button, independent of the plugin that renders it.
+///
+/// Port of an entry `NotificationUtils.addNotificationActions` adds
+/// (`:373-399`).
+class NotificationAction {
+  const NotificationAction({required this.id, required this.title});
+
+  final String id;
+
+  /// The Kotlin's own hardcoded English. `addNotificationActions` passes string
+  /// literals, not `getString(R.string...)`, so there is nothing translated to
+  /// port — and the producer runs in a background isolate with no
+  /// `BuildContext` to resolve an `.arb` lookup against. Same reasoning as
+  /// [NotificationConfig.task]'s title and body.
+  final String title;
+
+  @override
+  bool operator ==(Object other) =>
+      other is NotificationAction && other.id == id && other.title == title;
+
+  @override
+  int get hashCode => Object.hash(id, title);
+
+  @override
+  String toString() => 'NotificationAction($id, $title)';
+}
+
+/// Port of `NotificationUtils.addNotificationActions` (`:373-399`), for the
+/// types this port produces.
+///
+/// Kotlin adds *Mark as Read* to every actionable notification and then one
+/// type-specific action in a `when`. Only the `task` arm has a live producer in
+/// either app — the other four (`TYPE_SURVEY`, `TYPE_STORAGE`,
+/// `TYPE_JOIN_REQUEST`, `TYPE_RESOURCE`) hang off factories nothing calls, so
+/// they are left out rather than shipped with no caller. Add the arm when a
+/// producer appears; it is one line each.
+///
+/// A non-actionable config gets none, as `buildNotification`'s
+/// `if (config.actionable)` decides (`:357-359`).
+List<NotificationAction> notificationActionsFor(NotificationConfig config) {
+  if (!config.actionable) return const [];
+  return [
+    const NotificationAction(
+      id: NotificationTapActions.markAsRead,
+      title: 'Mark as Read',
+    ),
+    if (config.type == NotificationTypes.task)
+      const NotificationAction(
+        id: NotificationTapActions.open,
+        title: 'View Task',
+      ),
+  ];
+}

--- a/flutter/lib/core/notifications/notification_tap.dart
+++ b/flutter/lib/core/notifications/notification_tap.dart
@@ -37,11 +37,24 @@ abstract final class NotificationTapActions {
 
 /// What the OS hands back when a notification is tapped.
 ///
-/// Kotlin puts three extras on both of its intents — `notification_type`,
-/// `notification_id`, `related_id` (`NotificationUtils.kt:60-62`,
-/// `:401-406`, `:413-424`) — where the plugin gives one opaque `payload`
-/// string. The JSON below uses the Kotlin's own extra names so the two are
-/// readable side by side.
+/// Kotlin uses two intents and they do **not** carry the same extras, which is
+/// worth stating because an earlier draft of this comment claimed they did.
+/// `createNotificationIntent` (`:413-424`, the body tap) puts
+/// `notification_type`, `notification_id`, `from_notification` and
+/// `config.extras`; `createOpenPendingIntent` (`:400-411`, the action button)
+/// puts `notification_type`, `notification_id` and `related_id` — and only that
+/// one carries `related_id` at all. The body branch reads the *extras* instead
+/// (`surveyId`, `taskId`), which for the task factory happen to hold the same
+/// string as `relatedId`.
+///
+/// The port carries `related_id` on both, because it resolves both through one
+/// resolver (see `NotificationDestinationResolver.resolveFor`) and the extras
+/// Kotlin's body branch reads are discarded by every fragment it hands them to.
+/// Not equivalent in general: `createStorageWarningNotification(percent,
+/// customId)` sets `id = customId`, `relatedId = "storage"` and **no** extras.
+///
+/// The plugin gives one opaque `payload` string, so the JSON below uses the
+/// Kotlin's own extra names to keep the two readable side by side.
 class NotificationTapPayload {
   const NotificationTapPayload({
     required this.type,
@@ -152,11 +165,16 @@ class NotificationAction {
 
   final String id;
 
-  /// The Kotlin's own hardcoded English. `addNotificationActions` passes string
-  /// literals, not `getString(R.string...)`, so there is nothing translated to
-  /// port — and the producer runs in a background isolate with no
-  /// `BuildContext` to resolve an `.arb` lookup against. Same reasoning as
-  /// [NotificationConfig.task]'s title and body.
+  /// The Kotlin's own hardcoded English. `addNotificationActions`
+  /// (`NotificationUtils.kt:379,383`) passes string *literals*, not
+  /// `getString(R.string...)`, so there is nothing translated to port. Same
+  /// reasoning as [NotificationConfig.task]'s title and body.
+  ///
+  /// Not because a background isolate cannot localise — it can, with
+  /// `AppLocalizations.delegate.load(locale)` and no `BuildContext`. An earlier
+  /// draft said otherwise and it is worth correcting, because the port *does*
+  /// carry a translated `markAsRead` for the bell screen and the next reader
+  /// will reach for it. The behaviour is right; only the reason was wrong.
   final String title;
 
   @override

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1680,10 +1680,12 @@ class NotificationDao extends DatabaseAccessor<AppDatabase>
   /// fresh `createdAt` (Kotlin's `Date`), and flags server-originated rows for
   /// read-state upload via `needsSync`.
   ///
-  /// Selection mode's "mark selected as read" is its one caller, and the stamp
-  /// is deliberate there: it moves the marked rows to the top of the list in
-  /// the Android app, so the port has to do the same or the two lists order
-  /// differently. See [markOneAsRead] for the single-row path.
+  /// Two callers, both stamping deliberately: selection mode's "mark selected
+  /// as read", and the tray's *Mark as Read* / *View Task* action buttons
+  /// (`NotificationActionReceiver.kt:81` calls the same bulk overload). The
+  /// stamp moves the marked rows to the top of the list in the Android app, so
+  /// the port has to do the same or the two lists order differently. See
+  /// [markOneAsRead] for the single-row path, which is the tray *body* tap.
   Future<int> markAsRead(Iterable<String> ids, {int? createdAt}) async {
     final values = ids.toList(growable: false);
     if (values.isEmpty) return 0;

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -2136,8 +2136,6 @@
   "courseProgressCount": "التقدم {current} من {max}",
   "resourceNotificationMessage": "لديك {count} موارد لم يتم تنزيلها",
   "taskNotificationMessage": "{title} مستحق في {date}",
-  "storageRunningLow": "التخزين قليل:",
-  "storageAvailable": "التخزين المتاح:",
   "joinRequestPrefix": "طلب الانضمام:",
   "userRequestedToJoinTeam": "{user} قد طلب الانضمام إلى {team}",
   "markAsRead": "وضع علامة كمقروء",
@@ -2148,5 +2146,9 @@
   "markAllAsRead": "وضع علامة \"مقروء\" على الجميع",
   "selectedCount": "تم تحديد {count}",
   "markSelectedAsRead": "تعليم كمقروء",
-  "cancelSelection": "إلغاء التحديد"
+  "cancelSelection": "إلغاء التحديد",
+  "storageRunningLow": "التخزين قليل: ",
+  "storageAvailable": "التخزين المتاح: ",
+  "playbackSpeed": "سرعة التشغيل",
+  "playbackSpeedValue": "{speed}x"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -2138,8 +2138,6 @@
   "courseProgressCount": "Progreso {current} de {max}",
   "resourceNotificationMessage": "Tienes {count} recursos no descargados",
   "taskNotificationMessage": "{title} vence en {date}",
-  "storageRunningLow": "Almacenamiento bajo:",
-  "storageAvailable": "Almacenamiento disponible:",
   "joinRequestPrefix": "Solicitud de Unión:",
   "userRequestedToJoinTeam": "{user} ha solicitado unirse a {team}",
   "markAsRead": "Marcar como leído",
@@ -2149,5 +2147,9 @@
   "daysAgo": "Hace {count} día(s)",
   "selectedCount": "{count} seleccionado(s)",
   "markSelectedAsRead": "Marcar como leído",
-  "cancelSelection": "Cancelar selección"
+  "cancelSelection": "Cancelar selección",
+  "storageRunningLow": "Almacenamiento bajo: ",
+  "storageAvailable": "Almacenamiento disponible: ",
+  "playbackSpeed": "Velocidad de reproducción",
+  "playbackSpeedValue": "{speed}x"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -2279,8 +2279,6 @@
   "courseProgressCount": "Progression {current} sur {max}",
   "resourceNotificationMessage": "Vous avez {count} ressources non téléchargées",
   "taskNotificationMessage": "{title} est dû le {date}",
-  "storageRunningLow": "Espace de stockage presque plein:",
-  "storageAvailable": "Espace de stockage disponible:",
   "joinRequestPrefix": "Demande d'adhésion :",
   "userRequestedToJoinTeam": "{user} a demandé à rejoindre {team}",
   "markAsRead": "Marquer comme lu",
@@ -2291,5 +2289,9 @@
   "markAllAsRead": "Marquer tout comme lu",
   "selectedCount": "{count} sélectionné(s)",
   "markSelectedAsRead": "Marquer comme lu",
-  "cancelSelection": "Annuler la sélection"
+  "cancelSelection": "Annuler la sélection",
+  "storageRunningLow": "Espace de stockage presque plein: ",
+  "storageAvailable": "Espace de stockage disponible: ",
+  "playbackSpeed": "Vitesse de lecture",
+  "playbackSpeedValue": "{speed}x"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -505,8 +505,6 @@
   "courseProgressCount": "{current} को {max} प्रगति",
   "resourceNotificationMessage": "तपाईंसँग {count} स्रोतहरू डाउनलोड गरिएको छैन",
   "taskNotificationMessage": "{title} {date} मा समाप्त हुन्छ",
-  "storageRunningLow": "स्टोरेज गम्भीर रूपमा कम:",
-  "storageAvailable": "स्टोरेज उपलब्ध:",
   "joinRequestPrefix": "सामेल हुने अनुरोध:",
   "userRequestedToJoinTeam": "{user} ले {team} मा सामेल हुन अनुरोध गरेको छ",
   "markAsRead": "पढिएको रूपमा चिन्ह लगाउनुहोस्",
@@ -517,5 +515,9 @@
   "markAllAsRead": "सबैलाई पढिएको रूपमा चिन्ह लगाउनुहोस्",
   "selectedCount": "{count} छानिएको",
   "markSelectedAsRead": "पढेको चिन्ह लगाउनुहोस्",
-  "cancelSelection": "चयन रद्द गर्नुहोस्"
+  "cancelSelection": "चयन रद्द गर्नुहोस्",
+  "storageRunningLow": "स्टोरेज गम्भीर रूपमा कम: ",
+  "storageAvailable": "स्टोरेज उपलब्ध: ",
+  "playbackSpeed": "प्लेब्याक गति",
+  "playbackSpeedValue": "{speed}x"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -505,8 +505,6 @@
   "courseProgressCount": "Habka {current} ee {max}",
   "resourceNotificationMessage": "Waxaad haysataa {count} agab aan la soo dejisan",
   "taskNotificationMessage": "{title} waa inuu dhamaadaa {date}",
-  "storageRunningLow": "Xaddida maaliyadeed waa tagaa:",
-  "storageAvailable": "Xaddida maaliyadeed waa heli kara:",
   "joinRequestPrefix": "Codsi ku biirid:",
   "userRequestedToJoinTeam": "{user} ayaa codsaday ku biirista {team}",
   "markAsRead": "Calaamadee sidii la aqriyay",
@@ -517,5 +515,9 @@
   "markAllAsRead": "Calaamadee dhammaan sidii la aqriyay",
   "selectedCount": "{count} la doortay",
   "markSelectedAsRead": "Calaamadee akhrinta",
-  "cancelSelection": "Jooji doortashada"
+  "cancelSelection": "Jooji doortashada",
+  "storageRunningLow": "Xaddida maaliyadeed waa tagaa: ",
+  "storageAvailable": "Xaddida maaliyadeed waa heli kara: ",
+  "playbackSpeed": "Xawaaraha dib-u-daawashada",
+  "playbackSpeedValue": "{speed}x"
 }

--- a/flutter/lib/providers/notification_tap_provider.dart
+++ b/flutter/lib/providers/notification_tap_provider.dart
@@ -179,13 +179,30 @@ class NotificationTapHandler {
     // bell is a live drift stream that needs no explicit refresh.
     if (tap.actionId == NotificationTapActions.markAsRead) return null;
 
-    final database = ref.read(appDatabaseProvider);
-    final destination = await NotificationDestinationResolver(
-      taskDao: database.teamTaskDao,
-      teamDao: database.teamDao,
-    ).resolveFor(type: payload.type, relatedId: payload.relatedId);
-    if (destination == null) return null;
-    return notificationDestinationLocation(destination);
+    // Its own guard, not the read-mark's. `resolveFor` reads two DAOs, and
+    // Kotlin's equivalent lookups sit inside `viewModelScope.launch` blocks
+    // whose failure leaves the fragment alone rather than crashing it
+    // (`resolveAndOpenTeam`, `handleTaskNavigation`). A tap that cannot resolve
+    // its destination should navigate nowhere, not throw out of the stream
+    // listener that delivered it.
+    try {
+      final database = ref.read(appDatabaseProvider);
+      final destination = await NotificationDestinationResolver(
+        taskDao: database.teamTaskDao,
+        teamDao: database.teamDao,
+      ).resolveFor(type: payload.type, relatedId: payload.relatedId);
+      if (destination == null) return null;
+      return notificationDestinationLocation(destination);
+    } catch (error, stack) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stack,
+          library: 'notification tap',
+        ),
+      );
+      return null;
+    }
   }
 }
 

--- a/flutter/lib/providers/notification_tap_provider.dart
+++ b/flutter/lib/providers/notification_tap_provider.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/notifications/notification_presenter.dart';
+import '../core/notifications/notification_tap.dart';
+import '../ui/notifications/notification_destination.dart';
+import 'app_providers.dart';
+import 'session_provider.dart';
+
+/// Where taps on system notifications come from.
+///
+/// An interface for the same reason [DeepLinkSource] is one: the production
+/// implementation calls into a method channel, which throws
+/// `MissingPluginException` under `flutter test`, and the interesting half is
+/// the policy in [NotificationTapHandler].
+abstract interface class NotificationTapSource {
+  /// The tap that launched the app, if it was launched by one.
+  ///
+  /// Port of nothing in particular and of the whole cold-start case at once:
+  /// Android hands `DashboardActivity` the notification's `Intent` in
+  /// `onCreate`, and `handleNotificationIntent(intent)` reads it there
+  /// (`DashboardActivity.kt:188`). The plugin splits the same thing in two —
+  /// this, and [taps] for a tap that arrives while the app is already up,
+  /// which is Kotlin's `onNewIntent` (`:1106`).
+  Future<NotificationTap?> launchTap();
+
+  /// Taps delivered while the app is already running.
+  Stream<NotificationTap> taps();
+}
+
+/// `flutter_local_notifications`-backed [NotificationTapSource].
+class LocalNotificationsTapSource implements NotificationTapSource {
+  LocalNotificationsTapSource([FlutterLocalNotificationsPlugin? plugin])
+    : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  @override
+  Future<NotificationTap?> launchTap() async {
+    final details = await _plugin.getNotificationAppLaunchDetails();
+    if (details == null || !details.didNotificationLaunchApp) return null;
+    return notificationTapFrom(details.notificationResponse);
+  }
+
+  @override
+  Stream<NotificationTap> taps() => LocalNotificationsPresenter.responses
+      .map(notificationTapFrom)
+      .where((tap) => tap != null)
+      .cast<NotificationTap>();
+}
+
+/// Translates the plugin's response into the port's own value, or null when
+/// there is nothing to act on.
+///
+/// Three things are dropped, each deliberately:
+///
+///   * a response with no payload this app wrote — an upgrade can leave an
+///     older build's notification in the tray, and Kotlin's own extra-less
+///     notifications (`ServerReachabilityWorker.kt:132-138`) reach
+///     `handleNotificationIntent` and fall through both its branches, i.e. a
+///     plain app launch;
+///   * a *dismissal*, which the plugin reports through the same callback and
+///     Android's `PendingIntent` machinery never delivers at all — a swipe-away
+///     is not a tap and must not mark anything read;
+///   * an action id this build does not know, for the same upgrade reason.
+NotificationTap? notificationTapFrom(NotificationResponse? response) {
+  if (response == null) return null;
+  if (response.notificationResponseType ==
+      NotificationResponseType.notificationDismissed) {
+    return null;
+  }
+  final payload = NotificationTapPayload.decode(response.payload);
+  if (payload == null) return null;
+  final actionId = response.actionId;
+  if (actionId == null || actionId.isEmpty) {
+    return NotificationTap(payload: payload);
+  }
+  if (actionId != NotificationTapActions.markAsRead &&
+      actionId != NotificationTapActions.open) {
+    return null;
+  }
+  return NotificationTap(payload: payload, actionId: actionId);
+}
+
+final notificationTapSourceProvider = Provider<NotificationTapSource>(
+  (ref) => LocalNotificationsTapSource(),
+);
+
+/// Handles one tap on a system notification, and says where to go.
+///
+/// Port of `services/NotificationActionReceiver.kt` together with
+/// `DashboardActivity.handleNotificationIntent` (`:478-560`) — the Kotlin
+/// splits them because a broadcast and an activity intent arrive at different
+/// components, and here they are the same callback with a different `actionId`.
+/// Shaped after [DeepLinkHandler]: returns a location for the caller to
+/// navigate to rather than navigating itself, so the whole policy is testable
+/// without a widget.
+///
+/// **The three gestures, and why they are not one branch.**
+///
+/// | gesture | Kotlin | marks read via | navigates |
+/// |---|---|---|---|
+/// | the body | `handleNotificationIntent`'s `from_notification` branch | `markNotificationAsRead(id, userId)` — **does not** stamp `createdAt` | yes |
+/// | *Mark as Read* | `ACTION_MARK_AS_READ` (`:34-39`) | `markNotificationsAsRead({id})` — **stamps** | no |
+/// | *View Task* | `ACTION_OPEN_NOTIFICATION` (`:51-66`) | `markNotificationsAsRead({id})` — **stamps** | yes |
+///
+/// The two read paths are two different DAO statements in the Kotlin and have
+/// to stay two here: the stamping one rewrites `createdAt`, which is the list's
+/// sort key *and* is uploaded back to the server document's `time` by
+/// `syncNotificationReads`. Phase 127 separated them and left the non-stamping
+/// one with no caller at all; this is its caller.
+///
+/// **What it does not do, on purpose.** Kotlin's read-marking here matches no
+/// row for the only notification either app raises. `TaskDeadlineNotifier`
+/// mints the tray notification with `id = task.id` (as
+/// `TaskNotificationWorker.kt:48-53` does), while a `task` notification *row*
+/// is a synced CouchDB notification document whose id is its own `_id` and
+/// which carries the task id in `relatedId`. So `markNotificationAsRead` and
+/// `markAsRead` both look up an id that is not in the table and update nothing
+/// — `markAsRead` even early-returns on the empty `getByIds`. Resolving
+/// `relatedId` back to a notification row would fix that, and would be an
+/// improvement the Android app does not have. It is reproduced and recorded
+/// instead; see `PHASE_130_NOTES.md`.
+class NotificationTapHandler {
+  NotificationTapHandler(this.ref);
+
+  final Ref ref;
+
+  /// Returns the location to navigate to, or null when the tap navigates
+  /// nowhere (*Mark as Read*, or a type with no destination).
+  Future<String?> handle(NotificationTap tap) async {
+    final payload = tap.payload;
+    final repository = ref.read(notificationsRepositoryProvider);
+    try {
+      if (tap.isBodyTap) {
+        // `markDatabaseNotificationAsRead(it)` (`DashboardActivity.kt:486,
+        // :701-703`). The user id is what routes a `summary_` id to
+        // `markSummaryAsRead`; Kotlin passes `user?.id` and tolerates null —
+        // `checkUser()` calls `logout()` without stopping the enclosing
+        // coroutine, so the Android app reaches here with a null user too.
+        //
+        // Awaited rather than read: this handler runs from a scope that never
+        // watches `sessionProvider`, and `ref.read(...).valueOrNull` would be
+        // null until something else resolved it. The `await` is inside the
+        // `try` because a future can reject where `valueOrNull` could not —
+        // the correction Phase 100's fix needed on harvest.
+        final user = await ref.read(sessionProvider.future);
+        await repository.markNotificationAsRead(
+          payload.notificationId,
+          user?.id,
+        );
+      } else {
+        // Both action arms of `NotificationActionReceiver` call
+        // `notificationsRepository.markNotificationsAsRead(setOf(id))`
+        // (`:81`), the bulk statement, which stamps.
+        await repository.markAsRead({payload.notificationId});
+      }
+    } catch (error, stack) {
+      // `NotificationActionReceiver` wraps its write in `try/catch` with an
+      // `e.printStackTrace()` and carries on to the navigation (`:76-84`); the
+      // dashboard's `markNotificationAsRead` does the same
+      // (`DashboardViewModel.kt:246-254`). A failed read-mark must not cost the
+      // user the navigation they asked for.
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stack,
+          library: 'notification tap',
+        ),
+      );
+    }
+
+    // *Mark as Read* navigates nowhere. It does bring the app to the
+    // foreground in the Android app — `markNotificationAsRead`'s tail runs
+    // `startActivity(DashboardActivity, action = REFRESH_NOTIFICATION_BADGE)`
+    // unconditionally (`:104-112`) — which here is what tapping the action does
+    // by itself, since `showsUserInterface: true` launches the app and the
+    // bell is a live drift stream that needs no explicit refresh.
+    if (tap.actionId == NotificationTapActions.markAsRead) return null;
+
+    final database = ref.read(appDatabaseProvider);
+    final destination = await NotificationDestinationResolver(
+      taskDao: database.teamTaskDao,
+      teamDao: database.teamDao,
+    ).resolveFor(type: payload.type, relatedId: payload.relatedId);
+    if (destination == null) return null;
+    return notificationDestinationLocation(destination);
+  }
+}
+
+final notificationTapHandlerProvider = Provider(NotificationTapHandler.new);

--- a/flutter/lib/providers/notification_tap_provider.dart
+++ b/flutter/lib/providers/notification_tap_provider.dart
@@ -60,9 +60,13 @@ class LocalNotificationsTapSource implements NotificationTapSource {
 ///     notifications (`ServerReachabilityWorker.kt:132-138`) reach
 ///     `handleNotificationIntent` and fall through both its branches, i.e. a
 ///     plain app launch;
-///   * a *dismissal*, which the plugin reports through the same callback and
-///     Android's `PendingIntent` machinery never delivers at all — a swipe-away
-///     is not a tap and must not mark anything read;
+///   * a *dismissal*. The plugin's `ActionBroadcastReceiver` does forward one
+///     through this same callback, but only when `dismissIsolate` is set on the
+///     notification, and [LocalNotificationsPresenter] never sets it — so no
+///     dismissal reaches here today and this arm is defensive. Kept because the
+///     cost of being wrong is asymmetric: a swipe-away treated as a tap marks a
+///     notification read that the user deliberately ignored, and on the
+///     stamping path reorders their whole list to say so;
 ///   * an action id this build does not know, for the same upgrade reason.
 NotificationTap? notificationTapFrom(NotificationResponse? response) {
   if (response == null) return null;

--- a/flutter/lib/repository/notifications_repository.dart
+++ b/flutter/lib/repository/notifications_repository.dart
@@ -95,9 +95,19 @@ class NotificationsRepository {
   /// `NotificationUtils.createSummaryNotification` (`:190`) for the tray. The
   /// tray's *Mark as Read* action button is **not** this path — it goes through
   /// `NotificationActionReceiver` (`:81`) to [markAsRead], and so does stamp.
-  /// The port has no tray handling yet, so this has no caller: it is kept (and
-  /// pinned by tests) because the screen was wired to it by mistake, and the
-  /// phase that ports tray actions needs it to be right.
+  ///
+  /// Its caller in the port is `NotificationTapHandler`'s body-tap arm
+  /// (Phase 130). Until that landed this method had none at all, which is why
+  /// Phase 127 pinned it by tests rather than deleting it — the screen had been
+  /// wired to it by mistake, and the distinction had to survive until the tray
+  /// path arrived to need it.
+  ///
+  /// One thing it does **not** do on the only notification either app raises:
+  /// anything. The tray notification's id is the *task* id, while a `task`
+  /// notification row is a synced document keyed on its own `_id`, so this
+  /// looks up an id that is not in the table. At parity, and recorded in
+  /// `PHASE_130_NOTES.md` rather than repaired — resolving `relatedId` back to
+  /// the row would be an improvement the Android app does not have.
   Future<int> markNotificationAsRead(String id, String? userId) {
     if (id.startsWith('summary_')) {
       return _dao.markSummaryAsRead(userId, id.substring('summary_'.length));

--- a/flutter/lib/ui/notification_tap_scope.dart
+++ b/flutter/lib/ui/notification_tap_scope.dart
@@ -63,7 +63,20 @@ class _NotificationTapScopeState extends ConsumerState<NotificationTapScope> {
       // Listening before awaiting the launch tap, as `DeepLinkScope` does: a
       // tap arriving in that window would otherwise be dropped, and a
       // broadcast stream does not replay it.
-      _subscription = source.taps().listen(_handle);
+      _subscription = source.taps().listen(
+        _handle,
+        // `_handle` is async, so an exception inside it would become an
+        // unhandled async error rather than reaching here — which is why
+        // `NotificationTapHandler.handle` guards both of its halves itself.
+        // This covers the other side: an error the *source* emits.
+        onError: (Object error, StackTrace stack) => FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: error,
+            stack: stack,
+            library: 'notification taps',
+          ),
+        ),
+      );
       final launch = await source.launchTap();
       if (launch != null) await _handle(launch);
     } catch (error, stack) {

--- a/flutter/lib/ui/notification_tap_scope.dart
+++ b/flutter/lib/ui/notification_tap_scope.dart
@@ -77,8 +77,7 @@ class _NotificationTapScopeState extends ConsumerState<NotificationTapScope> {
           ),
         ),
       );
-      final launch = await source.launchTap();
-      if (launch != null) await _handle(launch);
+      // MUTATION A: the cold-start tap is never asked for.
     } catch (error, stack) {
       // A platform channel failure must not take startup down with it.
       FlutterError.reportError(
@@ -95,7 +94,8 @@ class _NotificationTapScopeState extends ConsumerState<NotificationTapScope> {
     if (!mounted) return;
     final location = await ref.read(notificationTapHandlerProvider).handle(tap);
     if (!mounted || location == null) return;
-    ref.read(routerProvider).go(location);
+    // MUTATION B: the navigation is dropped.
+    location.length;
   }
 
   @override

--- a/flutter/lib/ui/notification_tap_scope.dart
+++ b/flutter/lib/ui/notification_tap_scope.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/notifications/notification_tap.dart';
+import '../providers/notification_tap_provider.dart';
+import 'router.dart';
+
+/// Delivers taps on system notifications to the router.
+///
+/// Replaces `DashboardActivity`'s `onCreate`/`onNewIntent` pair
+/// (`:188` and `:1106`, both calling `handleNotificationIntent`): the tap that
+/// launched the app and a tap that arrives while it is running are the same two
+/// cases, and here they are a future and a stream from one source. Wrapped
+/// around the navigator, like [DeepLinkScope] and `OutboxDrainScope`, so it
+/// follows the app rather than any one screen — and unlike the Kotlin, which
+/// hangs the whole slice off `initializeDashboard()` and therefore ignores a
+/// notification tap entirely for an inactive user (`:301-306` returns before
+/// `:188`).
+///
+/// Navigation goes through [routerProvider] rather than `GoRouter.of(context)`
+/// for the reason [DeepLinkScope] documents: this widget is mounted from
+/// `MaterialApp.router`'s `builder`, whose context sits *above* the
+/// `InheritedGoRouter` the router delegate inserts.
+///
+/// There is no de-duplication between [NotificationTapSource.launchTap] and
+/// the stream, because the plugin does not double-deliver: `initialize`'s own
+/// documentation splits them ("fired when the user selects a notification …
+/// [while the] application was running. To handle when a notification launched
+/// an application, use `getNotificationAppLaunchDetails`").
+class NotificationTapScope extends ConsumerStatefulWidget {
+  const NotificationTapScope({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  ConsumerState<NotificationTapScope> createState() =>
+      _NotificationTapScopeState();
+}
+
+class _NotificationTapScopeState extends ConsumerState<NotificationTapScope> {
+  StreamSubscription<NotificationTap>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _start() async {
+    if (!mounted) return;
+    try {
+      // Inside the guard: the production source constructs the plugin, which
+      // reaches for a platform channel.
+      final source = ref.read(notificationTapSourceProvider);
+      // Listening before awaiting the launch tap, as `DeepLinkScope` does: a
+      // tap arriving in that window would otherwise be dropped, and a
+      // broadcast stream does not replay it.
+      _subscription = source.taps().listen(_handle);
+      final launch = await source.launchTap();
+      if (launch != null) await _handle(launch);
+    } catch (error, stack) {
+      // A platform channel failure must not take startup down with it.
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stack,
+          library: 'notification taps',
+        ),
+      );
+    }
+  }
+
+  Future<void> _handle(NotificationTap tap) async {
+    if (!mounted) return;
+    final location = await ref.read(notificationTapHandlerProvider).handle(tap);
+    if (!mounted || location == null) return;
+    ref.read(routerProvider).go(location);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/flutter/lib/ui/notification_tap_scope.dart
+++ b/flutter/lib/ui/notification_tap_scope.dart
@@ -77,7 +77,8 @@ class _NotificationTapScopeState extends ConsumerState<NotificationTapScope> {
           ),
         ),
       );
-      // MUTATION A: the cold-start tap is never asked for.
+      final launch = await source.launchTap();
+      if (launch != null) await _handle(launch);
     } catch (error, stack) {
       // A platform channel failure must not take startup down with it.
       FlutterError.reportError(
@@ -94,8 +95,7 @@ class _NotificationTapScopeState extends ConsumerState<NotificationTapScope> {
     if (!mounted) return;
     final location = await ref.read(notificationTapHandlerProvider).handle(tap);
     if (!mounted || location == null) return;
-    // MUTATION B: the navigation is dropped.
-    location.length;
+    ref.read(routerProvider).go(location);
   }
 
   @override

--- a/flutter/lib/ui/notification_tap_scope.dart
+++ b/flutter/lib/ui/notification_tap_scope.dart
@@ -25,10 +25,22 @@ import 'router.dart';
 /// `InheritedGoRouter` the router delegate inserts.
 ///
 /// There is no de-duplication between [NotificationTapSource.launchTap] and
-/// the stream, because the plugin does not double-deliver: `initialize`'s own
-/// documentation splits them ("fired when the user selects a notification …
-/// [while the] application was running. To handle when a notification launched
-/// an application, use `getNotificationAppLaunchDetails`").
+/// the stream, and the reason is **not** the one `initialize`'s dartdoc
+/// suggests. The Android side does not honour that split as a guarantee:
+/// `onNewIntent` both invokes `didReceiveNotificationResponse` *and* calls
+/// `mainActivity.setIntent(intent)`, and `getNotificationAppLaunchDetails`
+/// re-reads that intent on every call — so a tap already delivered through the
+/// callback keeps being reported as a launch tap for the rest of the process.
+///
+/// What makes this safe is narrower: [_start] runs **once**, from `initState`'s
+/// post-frame callback, so `launchTap` is asked exactly once per mount. That is
+/// a live trap rather than a theoretical one, because the sibling scope in this
+/// directory does the thing that would break it — `OutboxDrainScope` re-runs on
+/// `AppLifecycleState.resumed`. Adding a resume hook here (the obvious fix for
+/// "the app was backgrounded when the tap arrived") would replay the last tap
+/// on every foreground: yanking the user back to the tasks page and re-running
+/// the read-mark, `createdAt` restamp included. **If a resume hook ever lands,
+/// de-duplicate on the payload first.**
 class NotificationTapScope extends ConsumerStatefulWidget {
   const NotificationTapScope({required this.child, super.key});
 

--- a/flutter/lib/ui/notifications/notification_destination.dart
+++ b/flutter/lib/ui/notifications/notification_destination.dart
@@ -1,5 +1,6 @@
 import '../../data/local/app_database.dart';
 import '../../repository/notifications_repository.dart';
+import '../router.dart';
 
 enum NotificationDestinationKind {
   resources,
@@ -56,8 +57,39 @@ class NotificationDestinationResolver {
   final TeamTaskDao _taskDao;
   final TeamDao _teamDao;
 
-  Future<NotificationDestination?> resolve(NotificationRow notification) async {
-    switch (resolvedNotificationType(notification)) {
+  /// Resolves an in-app notification row.
+  Future<NotificationDestination?> resolve(NotificationRow notification) =>
+      resolveFor(
+        type: resolvedNotificationType(notification),
+        relatedId: notification.relatedId,
+      );
+
+  /// The same policy over the two fields it actually reads.
+  ///
+  /// Split out so the **system-tray** tap can share it. A tray tap carries no
+  /// row — Kotlin puts `notification_type` and `related_id` on the intent
+  /// (`NotificationUtils.kt:401-406`) and `handleNotificationIntent`'s
+  /// `auto_navigate` branch switches on those two alone — and the type it
+  /// carries is already `NotificationUtils.TYPE_*`, i.e. the same *resolved*
+  /// spelling `resolvedNotificationType` produces. So one switch serves both,
+  /// which is the point: a tray tap and a row tap on the same notification
+  /// should not land in different places, and Kotlin's own two paths agree on
+  /// the destination (`NotificationsFragment.kt:122-124` and
+  /// `DashboardViewModel.kt:216-223` both open the team's tasks page).
+  ///
+  /// They do differ in one respect, and this keeps the *row* tap's behaviour
+  /// for both. Kotlin's button path goes through
+  /// `TeamsRepositoryImpl.getTaskTeamInfo`, which returns null when the team
+  /// row is absent and therefore navigates nowhere at all; the row path goes
+  /// through `getTaskDetails` and `resolveAndOpenTeam`'s `?: relatedId`, which
+  /// still opens something. Sharing the forgiving one means a tray tap
+  /// navigates in a case where the Android app silently does nothing — a
+  /// divergence recorded in `PHASE_130_NOTES.md`, not an accident.
+  Future<NotificationDestination?> resolveFor({
+    required String type,
+    String? relatedId,
+  }) async {
+    switch (type) {
       case 'storage':
         return const NotificationDestination(
           NotificationDestinationKind.storage,
@@ -67,7 +99,7 @@ class NotificationDestinationResolver {
           NotificationDestinationKind.resources,
         );
       case 'team_join':
-        final teamId = _nonBlank(notification.relatedId);
+        final teamId = _nonBlank(relatedId);
         return teamId == null
             ? null
             : NotificationDestination(
@@ -75,7 +107,7 @@ class NotificationDestinationResolver {
                 teamId: teamId,
               );
       case 'chat':
-        final teamId = _nonBlank(notification.relatedId);
+        final teamId = _nonBlank(relatedId);
         return teamId == null
             ? null
             : NotificationDestination(
@@ -83,7 +115,7 @@ class NotificationDestinationResolver {
                 teamId: teamId,
               );
       case 'voice_reply':
-        final voiceId = _nonBlank(notification.relatedId);
+        final voiceId = _nonBlank(relatedId);
         return voiceId == null
             ? null
             : NotificationDestination(
@@ -91,9 +123,9 @@ class NotificationDestinationResolver {
                 voiceId: voiceId,
               );
       case 'task':
-        final relatedId = _nonBlank(notification.relatedId);
-        if (relatedId == null) return null;
-        final task = await _taskDao.getById(relatedId);
+        final id = _nonBlank(relatedId);
+        if (id == null) return null;
+        final task = await _taskDao.getById(id);
         return NotificationDestination(
           NotificationDestinationKind.teamTasks,
           // `resolveAndOpenTeam` is `resolve(relatedId) ?: relatedId`
@@ -102,24 +134,28 @@ class NotificationDestinationResolver {
           // instead made the tap silently do nothing — and a server task's row
           // is *never* cached, because the port has no `tasks` sync walk
           // (Phase 116's D16).
-          teamId: _nonBlank(task?.teamId) ?? relatedId,
+          //
+          // The tray path is the one case where the row *is* there:
+          // `TaskDeadlineNotifier` selects the task out of `team_tasks` to
+          // notify about it, so a tray tap resolves a real team id.
+          teamId: _nonBlank(task?.teamId) ?? id,
         );
       case 'join_request':
-        final relatedId = _nonBlank(notification.relatedId);
-        if (relatedId == null) return null;
+        final id = _nonBlank(relatedId);
+        if (id == null) return null;
         // `getJoinRequestTeamId` strips the `join_request_` prefix the
         // system-tray path puts on the id before looking the document up
         // (`NotificationsRepositoryImpl.kt:169-177`).
-        final requestId = relatedId.startsWith('join_request_')
-            ? relatedId.substring('join_request_'.length)
-            : relatedId;
+        final requestId = id.startsWith('join_request_')
+            ? id.substring('join_request_'.length)
+            : id;
         final request = await _teamDao.getById(requestId);
         return NotificationDestination(
           NotificationDestinationKind.teamMembers,
           // The strip happens *inside* `getJoinRequestTeamId`, so
           // `resolveAndOpenTeam`'s `?: relatedId` falls back to the id the
           // notification carried, prefix and all — not the stripped one.
-          teamId: _nonBlank(request?.teamId) ?? relatedId,
+          teamId: _nonBlank(request?.teamId) ?? id,
         );
       default:
         return null;
@@ -131,3 +167,42 @@ class NotificationDestinationResolver {
     return trimmed == null || trimmed.isEmpty ? null : trimmed;
   }
 }
+
+/// The in-app location a [NotificationDestination] opens.
+///
+/// Lifted out of `notifications_screen.dart`'s `_openNotification`, where it
+/// was a `switch` inside a private widget method, for two reasons.
+///
+/// The tray tap needs the same mapping, and a second copy of it is how a tray
+/// tap and a row tap on the same notification come to disagree — the shape
+/// Phase 124 avoided by building the row formatter on this same enum.
+///
+/// And it is now *enumerable*. `route_reachability_test.dart` had
+/// `notifications_screen.dart` in its `declared` blind-spot map, because the
+/// location was built in a switch and handed to `context.go` as a variable, so
+/// the only rule that could see the arms was the one that scans for `Routes.x`
+/// mentions anywhere in a file. A total function over the enum can be walked
+/// exhaustively instead: every kind, every location, checked against the real
+/// route table. A new kind with no arm will not compile, and an arm naming a
+/// path the router does not serve fails that test.
+String notificationDestinationLocation(NotificationDestination destination) =>
+    switch (destination.kind) {
+      NotificationDestinationKind.resources => Routes.resources,
+      // Kotlin opens the *system* storage settings here
+      // (`ACTION_INTERNAL_STORAGE_SETTINGS`, `NotificationsFragment.kt:131`).
+      // The port has its own free-up-space screen and no such channel, so this
+      // is the established divergence rather than a new one.
+      NotificationDestinationKind.storage => Routes.storageManagement,
+      NotificationDestinationKind.teamTasks =>
+        '${Routes.teams}/${destination.teamId}/tasks',
+      NotificationDestinationKind.teamMembers =>
+        '${Routes.teams}/${destination.teamId}/members?tab=requests',
+      NotificationDestinationKind.teamJoin =>
+        '${Routes.teams}/${destination.teamId}',
+      // The Flutter port has no team-chat tab yet (the upstream opens the
+      // team's ChatPage), so the team detail is the closest destination.
+      NotificationDestinationKind.teamChat =>
+        '${Routes.teams}/${destination.teamId}',
+      NotificationDestinationKind.voiceReply =>
+        '${Routes.voices}/${destination.voiceId}',
+    };

--- a/flutter/lib/ui/notifications/notification_destination.dart
+++ b/flutter/lib/ui/notifications/notification_destination.dart
@@ -138,6 +138,13 @@ class NotificationDestinationResolver {
           // The tray path is the one case where the row *is* there:
           // `TaskDeadlineNotifier` selects the task out of `team_tasks` to
           // notify about it, so a tray tap resolves a real team id.
+          //
+          // Same value as the Kotlin, different source, and worth saying so
+          // before someone "aligns" it: both Kotlin paths read the `"teams"`
+          // field out of the task's `link` JSON, where the port reads the
+          // `teamId` column — which `TeamTaskMapper` populates from exactly
+          // that field. Changing this to parse `link` would move the tray path
+          // with it for no gain.
           teamId: _nonBlank(task?.teamId) ?? id,
         );
       case 'join_request':

--- a/flutter/lib/ui/notifications/notifications_screen.dart
+++ b/flutter/lib/ui/notifications/notifications_screen.dart
@@ -7,7 +7,6 @@ import '../../providers/app_providers.dart';
 import '../../providers/notifications_provider.dart';
 import '../../repository/notifications_repository.dart';
 import '../components/relative_time.dart';
-import '../router.dart';
 import 'notification_destination.dart';
 import 'notification_format.dart';
 import 'notification_grouping.dart';
@@ -452,23 +451,10 @@ class _NotificationTile extends ConsumerWidget {
       teamDao: database.teamDao,
     ).resolve(notification);
     if (destination == null || !context.mounted) return;
-    final path = switch (destination.kind) {
-      NotificationDestinationKind.resources => Routes.resources,
-      NotificationDestinationKind.storage => Routes.storageManagement,
-      NotificationDestinationKind.teamTasks =>
-        '${Routes.teams}/${destination.teamId}/tasks',
-      NotificationDestinationKind.teamMembers =>
-        '${Routes.teams}/${destination.teamId}/members?tab=requests',
-      NotificationDestinationKind.teamJoin =>
-        '${Routes.teams}/${destination.teamId}',
-      // The Flutter port has no team-chat tab yet (the upstream opens the
-      // team's ChatPage), so the team detail is the closest destination.
-      NotificationDestinationKind.teamChat =>
-        '${Routes.teams}/${destination.teamId}',
-      NotificationDestinationKind.voiceReply =>
-        '${Routes.voices}/${destination.voiceId}',
-    };
-    context.go(path);
+    // The mapping itself lives beside the resolver, so the system-tray tap
+    // reaches the same screen this row does — see
+    // `notificationDestinationLocation`.
+    context.go(notificationDestinationLocation(destination));
   }
 
   Future<bool> _confirmDelete(BuildContext context) async {

--- a/flutter/test/core/notifications/notification_tap_test.dart
+++ b/flutter/test/core/notifications/notification_tap_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/notifications/notification_config.dart';
+import 'package:myplanet/core/notifications/notification_tap.dart';
+import 'package:myplanet/providers/notification_tap_provider.dart';
+
+/// The tray side of Phase 130. Everything here is what a tap carries and what
+/// buttons the notification offers — the half that has no Riverpod graph in it.
+void main() {
+  NotificationConfig taskConfig() => NotificationConfig.task(
+    taskId: 'task-42',
+    taskTitle: 'Read chapter 3',
+    deadlineLabel: 'Wed 19, August 2026',
+    urgent: true,
+  );
+
+  group('payload', () {
+    test('the config a task reminder is built from round-trips', () {
+      final config = taskConfig();
+      final decoded = NotificationTapPayload.decode(
+        NotificationTapPayload.forConfig(config).encode(),
+      );
+
+      // Kotlin's three intent extras, and the values `createTaskNotification`
+      // puts in them: `type`, `config.id` (the **task** id) and `relatedId`.
+      expect(decoded, isNotNull);
+      expect(decoded!.type, 'task');
+      expect(decoded.notificationId, 'task-42');
+      expect(decoded.relatedId, 'task-42');
+    });
+
+    test('the encoding uses the Kotlin extra names', () {
+      // Not cosmetic: these strings are the readable link between the two
+      // apps' handlers, and a reviewer checking this against
+      // `NotificationUtils.kt:60-62` should find the same three words.
+      expect(
+        NotificationTapPayload.forConfig(taskConfig()).encode(),
+        '{"notification_type":"task","notification_id":"task-42",'
+        '"related_id":"task-42"}',
+      );
+    });
+
+    test('a null relatedId is omitted rather than written as null', () {
+      const payload = NotificationTapPayload(
+        type: 'storage',
+        notificationId: 'user-1:storage',
+      );
+      expect(payload.encode(), isNot(contains('related_id')));
+      expect(NotificationTapPayload.decode(payload.encode()), payload);
+    });
+
+    test('anything this app did not write decodes to nothing', () {
+      // An upgrade can leave an older build's notification in the tray, and
+      // Kotlin posts tappable notifications with no extras at all
+      // (`ServerReachabilityWorker.kt:132-138`) whose tap falls through both
+      // branches of `handleNotificationIntent`. Neither is worth an exception
+      // on the launch path.
+      expect(NotificationTapPayload.decode(null), isNull);
+      expect(NotificationTapPayload.decode(''), isNull);
+      expect(NotificationTapPayload.decode('not json'), isNull);
+      expect(NotificationTapPayload.decode('[1,2,3]'), isNull);
+      expect(
+        NotificationTapPayload.decode('{"notification_type":"task"}'),
+        isNull,
+      );
+      expect(NotificationTapPayload.decode('{"notification_id":"x"}'), isNull);
+      // An empty id is no id: it would mark nothing and resolve nothing, and
+      // treating it as present costs a wasted navigation.
+      expect(
+        NotificationTapPayload.decode(
+          '{"notification_type":"task","notification_id":""}',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('actions', () {
+    test('a task reminder offers Mark as Read and View Task', () {
+      // `NotificationUtils.addNotificationActions` adds *Mark as Read* to
+      // every actionable config and then one type-specific action; the `task`
+      // arm is `builder.addAction(R.drawable.team, "View Task", …)`.
+      expect(notificationActionsFor(taskConfig()), const [
+        NotificationAction(
+          id: NotificationTapActions.markAsRead,
+          title: 'Mark as Read',
+        ),
+        NotificationAction(id: NotificationTapActions.open, title: 'View Task'),
+      ]);
+    });
+
+    test('createTaskNotification is actionable, as the Kotlin sets it', () {
+      // The field the port dropped. Without it the two buttons never appear,
+      // and the only reachable gesture is a body tap.
+      expect(taskConfig().actionable, isTrue);
+    });
+
+    test('a non-actionable config offers none', () {
+      // `buildNotification`'s `if (config.actionable)` gate, which is what
+      // makes the default `false` mean something.
+      const plain = NotificationConfig(
+        id: 'n-1',
+        type: 'resource',
+        title: 't',
+        message: 'm',
+        priority: NotificationPriority.defaultPriority,
+      );
+      expect(notificationActionsFor(plain), isEmpty);
+    });
+  });
+
+  group('what the plugin hands back', () {
+    NotificationResponse response({
+      String? actionId,
+      String? payload,
+      NotificationResponseType type =
+          NotificationResponseType.selectedNotification,
+    }) => NotificationResponse(
+      notificationResponseType: type,
+      actionId: actionId,
+      payload: payload,
+    );
+
+    final payload = NotificationTapPayload.forConfig(taskConfig()).encode();
+
+    test('a body tap has no action id', () {
+      final tap = notificationTapFrom(response(payload: payload));
+      expect(tap, isNotNull);
+      expect(tap!.isBodyTap, isTrue);
+      expect(tap.actionId, isNull);
+    });
+
+    test('an empty action id is a body tap, not an unknown action', () {
+      // Android delivers `""` rather than null on some paths, and reading that
+      // as an unknown action would drop the tap entirely.
+      final tap = notificationTapFrom(response(actionId: '', payload: payload));
+      expect(tap?.isBodyTap, isTrue);
+    });
+
+    test('each known action arrives as itself', () {
+      for (final id in const [
+        NotificationTapActions.markAsRead,
+        NotificationTapActions.open,
+      ]) {
+        expect(
+          notificationTapFrom(
+            response(actionId: id, payload: payload),
+          )?.actionId,
+          id,
+        );
+      }
+    });
+
+    test('a dismissal is not a tap', () {
+      // The plugin reports a swipe-away through the same callback; Android's
+      // `PendingIntent` machinery never delivers one at all. Treating it as a
+      // tap would mark a notification read the user deliberately ignored — and
+      // on the stamping path, reorder their whole list to say so.
+      expect(
+        notificationTapFrom(
+          response(
+            payload: payload,
+            type: NotificationResponseType.notificationDismissed,
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('an action this build does not know is dropped', () {
+      expect(
+        notificationTapFrom(
+          response(actionId: 'storage_settings', payload: payload),
+        ),
+        isNull,
+      );
+    });
+
+    test('a response with no payload is dropped', () {
+      expect(notificationTapFrom(response()), isNull);
+      expect(notificationTapFrom(null), isNull);
+    });
+  });
+}

--- a/flutter/test/l10n/format_derivation_test.dart
+++ b/flutter/test/l10n/format_derivation_test.dart
@@ -239,6 +239,33 @@ void main() {
       );
     });
 
+    test('the format path mirrors a trailing space too', () {
+      // The fourth derivation path, and the one the phase's own fix did *not*
+      // cover until the second audit pass pointed at it. No template value
+      // carrying a placeholder ends in a space today, so this is a guard on a
+      // shape rather than on live data — which is the point: the plain-text
+      // fix's dartdoc claimed no further rule could disagree, and this one
+      // could.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Searching in {folder}: ',
+          kotlinEnglish: r'Searching in %1$s: ',
+          translation: r'Recherche dans %1$s :',
+        ),
+        'Recherche dans {folder} : ',
+      );
+      // And still one-directional: a template with no trailing space is
+      // unaffected, which the group's other tests would catch but not state.
+      expect(
+        convertAndroidFormat(
+          templateValue: 'Searching in {folder}',
+          kotlinEnglish: r'Searching in %1$s',
+          translation: r'Recherche dans %1$s ',
+        ),
+        'Recherche dans {folder}',
+      );
+    });
+
     test('a blank or absent translation derives nothing', () {
       // Both plain-text rules carried an `isNotEmpty` guard before this
       // function existed, and it is load-bearing: writing `""` into a locale

--- a/flutter/test/l10n/format_derivation_test.dart
+++ b/flutter/test/l10n/format_derivation_test.dart
@@ -181,6 +181,86 @@ void main() {
     });
   });
 
+  group('plain text', () {
+    // Not a placeholder concern, but the same file: this is where the tool's
+    // derivation rules are tested, and the plain-text rules turned out to
+    // disagree with the recovery path about one character.
+    //
+    // Android's quoting is how a trailing space survives in `strings.xml`, and
+    // four template strings rely on it — every one a label a value is drawn
+    // straight after. The two plain-text rules wrote `translated[name]?.trim()`
+    // and stripped it; `--adopt`'s `_proposal` mirrors it. So `selected` and
+    // `select_resources`, repaired by hand, kept their space while
+    // `storage_running_low` and `storage_available`, derived by the tool, lost
+    // it in all five locales.
+
+    test('a trailing space the template carries is kept', () {
+      // The real Arabic value, read from the XML rather than written here, so
+      // this cannot pass against a stale copy. `"التخزين قليل: "` — Android's
+      // quotes are the XML's, the space inside them is the string's.
+      final arabic = _kotlin('ar', 'storage_running_low');
+      expect(arabic, endsWith(' '), reason: 'the XML premise of this test');
+      expect(
+        derivePlainTextValue(
+          templateEnglish: 'Storage running low: ',
+          translation: arabic,
+        ),
+        endsWith(' '),
+      );
+    });
+
+    test('a translation that never had the space is given it', () {
+      // `values-ar/select_resources` is unquoted and so carries no trailing
+      // space at all, where the other four locales do. The template's space is
+      // the one that matters — it is the app's own layout decision — so the
+      // mirror adds it rather than trusting each translator to have kept it.
+      // This is why the fix is a mirror and not a "don't trim".
+      expect(_kotlin('ar', 'select_resources'), isNot(endsWith(' ')));
+      expect(
+        derivePlainTextValue(
+          templateEnglish: 'Select resources: ',
+          translation: _kotlin('ar', 'select_resources'),
+        ),
+        'اختر الموارد: ',
+      );
+    });
+
+    test('a template with no trailing space still gets a trimmed value', () {
+      // The mirror is one-directional: it never *removes* whitespace the
+      // template does not ask for, and the surrounding trim still runs. A
+      // regression that mirrored in both directions would start writing
+      // trailing spaces into 890 ordinary strings.
+      expect(
+        derivePlainTextValue(
+          templateEnglish: 'Delete',
+          translation: '  Supprimer  ',
+        ),
+        'Supprimer',
+      );
+    });
+
+    test('a blank or absent translation derives nothing', () {
+      // Both plain-text rules carried an `isNotEmpty` guard before this
+      // function existed, and it is load-bearing: writing `""` into a locale
+      // file displaces the English fallback with nothing at all, which
+      // `locale_coverage_test`'s non-empty check would then fail on.
+      expect(
+        derivePlainTextValue(templateEnglish: 'Delete', translation: null),
+        isNull,
+      );
+      expect(
+        derivePlainTextValue(templateEnglish: 'Delete', translation: '   '),
+        isNull,
+      );
+      // Including when the template ends in a space — the mirror must not
+      // turn nothing into a lone space.
+      expect(
+        derivePlainTextValue(templateEnglish: 'Selected: ', translation: ''),
+        isNull,
+      );
+    });
+  });
+
   group('what shipped', () {
     // The derived values, pinned against the Kotlin XML rather than copied
     // here: the claim is that the `.arb` tracks the Android app's translations,

--- a/flutter/test/l10n/locale_coverage_test.dart
+++ b/flutter/test/l10n/locale_coverage_test.dart
@@ -266,6 +266,62 @@ void main() {
     }
   });
 
+  test('a deliberate trailing space survives into every locale', () {
+    // Four template strings end in a space, and every one of them is a label
+    // that a value is drawn straight after: `Storage running low: `,
+    // `Storage available: `, `Selected: `, `Select resources: `. Android's
+    // quoting exists precisely so a trailing space survives in `strings.xml`
+    // (`<string name="storage_running_low">"Storage running low: "</string>`),
+    // and all five Kotlin locales carry it.
+    //
+    // `tool/arb_from_strings_xml.dart` derived them through
+    // `translated[name]?.trim()`, so it stripped exactly the character the
+    // quoting was there to protect. `selected` and `selectResources` were
+    // repaired by hand through `--adopt`, whose `_proposal` does mirror the
+    // space; the two storage keys came through the plain-text path and lost it
+    // in all five locales.
+    //
+    // A missing space is not always visible — `formatStorageNotification`
+    // interpolates `'$runningLow $percent%'`, so its own space masks the loss,
+    // and `renderNotificationHtml` collapses the double space the Kotlin ends
+    // up with. The next consumer that concatenates without a separator gets
+    // `Almacenamiento bajo:10%`, in a string a translator cannot see is wrong.
+    // So the guard is on the derivation's output, not on one caller.
+    final template = readArb('en');
+    final labelKeys = keysOf(template).where((key) {
+      final value = template[key];
+      return value is String && value.endsWith(' ');
+    }).toList();
+    expect(
+      labelKeys,
+      isNotEmpty,
+      reason:
+          'the template has stopped carrying trailing-space labels, so '
+          'this guard now proves nothing — delete it or repoint it',
+    );
+
+    final stripped = <String>[];
+    for (final code in {...LocaleNotifier.supportedLanguageCodes, 'es'}) {
+      if (code == 'en') continue;
+      final arb = readArb(code);
+      for (final key in labelKeys) {
+        final value = arb[key];
+        // Absent is fine: the key falls back to the English, space and all.
+        if (value is! String) continue;
+        if (!value.endsWith(' ')) stripped.add('$code/$key = "$value"');
+      }
+    }
+
+    expect(
+      stripped,
+      isEmpty,
+      reason:
+          'these locale values lost the template\'s trailing space, so the '
+          'label runs into the value it prefixes:\n'
+          '${stripped.map((entry) => '  $entry').join('\n')}',
+    );
+  });
+
   test('no locale file declares the same key twice', () {
     // `gen-l10n` parses ARB as JSON, and a duplicate key is not an error there:
     // the last value silently wins and one getter is emitted. That is how

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -316,12 +316,21 @@ void main() {
     // already held the Kotlin value unflagged and is left alone — replacing one
     // valid translation with another is not a repair. That makes es +3 where
     // the rest are +4.
+    //
+    // Phase 130 adds two per locale, both incidental to its trailing-space fix
+    // and both real: `playbackSpeed` and `playbackSpeedValue` derive from the
+    // Kotlin `playback_speed`/`playback_speed_format` and had simply never been
+    // through the tool — the phase that added the English keys did not re-run
+    // it. `playbackSpeedValue` is `{speed}x` in all five locales, identical to
+    // the English because the Kotlin string is `%1$sx` in all five: a
+    // multiplier suffix nobody translates. That is the translation, not a
+    // missing one.
     const humanReviewed = {
-      'ar': 410,
-      'es': 462,
-      'fr': 409,
-      'ne': 411,
-      'so': 411,
+      'ar': 412,
+      'es': 464,
+      'fr': 411,
+      'ne': 413,
+      'so': 413,
     };
 
     for (final code in locales) {

--- a/flutter/test/providers/notification_tap_handler_test.dart
+++ b/flutter/test/providers/notification_tap_handler_test.dart
@@ -1,0 +1,420 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/notifications/notification_config.dart';
+import 'package:myplanet/core/notifications/notification_tap.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/notification_tap_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/notifications_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// `NotificationTapHandler` — the port of `NotificationActionReceiver` plus
+/// `DashboardActivity.handleNotificationIntent`.
+///
+/// Before Phase 130 the port raised system notifications and tapping one did
+/// nothing at all: no payload on the notification, no response callback, no
+/// handler. `NotificationsRepository.markNotificationAsRead` — the correct port
+/// of Kotlin's body-tap handler — had no caller anywhere in `lib/`.
+///
+/// The three gestures are three different behaviours in the Kotlin and the
+/// tests are grouped that way. The distinction that matters most is which of
+/// the two read-marking statements runs: the bulk one stamps `createdAt`, which
+/// is the notification list's sort key *and* is uploaded back into the server
+/// document's `time`, and the single one does not.
+void main() {
+  late AppDatabase database;
+  late PlanetPrefs prefs;
+
+  /// A fixed clock, so a stamped `createdAt` is distinguishable from the
+  /// row's own age by value rather than by "roughly now".
+  const stampedAt = 1_700_000_000_000;
+  const rowCreatedAt = 500;
+
+  UserRow user() => UserRow(
+    id: 'user-1',
+    name: 'ada',
+    rolesList: const [],
+    userAdmin: false,
+    joinDate: 0,
+    isArchived: false,
+    isUpdated: false,
+  );
+
+  NotificationsRepository repositoryFor() => NotificationsRepository(
+    database.notificationDao,
+    teamNotificationDao: database.teamNotificationDao,
+    newsDao: database.newsDao,
+    teamTaskDao: database.teamTaskDao,
+    teamDao: database.teamDao,
+    userDao: database.userDao,
+    now: () => DateTime.fromMillisecondsSinceEpoch(stampedAt),
+  );
+
+  ProviderContainer containerFor({
+    UserRow? current,
+    bool sessionFails = false,
+  }) {
+    final container = ProviderContainer(
+      overrides: [
+        planetPrefsProvider.overrideWithValue(prefs),
+        appDatabaseProvider.overrideWithValue(database),
+        notificationsRepositoryProvider.overrideWithValue(repositoryFor()),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(current, fails: sessionFails),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  /// A synced `newTask` notification row. `parseNotification` stores the
+  /// server's raw type verbatim, so the stored type is `newTask` and
+  /// `resolveNotificationType` maps it to `task` at read time.
+  Future<void> insertNotification({
+    required String id,
+    String type = 'newTask',
+    String? relatedId = 'task-42',
+    bool isRead = false,
+  }) => database.notificationDao.upsert(
+    NotificationsCompanion.insert(
+      id: id,
+      userId: 'user-1',
+      type: Value(type),
+      relatedId: Value(relatedId),
+      message: const Value('Read chapter 3 Wed 19, August 2026'),
+      isRead: Value(isRead),
+      isFromServer: const Value(true),
+      // A synced row carries the document's `rev`, and
+      // `getPendingSyncNotifications` filters on it: a row with no rev was
+      // authored locally and cannot be PUT back.
+      rev: const Value('1-abc'),
+      createdAt: rowCreatedAt,
+    ),
+  );
+
+  /// The task the deadline reminder was raised for, with its team id where the
+  /// mapper puts it — out of `link.teams`.
+  Future<void> insertTask() => database.teamTaskDao.upsertAll([
+    TeamTasksCompanion.insert(
+      id: 'task-42',
+      title: const Value('Read chapter 3'),
+      teamId: 'team-9',
+      assignee: const Value('user-1'),
+      deadline: const Value(0),
+    ),
+  ]);
+
+  /// The tap the port's own producer delivers. `TaskDeadlineNotifier` builds
+  /// this exact config, so the payload is not invented here.
+  NotificationTap tapFor({String? actionId, String taskId = 'task-42'}) =>
+      NotificationTap(
+        actionId: actionId,
+        payload: NotificationTapPayload.forConfig(
+          NotificationConfig.task(
+            taskId: taskId,
+            taskTitle: 'Read chapter 3',
+            deadlineLabel: 'Wed 19, August 2026',
+            urgent: true,
+          ),
+        ),
+      );
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    database = AppDatabase.memory();
+  });
+  tearDown(() => database.close());
+
+  group('the notification body', () {
+    test('reaches the tasks page of the task’s team', () async {
+      await insertTask();
+      final container = containerFor(current: user());
+
+      final location = await container
+          .read(notificationTapHandlerProvider)
+          .handle(tapFor());
+
+      // `handleTaskNavigation` → `TeamDetailFragment(navigateToPage = TasksPage)`,
+      // which is where the in-app row tap lands too.
+      expect(location, '/life/teams/team-9/tasks');
+    });
+
+    test('marks read without stamping createdAt', () async {
+      // The distinction Phase 127 separated and left with no caller. This is
+      // the caller: `markDatabaseNotificationAsRead` goes through
+      // `NotificationDao.markOneAsRead`, whose SQL has no `createdAt` column
+      // in it at all.
+      await insertTask();
+      await insertNotification(id: 'task-42');
+      final container = containerFor(current: user());
+
+      await container.read(notificationTapHandlerProvider).handle(tapFor());
+
+      final row = await database.notificationDao.getById('task-42');
+      expect(row!.isRead, isTrue);
+      expect(
+        row.createdAt,
+        rowCreatedAt,
+        reason:
+            'the body tap must not restamp — the list sorts on this and '
+            'syncNotificationReads uploads it as the document’s `time`',
+      );
+    });
+
+    test('a summary id marks the whole type read', () async {
+      // The `summary_` branch is unique to this path — the bulk statement the
+      // action buttons use has no such prefix handling. Nothing in either app
+      // mints a `summary_` id today (`createSummaryNotification` has no live
+      // caller), so this pins the branch rather than a live behaviour.
+      await insertNotification(id: 'n-1', type: 'storage');
+      await insertNotification(id: 'n-2', type: 'storage');
+      await insertNotification(id: 'n-3', type: 'resource');
+      final container = containerFor(current: user());
+
+      await container
+          .read(notificationTapHandlerProvider)
+          .handle(
+            const NotificationTap(
+              payload: NotificationTapPayload(
+                type: 'storage',
+                notificationId: 'summary_storage',
+              ),
+            ),
+          );
+
+      expect((await database.notificationDao.getById('n-1'))!.isRead, isTrue);
+      expect((await database.notificationDao.getById('n-2'))!.isRead, isTrue);
+      expect(
+        (await database.notificationDao.getById('n-3'))!.isRead,
+        isFalse,
+        reason: 'markSummaryAsRead is scoped to one type',
+      );
+    });
+
+    test('resolves the session rather than reading it unwatched', () async {
+      // The rule this project turned into a rule after four independent
+      // instances: nothing here watches `sessionProvider`, so
+      // `ref.read(sessionProvider).valueOrNull` is null while it loads. A null
+      // user routes a `summary_` id to `markSummaryAsRead(null, type)`, which
+      // matches no row — so the read-marking silently does nothing.
+      await insertNotification(id: 'n-1', type: 'storage');
+      final container = containerFor(current: user());
+      // Deliberately *not* resolving the session first.
+
+      await container
+          .read(notificationTapHandlerProvider)
+          .handle(
+            const NotificationTap(
+              payload: NotificationTapPayload(
+                type: 'storage',
+                notificationId: 'summary_storage',
+              ),
+            ),
+          );
+
+      expect((await database.notificationDao.getById('n-1'))!.isRead, isTrue);
+    });
+
+    test('a rejecting session still navigates', () async {
+      // The correction Phase 100's fix needed on harvest: the `await` belongs
+      // *inside* the `try`, because a future can reject where `valueOrNull`
+      // could not. Kotlin's read-mark is wrapped in its own try/catch and the
+      // navigation follows regardless.
+      await insertTask();
+      final container = containerFor(sessionFails: true);
+
+      expect(
+        await container.read(notificationTapHandlerProvider).handle(tapFor()),
+        '/life/teams/team-9/tasks',
+      );
+    });
+  });
+
+  group('Mark as Read', () {
+    test('marks read, stamps, and navigates nowhere', () async {
+      await insertTask();
+      await insertNotification(id: 'task-42');
+      final container = containerFor(current: user());
+
+      final location = await container
+          .read(notificationTapHandlerProvider)
+          .handle(tapFor(actionId: NotificationTapActions.markAsRead));
+
+      expect(
+        location,
+        isNull,
+        reason:
+            'ACTION_MARK_AS_READ has no navigation arm; it only brings the '
+            'app to the foreground, which showsUserInterface already does',
+      );
+      final row = await database.notificationDao.getById('task-42');
+      expect(row!.isRead, isTrue);
+      expect(
+        row.createdAt,
+        stampedAt,
+        reason:
+            'NotificationActionReceiver:81 calls the bulk '
+            'markNotificationsAsRead, which passes its own Date()',
+      );
+    });
+
+    test('flags a server row for read-state upload', () async {
+      // The other half of what the stamping statement does, and the reason the
+      // stamp reaches another device at all.
+      await insertNotification(id: 'task-42');
+      final container = containerFor(current: user());
+
+      await container
+          .read(notificationTapHandlerProvider)
+          .handle(tapFor(actionId: NotificationTapActions.markAsRead));
+
+      final pending = await database.notificationDao
+          .getPendingSyncNotifications();
+      expect(pending.map((row) => row.id), ['task-42']);
+    });
+  });
+
+  group('View Task', () {
+    test('marks read, stamps, and navigates', () async {
+      await insertTask();
+      await insertNotification(id: 'task-42');
+      final container = containerFor(current: user());
+
+      final location = await container
+          .read(notificationTapHandlerProvider)
+          .handle(tapFor(actionId: NotificationTapActions.open));
+
+      expect(location, '/life/teams/team-9/tasks');
+      final row = await database.notificationDao.getById('task-42');
+      expect(row!.createdAt, stampedAt);
+    });
+
+    test('an uncached task still opens the team the id names', () async {
+      // `resolveAndOpenTeam`'s `resolve(relatedId) ?: relatedId`. Kotlin's
+      // *button* path is stricter than this — `getTaskTeamInfo` returns null
+      // when the team row is absent and navigates nowhere — and the port
+      // deliberately shares the row tap's forgiving resolver so a tray tap and
+      // a row tap land in the same place. Recorded in PHASE_130_NOTES.md.
+      final container = containerFor(current: user());
+
+      expect(
+        await container
+            .read(notificationTapHandlerProvider)
+            .handle(tapFor(actionId: NotificationTapActions.open)),
+        '/life/teams/task-42/tasks',
+      );
+    });
+  });
+
+  group('at parity: the tray marks nothing read on real data', () {
+    test('because the tray id and the row id are different documents', () async {
+      // The finding, reproduced rather than fixed. `TaskDeadlineNotifier`
+      // mints the notification with `id = task.id`, as
+      // `TaskNotificationWorker.kt:48-53` does. A `task` notification *row* is
+      // a synced CouchDB notification document: its id is its own `_id`, and
+      // the task id lands in `relatedId`. So every tray gesture looks up an id
+      // that is not in the table.
+      //
+      // Fixing it would mean resolving `relatedId` back to the row — an
+      // improvement the Android app does not have, and therefore a divergence
+      // rather than a repair. The navigation half works precisely because it
+      // reads `relatedId`, which is why the tap is still worth wiring.
+      await insertTask();
+      await insertNotification(id: 'n-77', relatedId: 'task-42');
+      final container = containerFor(current: user());
+
+      for (final actionId in const [
+        null,
+        NotificationTapActions.markAsRead,
+        NotificationTapActions.open,
+      ]) {
+        await container
+            .read(notificationTapHandlerProvider)
+            .handle(tapFor(actionId: actionId));
+      }
+
+      final row = await database.notificationDao.getById('n-77');
+      expect(
+        row!.isRead,
+        isFalse,
+        reason: 'no tray gesture reaches the row, in either app',
+      );
+      expect(row.createdAt, rowCreatedAt);
+    });
+  });
+
+  group('which field the destination is resolved from', () {
+    test('relatedId, not the notification id', () async {
+      // `handleNotificationIntent`'s `auto_navigate` branch reads
+      // `related_id` (`DashboardActivity.kt:536`), and the two are *not*
+      // interchangeable even though the task factory happens to set them to
+      // the same string. `createStorageWarningNotification(percent, customId)`
+      // sets `id = customId` and `relatedId = "storage"`; a `voice_reply`
+      // notification's `relatedId` is the news id while its own id is the
+      // notification document's. Feeding the resolver the notification id
+      // instead is invisible on the one producer the port has, which is
+      // exactly why it needs a test that separates them.
+      final container = containerFor(current: user());
+
+      expect(
+        await container
+            .read(notificationTapHandlerProvider)
+            .handle(
+              const NotificationTap(
+                payload: NotificationTapPayload(
+                  type: 'voice_reply',
+                  notificationId: 'n-1',
+                  relatedId: 'voice-7',
+                ),
+              ),
+            ),
+        '/life/voices/voice-7',
+      );
+    });
+  });
+
+  group('types with no destination', () {
+    test('an unknown type marks read and navigates nowhere', () async {
+      // `handleNotificationIntent`'s `else ->` opens the notifications list;
+      // the port stays where it is instead, for the reason `deepLinkRoute`
+      // gives for the same fall-through — yanking the user off the screen they
+      // are on is worse than doing nothing. The resolver returning null is the
+      // single place that decision lives.
+      await insertNotification(id: 'n-9', type: 'newsAdded');
+      final container = containerFor(current: user());
+
+      expect(
+        await container
+            .read(notificationTapHandlerProvider)
+            .handle(
+              const NotificationTap(
+                payload: NotificationTapPayload(
+                  type: 'course',
+                  notificationId: 'n-9',
+                ),
+              ),
+            ),
+        isNull,
+      );
+      expect((await database.notificationDao.getById('n-9'))!.isRead, isTrue);
+    });
+  });
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user, {this.fails = false});
+
+  final UserRow? user;
+  final bool fails;
+
+  @override
+  Future<UserRow?> build() async {
+    if (fails) throw StateError('no session');
+    return user;
+  }
+}

--- a/flutter/test/providers/notification_tap_handler_test.dart
+++ b/flutter/test/providers/notification_tap_handler_test.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/core/notifications/notification_config.dart';
@@ -128,7 +129,12 @@ void main() {
     prefs = PlanetPrefs(await SharedPreferences.getInstance());
     database = AppDatabase.memory();
   });
-  tearDown(() => database.close());
+  tearDown(() async {
+    // One test closes it mid-run to drive the resolver's failure path.
+    try {
+      await database.close();
+    } catch (_) {}
+  });
 
   group('the notification body', () {
     test('reaches the tasks page of the task’s team', () async {
@@ -346,6 +352,37 @@ void main() {
       );
       expect(row.createdAt, rowCreatedAt);
     });
+  });
+
+  group('a failure in one half does not cost the other', () {
+    test(
+      'a database the resolver cannot read navigates nowhere, quietly',
+      () async {
+        // Kotlin's lookups sit inside `viewModelScope.launch` blocks whose
+        // failure leaves the fragment alone. Here the listener that delivered the
+        // tap is a stream subscription, and an exception out of `handle` would be
+        // an unhandled async error — so the resolve has its own guard.
+        await insertNotification(id: 'task-42');
+        final container = containerFor(current: user());
+
+        // Captured rather than left to print: swallowing the failure silently
+        // would be the wrong outcome too, so this asserts it was reported.
+        final reported = <Object>[];
+        final previous = FlutterError.onError;
+        FlutterError.onError = (details) => reported.add(details.exception);
+        addTearDown(() => FlutterError.onError = previous);
+
+        // Closed under the handler's feet, which is what a disposed graph or a
+        // corrupt database file looks like from here.
+        await database.close();
+
+        expect(
+          await container.read(notificationTapHandlerProvider).handle(tapFor()),
+          isNull,
+        );
+        expect(reported, isNotEmpty, reason: 'the failure went unreported');
+      },
+    );
   });
 
   group('which field the destination is resolved from', () {

--- a/flutter/test/ui/notification_destination_test.dart
+++ b/flutter/test/ui/notification_destination_test.dart
@@ -180,4 +180,65 @@ void main() {
     );
     expect(await resolver.resolve(_notification('voice_reply')), isNull);
   });
+
+  test('a bell row and a tray tap on the same notification agree', () async {
+    // The claim Phase 130's whole design rests on: one mapping, two callers.
+    // A tray tap has no row, so it goes through `resolveFor(type:, relatedId:)`
+    // while the bell row goes through `resolve(row)` — and if those two ever
+    // diverge, the same notification opens two different screens depending on
+    // where the user tapped it. That is the shape `CLAUDE.md` records four
+    // times over ("a writer and a reader disagreeing about a key, where each
+    // half passes its own test and only the pair is wrong"), so the pair is
+    // what this tests.
+    //
+    // It is also the guard against re-inlining: if someone puts a second
+    // switch back into `notifications_screen.dart` and lets it drift, nothing
+    // else here would notice.
+    await database.teamTaskDao.upsertAll([
+      TeamTasksCompanion.insert(
+        id: 'task-42',
+        teamId: 'team-9',
+        title: const Value('Read chapter 3'),
+      ),
+    ]);
+    await database.teamDao.upsertAll([
+      TeamsCompanion.insert(id: 'request-7', teamId: const Value('team-3')),
+    ]);
+
+    // Every type the resolver answers for, with the `relatedId` shape each one
+    // carries in production.
+    const cases = {
+      'resource': null,
+      'storage': null,
+      'task': 'task-42',
+      'join_request': 'request-7',
+      'team_join': 'team-9',
+      'chat': 'team-9',
+      'voice_reply': 'news-5',
+    };
+
+    for (final entry in cases.entries) {
+      final fromRow = await resolver.resolve(
+        _notification(entry.key, relatedId: entry.value),
+      );
+      final fromTray = await resolver.resolveFor(
+        type: entry.key,
+        relatedId: entry.value,
+      );
+      expect(
+        fromTray,
+        fromRow,
+        reason: 'the two entry points disagree about "${entry.key}"',
+      );
+      expect(
+        fromRow,
+        isNotNull,
+        reason: 'this case proves nothing if both resolve to null',
+      );
+      expect(
+        notificationDestinationLocation(fromTray!),
+        notificationDestinationLocation(fromRow!),
+      );
+    }
+  });
 }

--- a/flutter/test/ui/notification_tap_scope_test.dart
+++ b/flutter/test/ui/notification_tap_scope_test.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/core/notifications/notification_tap.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/providers/notification_tap_provider.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/ui/notification_tap_scope.dart';
+import 'package:myplanet/ui/router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Mounts [NotificationTapScope] where the app mounts it — inside
+/// `MaterialApp.router`'s `builder` — for the same reason
+/// `deep_link_scope_test.dart` does: that context sits *above* the
+/// `InheritedGoRouter`, so `GoRouter.of(context)` would throw there and
+/// navigation has to go through `routerProvider`.
+///
+/// **This file exists because two mutations to the scope passed the whole
+/// suite.** A background mutation-testing pass injected them — the cold-start
+/// tap never asked for, and the resolved location computed and thrown away —
+/// and all 2301 tests stayed green, because nothing mounted this widget. Every
+/// other link in the tray chain had a guard; the two lines that connect them to
+/// the app did not. That is the phase's own subject arriving one layer up: a
+/// correct handler nothing can reach.
+void main() {
+  late PlanetPrefs prefs;
+  late _FakeSource source;
+  late _FakeHandler handler;
+
+  GoRouter buildRouter() => GoRouter(
+    initialLocation: '/home',
+    routes: [
+      GoRoute(path: '/home', builder: (_, _) => const Text('home')),
+      GoRoute(
+        path: '${Routes.teams}/:teamId/tasks',
+        builder: (_, _) => const Text('tasks'),
+      ),
+    ],
+  );
+
+  Future<void> pumpScope(WidgetTester tester, {GoRouter? router}) async {
+    final config = router ?? buildRouter();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          notificationTapSourceProvider.overrideWithValue(source),
+          notificationTapHandlerProvider.overrideWithValue(handler),
+          routerProvider.overrideWithValue(config),
+        ],
+        child: MaterialApp.router(
+          routerConfig: config,
+          builder: (context, child) =>
+              NotificationTapScope(child: child ?? const SizedBox.shrink()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  const tap = NotificationTap(
+    payload: NotificationTapPayload(
+      type: 'task',
+      notificationId: 'task-42',
+      relatedId: 'task-42',
+    ),
+  );
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    source = _FakeSource();
+    handler = _FakeHandler('/life/teams/team-9/tasks');
+  });
+  tearDown(() => source.dispose());
+
+  testWidgets('the tap that launched the app navigates', (tester) async {
+    // `DashboardActivity.onCreate` → `handleNotificationIntent(intent)`, which
+    // the plugin exposes as `getNotificationAppLaunchDetails` rather than
+    // through the response callback. Kills the "never asked for" mutation.
+    source.launch = tap;
+
+    await pumpScope(tester);
+
+    expect(handler.handled, [tap]);
+    expect(find.text('tasks'), findsOneWidget);
+  });
+
+  testWidgets('a tap while the app is running navigates', (tester) async {
+    // Kotlin's `onNewIntent` (`DashboardActivity.kt:1106`), which is the
+    // response callback here. Nothing is subscribed until the post-frame
+    // callback runs, so this also pins that the subscription happens at all.
+    await pumpScope(tester);
+    expect(find.text('home'), findsOneWidget);
+
+    source.emit(tap);
+    await tester.pumpAndSettle();
+
+    expect(handler.handled, [tap]);
+    expect(find.text('tasks'), findsOneWidget);
+  });
+
+  testWidgets('the subscription is taken before the launch tap is awaited', (
+    tester,
+  ) async {
+    // The ordering `DeepLinkScope` documents and this copies: a tap arriving
+    // between the two would otherwise be dropped, and a broadcast stream does
+    // not replay it. Driven by holding the launch future open and emitting
+    // while it is pending.
+    source.holdLaunch = true;
+
+    await pumpScope(tester);
+    source.emit(tap);
+    await tester.pumpAndSettle();
+
+    expect(
+      handler.handled,
+      [tap],
+      reason: 'a tap arriving while launchTap() was still pending was lost',
+    );
+
+    source.releaseLaunch(null);
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a handler that resolves nowhere leaves the app where it is', (
+    tester,
+  ) async {
+    // *Mark as Read* is this case: it marks read and returns null, and the
+    // Kotlin's `ACTION_MARK_AS_READ` arm has no navigation either.
+    handler = _FakeHandler(null);
+    source.launch = tap;
+
+    await pumpScope(tester);
+
+    expect(handler.handled, [tap]);
+    expect(find.text('home'), findsOneWidget);
+  });
+
+  testWidgets('a source with no platform channel does not break startup', (
+    tester,
+  ) async {
+    // Constructing the production source reaches for a method channel, so this
+    // is the ordinary case on any platform without the plugin. The Kotlin has
+    // no equivalent — an Android intent always arrives — so the guard is the
+    // port's own, and it must not take the first frame down with it.
+    source.throwOnLaunch = true;
+
+    await pumpScope(tester);
+
+    // Reported, not swallowed — `FlutterError.reportError`, which the test
+    // binding records and `takeException` consumes. Both halves matter: a
+    // silent failure here is a tray tap that stops working with no trace.
+    expect(tester.takeException(), isA<StateError>());
+    expect(find.text('home'), findsOneWidget);
+    expect(handler.handled, isEmpty);
+  });
+
+  testWidgets('an error the source emits is not an unhandled async error', (
+    tester,
+  ) async {
+    // `_handle` is async, so an exception inside it never reaches the
+    // subscription's `onError` — which is why the handler guards both of its
+    // own halves. This covers the other side.
+    await pumpScope(tester);
+
+    source.emitError(StateError('channel died'));
+    await tester.pumpAndSettle();
+
+    // Without the `onError` it would be an unhandled async error rather than a
+    // reported one, and the subscription would be torn down with it — so no
+    // later tap would arrive either.
+    expect(tester.takeException(), isA<StateError>());
+    expect(find.text('home'), findsOneWidget);
+
+    // The subscription survived, which is the half the report alone does not
+    // prove.
+    source.emit(tap);
+    await tester.pumpAndSettle();
+    expect(handler.handled, [tap]);
+    expect(find.text('tasks'), findsOneWidget);
+  });
+}
+
+class _FakeSource implements NotificationTapSource {
+  final _controller = StreamController<NotificationTap>.broadcast();
+  NotificationTap? launch;
+  bool throwOnLaunch = false;
+
+  /// Holds [launchTap] pending so a stream tap can be delivered while it is
+  /// still in flight.
+  bool holdLaunch = false;
+  final _held = Completer<NotificationTap?>();
+
+  void emit(NotificationTap tap) => _controller.add(tap);
+  void emitError(Object error) => _controller.addError(error);
+  void releaseLaunch(NotificationTap? tap) {
+    if (!_held.isCompleted) _held.complete(tap);
+  }
+
+  void dispose() => _controller.close();
+
+  @override
+  Future<NotificationTap?> launchTap() {
+    if (throwOnLaunch) throw StateError('no platform channel');
+    if (holdLaunch) return _held.future;
+    return Future.value(launch);
+  }
+
+  @override
+  Stream<NotificationTap> taps() => _controller.stream;
+}
+
+class _FakeHandler extends NotificationTapHandler {
+  _FakeHandler(this.location) : super(_unusedRef);
+
+  final String? location;
+  final List<NotificationTap> handled = [];
+
+  @override
+  Future<String?> handle(NotificationTap tap) async {
+    handled.add(tap);
+    return location;
+  }
+}
+
+/// The superclass takes a `Ref` it never uses once `handle` is overridden.
+final Ref _unusedRef = _NoRef();
+
+class _NoRef implements Ref {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('the fake handler reads no providers');
+}

--- a/flutter/test/ui/route_reachability_test.dart
+++ b/flutter/test/ui/route_reachability_test.dart
@@ -219,6 +219,66 @@ void main() {
     );
   });
 
+  test('every notification type the port declares has a resolver arm', () async {
+    // `NotificationTypes` is the set of `NotificationUtils.TYPE_*` values the
+    // port produces, and `resolveFor`'s `default: return null` swallows
+    // anything it has no arm for — silently, which is the failure class this
+    // whole file guards.
+    //
+    // The risk is not theoretical. The resolver is a port of the bell row's
+    // click handler (`NotificationsFragment.handleNotificationClick`), which
+    // has **no** `survey` or `course` arm, and those are two of Kotlin's six
+    // `TYPE_*` values. Add a survey tray notification and its payload decodes
+    // cleanly, its type is `'survey'`, and the tap does nothing — with the
+    // tray-tap test below still green, because that one drives only
+    // `NotificationConfig.task`.
+    //
+    // Dart has no reflection over static constants, so the hand-written list
+    // is reconciled against the source file: a constant added there and not
+    // here fails first, with a message saying to add it.
+    const declared = <String>{NotificationTypes.task};
+    final inSource = RegExp(r"static const \w+ = '([^']*)';")
+        .allMatches(
+          _stripComments(
+            File(
+              'lib/core/notifications/notification_config.dart',
+            ).readAsStringSync(),
+          ).split('class NotificationTypes').last,
+        )
+        .map((match) => match.group(1)!)
+        .toSet();
+    expect(
+      inSource,
+      declared,
+      reason:
+          'NotificationTypes gained or lost a constant; add it to this test so '
+          'its resolver arm is checked',
+    );
+
+    final database = container.read(appDatabaseProvider);
+    final resolver = NotificationDestinationResolver(
+      taskDao: database.teamTaskDao,
+      teamDao: database.teamDao,
+    );
+    for (final type in declared) {
+      // A non-blank relatedId, because several arms require one and returning
+      // null for a blank id is deliberate rather than a missing arm.
+      final destination = await resolver.resolveFor(
+        type: type,
+        relatedId: 'related-1',
+      );
+      expect(
+        destination,
+        isNotNull,
+        reason:
+            'the port can raise a "$type" notification and the resolver has no '
+            'arm for it, so tapping one does nothing',
+      );
+      final location = notificationDestinationLocation(destination!);
+      expect(_matches(router, _normalize(location)), isTrue, reason: location);
+    }
+  });
+
   test(
     'a system-tray tap on the notification the port raises navigates',
     () async {
@@ -340,7 +400,11 @@ void main() {
     );
     expect(
       presenter,
-      contains('onDidReceiveNotificationResponse:'),
+      // The *value*, not the parameter name. `onDidReceiveNotificationResponse:
+      // null,` contains the name and drops every tap that arrives while the app
+      // is running — the second audit pass injected exactly that and watched
+      // this rule stay green.
+      contains('onDidReceiveNotificationResponse: _responses.add'),
       reason: 'the plugin has nowhere to deliver a tap',
     );
     expect(
@@ -359,6 +423,25 @@ void main() {
             'however correct the handler behind it is',
       );
     }
+
+    // A fourth link, and the least obvious one: `initialize` is where the
+    // plugin accepts the response handler, and the only thing that reaches it
+    // in the UI isolate is `main.dart` asking for the notification permission.
+    // Move that request to a screen — a plausible refactor, since that is where
+    // a permission prompt usually belongs — and every warm tap is dropped for
+    // the whole process, with nothing else here to notice. (The *launch* tap
+    // survives: `getNotificationAppLaunchDetails` goes through the handler
+    // Android registers in `onAttachedToEngine`, independent of Dart's
+    // `initialize`.)
+    expect(
+      _stripComments(File('lib/main.dart').readAsStringSync()),
+      // The *call*, not the declaration — which is still in the file after the
+      // call is removed, and is what a first cut of this assertion matched.
+      contains('unawaited(_requestNotificationPermission());'),
+      reason:
+          'nothing else in the UI isolate calls the presenter, so without this '
+          'the plugin is never initialized and no running-app tap is delivered',
+    );
   });
 
   test('every deep-link section resolves to a registered route', () {

--- a/flutter/test/ui/route_reachability_test.dart
+++ b/flutter/test/ui/route_reachability_test.dart
@@ -1,13 +1,19 @@
 import 'dart:io';
 
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:myplanet/core/deeplinks/deep_link.dart';
+import 'package:myplanet/core/notifications/notification_config.dart';
+import 'package:myplanet/core/notifications/notification_tap.dart';
 import 'package:myplanet/core/prefs/planet_prefs.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/deep_link_provider.dart';
+import 'package:myplanet/providers/notification_tap_provider.dart';
+import 'package:myplanet/ui/notifications/notification_destination.dart';
 import 'package:myplanet/ui/router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -23,7 +29,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// enumerate a hand-written list, so a route or a `context.push` added later is
 /// covered without anyone remembering to come back here.
 ///
-/// Four rules:
+/// Four rules over the route table:
 ///
 /// 1. **Every `Routes` constant resolves to a registered route.** A constant
 ///    naming a path the router does not serve is a screen nobody can open.
@@ -34,6 +40,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// 4. **Every registered route is navigated to from somewhere.** A route
 ///    nothing links to is a screen the user cannot reach; the allowlist is the
 ///    set of deliberate exceptions, each with its reason.
+///
+/// And two over the entry points that do not go through `context.go` at all —
+/// the deep link, and (Phase 130) the **system-tray notification tap**. A tray
+/// tap is the same failure class arriving from outside the widget tree: the
+/// port raised notifications for four phases and tapping one did nothing,
+/// which no route test could see because there was no navigation call to scan
+/// for. So these two exercise the real handler rather than the source text.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -151,9 +164,13 @@ void main() {
       // destinations are `Routes` constants in the same file, which rule three
       // reads.
       'lib/ui/dashboard/dashboard_drawer.dart': 'context.go(route)',
-      // Built in a switch and handed over as a variable; the arms themselves
-      // are read by rules two and three.
-      'lib/ui/notifications/notifications_screen.dart': 'context.go(path)',
+      // `context.go(notificationDestinationLocation(destination))`. The switch
+      // it used to inline moved to `notification_destination.dart` — where the
+      // tray tap shares it — so the arms are now walked *exhaustively* over
+      // `NotificationDestinationKind` by the notification-tap test below,
+      // which is a stronger guard than rule three's `Routes.x` scan was.
+      'lib/ui/notifications/notifications_screen.dart':
+          'notificationDestinationLocation(destination)',
       // `'${Routes.addHealth}$patientQuery'` — the query string is built in a
       // local, so the prefix is checked and the suffix is not.
       'lib/ui/health/my_health_screen.dart': 'a query string in a local',
@@ -172,6 +189,176 @@ void main() {
           "site or add the file to this test's `declared` map with the reason:"
           '\n${undeclared.map((s) => '  $s').join('\n')}',
     );
+  });
+
+  test('every notification destination resolves to a registered route', () {
+    // Exhaustive over the enum, so a new kind cannot be added without an arm
+    // (that would not compile) and an arm cannot name a path the router does
+    // not serve. This is what the extraction bought: the mapping used to be a
+    // `switch` inside a private widget method, reachable only by the scanner's
+    // "a `Routes.x` mentioned anywhere in this file counts as reached" rule —
+    // which cannot tell a live arm from a dead one.
+    final unresolved = <String>[];
+    for (final kind in NotificationDestinationKind.values) {
+      final location = notificationDestinationLocation(
+        // Values for the two id-carrying kinds; the rest ignore them.
+        NotificationDestination(kind, teamId: 'team-1', voiceId: 'voice-1'),
+      );
+      if (!_matches(router, _normalize(location))) {
+        unresolved.add('$kind -> $location');
+      }
+    }
+
+    expect(
+      unresolved,
+      isEmpty,
+      reason:
+          'These notification destinations name locations no route matches, so '
+          'both the bell row and a system-tray tap land on the error page:\n'
+          '${unresolved.map((entry) => '  $entry').join('\n')}',
+    );
+  });
+
+  test(
+    'a system-tray tap on the notification the port raises navigates',
+    () async {
+      // The reachability guard for an entry point outside the route table.
+      //
+      // The port has exactly one producer of an OS notification —
+      // `TaskDeadlineNotifier`, via `NotificationConfig.task` — so this drives
+      // the tap that producer's own notification delivers, through the real
+      // payload codec and the real handler, and asserts it reaches a location
+      // the router serves. Before Phase 130 every piece of that chain was
+      // missing: no `payload` on the notification, no response callback, no
+      // handler, and `markNotificationAsRead` with no caller in `lib/`.
+      //
+      // A fixture that hand-built a `NotificationTap` would prove nothing about
+      // the producer, which is the Phase 113 lesson — "every fixture fabricated
+      // the join, and that was the symptom". So the payload comes from
+      // `NotificationTapPayload.forConfig` over the config the notifier builds.
+      final database = container.read(appDatabaseProvider);
+      await database.teamTaskDao.upsertAll([
+        TeamTasksCompanion.insert(
+          id: 'task-42',
+          teamId: 'team-9',
+          title: const Value('Read chapter 3'),
+          assignee: const Value('user-1'),
+        ),
+      ]);
+
+      final tap = NotificationTap(
+        payload: NotificationTapPayload.forConfig(
+          NotificationConfig.task(
+            taskId: 'task-42',
+            taskTitle: 'Read chapter 3',
+            deadlineLabel: 'Wed 19, August 2026',
+            urgent: true,
+          ),
+        ),
+      );
+
+      final location = await container
+          .read(notificationTapHandlerProvider)
+          .handle(tap);
+
+      expect(location, isNotNull, reason: 'the tap navigates nowhere');
+      expect(_matches(router, _normalize(location!)), isTrue, reason: location);
+    },
+  );
+
+  test(
+    'every action the notification offers is one the handler knows',
+    () async {
+      // The other half of the same chain, and the half most likely to rot: the
+      // buttons are strings the OS holds while the app is dead, so a rename on
+      // one side and not the other is silent. `notificationTapFrom` drops an
+      // action id it does not recognise, so an unknown one is not a crash — it
+      // is a button that does nothing.
+      final config = NotificationConfig.task(
+        taskId: 'task-42',
+        taskTitle: 'Read chapter 3',
+        deadlineLabel: 'Wed 19, August 2026',
+        urgent: true,
+      );
+      final payload = NotificationTapPayload.forConfig(config).encode();
+
+      final actions = notificationActionsFor(config);
+      expect(
+        actions,
+        isNotEmpty,
+        reason: 'createTaskNotification is actionable',
+      );
+      for (final action in actions) {
+        expect(
+          notificationTapFrom(
+            NotificationResponse(
+              notificationResponseType:
+                  NotificationResponseType.selectedNotificationAction,
+              actionId: action.id,
+              payload: payload,
+            ),
+          ),
+          isNotNull,
+          reason:
+              'the notification offers "${action.title}" (${action.id}) and the '
+              'handler does not recognise it, so tapping it does nothing',
+        );
+      }
+    },
+  );
+
+  test('the platform wiring a tap depends on is present', () {
+    // The three links in the chain that no behavioural test can exercise,
+    // because each is an argument to a plugin call and
+    // `FlutterLocalNotificationsPlugin` has a private constructor — it cannot
+    // be faked or subclassed from here. Asserted on the source text instead,
+    // which is what four of the rules above already do, and named as such
+    // rather than left as an assumed-covered gap.
+    //
+    // Every one of the three was missing before Phase 130, and each on its own
+    // is enough to make a tap do nothing at all:
+    //
+    //   * no `payload` — the tap arrives knowing *that* a notification was
+    //     tapped and nothing about which one;
+    //   * no response callback at `initialize` — the plugin has nowhere to
+    //     deliver a tap that arrives while the app is running;
+    //   * no `NotificationTapScope` in the widget tree — nobody asks for the
+    //     launch tap or listens to the stream, so the handler is dead code.
+    //
+    // `DeepLinkScope` is checked alongside it: it is the same exposure (a
+    // scope silently dropped from `app.dart`'s builder disables its whole
+    // entry point) and nothing else guarded it.
+    final presenter = _stripComments(
+      File(
+        'lib/core/notifications/notification_presenter.dart',
+      ).readAsStringSync(),
+    );
+    expect(
+      presenter,
+      contains('payload: NotificationTapPayload.forConfig(config).encode()'),
+      reason: 'the shown notification carries no id for a tap to act on',
+    );
+    expect(
+      presenter,
+      contains('onDidReceiveNotificationResponse:'),
+      reason: 'the plugin has nowhere to deliver a tap',
+    );
+    expect(
+      presenter,
+      contains('notificationActionsFor(config)'),
+      reason: 'the notification offers none of its Kotlin action buttons',
+    );
+
+    final app = _stripComments(File('lib/app.dart').readAsStringSync());
+    for (final scope in const ['NotificationTapScope', 'DeepLinkScope']) {
+      expect(
+        app,
+        contains('$scope('),
+        reason:
+            '$scope is not mounted in app.dart, so its entry point is dead '
+            'however correct the handler behind it is',
+      );
+    }
   });
 
   test('every deep-link section resolves to a registered route', () {

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -1279,5 +1279,14 @@ String? convertAndroidFormat({
     if (!rendered.contains('{$name}')) return null;
   }
   if (_printfSpecifier.hasMatch(rendered)) return null;
-  return rendered;
+  // The same mirror the plain-text rules get through [derivePlainTextValue].
+  // `translation.trim()` above strips a deliberate trailing space exactly as
+  // `translated[name]?.trim()` used to, and this is a *fourth* derivation path
+  // — so "one function, no third rule can disagree" was true of the plain-text
+  // rules and not of this one. Unreachable today (no `app_en.arb` value
+  // containing a placeholder ends in a space) and closed anyway, because the
+  // guard that would catch it — `locale_coverage_test`'s check over every
+  // template key ending in a space — would then fail with no way for the tool
+  // to produce a passing value, pointing at the test rather than at the gap.
+  return _mirrorTrailingSpace(rendered, templateValue);
 }

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -208,8 +208,11 @@ void main(List<String> args) {
         orElse: () => '',
       );
       if (exactNamed.isNotEmpty) {
-        final value = translated[exactNamed]?.trim();
-        if (value != null && value.isNotEmpty) {
+        final value = derivePlainTextValue(
+          templateEnglish: templateValue,
+          translation: translated[exactNamed],
+        );
+        if (value != null) {
           derived[key] = value;
           byName++;
           continue;
@@ -219,11 +222,16 @@ void main(List<String> args) {
       final sameText = byEnglishText[wanted] ?? const [];
       if (sameText.isEmpty) continue;
       final candidates = sameText
-          .map((name) => translated[name]?.trim())
-          .where((value) => value != null && value.isNotEmpty)
+          .map(
+            (name) => derivePlainTextValue(
+              templateEnglish: templateValue,
+              translation: translated[name],
+            ),
+          )
+          .whereType<String>()
           .toSet();
       if (candidates.length == 1) {
-        derived[key] = candidates.single!;
+        derived[key] = candidates.single;
         byText++;
       }
     }
@@ -711,12 +719,45 @@ String _proposal(MatchTier tier, String translation, String templateEnglish) {
 
 final _endsWithWordCharacter = RegExp(r'[\p{L}\p{N}]$', unicode: true);
 
+/// The value to write for a plain-text key, or null when there is nothing
+/// usable to write.
+///
+/// This is the whole of what the two plain-text derivation rules do with a
+/// candidate translation, and it exists as one exported function because both
+/// of them used to do it *slightly* differently from the recovery path: they
+/// wrote `translated[name]?.trim()`, and `--adopt`'s [_proposal] mirrors the
+/// template's trailing space.
+///
+/// That divergence cost the port a character in ten places. `storage_running_low`
+/// and `storage_available` are `"Storage running low: "` / `"Storage available: "`
+/// in `values/strings.xml` and carry the same trailing space in all five
+/// translated locales; the by-name rule trimmed it out of every one of them,
+/// while `selected` and `select_resources` — repaired by hand through `--adopt`
+/// — kept theirs. Same four labels, same deliberate space, two derivation paths
+/// disagreeing about it. `test/l10n/locale_coverage_test.dart` now guards the
+/// output rather than the path, so a third rule cannot reintroduce it.
+///
+/// A translation that is blank once trimmed is *no* translation and returns
+/// null, which is what the `isNotEmpty` guards these two rules already carried
+/// were for.
+String? derivePlainTextValue({
+  required String templateEnglish,
+  required String? translation,
+}) {
+  final value = translation?.trim();
+  if (value == null || value.isEmpty) return null;
+  return _mirrorTrailingSpace(value, templateEnglish);
+}
+
 /// Keeps a trailing space the template carries deliberately.
 ///
 /// `selected` is `"Selected: "` in both `app_en.arb` and the Kotlin XML, where
 /// Android's quoting exists precisely to protect that space — it is a label
 /// prefix, and the value is drawn straight after it. Trimming the translation
 /// would close the gap in every language but English.
+///
+/// A *leading* space is not mirrored, and no template carries one; if one ever
+/// does, this is the function to extend rather than a third one to add.
 String _mirrorTrailingSpace(String value, String templateEnglish) =>
     templateEnglish.endsWith(' ') && !value.endsWith(' ') ? '$value ' : value;
 


### PR DESCRIPTION
Lane C of the Phase 130 parallel round. Draft, opened as the lane's comms channel.

## Task 1 — a correct handler nothing can reach

Phase 127 left `NotificationsRepository.markNotificationAsRead` with no caller: it is the
correct port of Kotlin's tray/dashboard handler, but `NotificationActionReceiver` and
`DashboardActivity.handleNotificationIntent` are unported. The port raises system
notifications (`TaskDeadlineNotifier`) and **tapping one does nothing** — no navigation, no
read-marking. Porting the entry points, reusing `NotificationDestinationResolver` rather than
deriving a second mapping, and extending `test/ui/route_reachability_test.dart` to cover the
tray entry.

## Task 2 — the derivation eats a deliberate trailing space

`tool/arb_from_strings_xml.dart`'s plain-text paths `.trim()` without `_mirrorTrailingSpace`.

## Files owned

`lib/ui/notifications/`, `lib/repository/notifications_repository.dart`,
`lib/core/notifications/`, the notification platform/receiver wiring, notification-intent
handling in `lib/ui/router.dart` and the app entry, `tool/arb_from_strings_xml.dart`,
`lib/l10n/*.arb`, `test/l10n/`, and their tests.

Lane A may relay `%d`-carrying `take_test`/`retake_test` keys for derivation into the locale
files — comment on this PR and it reaches the lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXNiy1J9wcB7shZQJNjLTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXNiy1J9wcB7shZQJNjLTD)_