### PR TITLE
feat(flutter): Phase 131 — close the resource-update notification row

### DIFF
--- a/flutter/PHASE_131_NOTES.md
+++ b/flutter/PHASE_131_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 131 — close the resource-update notification row
+
+Lane A. Work in progress.
+
+`NotificationsRepository.updateResourceNotification` is ported, has six tests,
+and has no production caller. This phase gives it one: the count
+(`countLibrariesNeedingUpdate`), the dashboard hook, and whatever that makes
+reachable in `notification_format.dart`.

--- a/flutter/PHASE_131_NOTES.md
+++ b/flutter/PHASE_131_NOTES.md
@@ -1,8 +1,308 @@
-# Phase 131 — close the resource-update notification row
+# Phase 131 — the resource-update notification row, and the brief that was wrong about it
 
-Lane A. Work in progress.
+Lane A. One item from Phase 130's *Reported, not fixed* list: the Android bell
+carries a *"You have N resources not downloaded"* row and the port's never did,
+because `NotificationsRepository.updateResourceNotification` was ported with six
+tests and **no production caller** — the "ported, tested, green and dead" class.
 
-`NotificationsRepository.updateResourceNotification` is ported, has six tests,
-and has no production caller. This phase gives it one: the count
-(`countLibrariesNeedingUpdate`), the dashboard hook, and whatever that makes
-reachable in `notification_format.dart`.
+Two `parity-auditor` passes at `effort: max` were run, one on the Kotlin before
+any Dart and one on the finished diff. **The first overturned the brief's central
+factual claim and caught a defect this lane had just written**, which is the
+fifth round running that a lane's own reading of the Kotlin needed the audit to
+correct.
+
+---
+
+## What the ground-truth audit corrected
+
+### The predicate is the shelf, not the catalog
+
+Phase 130's note — and this lane's brief, quoting it — said
+`MyLibraryDao.countPublicNeedingUpdateForUserPattern` is
+`isPrivate = 0 AND (userId IS NULL OR userId NOT LIKE :userPattern)`, "the
+catalog predicate Phase 97 already ported for `watchResources`, counted rather
+than listed."
+
+It is not. `MyLibraryDao.kt:119-124` is:
+
+```sql
+SELECT COUNT(*) FROM my_library WHERE isPrivate = 0
+  AND userId LIKE :userPattern ESCAPE '\'
+  AND (resourceOffline = 0
+       OR (resourceLocalAddress IS NOT NULL AND _rev IS NOT downloadedRev))
+```
+
+`userId LIKE` — the **My Library shelf**, plus a third clause the brief did not
+mention at all. The catalog predicate `(userId IS NULL OR userId NOT LIKE …)`
+lives in `getPublicNotUserPattern` at `MyLibraryDao.kt:126-130`, the very next
+method. A reader who scrolled two lines too far wrote the note, and it was
+repeated verbatim into a brief a round later.
+
+The difference is not cosmetic: under the catalog reading the row would have
+counted resources the user has never added and excluded every resource they
+have, which is the opposite of what the notification means. It also decides
+where the tap lands — `openMyFragment` (`DashboardActivity.kt:951-959`)
+overwrites the fragment arguments with `isMyCourseLib = true`, so the Android
+tap opens **My Library**, consistent with a shelf-scoped count.
+
+`test/repository/resources_needing_update_count_test.dart` pins the distinction
+with a fixture that counts 1 under the shelf predicate and 2 under the catalog
+one, so re-seeding the mistake fails the suite.
+
+### The third clause, and why `IS NOT` is load-bearing
+
+`resourceOffline = 0 OR (resourceLocalAddress IS NOT NULL AND _rev IS NOT
+downloadedRev)` — never downloaded, or downloaded and stale. `downloadedRev` is
+stamped from `_rev` when the file lands (`ResourcesRepositoryImpl.kt:369,390,404`)
+and then stays put while `_rev` follows the sync, which is what makes the
+comparison mean anything.
+
+SQLite's `IS NOT` is the **null-safe** inequality. The table the audit produced,
+for `resourceOffline = 1` with a non-null local address:
+
+| `_rev` | `downloadedRev` | counted |
+|---|---|---|
+| `3-abc` | NULL | **yes** |
+| NULL | NULL | no |
+| `4-def` | `3-abc` | yes |
+| `3-abc` | `3-abc` | no |
+
+Row 1 is the one a mis-port loses. Written `_rev != downloadedRev` the
+comparison is SQL NULL, hence falsy, and every row an older build marked offline
+without stamping `downloadedRev` silently drops out of the count. Following
+Phase 122's practice the test was mutation-checked: swapping `IS NOT` for `!=`
+in the query turns **exactly one** test red, the one written for it. A test that
+cannot fail reads as coverage without being any.
+
+One exclusion neither the brief nor this lane had listed, and the audit did:
+`resourceOffline = 1` with a NULL `resourceLocalAddress` is never counted,
+whatever the revisions say — `resource_local_address IS NOT NULL` is an `AND`
+*inside* the `OR`, not a third top-level case.
+
+### The "throttled focus path" is a data-change path
+
+The brief called `DashboardActivity.kt:623-630` "the throttled focus path". It
+is `onRealmDataChange`, reached from `setupDashboardDataObserver` (`:591-595`)
+collecting `dashboardDataFlow` — a **data-change** path. `onResume`
+(`:1097-1101`) calls only `checkNotificationPermissionStatus()` and
+`updateLastSyncStatus()`, and the audit established that
+`checkNotificationPermissionStatus` cannot reach `onNotificationPermissionGranted`
+(`BasePermissionActivity.kt:438-453` only ever calls
+`onNotificationPermissionChanged(false)`), so resume is not even an indirect
+trigger through it.
+
+The three real trigger points:
+
+1. **load** — `initializeDashboard` → `binding.root.post { checkIfShouldShowNotifications() }`
+   (`:193`, `:690-699`), gated `fromLogin || !notificationsShownThisSession`,
+   after `delay(1000)`;
+2. **data change** — `:591-595` → `:622-630`, gated on the same flag, throttled
+   to once per 5000 ms;
+3. **notification permission granted** — `:1116-1121`, gated, unthrottled.
+
+The audit then supplied the thing that actually decides the port's design, and
+it is a *lifecycle* fact rather than a call site: `collectWhenStarted` is
+`repeatOnLifecycle(STARTED)` (`FlowExtensions.kt:38-43`), and a Room `Flow`
+emits its current result on collection. Foregrounding the dashboard restarts the
+collection and re-runs the check. So the Android app *does* refresh on
+foreground — through lifecycle-scoped re-collection, not through `onResume`.
+
+That is why the port watches a drift count stream rather than firing once on
+mount: a `StreamProvider` scoped to the mounted dashboard is the same shape, and
+it is the substitution the port already makes for
+`RealtimeSyncManager.dataUpdateFlow` throughout (`watchResources` says so at its
+own declaration). Two of `dashboardDataFlow`'s four merged flows are
+`my_library` queries, which is precisely the invalidation `readsFrom:
+{myLibraryTable}` subscribes to.
+
+Three omissions, each deliberate and none an invention:
+
+* **no 1000 ms delay** — it lets the Kotlin dashboard draw before a DB round
+  trip; a drift stream's first emission is already off the first frame;
+* **no 5 s throttle** — it guards storming Realm change callbacks, and the write
+  is already a no-op on an unchanged count;
+* **no permission trigger** — it exists so Kotlin can raise an OS notification
+  it suppressed, and `createResourceNotification` has no production caller in
+  the Android app either (`DashboardUiState.newNotifications` has no writer;
+  `PHASE_130_NOTES.md` found the same thing from the other end).
+
+### The phase title was wrong, and so was the row it described
+
+The brief calls the string *"You have N undownloaded resources"*.
+`values/strings.xml:658` is `You have %1$d resources not downloaded`, which is
+what the port's `resourceNotificationMessage` already says in all six locales.
+It is a plain `<string>`, **not** a `<plurals>`, so Kotlin renders "You have 1
+resources not downloaded" at a count of one. The port's ARB entry is a simple
+`{count}` placeholder rather than a plural, so it reproduces the quirk — worth
+recording, because it looks like a bug to fix and fixing it would be a
+divergence.
+
+---
+
+## The defect this lane wrote, caught by the audit and demonstrated failing
+
+The first cut put `ref.watch(resourceUpdateNotificationProvider(session.id))`
+next to the unread-badge read at the top of `HomeScreen.build` — **above** the
+`if (isInactive) return const InactiveDashboardScreen();` early return.
+
+`DashboardActivity.kt:165-182` calls `handleGuestAccess()` at `:169` and
+`return@launch`es **before** `initializeDashboard()` at `:176`. Despite its name
+`handleGuestAccess` (`:301-315`) gates on `rolesList.isEmpty() && userAdmin !=
+true` — the *inactive* condition, not guest. So for an inactive user none of the
+three triggers ever runs: no data observer, no notification check, no badge.
+
+Placed above the return, the port authored a row the Android app never writes,
+for the one user who has no bell to see it in. `test/ui/resource_notification_reachability_test.dart`'s
+*an inactive user gets no resource notification* failed on that code:
+
+```
+Expected: null
+  Actual: NotificationRow:<NotificationRow(id: org.couchdb.user:inert:resource:count, …
+00:02 +2 -1: an inactive user gets no resource notification [E]
+```
+
+Moving the watch below the early return makes it pass, and a sibling test pins
+the other half of the same gate: a **guest** carries `roles: ["guest"]`, so
+`rolesList` is non-empty, the guest falls through to the full dashboard, and
+does get the row. There is no guest gating on this path in either app.
+
+## Failing-first evidence for the phase itself
+
+Before any production change, both reachability tests failed on the dead row:
+
+```
+Expected: not null
+  Actual: <null>
+   … the dashboard must author the resource-update notification
+```
+
+The second test is the one that answers the brief's third question rather than
+assuming it. `notification_format.dart`'s `resource` arm reads
+`kotlinToIntOrNull(message)`, which only succeeds on a bare integer; the test
+takes the row **the live writer produced** and asserts it formats to
+`You have 3 resources not downloaded`. A fixture-built row could not have shown
+that the writer and the reader agree — which is the shape of Phase 74's
+reactions and Phase 100's verification photo, where each half passed alone.
+
+## What was ported
+
+| piece | where |
+|---|---|
+| `likeEscapedUserPattern` — `ResourcesRepositoryImpl.userIdPattern` (`:64-70`) | `lib/data/local/app_database.dart`, above `MyLibraryDao` |
+| `countResourcesNeedingUpdate` / `watchResourcesNeedingUpdateCount` — `countPublicNeedingUpdateForUserPattern` (`MyLibraryDao.kt:119-124`) | `MyLibraryDao`, after `resourcesOnShelf` |
+| `countLibrariesNeedingUpdate` (`:213-216`), null guard included | `lib/repository/resources_repository.dart`, after `localCount` |
+| `DashboardViewModel.updateResourceNotification` (`:134-137`) + its trigger points | `resourceUpdateNotificationProvider`, `lib/providers/dashboard_providers.dart` |
+| the call site | `lib/ui/dashboard/home_screen.dart`, **below** the inactive-user return |
+
+`NotificationsRepository.updateResourceNotification` itself needed no change:
+the audit read the Kotlin in full (`NotificationsRepositoryImpl.kt:51-80`) and
+the port already matches it — the `<userId>:resource:count` id, the bare count
+as the message, `relatedId` set to the same count (nothing reads it), the hard
+`deleteById` at zero, and unread + restamped on a change **in either
+direction**. That last one matters: a count dropping 5 → 3 re-marks the row
+unread in both apps, and the zero case is a delete, so a user who reads the
+notification at 3, downloads all three, then adds two more gets a *new unread*
+row rather than a re-marked one.
+
+### Quirks reproduced rather than fixed
+
+* **The null guard is `== null`, not `isNullOrBlank`**, unlike the sibling
+  `getMyLibrary`/`getMyLibraryFlow`. A blank user id therefore reaches the query
+  as the pattern `%""%`, matching nothing (a serialized `["a","b"]` renders its
+  separator `","`, never `""`). Pinned as 0-either-way so the difference reads
+  as deliberate.
+* **A user id containing a backslash can never match — in either app.** The
+  column holds a JSON list, so `a\b` is *stored* as `["a\\b"]`; the pattern goes
+  the other way, escaping for `LIKE` and being unescaped again by `ESCAPE '\'`,
+  so it looks for a single backslash. Kotlin's Gson converter and `userIdPattern`
+  produce exactly the same mismatch. `_` and `%` are **not** JSON-escaped, so
+  those two escape correctly and are tested doing so. Unreachable in practice
+  (`org.couchdb.user:<name>`), and the fix would have to be made in both apps at
+  once — see *Reported, not fixed*.
+
+## Regions touched
+
+* `lib/data/local/app_database.dart` — one new top-level function above
+  `MyLibraryDao`, two new methods plus one private helper inside it, after
+  `resourcesOnShelf`. **No schema change and no `schemaVersion` bump**: a
+  counting query adds no DDL.
+* `lib/repository/resources_repository.dart` — two methods after `localCount`.
+* `lib/providers/dashboard_providers.dart` — one provider after
+  `myLibraryStreamProvider`.
+* `lib/ui/dashboard/home_screen.dart` — one `ref.watch` immediately below the
+  `isInactive` early return in `build`.
+* `test/ui/home_screen_test.dart`, `test/ui/inactive_dashboard_screen_test.dart`
+  — one override each in the existing harness builders (see below).
+* new: `test/repository/resources_needing_update_count_test.dart` (17),
+  `test/ui/resource_notification_reachability_test.dart` (4).
+
+### A note for anyone writing tests against this screen
+
+Adding a live drift stream to `HomeScreen` turned **25 existing tests red at
+once**, all with `'!timersPending'` and none with a failed expectation.
+Cancelling a drift query stream schedules a zero-duration timer through
+`StreamQueryStore.markAsClosed`; if the `ProviderScope` is disposed by the
+harness backstop *after* the body returns, that timer is still pending and the
+binding asserts. `team_voices_screen_test.dart:40-43` had already documented
+this, which is why every other screen test overrides its streams.
+
+Two ways out, and this phase uses both deliberately: the existing harnesses
+override the new provider (they are not testing it), and the reachability file —
+which must run the real stream — unmounts the tree and settles *inside* the test
+body, then reads the database, which outlives the widget. It belongs with the
+`pumpAndSettle` traps `CLAUDE.md` already lists for the resource viewer and the
+exam screen: **a failure that names a timer is the harness, not the behaviour.**
+
+---
+
+## Reported, not fixed
+
+1. **`MyLibraryDao.watchResources` does not escape its `LIKE` pattern**, where
+   the count added here does and the Kotlin does throughout. It interpolates
+   `'%"$shelfUserId"%'` directly, so a user id containing `_` (LIKE's
+   single-character wildcard) matches another user's shelf entry, and one
+   containing `%` matches almost anything. The file is in this lane's set but
+   the change is outside this phase: it moves catalog/shelf membership for every
+   consumer of `resources_providers.dart`, which is not, and it wants its own
+   failing-first test per call site. `likeEscapedUserPattern` is now available
+   for whoever takes it. Same applies to `resourcesOnShelf` on the line above.
+2. **The JSON/LIKE escaping mismatch is a genuine two-app bug**, described
+   above. Nobody should fix it in the port alone: the two apps would then
+   disagree about shelf membership for the affected ids. It needs escaping
+   against the stored JSON form (`jsonEncode(userId)` minus its brackets) in
+   `ResourcesRepositoryImpl.userIdPattern` and here at the same time.
+   Unreachable today.
+3. **`MyLibraryTable.userId` is non-nullable with a `'[]'` default**, so
+   `watchResources`' catalog arm `r.userId.isNull() | …` has a branch that can
+   never be true. Harmless — `'[]'` matches no `%"x"%` pattern — but it is dead
+   SQL that reads as a ported condition. Not touched because changing it is a
+   schema question.
+4. **The Kotlin's inactive-user gate silences the whole bell, not just this
+   row.** For `rolesList.isEmpty() && userAdmin != true` there is no data
+   observer, no notification check and no badge, because `handleGuestAccess`
+   returns before `initializeDashboard`. The port's `InactiveDashboardScreen`
+   reaches the same outcome by having no bell at all. Recorded because it is not
+   obvious from the method name, and because the next person to add a
+   dashboard-load side effect will face the same placement question this phase
+   got wrong on the first try.
+5. **`updateResourceNotification` upserts on an unchanged count where the port
+   returns early.** Kotlin rewrites `message` and `relatedId` to the same values
+   and leaves `isRead`/`createdAt` alone; the port skips the write entirely. The
+   observable state is identical unless a row's `relatedId` has drifted from its
+   `message`, which no writer can produce. Left alone — the method has six tests
+   and is not this phase's to churn.
+6. **`relatedId` on this row is the count, not a resource id**, in both apps,
+   and nothing reads it (`NotificationsFragment.kt:128` is
+   `"resource" -> openMyFragment(ResourcesFragment())`). It is a field carrying
+   a value that looks like an identifier and is not one. Recorded for whoever
+   next reads a `relatedId` generically.
+7. **The Android tap opens My Library, the port's opens the catalog.**
+   `openMyFragment` overwrites the fragment arguments with `isMyCourseLib = true`
+   (`DashboardActivity.kt:951-959`); the port's resolver maps `resource` to
+   `/resources`, which is the catalog unless `resourceShelfOnlyProvider` happens
+   to be set. Now that the row exists this is reachable, where before it was
+   dead either way. The change is one line in
+   `lib/ui/notifications/notification_destination.dart` — **not in this lane's
+   file set**, which is why it is here rather than in the diff. It should
+   probably set the shelf toggle the way `_openLibraryCard` does, since the
+   count it comes from is shelf-scoped.

--- a/flutter/PHASE_131_NOTES.md
+++ b/flutter/PHASE_131_NOTES.md
@@ -121,10 +121,17 @@ Three omissions, each deliberate and none an invention:
   trip; a drift stream's first emission is already off the first frame;
 * **no 5 s throttle** — it guards storming Realm change callbacks, and the write
   is already a no-op on an unchanged count;
-* **no permission trigger** — it exists so Kotlin can raise an OS notification
-  it suppressed, and `createResourceNotification` has no production caller in
-  the Android app either (`DashboardUiState.newNotifications` has no writer;
-  `PHASE_130_NOTES.md` found the same thing from the other end).
+* **no permission trigger** — and *not* for the reason the first draft of this
+  file gave. `onNotificationPermissionGranted` (`:1116-1121`) raises nothing:
+  its `super` is a bare toast (`BasePermissionActivity.kt:487-489`) and its body
+  is the same `checkAndCreateNewNotifications` call as the other two triggers,
+  so it writes this row rather than re-raising a suppressed notification. It
+  needs no port because granting a permission changes nothing in `my_library`,
+  so the live count stream already holds the value that call would recompute.
+  (The claim it replaces — that the trigger re-raises an OS notification — was
+  the "named the right function and misread it" shape again, in the very file
+  documenting that shape. `createResourceNotification` really does have no
+  production caller, but that is a separate fact and not this trigger's job.)
 
 ### The phase title was wrong, and so was the row it described
 
@@ -255,17 +262,105 @@ exam screen: **a failure that names a timer is the harness, not the behaviour.**
 
 ---
 
+## What the second audit found in this lane's own finished code
+
+Run against the green diff, as `CLAUDE.md` requires. It confirmed the SQL
+character-for-character against the generated table, re-ran all three mutations
+this phase claimed (`IS NOT`→`!=`: 1 red; shelf→catalog predicate: 9 red;
+watch above the inactive return: 1 red), and established two things this lane
+had not checked and had been lucky about:
+
+* **`asyncMap` pausing a drift stream loses nothing.** `QueryStream` only calls
+  `markAsClosed` when its listener set is *empty*; a pause keeps the
+  table-change subscription alive and refetches on resume, and the resume
+  re-push cannot loop because `_QueryStreamListener.add` drops an identical row.
+  Measured: one emission on mount, one per write, none over 300 ms idle.
+* **A throwing write does not terminate the stream.** With a repository whose
+  first `updateResourceNotification` throws, the provider goes to `AsyncError`,
+  the stream survives, and the next `my_library` write retries and succeeds.
+  That is `DashboardViewModel.kt:354-362`'s `try/catch { printStackTrace }` plus
+  its re-triggering, reproduced — `HomeScreen` discards the `AsyncValue`, so
+  nothing surfaces to the user, matching.
+
+And it found one real divergence, plus three factual errors in this file.
+
+### The writer outlived the dashboard
+
+`resourceUpdateNotificationProvider` was a plain `StreamProvider.family`, so its
+element lived for the container's lifetime rather than the screen's, and
+`SessionNotifier.signOut` invalidates nothing. Kotlin cannot do this:
+`collectWhenStarted` is `repeatOnLifecycle(STARTED)` bound to the activity, and
+the collection stops when the dashboard finishes.
+
+The concrete failure: Alice reads her notification and logs out; Bob signs in
+and syncs; the sync writes `my_library`; **Alice's** row is rewritten unread with
+a `createdAt` from inside Bob's session. Not data loss — it converges when Alice
+next opens the dashboard — but `createdAt` is the sort key for
+`NotificationDao.watchForUser` (`ORDER BY isRead ASC, createdAt DESC`) and drives
+the relative-time label, so the row's position and age are wrong meanwhile.
+
+Demonstrated failing (`the writer does not outlive the dashboard`), fixed with
+`.autoDispose`, and mutation-checked: reverting to a plain family turns that one
+test red again. Worth stating because the house style points the other way — the
+neighbouring families in `dashboard_providers.dart` are deliberately not
+auto-disposing, and that is right for all of them, because **they are pure
+readers**. This is the only provider in the file that writes, which is exactly
+what makes a stale live stream cost something. The comment at the call site had
+claimed the subscription "lives exactly as long as the dashboard does"; it now
+does, rather than only saying so.
+
+### A fresh dead method, in the phase about dead methods
+
+`ResourcesRepository.countResourcesNeedingUpdate` — the `Future` form, the
+literal shape of the Kotlin `countLibrariesNeedingUpdate` — had no production
+caller. Only the stream form is used, and only tests called the other. A phase
+whose stated subject is retiring ported-tested-green-and-dead code has no
+business leaving a new instance behind, so it and the DAO method under it are
+deleted; the tests now call the stream through a one-line `countNeedingUpdate`
+helper, which has the side benefit of exercising the production path.
+
+### Three corrections to this file
+
+Recorded in place above rather than only here, because the next round is briefed
+from the *Reported, not fixed* list and a wrong entry there is worse than a
+missing one.
+
+1. **The permission-trigger rationale was wrong.**
+   `onNotificationPermissionGranted` raises nothing — same body as the other two
+   triggers. Corrected in the omissions list; the conclusion survives for a
+   different reason.
+2. **"Reported, not fixed" item 1 named two unescaped `LIKE` sites; there are
+   five**, two of them in `CourseDao`. A lane briefed from the short list would
+   have fixed resources and left courses — the half-migration shape that has
+   cost rounds before. Now a table.
+3. **`resource_local_address IS NOT NULL` is not "a file on disk".**
+   `MyLibraryMapper._attachmentOf` writes the CouchDB attachment *name* there on
+   every sync, downloaded or not (`MyLibrary.kt:262` does the same, so parity is
+   intact and the query is right). The gloss would have led a reader to
+   mis-predict the offline-with-no-attachment fixture, which passes only because
+   it is a shape a sync cannot produce. Corrected at the column and in the test.
+
 ## Reported, not fixed
 
-1. **`MyLibraryDao.watchResources` does not escape its `LIKE` pattern**, where
-   the count added here does and the Kotlin does throughout. It interpolates
-   `'%"$shelfUserId"%'` directly, so a user id containing `_` (LIKE's
-   single-character wildcard) matches another user's shelf entry, and one
-   containing `%` matches almost anything. The file is in this lane's set but
-   the change is outside this phase: it moves catalog/shelf membership for every
-   consumer of `resources_providers.dart`, which is not, and it wants its own
-   failing-first test per call site. `likeEscapedUserPattern` is now available
-   for whoever takes it. Same applies to `resourcesOnShelf` on the line above.
+1. **Five unescaped `LIKE` interpolations in `app_database.dart`**, where the
+   count added here escapes and the Kotlin escapes throughout
+   (`ResourcesRepositoryImpl.userIdPattern`, `CoursesRepositoryImpl.userIdPattern`).
+   A user id containing `_` — LIKE's single-character wildcard — matches another
+   user's shelf entry; one containing `%` matches almost anything. All five,
+   because a list naming two of them would get half the class fixed:
+
+   | line | site |
+   |---|---|
+   | `1108` | `MyLibraryDao.watchResources`, shelf arm |
+   | `1114` | `MyLibraryDao.watchResources`, catalog arm (`.not()`) |
+   | `1134` | `MyLibraryDao.resourcesOnShelf` |
+   | `1430` | `CourseDao.watchCourses` |
+   | `1486` | `CourseDao.coursesOnShelf` |
+
+   Outside this phase: the change moves catalog/shelf membership for every
+   consumer of `resources_providers.dart` and `courses_providers.dart`, and it
+   wants a failing-first test per call site. `likeEscapedUserPattern` is now
+   available for whoever takes it.
 2. **The JSON/LIKE escaping mismatch is a genuine two-app bug**, described
    above. Nobody should fix it in the port alone: the two apps would then
    disagree about shelf membership for the affected ids. It needs escaping
@@ -277,7 +372,22 @@ exam screen: **a failure that names a timer is the harness, not the behaviour.**
    never be true. Harmless — `'[]'` matches no `%"x"%` pattern — but it is dead
    SQL that reads as a ported condition. Not touched because changing it is a
    schema question.
-4. **The Kotlin's inactive-user gate silences the whole bell, not just this
+4. **The port's `isInactive` carries a `!isGuest` term the Kotlin does not
+   have.** `home_screen.dart:352-356` is
+   `session != null && !isGuest && rolesList.isEmpty && !userAdmin`;
+   `DashboardActivity.kt:302` has no guest term. A user whose `_id` starts
+   `guest_` *and* whose `rolesList` is empty would get the inactive dashboard
+   (and no row) in Kotlin, and the full dashboard plus the row here.
+   Unreachable — `UserRepositoryImpl.kt:150-153` gives every guest
+   `roles: ["guest"]`, and nothing in the port creates a guest row at all — so
+   it is not fixed. Recorded because **this phase's whole placement rationale
+   rests on that predicate**, and the guard added for it cannot separate the two
+   terms: the guest fixture carries `rolesList: const ['guest']`, which fails
+   `!isGuest` and `rolesList.isEmpty` alike. A fixture with
+   `id: 'guest_ada', rolesList: const []` would distinguish them, and should be
+   added by whoever aligns the predicate.
+
+5. **The Kotlin's inactive-user gate silences the whole bell, not just this
    row.** For `rolesList.isEmpty() && userAdmin != true` there is no data
    observer, no notification check and no badge, because `handleGuestAccess`
    returns before `initializeDashboard`. The port's `InactiveDashboardScreen`
@@ -285,18 +395,18 @@ exam screen: **a failure that names a timer is the harness, not the behaviour.**
    obvious from the method name, and because the next person to add a
    dashboard-load side effect will face the same placement question this phase
    got wrong on the first try.
-5. **`updateResourceNotification` upserts on an unchanged count where the port
+6. **`updateResourceNotification` upserts on an unchanged count where the port
    returns early.** Kotlin rewrites `message` and `relatedId` to the same values
    and leaves `isRead`/`createdAt` alone; the port skips the write entirely. The
    observable state is identical unless a row's `relatedId` has drifted from its
    `message`, which no writer can produce. Left alone — the method has six tests
    and is not this phase's to churn.
-6. **`relatedId` on this row is the count, not a resource id**, in both apps,
+7. **`relatedId` on this row is the count, not a resource id**, in both apps,
    and nothing reads it (`NotificationsFragment.kt:128` is
    `"resource" -> openMyFragment(ResourcesFragment())`). It is a field carrying
    a value that looks like an identifier and is not one. Recorded for whoever
    next reads a `relatedId` generically.
-7. **The Android tap opens My Library, the port's opens the catalog.**
+8. **The Android tap opens My Library, the port's opens the catalog.**
    `openMyFragment` overwrites the fragment arguments with `isMyCourseLib = true`
    (`DashboardActivity.kt:951-959`); the port's resolver maps `resource` to
    `/resources`, which is the catalog unless `resourceShelfOnlyProvider` happens

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1135,7 +1135,12 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
 
   /// Port of `MyLibraryDao.countPublicNeedingUpdateForUserPattern`
   /// (`MyLibraryDao.kt:119-124`) — how many of the user's shelf resources are
-  /// not on the device, or are on it but stale.
+  /// not on the device, or are on it but stale. Streams rather than reads once,
+  /// because in the port the stream is also the trigger: the Kotlin recomputes
+  /// on every emission of `DashboardViewModel.dashboardDataFlow` (`:207-214`),
+  /// two of whose four merged flows are `my_library` queries, and `readsFrom`
+  /// makes drift re-run this on any write to that table. Same substitution
+  /// [watchResources] makes for `RealtimeSyncManager.dataUpdateFlow`.
   ///
   /// This is the **shelf** predicate (`userId LIKE`), not the catalog one
   /// (`userId IS NULL OR userId NOT LIKE`) that sits immediately below it in
@@ -1145,11 +1150,15 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   ///
   /// The third clause is two cases, not one:
   ///
-  /// * `resource_offline = 0` — never downloaded.
+  /// * `resource_offline = 0` — not downloaded.
   /// * `resource_local_address IS NOT NULL AND _rev IS NOT downloaded_rev` —
-  ///   downloaded, but the server document moved on since. `downloadedRev` is
-  ///   stamped by [markDownloaded] and stays put while `rev` follows the sync,
-  ///   which is exactly what makes the comparison meaningful.
+  ///   the document has an attachment and the server has moved past the
+  ///   revision we fetched. Note `resource_local_address` is **not** evidence
+  ///   of a file on disk: `MyLibraryMapper._attachmentOf` writes the CouchDB
+  ///   attachment *name* there on every sync, downloaded or not, exactly as
+  ///   `MyLibrary.kt:262` does. What makes the comparison meaningful is
+  ///   `downloadedRev`, which [markDownloaded] stamps from `rev` when the file
+  ///   actually lands and which then stays put while `rev` follows the sync.
   ///
   /// `IS NOT` is SQLite's **null-safe** inequality, not `!=`: two NULLs compare
   /// equal (so the row is excluded) and NULL against a value compares unequal
@@ -1163,23 +1172,7 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   /// takes no `ESCAPE`, and the Kotlin pattern is escaped
   /// ([likeEscapedUserPattern]). Keeping the statement verbatim also lets it be
   /// read side by side with the `@Query` it ports.
-  Future<int> countResourcesNeedingUpdate(String userId) async =>
-      (await _needingUpdateQuery(userId).getSingle()).read<int>('c');
-
-  /// The reactive form of [countResourcesNeedingUpdate].
-  ///
-  /// The Kotlin recomputes on every emission of
-  /// `DashboardViewModel.dashboardDataFlow` (`:207-214`), two of whose four
-  /// merged flows are `my_library` queries. `readsFrom` makes drift re-run this
-  /// on any write to that table, which is the same trigger — and the same
-  /// substitution the port already makes for `queryListFlow` /
-  /// `RealtimeSyncManager.dataUpdateFlow` in [watchResources].
-  Stream<int> watchResourcesNeedingUpdateCount(String userId) =>
-      _needingUpdateQuery(
-        userId,
-      ).watchSingle().map((row) => row.read<int>('c'));
-
-  Selectable<QueryRow> _needingUpdateQuery(String userId) => customSelect(
+  Stream<int> watchResourcesNeedingUpdateCount(String userId) => customSelect(
     'SELECT COUNT(*) AS c FROM my_library '
     'WHERE is_private = 0 '
     "AND user_id LIKE ?1 ESCAPE '\\' "
@@ -1187,7 +1180,7 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
     'OR (resource_local_address IS NOT NULL AND _rev IS NOT downloaded_rev))',
     variables: [Variable<String>(likeEscapedUserPattern(userId))],
     readsFrom: {myLibraryTable},
-  );
+  ).watchSingle().map((row) => row.read<int>('c'));
 
   /// Port of `ResourcesRepositoryImpl.removeDeletedResources` — drops local rows
   /// the server no longer lists.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1024,6 +1024,26 @@ class UserDao extends DatabaseAccessor<AppDatabase> with _$UserDaoMixin {
   }
 }
 
+/// Port of `ResourcesRepositoryImpl.userIdPattern` (`:64-70`) — a user id as
+/// the `LIKE` pattern that finds it inside the serialized JSON list
+/// `my_library.user_id` holds.
+///
+/// The three replacements are in the Kotlin's order, and the order matters:
+/// escaping `\` first means the backslashes this function itself introduces
+/// are not escaped again. The result is only valid against a `LIKE` carrying
+/// `ESCAPE '\'`.
+///
+/// A user id is `org.couchdb.user:ada` in practice, which contains no `LIKE`
+/// metacharacter — but `_` matches any single character, so an id containing
+/// one would otherwise match a *different* user's shelf entry.
+String likeEscapedUserPattern(String userId) {
+  final escaped = userId
+      .replaceAll('\\', '\\\\')
+      .replaceAll('%', '\\%')
+      .replaceAll('_', '\\_');
+  return '%"$escaped"%';
+}
+
 /// Port of `data/room/dao/MyLibraryDao.kt`.
 @DriftAccessor(tables: [MyLibraryTable])
 class MyLibraryDao extends DatabaseAccessor<AppDatabase>
@@ -1112,6 +1132,62 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   Future<List<MyLibraryRow>> resourcesOnShelf(String userId) => (select(
     myLibraryTable,
   )..where((r) => r.userId.like('%"$userId"%'))).get();
+
+  /// Port of `MyLibraryDao.countPublicNeedingUpdateForUserPattern`
+  /// (`MyLibraryDao.kt:119-124`) — how many of the user's shelf resources are
+  /// not on the device, or are on it but stale.
+  ///
+  /// This is the **shelf** predicate (`userId LIKE`), not the catalog one
+  /// (`userId IS NULL OR userId NOT LIKE`) that sits immediately below it in
+  /// the Kotlin DAO and is easy to mistake for it. The count answers "how many
+  /// of *your* resources still need downloading", so a resource nobody put on
+  /// your shelf is not your problem.
+  ///
+  /// The third clause is two cases, not one:
+  ///
+  /// * `resource_offline = 0` — never downloaded.
+  /// * `resource_local_address IS NOT NULL AND _rev IS NOT downloaded_rev` —
+  ///   downloaded, but the server document moved on since. `downloadedRev` is
+  ///   stamped by [markDownloaded] and stays put while `rev` follows the sync,
+  ///   which is exactly what makes the comparison meaningful.
+  ///
+  /// `IS NOT` is SQLite's **null-safe** inequality, not `!=`: two NULLs compare
+  /// equal (so the row is excluded) and NULL against a value compares unequal
+  /// (so the row is counted). That is load-bearing — a row marked offline by an
+  /// older build that never wrote `downloadedRev` carries NULL there against a
+  /// non-null `_rev`, and the Kotlin counts it as needing an update. Written
+  /// with `!=` it would be SQL NULL, hence false, and those rows would vanish
+  /// from the count.
+  ///
+  /// Raw SQL rather than the query builder for one reason: drift's `like()`
+  /// takes no `ESCAPE`, and the Kotlin pattern is escaped
+  /// ([likeEscapedUserPattern]). Keeping the statement verbatim also lets it be
+  /// read side by side with the `@Query` it ports.
+  Future<int> countResourcesNeedingUpdate(String userId) async =>
+      (await _needingUpdateQuery(userId).getSingle()).read<int>('c');
+
+  /// The reactive form of [countResourcesNeedingUpdate].
+  ///
+  /// The Kotlin recomputes on every emission of
+  /// `DashboardViewModel.dashboardDataFlow` (`:207-214`), two of whose four
+  /// merged flows are `my_library` queries. `readsFrom` makes drift re-run this
+  /// on any write to that table, which is the same trigger — and the same
+  /// substitution the port already makes for `queryListFlow` /
+  /// `RealtimeSyncManager.dataUpdateFlow` in [watchResources].
+  Stream<int> watchResourcesNeedingUpdateCount(String userId) =>
+      _needingUpdateQuery(
+        userId,
+      ).watchSingle().map((row) => row.read<int>('c'));
+
+  Selectable<QueryRow> _needingUpdateQuery(String userId) => customSelect(
+    'SELECT COUNT(*) AS c FROM my_library '
+    'WHERE is_private = 0 '
+    "AND user_id LIKE ?1 ESCAPE '\\' "
+    'AND (resource_offline = 0 '
+    'OR (resource_local_address IS NOT NULL AND _rev IS NOT downloaded_rev))',
+    variables: [Variable<String>(likeEscapedUserPattern(userId))],
+    readsFrom: {myLibraryTable},
+  );
 
   /// Port of `ResourcesRepositoryImpl.removeDeletedResources` — drops local rows
   /// the server no longer lists.

--- a/flutter/lib/providers/dashboard_providers.dart
+++ b/flutter/lib/providers/dashboard_providers.dart
@@ -25,6 +25,71 @@ final myLibraryStreamProvider =
           .watchResources(shelfUserId: userId, myLibrary: true),
     );
 
+/// Port of `DashboardViewModel.updateResourceNotification` (`:134-137`) and the
+/// `DashboardActivity` trigger points that call it, via
+/// `checkAndCreateNewNotifications` (`:354-362`).
+///
+/// The Android bell carries a *"You have N resources not downloaded"* row; the
+/// port's never did, because `NotificationsRepository.updateResourceNotification`
+/// was ported with six tests and **no caller** — the "ported, tested, green and
+/// dead" class. This provider is that caller.
+///
+/// ## Why a stream, when the Kotlin calls a suspend function
+///
+/// The Kotlin fires the same one-line body from three places
+/// (`DashboardActivity.kt`):
+///
+/// 1. dashboard load — `initializeDashboard` → `checkIfShouldShowNotifications`
+///    (`:193`, `:690-698`), once per Activity unless launched from login,
+///    after a `delay(1000)`;
+/// 2. **data change** — `setupDashboardDataObserver` (`:591-595`) collects
+///    `dashboardDataFlow`, two of whose four merged flows are `my_library`
+///    queries, and `onRealmDataChange` (`:622-630`) re-runs the check, throttled
+///    to once per 5s;
+/// 3. notification permission granted (`:1116-1121`), unthrottled.
+///
+/// Watching the count collapses (1) and (2) into one subscription: the first
+/// emission is the load, and drift re-runs the query on any `my_library` write,
+/// which is what `dashboardDataFlow` was merging those two flows to detect.
+/// That is the substitution the port already makes for
+/// `RealtimeSyncManager.dataUpdateFlow` throughout.
+///
+/// Three deliberate omissions, none of them an improvement invented here:
+///
+/// * **No 1000ms delay.** It exists to let the Kotlin dashboard draw before a
+///   DB round trip on the main-thread-adjacent path; a drift stream's first
+///   emission is already off the first frame.
+/// * **No 5s throttle.** The Kotlin's guards a pair of Realm change callbacks
+///   that storm; drift coalesces its own updates, and the write is a no-op when
+///   the count is unchanged (`updateResourceNotification` returns early on an
+///   equal message), so a burst of shelf writes costs at most one row update.
+/// * **No permission trigger.** It exists so the Kotlin can *raise an OS
+///   notification* it suppressed while permission was denied. This row is a
+///   bell row only — `DashboardUiState.newNotifications` has no writer, so
+///   `createResourceNotification` never fires in the Android app either
+///   (`PHASE_130_NOTES.md`). Nothing to re-raise.
+///
+/// The unread badge needs no equivalent of `checkAndCreateNewNotifications`'
+/// second half: `unreadNotificationCountProvider` is itself a drift stream, so
+/// writing the row updates the badge without a push into UI state.
+///
+/// The count is a value, not a void, so a test can assert what was written and
+/// a caller can watch it; the write is the point.
+final resourceUpdateNotificationProvider = StreamProvider.family<int, String>((
+  ref,
+  userId,
+) {
+  if (userId.isEmpty) return Stream.value(0);
+  final notifications = ref.watch(notificationsRepositoryProvider);
+  return ref
+      .watch(resourcesRepositoryProvider)
+      .watchResourcesNeedingUpdateCount(userId)
+      .asyncMap((count) async {
+        await notifications.updateResourceNotification(userId, count);
+        return count;
+      });
+});
+
 /// The user's joined courses — `coursesRepository.getMyCoursesFlow(userId)`,
 /// including its blank-title filter (`renderMyCourses` drops those before
 /// counting).

--- a/flutter/lib/providers/dashboard_providers.dart
+++ b/flutter/lib/providers/dashboard_providers.dart
@@ -63,32 +63,47 @@ final myLibraryStreamProvider =
 ///   that storm; drift coalesces its own updates, and the write is a no-op when
 ///   the count is unchanged (`updateResourceNotification` returns early on an
 ///   equal message), so a burst of shelf writes costs at most one row update.
-/// * **No permission trigger.** It exists so the Kotlin can *raise an OS
-///   notification* it suppressed while permission was denied. This row is a
-///   bell row only — `DashboardUiState.newNotifications` has no writer, so
-///   `createResourceNotification` never fires in the Android app either
-///   (`PHASE_130_NOTES.md`). Nothing to re-raise.
+/// * **No permission trigger.** `onNotificationPermissionGranted`
+///   (`:1116-1121`) does not raise anything — its `super` is a bare toast
+///   (`BasePermissionActivity.kt:487-489`) and its body is the *same*
+///   `checkAndCreateNewNotifications` call as the other two triggers, so it
+///   writes this row rather than re-raising a suppressed one. It needs no port
+///   for a different reason: granting a permission changes nothing in
+///   `my_library`, so the live count stream already holds the value that call
+///   would have recomputed.
 ///
 /// The unread badge needs no equivalent of `checkAndCreateNewNotifications`'
 /// second half: `unreadNotificationCountProvider` is itself a drift stream, so
 /// writing the row updates the badge without a push into UI state.
 ///
+/// **`autoDispose`, unlike every other family in this file.** The neighbours
+/// are pure readers, where a stream outliving its screen costs nothing; this
+/// one *writes*. A plain family's element lives for the container's lifetime,
+/// and `SessionNotifier.signOut` invalidates nothing — so after logout the
+/// stream would stay subscribed and a later sync would rewrite the previous
+/// user's row, unread, stamped from inside somebody else's session. Kotlin
+/// cannot: `collectWhenStarted` is `repeatOnLifecycle(STARTED)` bound to the
+/// activity (`FlowExtensions.kt:38-43`), so the collection stops when the
+/// dashboard does. Auto-disposing gives the port that same lifetime.
+///
+/// Tab switches are unaffected either way — `DashboardShell` is a
+/// `StatefulShellRoute`, so `HomeScreen` stays mounted across branches, which
+/// is the Kotlin activity's scope too.
+///
 /// The count is a value, not a void, so a test can assert what was written and
 /// a caller can watch it; the write is the point.
-final resourceUpdateNotificationProvider = StreamProvider.family<int, String>((
-  ref,
-  userId,
-) {
-  if (userId.isEmpty) return Stream.value(0);
-  final notifications = ref.watch(notificationsRepositoryProvider);
-  return ref
-      .watch(resourcesRepositoryProvider)
-      .watchResourcesNeedingUpdateCount(userId)
-      .asyncMap((count) async {
-        await notifications.updateResourceNotification(userId, count);
-        return count;
-      });
-});
+final resourceUpdateNotificationProvider = StreamProvider.autoDispose
+    .family<int, String>((ref, userId) {
+      if (userId.isEmpty) return Stream.value(0);
+      final notifications = ref.watch(notificationsRepositoryProvider);
+      return ref
+          .watch(resourcesRepositoryProvider)
+          .watchResourcesNeedingUpdateCount(userId)
+          .asyncMap((count) async {
+            await notifications.updateResourceNotification(userId, count);
+            return count;
+          });
+    });
 
 /// The user's joined courses — `coursesRepository.getMyCoursesFlow(userId)`,
 /// including its blank-title filter (`renderMyCourses` drops those before

--- a/flutter/lib/repository/resources_repository.dart
+++ b/flutter/lib/repository/resources_repository.dart
@@ -67,24 +67,21 @@ class ResourcesRepository {
   /// the device or stale on it. Feeds the bell's *"You have N resources not
   /// downloaded"* row.
   ///
+  /// Streaming rather than a `Future`, because in the port the stream *is* the
+  /// trigger. The Kotlin re-runs its suspend count from each of
+  /// `DashboardActivity`'s trigger points; here a drift watch over `my_library`
+  /// covers the load and data-change ones together, the same substitution
+  /// [watchResources] makes for `RealtimeSyncManager.dataUpdateFlow`. A
+  /// `Future` twin was written first and deleted: it had no caller, and a phase
+  /// whose whole subject is retiring ported-but-dead code should not leave a
+  /// fresh one behind.
+  ///
   /// The null guard is the Kotlin's, quirk included: it tests `userId == null`
   /// and **not** `isNullOrBlank`, unlike the sibling `getMyLibrary` /
   /// `getMyLibraryFlow` two methods above it. So a blank user id reaches the
   /// DAO and matches on the pattern `%""%` rather than short-circuiting. It
   /// counts nothing in practice — no shelf list contains an empty string — but
   /// reproducing the guard as written keeps a future divergence honest.
-  Future<int> countResourcesNeedingUpdate(String? userId) {
-    if (userId == null) return Future.value(0);
-    return _dao.countResourcesNeedingUpdate(userId);
-  }
-
-  /// The reactive form of [countResourcesNeedingUpdate], and the one the
-  /// dashboard actually uses.
-  ///
-  /// The Kotlin has no streaming counterpart because it re-runs the suspend
-  /// count from each of `DashboardActivity`'s trigger points; here the stream
-  /// *is* the trigger, the same substitution [watchResources] makes for
-  /// `RealtimeSyncManager.dataUpdateFlow`.
   Stream<int> watchResourcesNeedingUpdateCount(String? userId) {
     if (userId == null) return Stream.value(0);
     return _dao.watchResourcesNeedingUpdateCount(userId);

--- a/flutter/lib/repository/resources_repository.dart
+++ b/flutter/lib/repository/resources_repository.dart
@@ -62,6 +62,34 @@ class ResourcesRepository {
 
   Future<int> localCount() => _dao.count();
 
+  /// Port of `ResourcesRepositoryImpl.countLibrariesNeedingUpdate`
+  /// (`:213-216`) — how many of the user's shelf resources are missing from
+  /// the device or stale on it. Feeds the bell's *"You have N resources not
+  /// downloaded"* row.
+  ///
+  /// The null guard is the Kotlin's, quirk included: it tests `userId == null`
+  /// and **not** `isNullOrBlank`, unlike the sibling `getMyLibrary` /
+  /// `getMyLibraryFlow` two methods above it. So a blank user id reaches the
+  /// DAO and matches on the pattern `%""%` rather than short-circuiting. It
+  /// counts nothing in practice — no shelf list contains an empty string — but
+  /// reproducing the guard as written keeps a future divergence honest.
+  Future<int> countResourcesNeedingUpdate(String? userId) {
+    if (userId == null) return Future.value(0);
+    return _dao.countResourcesNeedingUpdate(userId);
+  }
+
+  /// The reactive form of [countResourcesNeedingUpdate], and the one the
+  /// dashboard actually uses.
+  ///
+  /// The Kotlin has no streaming counterpart because it re-runs the suspend
+  /// count from each of `DashboardActivity`'s trigger points; here the stream
+  /// *is* the trigger, the same substitution [watchResources] makes for
+  /// `RealtimeSyncManager.dataUpdateFlow`.
+  Stream<int> watchResourcesNeedingUpdateCount(String? userId) {
+    if (userId == null) return Stream.value(0);
+    return _dao.watchResourcesNeedingUpdateCount(userId);
+  }
+
   /// Gets a single resource by its local id.
   Future<MyLibraryRow?> getById(String id) => _dao.getById(id);
 

--- a/flutter/lib/ui/dashboard/home_screen.dart
+++ b/flutter/lib/ui/dashboard/home_screen.dart
@@ -358,6 +358,30 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       return const InactiveDashboardScreen();
     }
 
+    // `DashboardActivity.checkIfShouldShowNotifications` (`:193`, `:690-698`) —
+    // the dashboard is what keeps the bell's resource-update row current, and
+    // watching the count is also its data-change trigger. See
+    // [resourceUpdateNotificationProvider].
+    //
+    // **This has to sit below the inactive-user return, not above it.**
+    // `DashboardActivity.kt:165-182` calls `handleGuestAccess()` and
+    // `return@launch`es *before* `initializeDashboard()`, so for a user with no
+    // roles and no admin flag none of the Kotlin's three triggers ever runs.
+    // Placed above, the port would author a row the Android app never writes,
+    // on the one screen with no bell to show it — which is what the reachability
+    // test caught. Despite the Kotlin method's name the gate is the *inactive*
+    // condition, not guest: a guest carries `roles: ["guest"]`, falls through to
+    // the full dashboard, and does get the row.
+    //
+    // Watched rather than read so the subscription lives exactly as long as the
+    // dashboard does, which is the Kotlin's Activity scope. The value is unused
+    // here: the row it writes reaches the badge through
+    // `unreadNotificationCountProvider`'s own stream, which is why the port
+    // needs no equivalent of `checkAndCreateNewNotifications`' second half.
+    if (session != null) {
+      ref.watch(resourceUpdateNotificationProvider(session.id));
+    }
+
     return Scaffold(
       drawer: const DashboardDrawer(),
       // `binding.fabMyActivity` — opens the login-activity chart.

--- a/flutter/test/repository/resources_needing_update_count_test.dart
+++ b/flutter/test/repository/resources_needing_update_count_test.dart
@@ -1,0 +1,265 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/resources_repository.dart';
+
+class _MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Port tests for `ResourcesRepositoryImpl.countLibrariesNeedingUpdate`
+/// (`:213-216`) and the DAO query behind it,
+/// `MyLibraryDao.countPublicNeedingUpdateForUserPattern`
+/// (`MyLibraryDao.kt:119-124`):
+///
+/// ```sql
+/// SELECT COUNT(*) FROM my_library WHERE isPrivate = 0
+///   AND userId LIKE :userPattern ESCAPE '\'
+///   AND (resourceOffline = 0
+///        OR (resourceLocalAddress IS NOT NULL AND _rev IS NOT downloadedRev))
+/// ```
+void main() {
+  late AppDatabase db;
+  late ResourcesRepository repository;
+
+  const userId = 'org.couchdb.user:ada';
+
+  setUp(() {
+    db = AppDatabase.memory();
+    repository = ResourcesRepository(
+      _MockPlanetApi(),
+      db.myLibraryDao,
+      db.removedLogDao,
+    );
+  });
+
+  tearDown(() => db.close());
+
+  Future<void> insert(
+    String id, {
+    List<String> userId = const [],
+    bool isPrivate = false,
+    bool offline = false,
+    String? localAddress,
+    String? rev,
+    String? downloadedRev,
+  }) => db.myLibraryDao.upsertAll([
+    MyLibraryTableCompanion.insert(
+      id: id,
+      userId: Value(userId),
+      isPrivate: Value(isPrivate),
+      resourceOffline: Value(offline),
+      resourceLocalAddress: Value(localAddress),
+      rev: Value(rev),
+      downloadedRev: Value(downloadedRev),
+    ),
+  ]);
+
+  group('the shelf scope', () {
+    test('counts only the signed-in user\'s shelf', () async {
+      await insert('mine', userId: const [userId]);
+      await insert('theirs', userId: const ['org.couchdb.user:bob']);
+      await insert('nobodys');
+
+      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+    });
+
+    test(
+      'is the shelf predicate, not the catalog one — a resource on nobody\'s '
+      'shelf is not counted',
+      () async {
+        // The distinction this pins: `countPublicNeedingUpdateForUserPattern`
+        // uses `userId LIKE`, while `getPublicNotUserPattern` immediately below
+        // it in the same Kotlin DAO uses `userId IS NULL OR userId NOT LIKE`.
+        // `PHASE_130_NOTES.md` cited the second for the first. Under the
+        // catalog predicate this fixture would count 2 (`theirs` + `nobodys`)
+        // and exclude the user's own.
+        await insert('mine', userId: const [userId]);
+        await insert('theirs', userId: const ['org.couchdb.user:bob']);
+        await insert('nobodys');
+
+        expect(await repository.countResourcesNeedingUpdate(userId), 1);
+      },
+    );
+
+    test('counts a shelf shared with other users', () async {
+      await insert('shared', userId: const ['org.couchdb.user:bob', userId]);
+      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+    });
+
+    test('excludes private resources', () async {
+      await insert('pub', userId: const [userId]);
+      await insert('priv', userId: const [userId], isPrivate: true);
+      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+    });
+  });
+
+  group('the download predicate', () {
+    test('counts a resource that was never downloaded', () async {
+      await insert('a', userId: const [userId]);
+      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+    });
+
+    test('counts a downloaded resource the server has moved past', () async {
+      await insert(
+        'a',
+        userId: const [userId],
+        offline: true,
+        localAddress: '/tmp/a',
+        rev: '4-def',
+        downloadedRev: '3-abc',
+      );
+      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+    });
+
+    test('does not count a downloaded resource that is current', () async {
+      await insert(
+        'a',
+        userId: const [userId],
+        offline: true,
+        localAddress: '/tmp/a',
+        rev: '3-abc',
+        downloadedRev: '3-abc',
+      );
+      expect(await repository.countResourcesNeedingUpdate(userId), 0);
+    });
+
+    test(
+      'counts a downloaded resource whose downloadedRev was never stamped',
+      () async {
+        // The `IS NOT` trap, and the reason the Kotlin does not write `!=`.
+        // SQLite's `IS NOT` is the **null-safe** inequality: `'3-abc' IS NOT
+        // NULL` is true, so this row counts. Written `_rev != downloadedRev`
+        // the comparison would be SQL NULL — falsy — and every row an older
+        // build marked offline without stamping `downloadedRev` would silently
+        // drop out of the count.
+        //
+        // This is the one assertion in the file that a plausible mis-port
+        // passes everything else while failing.
+        await insert(
+          'a',
+          userId: const [userId],
+          offline: true,
+          localAddress: '/tmp/a',
+          rev: '3-abc',
+        );
+        expect(await repository.countResourcesNeedingUpdate(userId), 1);
+      },
+    );
+
+    test('does not count a local resource with neither rev', () async {
+      // A locally-created resource that has never been uploaded carries a null
+      // `_rev`; `NULL IS NOT NULL` is false, so it is not "needing update".
+      await insert(
+        'a',
+        userId: const [userId],
+        offline: true,
+        localAddress: '/tmp/a',
+      );
+      expect(await repository.countResourcesNeedingUpdate(userId), 0);
+    });
+
+    test(
+      'does not count a resource flagged offline with no local address',
+      () async {
+        // `resource_local_address IS NOT NULL` is an `AND` *inside* the `OR`,
+        // not a third top-level case: the stale branch needs a file on disk to
+        // be stale about, whatever the revisions say.
+        await insert(
+          'a',
+          userId: const [userId],
+          offline: true,
+          rev: '9-zzz',
+          downloadedRev: '1-aaa',
+        );
+        expect(await repository.countResourcesNeedingUpdate(userId), 0);
+      },
+    );
+  });
+
+  group('the null guard', () {
+    test('a null user id counts nothing', () async {
+      await insert('a', userId: const [userId]);
+      expect(await repository.countResourcesNeedingUpdate(null), 0);
+    });
+
+    test('a blank user id reaches the query, as the Kotlin lets it', () async {
+      // `countLibrariesNeedingUpdate` tests `userId == null`, **not**
+      // `isNullOrBlank`, unlike `getMyLibrary`/`getMyLibraryFlow` above it. The
+      // pattern becomes `%""%`, which matches nothing real — a serialized
+      // `["a","b"]` renders its separator as `","`, never `""` — so the count is
+      // 0 either way. Pinned because the guard as written is the port's, and a
+      // future reader should see the difference is deliberate.
+      await insert('a', userId: const [userId]);
+      expect(await repository.countResourcesNeedingUpdate(''), 0);
+    });
+  });
+
+  group('the LIKE pattern', () {
+    test('escapes a user id containing an underscore', () async {
+      // `_` is LIKE's single-character wildcard. Unescaped, `%"a_b"%` matches
+      // `a1b`, so one user's shelf would count another's resources. Kotlin
+      // escapes `\`, `%` and `_` in `userIdPattern` (`:64-70`).
+      await insert('mine', userId: const ['a_b']);
+      await insert('theirs', userId: const ['a1b']);
+
+      expect(await repository.countResourcesNeedingUpdate('a_b'), 1);
+      expect(await repository.countResourcesNeedingUpdate('a1b'), 1);
+    });
+
+    test('escapes a user id containing a percent sign', () async {
+      await insert('mine', userId: const ['a%b']);
+      await insert('theirs', userId: const ['axxb']);
+
+      expect(await repository.countResourcesNeedingUpdate('a%b'), 1);
+    });
+
+    test('cannot match a user id containing a backslash — in either app', () {
+      // Not a port bug: the two escaping layers do not compose, and they do not
+      // compose in the Kotlin either.
+      //
+      // The column holds a JSON list, so `[r'a\b']` is *stored* as the eight
+      // characters `["a\\b"]` — JSON doubles the backslash. The pattern goes
+      // the other way: `userIdPattern` escapes the backslash for LIKE, and
+      // `ESCAPE '\'` then unescapes it, so the query looks for the single
+      // backslash `"a\b"`. It never matches what was written.
+      //
+      // Kotlin's Gson converter and `ResourcesRepositoryImpl.userIdPattern`
+      // (`:64-70`) produce exactly the same mismatch, so reproducing it is
+      // parity. It is unreachable in practice — a CouchDB user id is
+      // `org.couchdb.user:<name>` — and the fix, if it were ever wanted, is to
+      // escape against the *stored* JSON form rather than the raw id, in both
+      // apps at once. Recorded in `PHASE_131_NOTES.md`.
+      expect(jsonEncode([r'a\b']), r'["a\\b"]');
+      expect(likeEscapedUserPattern(r'a\b'), r'%"a\\b"%');
+    });
+  });
+
+  group('the reactive form', () {
+    test('re-emits when the shelf changes', () async {
+      await insert('a', userId: const [userId]);
+
+      final counts = <int>[];
+      final subscription = repository
+          .watchResourcesNeedingUpdateCount(userId)
+          .listen(counts.add);
+      await pumpEventQueue();
+
+      await insert('b', userId: const [userId]);
+      await pumpEventQueue();
+
+      // Downloading `a` takes it back out of the count.
+      await db.myLibraryDao.markDownloaded('a', '/tmp/a', null);
+      await pumpEventQueue();
+
+      await subscription.cancel();
+      expect(counts, [1, 2, 1]);
+    });
+
+    test('a null user id yields a single zero', () async {
+      expect(await repository.watchResourcesNeedingUpdateCount(null).first, 0);
+    });
+  });
+}

--- a/flutter/test/repository/resources_needing_update_count_test.dart
+++ b/flutter/test/repository/resources_needing_update_count_test.dart
@@ -37,6 +37,11 @@ void main() {
 
   tearDown(() => db.close());
 
+  /// The production path — there is no `Future` form to test against, by
+  /// design: the dashboard watches, so the tests watch too.
+  Future<int> countNeedingUpdate(String? userId) =>
+      repository.watchResourcesNeedingUpdateCount(userId).first;
+
   Future<void> insert(
     String id, {
     List<String> userId = const [],
@@ -63,7 +68,7 @@ void main() {
       await insert('theirs', userId: const ['org.couchdb.user:bob']);
       await insert('nobodys');
 
-      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+      expect(await countNeedingUpdate(userId), 1);
     });
 
     test(
@@ -80,26 +85,26 @@ void main() {
         await insert('theirs', userId: const ['org.couchdb.user:bob']);
         await insert('nobodys');
 
-        expect(await repository.countResourcesNeedingUpdate(userId), 1);
+        expect(await countNeedingUpdate(userId), 1);
       },
     );
 
     test('counts a shelf shared with other users', () async {
       await insert('shared', userId: const ['org.couchdb.user:bob', userId]);
-      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+      expect(await countNeedingUpdate(userId), 1);
     });
 
     test('excludes private resources', () async {
       await insert('pub', userId: const [userId]);
       await insert('priv', userId: const [userId], isPrivate: true);
-      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+      expect(await countNeedingUpdate(userId), 1);
     });
   });
 
   group('the download predicate', () {
     test('counts a resource that was never downloaded', () async {
       await insert('a', userId: const [userId]);
-      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+      expect(await countNeedingUpdate(userId), 1);
     });
 
     test('counts a downloaded resource the server has moved past', () async {
@@ -111,7 +116,7 @@ void main() {
         rev: '4-def',
         downloadedRev: '3-abc',
       );
-      expect(await repository.countResourcesNeedingUpdate(userId), 1);
+      expect(await countNeedingUpdate(userId), 1);
     });
 
     test('does not count a downloaded resource that is current', () async {
@@ -123,7 +128,7 @@ void main() {
         rev: '3-abc',
         downloadedRev: '3-abc',
       );
-      expect(await repository.countResourcesNeedingUpdate(userId), 0);
+      expect(await countNeedingUpdate(userId), 0);
     });
 
     test(
@@ -145,7 +150,7 @@ void main() {
           localAddress: '/tmp/a',
           rev: '3-abc',
         );
-        expect(await repository.countResourcesNeedingUpdate(userId), 1);
+        expect(await countNeedingUpdate(userId), 1);
       },
     );
 
@@ -158,15 +163,19 @@ void main() {
         offline: true,
         localAddress: '/tmp/a',
       );
-      expect(await repository.countResourcesNeedingUpdate(userId), 0);
+      expect(await countNeedingUpdate(userId), 0);
     });
 
     test(
       'does not count a resource flagged offline with no local address',
       () async {
         // `resource_local_address IS NOT NULL` is an `AND` *inside* the `OR`,
-        // not a third top-level case: the stale branch needs a file on disk to
-        // be stale about, whatever the revisions say.
+        // not a third top-level case. Note the column holds the CouchDB
+        // attachment *name*, not a path — `MyLibraryMapper._attachmentOf`
+        // writes it on every sync — so a synced resource normally has one and
+        // this fixture (offline with no attachment at all) is a shape only a
+        // hand-built row reaches. It is here to pin the `AND`, not to describe
+        // a state the sync produces.
         await insert(
           'a',
           userId: const [userId],
@@ -174,7 +183,7 @@ void main() {
           rev: '9-zzz',
           downloadedRev: '1-aaa',
         );
-        expect(await repository.countResourcesNeedingUpdate(userId), 0);
+        expect(await countNeedingUpdate(userId), 0);
       },
     );
   });
@@ -182,7 +191,7 @@ void main() {
   group('the null guard', () {
     test('a null user id counts nothing', () async {
       await insert('a', userId: const [userId]);
-      expect(await repository.countResourcesNeedingUpdate(null), 0);
+      expect(await countNeedingUpdate(null), 0);
     });
 
     test('a blank user id reaches the query, as the Kotlin lets it', () async {
@@ -193,7 +202,7 @@ void main() {
       // 0 either way. Pinned because the guard as written is the port's, and a
       // future reader should see the difference is deliberate.
       await insert('a', userId: const [userId]);
-      expect(await repository.countResourcesNeedingUpdate(''), 0);
+      expect(await countNeedingUpdate(''), 0);
     });
   });
 
@@ -205,15 +214,15 @@ void main() {
       await insert('mine', userId: const ['a_b']);
       await insert('theirs', userId: const ['a1b']);
 
-      expect(await repository.countResourcesNeedingUpdate('a_b'), 1);
-      expect(await repository.countResourcesNeedingUpdate('a1b'), 1);
+      expect(await countNeedingUpdate('a_b'), 1);
+      expect(await countNeedingUpdate('a1b'), 1);
     });
 
     test('escapes a user id containing a percent sign', () async {
       await insert('mine', userId: const ['a%b']);
       await insert('theirs', userId: const ['axxb']);
 
-      expect(await repository.countResourcesNeedingUpdate('a%b'), 1);
+      expect(await countNeedingUpdate('a%b'), 1);
     });
 
     test('cannot match a user id containing a backslash — in either app', () {

--- a/flutter/test/ui/home_screen_test.dart
+++ b/flutter/test/ui/home_screen_test.dart
@@ -116,6 +116,17 @@ void main() {
       () => keyIvSync ?? RecordingKeyIvSync(),
     ),
     unreadNotificationCountProvider.overrideWith((ref) => Stream.value(0)),
+    // The dashboard now keeps the bell's resource-update row current by
+    // watching a live drift count (Phase 131). Overridden here for the reason
+    // `team_voices_screen_test.dart:40-43` gives: a real drift query stream
+    // leaves a pending timer when the provider scope is torn down, and every
+    // test in this file would fail on the harness backstop rather than on
+    // anything it asserts. The behaviour itself is covered end to end in
+    // `resource_notification_reachability_test.dart`, which mounts this screen
+    // against a real database and unmounts it inside the test body.
+    resourceUpdateNotificationProvider.overrideWith(
+      (ref, userId) => Stream.value(0),
+    ),
     myLibraryStreamProvider.overrideWith(
       (ref, userId) => Stream.value(library),
     ),

--- a/flutter/test/ui/inactive_dashboard_screen_test.dart
+++ b/flutter/test/ui/inactive_dashboard_screen_test.dart
@@ -58,6 +58,14 @@ void main() {
     planetPrefsProvider.overrideWithValue(await _prefs()),
     healthKeyIvSyncProvider.overrideWith(() => RecordingKeyIvSync()),
     unreadNotificationCountProvider.overrideWith((ref) => Stream.value(0)),
+    // Overridden for the drift pending-timer reason
+    // `home_screen_test.dart` documents. Note the *inactive* cases here would
+    // pass without it — `HomeScreen` returns before reaching the watch, which
+    // is the Kotlin's `handleGuestAccess` early return and is asserted directly
+    // in `resource_notification_reachability_test.dart`.
+    resourceUpdateNotificationProvider.overrideWith(
+      (ref, userId) => Stream.value(0),
+    ),
     myLibraryStreamProvider.overrideWith(
       (ref, userId) => Stream.value(const []),
     ),

--- a/flutter/test/ui/resource_notification_reachability_test.dart
+++ b/flutter/test/ui/resource_notification_reachability_test.dart
@@ -1,0 +1,288 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/l10n/app_localizations.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/dashboard_providers.dart';
+import 'package:myplanet/providers/health_provider.dart';
+import 'package:myplanet/providers/life_provider.dart';
+import 'package:myplanet/providers/network_status_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/sync_state.dart';
+import 'package:myplanet/ui/dashboard/home_screen.dart';
+import 'package:myplanet/ui/notifications/notification_format.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/widget_harness.dart';
+
+/// Reachability guard for the resource-update notification row (Phase 131).
+///
+/// `NotificationsRepository.updateResourceNotification` was ported with six
+/// tests and no production caller — the "ported, tested, green and dead" class.
+/// Every one of those tests calls the writer directly, so none of them could
+/// see that nothing in the app ever does.
+///
+/// The three questions this file asks, per `CLAUDE.md`:
+/// **who writes this table** (the dashboard, on load), **can the writer produce
+/// values the reader's predicate matches** (`notification_format.dart`'s
+/// `resource` arm needs a bare integer, which is what the writer stores), and
+/// **does anything navigate here** (the bell, whose unread badge the row feeds).
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+class _TestLastSyncNotifier extends LastSyncNotifier {
+  @override
+  int build() => 0;
+}
+
+class _TestNetworkStatusNotifier extends NetworkStatusNotifier {
+  @override
+  NetworkStatus build() => NetworkStatus.connected;
+}
+
+class _NoopKeyIvSync extends HealthKeyIvSyncNotifier {
+  @override
+  Future<void> sync(String? role) async {}
+}
+
+UserRow _user(String id) => UserRow(
+  id: id,
+  name: 'ada',
+  rolesList: const ['learner'],
+  userAdmin: false,
+  joinDate: 0,
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  isArchived: false,
+  isUpdated: false,
+);
+
+void main() {
+  late AppDatabase database;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const {});
+    database = AppDatabase.memory();
+  });
+
+  tearDown(() => database.close());
+
+  /// A `my_library` row shaped the way a synced server document lands, not the
+  /// way a fixture would find convenient: `userId` is the JSON list
+  /// `MyLibraryDao` matches with `LIKE '%"<id>"%'`, and the download state is
+  /// spelled with the same three columns the Kotlin predicate reads.
+  MyLibraryTableCompanion resource(
+    String id, {
+    required List<String> userId,
+    bool isPrivate = false,
+    bool offline = false,
+    String? localAddress,
+    String? rev,
+    String? downloadedRev,
+  }) => MyLibraryTableCompanion.insert(
+    id: id,
+    userId: Value(userId),
+    title: Value('Resource $id'),
+    titleNormal: Value('resource $id'),
+    isPrivate: Value(isPrivate),
+    resourceOffline: Value(offline),
+    resourceLocalAddress: Value(localAddress),
+    rev: Value(rev),
+    downloadedRev: Value(downloadedRev),
+  );
+
+  Future<List<Override>> overrides(UserRow user) async => [
+    appDatabaseProvider.overrideWithValue(database),
+    sessionProvider.overrideWith(() => _TestSessionNotifier(user)),
+    planetPrefsProvider.overrideWithValue(
+      PlanetPrefs(await SharedPreferences.getInstance()),
+    ),
+    healthKeyIvSyncProvider.overrideWith(_NoopKeyIvSync.new),
+    myCoursesStreamProvider.overrideWith(
+      (ref, userId) => Stream.value(const []),
+    ),
+    myTeamsStreamProvider.overrideWith((ref, userId) => Stream.value(const [])),
+    lifeItemsProvider.overrideWith((ref) => Stream.value(const [])),
+    pendingSurveysProvider.overrideWith((ref, userId) async => const []),
+    lastSyncProvider.overrideWith(_TestLastSyncNotifier.new),
+    completedCoursesProvider.overrideWith((ref, userId) async => const []),
+    teamNotificationsProvider.overrideWith((ref, userId) async => const {}),
+    offlineLoginCountProvider.overrideWith((ref, userName) async => 0),
+    networkStatusProvider.overrideWith(_TestNetworkStatusNotifier.new),
+  ];
+
+  /// Mounts the dashboard against the real database and then tears the tree
+  /// down again *inside* the test body.
+  ///
+  /// The teardown is not tidiness. This file is the one place in the suite that
+  /// runs `HomeScreen` with live drift query streams rather than overridden
+  /// ones (`team_voices_screen_test.dart:40-43` explains why the others do
+  /// not): cancelling a drift stream schedules a zero-duration timer through
+  /// `StreamQueryStore.markAsClosed`, and if the `ProviderScope` is disposed by
+  /// the harness backstop after the body returns, that timer is still pending
+  /// and every test here fails with `'!timersPending'` — a failure that says
+  /// nothing about the behaviour under test. Unmounting and settling first lets
+  /// the cancel run while there is still a fake clock to run it on.
+  ///
+  /// The assertions come after, reading the database directly, which is what
+  /// makes that ordering harmless: the row outlives the widget.
+  Future<void> mountDashboard(WidgetTester tester, UserRow user) async {
+    await tester.pumpWidget(
+      wrapScreen(const HomeScreen(), overrides: await overrides(user)),
+    );
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('loading the dashboard writes the resource-update notification', (
+    tester,
+  ) async {
+    const userId = 'org.couchdb.user:ada';
+    await database.myLibraryDao.upsertAll([
+      // On the shelf, public, never downloaded — counts.
+      resource('a', userId: const [userId]),
+      // On the shelf, public, downloaded but the server moved on — counts.
+      resource(
+        'b',
+        userId: const [userId],
+        offline: true,
+        localAddress: '/tmp/b',
+        rev: '2-def',
+        downloadedRev: '1-abc',
+      ),
+      // On the shelf, downloaded and current — does not count.
+      resource(
+        'c',
+        userId: const [userId],
+        offline: true,
+        localAddress: '/tmp/c',
+        rev: '1-abc',
+        downloadedRev: '1-abc',
+      ),
+      // Not on this user's shelf — does not count.
+      resource('d', userId: const ['org.couchdb.user:bob']),
+      // Private — does not count, whatever its download state.
+      resource('e', userId: const [userId], isPrivate: true),
+      // Flagged offline but with no local address: the second disjunct
+      // requires `resource_local_address IS NOT NULL`, so this is excluded
+      // however the revisions compare. Easy to miss — it is an `AND` inside
+      // the `OR`, not a third top-level case.
+      resource('f', userId: const [userId], offline: true, rev: '9-zzz'),
+    ]);
+
+    await mountDashboard(tester, _user(userId));
+
+    final row = await database.notificationDao.getById(
+      '$userId:resource:count',
+    );
+    expect(
+      row,
+      isNotNull,
+      reason: 'the dashboard must author the resource-update notification',
+    );
+    expect(row!.message, '2');
+    expect(row.type, 'resource');
+    expect(row.isRead, isFalse);
+  });
+
+  testWidgets('the row the dashboard writes renders through the resource arm', (
+    tester,
+  ) async {
+    const userId = 'org.couchdb.user:ada';
+    await database.myLibraryDao.upsertAll([
+      resource('a', userId: const [userId]),
+      resource('b', userId: const [userId]),
+      resource('c', userId: const [userId]),
+    ]);
+
+    await mountDashboard(tester, _user(userId));
+
+    final row = await database.notificationDao.getById(
+      '$userId:resource:count',
+    );
+    expect(row, isNotNull);
+
+    // `notification_format.dart`'s `resource` arm reads `kotlinToIntOrNull`,
+    // which only succeeds on a bare integer. This asserts the live writer
+    // produces a value that predicate matches — the second reachability
+    // question, and the one a fixture-built row cannot answer.
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(
+      formatNotification(row!, l10n: l10n).text,
+      'You have 3 resources not downloaded',
+    );
+  });
+
+  testWidgets('an inactive user gets no resource notification', (tester) async {
+    // `DashboardActivity.kt:165-182` calls `handleGuestAccess()` and
+    // `return@launch`es **before** `initializeDashboard()`, so for a user with
+    // no roles and no admin flag none of the three triggers ever runs — no data
+    // observer, no notification check, no badge. The port's equivalent gate is
+    // `HomeScreen.build`'s early return to `InactiveDashboardScreen`, and the
+    // watch has to sit below it: placed above, the port would author a row the
+    // Android app never writes, on the one screen that cannot show it.
+    //
+    // Despite its name `handleGuestAccess` gates on the *inactive* condition,
+    // not on guest — a guest carries `roles: ["guest"]`, so `rolesList` is
+    // non-empty and a guest falls through to the full dashboard and does get
+    // the row. The test below pins that half too.
+    const userId = 'org.couchdb.user:inert';
+    await database.myLibraryDao.upsertAll([
+      resource('a', userId: const [userId]),
+      resource('b', userId: const [userId]),
+    ]);
+
+    final inactive = UserRow(
+      id: userId,
+      name: 'inert',
+      rolesList: const [],
+      userAdmin: false,
+      joinDate: 0,
+      isArchived: false,
+      isUpdated: false,
+    );
+
+    await mountDashboard(tester, inactive);
+
+    expect(
+      await database.notificationDao.getById('$userId:resource:count'),
+      isNull,
+      reason: 'the inactive dashboard runs none of the Kotlin triggers',
+    );
+  });
+
+  testWidgets('a guest does get one — `roles: ["guest"]` is not empty', (
+    tester,
+  ) async {
+    const userId = 'guest_ada';
+    await database.myLibraryDao.upsertAll([
+      resource('a', userId: const [userId]),
+    ]);
+
+    final guest = UserRow(
+      id: userId,
+      name: 'guest_ada',
+      rolesList: const ['guest'],
+      userAdmin: false,
+      joinDate: 0,
+      isArchived: false,
+      isUpdated: false,
+    );
+
+    await mountDashboard(tester, guest);
+
+    final row = await database.notificationDao.getById(
+      '$userId:resource:count',
+    );
+    expect(row, isNotNull, reason: 'Kotlin has no guest gate on this path');
+    expect(row!.message, '1');
+  });
+}

--- a/flutter/test/ui/resource_notification_reachability_test.dart
+++ b/flutter/test/ui/resource_notification_reachability_test.dart
@@ -285,4 +285,67 @@ void main() {
     expect(row, isNotNull, reason: 'Kotlin has no guest gate on this path');
     expect(row!.message, '1');
   });
+
+  test('the writer does not outlive the dashboard', () async {
+    // `setupDashboardDataObserver` (`DashboardActivity.kt:591-595`) collects
+    // through `collectWhenStarted`, i.e. `repeatOnLifecycle(STARTED)`
+    // (`FlowExtensions.kt:38-43`), bound to the activity. When the dashboard
+    // finishes — logout, or any route that replaces it — the collection stops
+    // and nothing rewrites the row until the user opens the dashboard again.
+    //
+    // A plain `StreamProvider.family` does not do that: its element lives for
+    // the container's lifetime, so the stream stays subscribed after the last
+    // listener goes and keeps writing. `SessionNotifier.signOut` invalidates
+    // nothing, so the concrete failure is: Alice reads her notification and
+    // logs out, Bob signs in and syncs, the sync writes `my_library`, and
+    // *Alice's* row is rewritten unread with a `createdAt` from inside Bob's
+    // session — which is the sort key for `watchForUser`
+    // (`ORDER BY isRead ASC, createdAt DESC`) and the relative-time label.
+    //
+    // Hence `.autoDispose`. Note the neighbouring families in this file are
+    // deliberately *not* auto-disposing — they are pure readers, where a stale
+    // live stream costs nothing. This is the only one that writes.
+    const userId = 'org.couchdb.user:alice';
+    final container = ProviderContainer(
+      overrides: [appDatabaseProvider.overrideWithValue(database)],
+    );
+    addTearDown(container.dispose);
+
+    await database.myLibraryDao.upsertAll([
+      resource('a', userId: const [userId]),
+    ]);
+
+    final subscription = container.listen(
+      resourceUpdateNotificationProvider(userId),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    await pumpEventQueue();
+    expect(
+      await database.notificationDao.getById('$userId:resource:count'),
+      isNotNull,
+      reason: 'the dashboard writes while it is listening',
+    );
+
+    // The dashboard goes away, and the row is cleared the way a user deleting
+    // it from the bell would clear it.
+    subscription.close();
+    // Riverpod schedules auto-disposal rather than doing it inline, so the
+    // cancellation has to be given a turn of the event loop before the row is
+    // cleared — otherwise the stream is still live and simply rewrites it.
+    await pumpEventQueue();
+    await database.notificationDao.deleteById('$userId:resource:count');
+
+    // Someone else's session syncs and touches the shelf.
+    await database.myLibraryDao.upsertAll([
+      resource('b', userId: const [userId]),
+    ]);
+    await pumpEventQueue();
+
+    expect(
+      await database.notificationDao.getById('$userId:resource:count'),
+      isNull,
+      reason: 'nothing should write this row once the dashboard is gone',
+    );
+  });
 }


### PR DESCRIPTION
Lane A of the Phase 131 parallel round. **Ready — gate green, both audit passes run.**

`NotificationsRepository.updateResourceNotification` was ported with six tests and no
production caller, so the port's bell never carried the Android app's *"You have N resources
not downloaded"* row. It has a caller now: the count, the dashboard hook, and the
`notification_format.dart` `resource` arm those make live.

## For the integrator

- Base `claude/kotlin-flutter-dart-migration-d3gmrd`, `mergeable_state: clean`, all five checks green on `1915a7e`.
- **No Drift `schemaVersion` bump** — a counting query adds no DDL. No lane needed one this round.
- Files touched, all within this lane's allocation:
  `flutter/lib/data/local/app_database.dart`, `flutter/lib/repository/resources_repository.dart`,
  `flutter/lib/providers/dashboard_providers.dart`, `flutter/lib/ui/dashboard/home_screen.dart`,
  plus `flutter/test/ui/home_screen_test.dart`, `flutter/test/ui/inactive_dashboard_screen_test.dart`,
  two new test files and `flutter/PHASE_131_NOTES.md`.
  `notification_format.dart` and `notifications_repository.dart` were **read but not modified** —
  the existing `resource` arm and writer both turned out correct once a caller existed.
- **Merge note:** adding a live drift stream to `HomeScreen` requires the two existing dashboard
  test harnesses to override `resourceUpdateNotificationProvider`. If another lane also touched
  `home_screen_test.dart`, check that override survived the merge — without it 22 tests fail on
  `'!timersPending'` with no failed expectation, which reads like an unrelated flake.

## The brief's premise was wrong

`countPublicNeedingUpdateForUserPattern` (`MyLibraryDao.kt:119-124`) is the **My Library shelf**
predicate (`userId LIKE`) plus a not-downloaded-or-stale clause — not the public-catalog predicate.
The catalog one is `getPublicNotUserPattern`, the next method down. Phase 130's note read two lines
too far and the brief repeated it. Under the wrong reading the row would have counted resources the
user has never added and excluded every one they have. Pinned by a fixture that counts 1 under the
shelf predicate and 2 under the catalog one.

## Three defects, each demonstrated failing first

1. **The dead row** — both reachability tests failed `Expected: not null / Actual: <null>`.
2. **Placement** — the watch first sat *above* `HomeScreen`'s inactive-user early return.
   `DashboardActivity` returns from `handleGuestAccess` before `initializeDashboard`, so an inactive
   user runs none of the triggers; the port was authoring a row Android never writes, for the one
   user with no bell to see it. A guest is *not* inactive (`roles: ["guest"]`) and does get the row.
3. **Lifetime** — the provider was a plain `StreamProvider.family`, so the writer outlived the
   screen. Alice reads her notification and logs out, Bob signs in and syncs, and the sync's
   `my_library` write rewrites *Alice's* row unread with a `createdAt` from inside Bob's session —
   the sort key for `watchForUser`. Kotlin's collection is activity-scoped; `.autoDispose` matches it.

All three mutation-checked: `IS NOT`→`!=` reddens exactly one test, shelf→catalog reddens nine,
reverting `.autoDispose` reddens one.

## Reported, not fixed — outside this lane's files

Full list in `flutter/PHASE_131_NOTES.md`. The two most actionable:

- **The Android tap opens My Library; the port's opens the catalog.** `openMyFragment` sets
  `isMyCourseLib = true`; the port maps `resource` → `/resources` with no shelf toggle. One line in
  `lib/ui/notifications/notification_destination.dart`. Now reachable, where before it was dead either way.
- **Five unescaped `LIKE` interpolations** in `app_database.dart`, two of them in `CourseDao`.
  Kotlin escapes throughout; `likeEscapedUserPattern` is now available for whoever takes it.

https://claude.ai/code/session_018pXGu1rcjgz8A48JViyxDL