### PR TITLE
Phase 132 (Lane B): plumb the team through the port's survey answer sheets

### DIFF
--- a/flutter/PHASE_132_NOTES.md
+++ b/flutter/PHASE_132_NOTES.md
@@ -18,7 +18,8 @@ The brief (and Phase 129's notes) said **"every answer sheet the port writes is
 team-less where Kotlin's carries the team."** The first half is true, the second
 overstates the comparison, and the audit was right to say so.
 
-Kotlin has **six** survey journeys, and only **two** carry a team:
+Kotlin has **seven** survey journeys (plus a course step's *exam*), and only
+**two** carry a team:
 
 | entry point | `isMySurvey` | `isTeam` | `teamId` |
 |---|---|---|---|
@@ -28,19 +29,26 @@ Kotlin has **six** survey journeys, and only **two** carry a team:
 | `SubmissionsAdapter:98` (my-surveys row) | true | false | `""` |
 | `BellDashboardFragment:256` (pending prompt) | true | false | `""` |
 | `CourseStepFragment:289` (a course step's survey) | false | false | `""` |
-| `CourseStepFragment:277-282` (a course step's **exam**) | false | false | absent |
+| `DashboardActivity:220` (`surveyNavigationEvent`) | false | false | `""` |
+| `CourseStepFragment:275-284` (a course step's **exam**) | false | false | absent |
 
 The flag and the id are only ever set together, and `TeamPagerAdapter:89-94` is
 the **only** producer of the pair — the other three `SurveyFragment()`
-constructions and `BaseExamFragment.navigateToSurveyList` set neither. So four
-of the six port paths were already at parity by doing nothing, and the phase is
-about the two that were not.
+constructions and `BaseExamFragment.navigateToSurveyList` set neither. So five
+of the seven port paths were already at parity by doing nothing, and the phase
+is about the two that were not.
+
+**The count was "six" in the first draft, and the implementation audit caught
+it**: `DashboardActivity:220`'s `surveyNavigationEvent` is an eighth
+`openSurvey` call site the table had omitted. It passes `false, false, ""`, so
+no port change follows and the conclusion is unaffected — but a table that
+claims to be exhaustive has to be.
 
 **The exam arm is confirmed unreachable with a team**, which Phase 129 claimed
 and this pass proved from the call sites rather than by analogy: `type` defaults
 to `"exam"` (`BaseExamFragment:52`) and is only overwritten from the bundle
 (`:95-99`); every survey site hard-codes `putString("type", "survey")`, and the
-one bundle that omits it — `CourseStepFragment:277-285` — carries only `stepId`
+one bundle that omits it — `CourseStepFragment:275-284` — carries only `stepId`
 and `stepNum`, so `isTeam` is false there and `if (isTeam) teamId else null` is
 structurally null.
 
@@ -67,7 +75,7 @@ Three choices in there are deliberate:
 * **`teamId` as the query key, not `team`.** `addResource` and `userInfo`
   already read exactly that key (`router.dart:267,319`), so the alternative
   would have made this the odd one out. The mutation that renames it is one of
-  the fourteen below, because a route reading `team` where the push writes
+  the fifteen below, because a route reading `team` where the push writes
   `teamId` is the Phase 74/100 shape.
 * **The location stays a literal at the call site.** A `surveyLocation(...)`
   helper in `router.dart` reads better and would have been *worse*:
@@ -123,6 +131,23 @@ and it also puts the order where Kotlin has it — the queue runs *after*
 `enqueue` dedupes on `(uploadType, itemId)`, so a path that pops twice cannot
 double-post.
 
+**A third half of the gate landed after the implementation audit.** Kotlin's
+condition is `!isMySurvey && exam?.isFromNation != true`, and the first cut
+ported only the second half. No pusher pairs `?submission=` with `?teamId=`, so
+a resumed team sheet is latent — but `updateSurveyResponse` deliberately
+carries no team, so such a sheet would have been asked for a profile it could
+not attribute. `widget.submissionId == null` makes the gate line-for-line, and
+a test drives a real resumed sheet through it (asserting the answer was stored,
+so the gate cannot pass merely because nothing happened).
+
+**`public_survey_screen` does *not* apply the `isFromNation` half**, and the
+asymmetry is now stated at the call site rather than left for the next reader
+to find. Kotlin's nation arm inside `PublicSurveyActivity` is
+`navigateToSurveyList` with `addToBackStack = false`, after which neither the
+back-stack listener nor `onFragmentDetached` fires and the answers are never
+POSTed at all. Porting the gate there would mean porting that, and delivering
+the answers is the deep link's whole purpose.
+
 **Review `user_information_screen.dart` with `git diff -w`.** Wrapping the
 returned `Scaffold` re-indents the whole build method: 292 changed lines, of
 which 28 are real. The alternative placements all cost a reindent of something,
@@ -163,12 +188,25 @@ thing in the round. `team_surveys_screen.dart` passed
 
 An adopted team survey always has a `sourceSurveyId`, so every Send from the
 team tab created the members' pending sheets against the **un-adopted
-original**: `parentId = <source>`, answers filed against the source, and the
-team's own copy — which is what `submissionsForTeam` and the adoptable list read
-— showing zero submissions forever. `surveys_screen.dart:118` already passed
-`row.id`; **the two screens disagreeing was the tell.** The port's `adoptSurvey`
-copies the questions onto the clone (`surveys_repository.dart:96-135`), so there
-was no lookup reason for the old value either.
+original**: `parentId = <source>`, so their answers filed against the source
+survey rather than against the team's own copy — mis-attributed at the parent
+id, which is what identifies a survey's responses.
+`surveys_screen.dart:118` already passed `row.id`; **the two screens
+disagreeing was the tell.** The port's `adoptSurvey` copies the questions onto
+the clone (`surveys_repository.dart:96-135`), so there was no lookup reason for
+the old value either.
+
+**The symptom I first wrote for this was the wrong mechanism, and the
+implementation audit was right to reject it.** I claimed the team's own copy
+"read zero submissions forever, because that is what `submissionsForTeam` and
+the adoptable list read". Neither reader can see a bulk-created sheet under
+*either* id: `getOrCreateSurveySubmission` writes no `teamId` column and no
+`parent` document (`submissions_repository.dart:683-695`), while
+`submissionsForTeam` is `byTeam` on that column and `_teamSubmissionSurveyIds`
+reads `parent._id`. Verified in both directions. The change is right because
+Kotlin does it and because the parent id is the attribution; it does **not**
+repair those readers, and the corrected reasoning now stands in the code
+comment and the test rather than only here.
 
 Worth recording so nobody re-litigates the severity: Kotlin's own Send button is
 **invisible** — `SurveysAdapter` sets `sendSurvey.visibility = View.GONE` in the
@@ -203,7 +241,7 @@ they could be written:
 
 ## Tests
 
-`test/ui/surveys/survey_team_context_test.dart`, 12 new tests, plus 5 in
+`test/ui/surveys/survey_team_context_test.dart`, 13 new tests, plus 5 in
 `user_information_screen_test.dart`, 1 in `team_surveys_screen_test.dart` and 2
 in `public_survey_screen_test.dart`.
 
@@ -222,14 +260,20 @@ passed alone while the whole was broken:
 * and one test that walks the whole journey — team tab → real
   `TakeSurveyScreen` → profile → back on the tab.
 
-**Mutation-tested: fourteen injected, fourteen killed**, each by a test that names
+**Mutation-tested: fifteen injected, fifteen killed**, each by a test that names
 it. Dropping the query parameter; renaming the route's read to `team`; dropping
 the forward at each of the two repository hops; dropping the public screen's id;
 re-seeding the Phase 106 pop gate; never asking who the respondent is; ignoring
 `isFromNation`; going to the submission detail instead of popping back; queueing
 before the profile step; not queueing on Cancel; dropping the team gate on the
 queue; deferring `_queueUpload`'s `ref` reads past its first `await`; and
-narrowing the pop hook to a `true` result, which is the back button's exit.
+narrowing the pop hook to a `true` result, which is the back button's exit; and
+dropping the resume half of the profile gate.
+
+The implementation audit ran sixteen of its own on a scratchpad copy, including
+one this set had not covered — breaking the *pushed path* to `/surveys/typo/…`,
+which `route_reachability_test` kills, confirming the guard still reads the new
+literal. None survived.
 
 The twelfth is the one worth the note: **queueing before the profile step
 passed at first.** `enqueue` refreshes an open row's payload, so the end state
@@ -285,6 +329,71 @@ notification UI; Lane C: `app/` and `docs/`), the change is additive and
 forwarding-only, and every other edit is inside the set. Flagged on the PR too.
 
 ## Reported, not fixed
+
+### Nothing sweeps `pendingUploads`, and this phase leans on that
+
+**The most important thing the implementation audit found, and my change made
+it reachable.** Kotlin has two ways a completed sheet reaches the server: the
+dismissal (`UserInformationFragment:303`) *and* `uploadManager.uploadSubmissions()`
+running unconditionally from `AutoSyncWorker:136`, `UserDataWorker:48` and
+`ServerReachabilityWorker:183,186`. A missed dismissal costs nothing there.
+
+The port has **no `queuePending` sweep in any sync or background path**. Its
+only writers of a submissions outbox row are four write-time call sites
+(`take_survey_screen:252`, `user_information_screen:471`,
+`take_exam_screen:544`, `submissions_screen:187`);
+`background_entrypoint.dart:177-184`'s `'submissions'` step is the *pull*, and
+`OutboxDrainScope` only drains rows that already exist.
+
+Before this phase a team survey's row was enqueued at submit time. Now it is
+enqueued at the profile screen's pop — the Kotlin order, and the one that
+avoids the double POST above — so two windows end with the sheet queued by
+nobody: **process death while the profile screen is open**, and the
+`if (!mounted) return` before the push. In both, `submissions` holds a
+`complete, isUpdated, !uploaded` team sheet with no outbox row, and it stays
+there until the same user completes some *other* submission, because
+`queuePending` is an unscoped sweep that then rescues it. Reproduce it by
+answering a team survey, tapping Submit, and force-stopping the app on "Your
+information".
+
+Not data loss — the answers are on the device — but for a field survey an
+indefinitely deferred delivery is the same outcome. **The fix is a
+`queuePending` step in the sync path**, beside the existing steps in
+`lib/providers/dashboard_sync_provider.dart` and
+`lib/background_entrypoint.dart`, which is where Kotlin's safety net lives.
+Both are outside this lane's set; the gap is pre-existing and port-wide (it
+applies equally to an exam attempt whose queue call fails), and it wants the
+owner of the sync path rather than a third out-of-set edit from here. Whoever
+takes it should treat it as the round's highest-value item.
+
+### `adoptSurvey` does not copy `courseId`/`stepId` onto the clone
+
+`createMappedSurvey` copies both onto an adopted team clone
+(`SurveysRepositoryImpl.kt:441-456`); `surveys_repository.dart:99-118` sets 14
+fields and neither, though `Surveys` has both columns
+(`tables.dart:541-542`). The Send fix above now depends on it: with the clone's
+own id being sent, `createBulkSurveySubmissions` resolves
+`survey?.courseId == null` and keys the members' sheets `<cloneId>` where
+Kotlin keys `"<cloneId>@<courseId>"` — Phase 125's class, in the one place the
+Phase 125 sweep cannot reach (`_repairSurveyParentId` returns 0 when
+`target == survey.id`). And `hasUnfinishedSurveys` selects by
+`getByCourseId`, so the port's clone is invisible to the mandatory-survey gate
+where Kotlin's is one more requirement in it. Reachable only for a
+`teamShareAllowed` survey that also carries a `courseId`. Two field copies in a
+file outside this set.
+
+### The Send id change is a parentId key change with no repair
+
+`createBulkSurveySubmissions`' existence check is
+`latestPendingByUserAndParent`, on the whole column. A team that used Send
+*before* this change has member sheets under `<sourceId>`; after it, Send
+creates a **second** pending sheet under `<cloneId>` — the shape
+`submissions_repository.dart:645-652` describes for the Phase 125 key change,
+which shipped `repairCourseSurveyParentIds` while this one ships nothing.
+Mitigating: Kotlin's Send button is invisible (`SurveysAdapter:62`, never set
+`VISIBLE`), so the port's is a surplus affordance and real usage is unknown. A
+decision rather than an obvious repair, and it belongs with whoever decides
+whether the port keeps that button at all.
 
 ### Adopt is gated on team leadership; Kotlin gates on guest
 
@@ -382,9 +491,11 @@ parsing `?teamId=`, and nothing navigates to it — it sits in
 `route_reachability_test`'s `allowed` map. This phase did **not** change that:
 `take_survey_screen` pushes the screen with `Navigator.push`, matching
 `public_survey_screen` and matching Kotlin, where it is a dialog over the
-survey rather than a destination. Either the route should be removed or a
-caller should use it; leaving a parsed-but-unreachable route is how the
-`teamId` this phase just wired sat unread in the first place.
+survey rather than a destination. What did change is that the route is now
+spare with **two** live builders instead of one, which the allowlist's reason
+string said out loud only after the implementation audit noticed it was stale.
+Either give the route a caller or delete it; leaving a parsed-but-unreachable
+route is how the `teamId` this phase wired sat unread in the first place.
 
 ### Kotlin's degenerate team survey has no guard, and the port inherits none
 
@@ -409,3 +520,31 @@ the *individual* list, losing the team context — and inside
 is POSTed. The port's nation-survey arm goes to the submission detail instead.
 Since the arm is dead in Kotlin and its Kotlin behaviour is partly broken,
 matching it would be porting a bug; recorded rather than copied.
+
+### Smaller confirmed divergences, all currently unreachable
+
+* **A whitespace-only team id.** `onDismiss`'s gate is exact string equality —
+  `if (safeTeamId == "") return` — so `" "` *uploads* in Kotlin, where
+  `user_information_screen`'s `.trim().isEmpty` does not. No port path can
+  produce one (the value comes from a route parameter fed by `team.id`), and
+  the repository's own `.trim()` is right there because that writer really is
+  `isNotBlank`. Left as is: the two Kotlin sites genuinely differ, so being
+  faithful means differing, and churning unreachable semantics costs more than
+  it buys.
+* **Two silent returns in `_submit`.** `if (id == null) return` leaves the user
+  on a reset form with no message when `submitResponse` finds no survey row,
+  and `if (!mounted) return` is the second window of the sweep item above.
+  Both pre-existing; the first is behaviourally unchanged by this phase.
+
+### Two of the thirteen new tests are negative controls
+
+`'a personal survey stores no team'` and `'a personal survey location builds a
+team-less screen'` assert an absence that holds trivially on the pre-fix tree.
+They are worth keeping — they are what would catch a future change that starts
+attributing personal sheets to a team — but they are controls, not evidence,
+and no mutation in the table below is killed by them alone.
+
+Related, and a claim of mine the audit trimmed: the whole-journey test's
+`pushTargets` hand-writes `queryParameters['teamId']`, so it *is* a third copy
+of the key. "No third copy" is true only of `tapOwnedSurvey` +
+`_buildFromRouter`, which is the pair that actually guards the route's read.

--- a/flutter/PHASE_132_NOTES.md
+++ b/flutter/PHASE_132_NOTES.md
@@ -1,0 +1,15 @@
+# Phase 132 — plumbing the team through the port's answer sheets
+
+Lane B of a three-lane round. Branch `claude/survey-team-context-m2p6`.
+
+Closes the reachability half of Phase 129 item 1: `createSurveyDraft(teamId:)`
+and `startExamSession(teamId:)` exist and are tested, and **no caller passes a
+team**, so every answer sheet the port writes is team-less where Kotlin's
+carries the team.
+
+Notes are written as the work proceeds; this file is a stub until the first
+findings land.
+
+## Reported, not fixed
+
+_(pending)_

--- a/flutter/PHASE_132_NOTES.md
+++ b/flutter/PHASE_132_NOTES.md
@@ -67,7 +67,7 @@ Three choices in there are deliberate:
 * **`teamId` as the query key, not `team`.** `addResource` and `userInfo`
   already read exactly that key (`router.dart:267,319`), so the alternative
   would have made this the odd one out. The mutation that renames it is one of
-  the thirteen below, because a route reading `team` where the push writes
+  the fourteen below, because a route reading `team` where the push writes
   `teamId` is the Phase 74/100 shape.
 * **The location stays a literal at the call site.** A `surveyLocation(...)`
   helper in `router.dart` reads better and would have been *worse*:
@@ -102,7 +102,7 @@ The two Kotlin reads of `teamId`, and what each became:
 | Kotlin | port |
 |---|---|
 | `submitForm:151-174` — a non-empty team routes the profile onto the *submission* rather than onto the signed-in user's own document | inert: this screen requires a `submissionId`, so it always takes Kotlin's `saveSubmission` arm anyway. Documented, not coded. |
-| `onDismiss:293-311` — a non-empty team uploads, **on every dismissal, Cancel included** | ported: `_queueUpload` is gated on the team id and `_cancel` now calls it |
+| `onDismiss:293-311` — a non-empty team uploads, **on every dismissal**: Save, Cancel, an outside tap, the back button | ported: `_queueUpload` is gated on the team id and hangs off the screen's `PopScope`, so all three exits take it |
 
 The toast and `popBackStack` that Kotlin gates on the same value are
 deliberately **not** ported to that gate: each port screen owns its own
@@ -111,6 +111,23 @@ and a second identical snackbar would queue behind the first on the one path
 that reaches the screen today. The pop is owned by `take_survey_screen`, which
 lands the respondent back on the team's surveys tab — Kotlin's
 `FragmentNavigator.popBackStack` — instead of on a submission detail.
+
+**The queue hangs off the pop, not off the buttons, and that was the second
+thing my own re-read caught.** `onDismiss` is not the Cancel handler — it is
+every dismissal, the system back button included. Wiring the two buttons left
+the back button as a silent third exit that saved nothing and sent nothing:
+exactly the defect the Cancel fix had just removed, in the same method. A
+`PopScope` whose `onPopInvokedWithResult` calls `_queueUpload` covers all three,
+and it also puts the order where Kotlin has it — the queue runs *after*
+`markSubmissionComplete`, so the enqueued payload carries the profile.
+`enqueue` dedupes on `(uploadType, itemId)`, so a path that pops twice cannot
+double-post.
+
+**Review `user_information_screen.dart` with `git diff -w`.** Wrapping the
+returned `Scaffold` re-indents the whole build method: 292 changed lines, of
+which 28 are real. The alternative placements all cost a reindent of something,
+and hanging one hook off the pop is what makes the three exits agree — which is
+the point, since two of them disagreeing is what this fixed.
 
 **The Cancel path had a hazard of its own, found by re-reading my own diff.**
 `_cancel` pops before the queue finishes, so the `State` can be disposed while
@@ -186,7 +203,7 @@ they could be written:
 
 ## Tests
 
-`test/ui/surveys/survey_team_context_test.dart`, 12 new tests, plus 4 in
+`test/ui/surveys/survey_team_context_test.dart`, 12 new tests, plus 5 in
 `user_information_screen_test.dart`, 1 in `team_surveys_screen_test.dart` and 2
 in `public_survey_screen_test.dart`.
 
@@ -205,13 +222,14 @@ passed alone while the whole was broken:
 * and one test that walks the whole journey — team tab → real
   `TakeSurveyScreen` → profile → back on the tab.
 
-**Mutation-tested: thirteen injected, thirteen killed**, each by a test that names
+**Mutation-tested: fourteen injected, fourteen killed**, each by a test that names
 it. Dropping the query parameter; renaming the route's read to `team`; dropping
 the forward at each of the two repository hops; dropping the public screen's id;
 re-seeding the Phase 106 pop gate; never asking who the respondent is; ignoring
 `isFromNation`; going to the submission detail instead of popping back; queueing
 before the profile step; not queueing on Cancel; dropping the team gate on the
-queue; and deferring `_queueUpload`'s `ref` reads past its first `await`.
+queue; deferring `_queueUpload`'s `ref` reads past its first `await`; and
+narrowing the pop hook to a `true` result, which is the back button's exit.
 
 The twelfth is the one worth the note: **queueing before the profile step
 passed at first.** `enqueue` refreshes an open row's payload, so the end state

--- a/flutter/PHASE_132_NOTES.md
+++ b/flutter/PHASE_132_NOTES.md
@@ -67,7 +67,7 @@ Three choices in there are deliberate:
 * **`teamId` as the query key, not `team`.** `addResource` and `userInfo`
   already read exactly that key (`router.dart:267,319`), so the alternative
   would have made this the odd one out. The mutation that renames it is one of
-  the twelve below, because a route reading `team` where the push writes
+  the thirteen below, because a route reading `team` where the push writes
   `teamId` is the Phase 74/100 shape.
 * **The location stays a literal at the call site.** A `surveyLocation(...)`
   helper in `router.dart` reads better and would have been *worse*:

--- a/flutter/PHASE_132_NOTES.md
+++ b/flutter/PHASE_132_NOTES.md
@@ -1,15 +1,393 @@
-# Phase 132 — plumbing the team through the port's answer sheets
+# Phase 132 — the team context an answer sheet is written with
 
-Lane B of a three-lane round. Branch `claude/survey-team-context-m2p6`.
+Lane B of a three-lane round. Branch `claude/survey-team-context-m2p6`, PR
+#16929.
 
-Closes the reachability half of Phase 129 item 1: `createSurveyDraft(teamId:)`
-and `startExamSession(teamId:)` exist and are tested, and **no caller passes a
-team**, so every answer sheet the port writes is team-less where Kotlin's
-carries the team.
+Closes the reachability half of Phase 129: `createSurveyDraft(teamId:)` and
+`startExamSession(teamId:)` shipped **with no caller**, so the parameter was
+correct, tested, green and dead.
 
-Notes are written as the work proceeds; this file is a stub until the first
-findings land.
+Two `parity-auditor` passes at `effort: max` ran per the standing rule — one on
+the Kotlin ground truth before any code, one aimed at this lane's own finished
+code. Both found real defects, and the ground-truth pass corrected my brief's
+own framing; the corrections are folded in below rather than appended.
+
+## The premise, corrected
+
+The brief (and Phase 129's notes) said **"every answer sheet the port writes is
+team-less where Kotlin's carries the team."** The first half is true, the second
+overstates the comparison, and the audit was right to say so.
+
+Kotlin has **six** survey journeys, and only **two** carry a team:
+
+| entry point | `isMySurvey` | `isTeam` | `teamId` |
+|---|---|---|---|
+| `SurveysAdapter:88` from the team detail's Surveys tab | false | **true** | **`team?._id`** |
+| `PublicSurveyActivity:100-108` (deep link) | false | **true** | **the link's team** |
+| `SurveysAdapter:88` from the individual list | false | false | `null` |
+| `SubmissionsAdapter:98` (my-surveys row) | true | false | `""` |
+| `BellDashboardFragment:256` (pending prompt) | true | false | `""` |
+| `CourseStepFragment:289` (a course step's survey) | false | false | `""` |
+| `CourseStepFragment:277-282` (a course step's **exam**) | false | false | absent |
+
+The flag and the id are only ever set together, and `TeamPagerAdapter:89-94` is
+the **only** producer of the pair — the other three `SurveyFragment()`
+constructions and `BaseExamFragment.navigateToSurveyList` set neither. So four
+of the six port paths were already at parity by doing nothing, and the phase is
+about the two that were not.
+
+**The exam arm is confirmed unreachable with a team**, which Phase 129 claimed
+and this pass proved from the call sites rather than by analogy: `type` defaults
+to `"exam"` (`BaseExamFragment:52`) and is only overwritten from the bundle
+(`:95-99`); every survey site hard-codes `putString("type", "survey")`, and the
+one bundle that omits it — `CourseStepFragment:277-285` — carries only `stepId`
+and `stepNum`, so `isTeam` is false there and `if (isTeam) teamId else null` is
+structurally null.
+
+## What landed, and why each piece is where it is
+
+### The chain (four links, one key)
+
+1. **`team_surveys_screen.dart`** pushes
+   `'${Routes.surveys}/${survey.id}?teamId=${Uri.encodeQueryComponent(teamId)}'`.
+2. **`router.dart`**'s `/life/surveys/:surveyId` reads
+   `state.uri.queryParameters['teamId']`.
+3. **`take_survey_screen.dart`** takes a nullable `teamId` and forwards it to
+   `submitResponse` — and **not** to the resume path.
+4. **`surveys_repository.dart`**'s `submitResponse` forwards it to
+   `createSurveyDraft`, which blank-guards it as `createExamSubmission:440`
+   does.
+
+Plus **`public_survey_screen.dart`**, Kotlin's second team-carrying site, where
+the value had been sitting two statements from the call and going only to
+`UserInformationScreen(teamId:)`.
+
+Three choices in there are deliberate:
+
+* **`teamId` as the query key, not `team`.** `addResource` and `userInfo`
+  already read exactly that key (`router.dart:267,319`), so the alternative
+  would have made this the odd one out. The mutation that renames it is one of
+  the twelve below, because a route reading `team` where the push writes
+  `teamId` is the Phase 74/100 shape.
+* **The location stays a literal at the call site.** A `surveyLocation(...)`
+  helper in `router.dart` reads better and would have been *worse*:
+  `route_reachability_test`'s scanner reads `'${Routes.x}/…'` literals out of
+  `lib/` and **skips `router.dart`**, so centralising would have made this
+  phase's one new navigation the one navigation that guard cannot see. It
+  handles the query string already (`_resolve` cuts at `?`).
+* **One nullable parameter for Kotlin's two arguments.** Sound because the flag
+  and the id are only ever set together (above), and because `isTeam` is the
+  sole switch on both Kotlin write sites — a `teamId` without the flag is
+  discarded there too.
+
+### The profile step — what `UserInformationScreen.teamId` is for
+
+The brief said the unread parameter is a symptom, not the defect. It is, and
+this is the defect: **`take_survey_screen` never opened that screen at all**, so
+a team survey collected nothing about its respondent.
+
+`continueExam:127-131` sends the last question of a team survey to
+`showUserInfoDialog` rather than to the thank-you dialog, and
+`showUserInfoDialog:153-164` opens `UserInformationFragment(sub.id, teamId,
+exam?.isFromNation != true)`. Its else arm — mark complete, toast, go to the
+survey list — is **dead in Kotlin**: `isMySurvey` is false at both team entry
+points, and `isFromNation`'s only writer is
+`myExam.isFromNation = !parentId.isNullOrEmpty()` (`StepExam.kt:55`) whose sole
+caller passes `""` (`SurveysRepositoryImpl.kt:387`). It is **live in the port**,
+because `SurveyMapper` reads the key off the document — so the arm is ported
+rather than dropped, and a nation survey skips the profile step here too.
+
+The two Kotlin reads of `teamId`, and what each became:
+
+| Kotlin | port |
+|---|---|
+| `submitForm:151-174` — a non-empty team routes the profile onto the *submission* rather than onto the signed-in user's own document | inert: this screen requires a `submissionId`, so it always takes Kotlin's `saveSubmission` arm anyway. Documented, not coded. |
+| `onDismiss:293-311` — a non-empty team uploads, **on every dismissal, Cancel included** | ported: `_queueUpload` is gated on the team id and `_cancel` now calls it |
+
+The toast and `popBackStack` that Kotlin gates on the same value are
+deliberately **not** ported to that gate: each port screen owns its own
+messaging, `PublicSurveyScreen` already thanks the respondent after its POST,
+and a second identical snackbar would queue behind the first on the one path
+that reaches the screen today. The pop is owned by `take_survey_screen`, which
+lands the respondent back on the team's surveys tab — Kotlin's
+`FragmentNavigator.popBackStack` — instead of on a submission detail.
+
+**The Cancel path had a hazard of its own, found by re-reading my own diff.**
+`_cancel` pops before the queue finishes, so the `State` can be disposed while
+the session future is still pending — and a `ref` read after disposal throws,
+straight into the `catch` that exists to make a *failed* queue harmless. The
+upload would have been skipped silently: the exact failure mode the gate was
+added to remove, reintroduced by the fix for it. Every `ref` read in
+`_queueUpload` is now taken synchronously, ahead of the first `await`, which
+keeps the standing rule (the `await` stays inside the `try`) while owing nothing
+to `ref` afterwards. A test holds the session pending until `pumpAndSettle` has
+disposed the route, so the window is real rather than incidental; the deferred
+version fails it.
+
+**Ordering matters here and it is now pinned.** Kotlin queues from `onDismiss`,
+*after* `markSubmissionComplete` writes the profile. The port used to queue in
+`_submit` for every path; for the team path that would enqueue a payload
+serialized before the profile existed. `OutboxRepository.enqueue` refreshes an
+open row's payload, so the end state usually survives — but a drain landing
+between the two calls `markUploaded`s the row out of `pendingUploads`
+permanently, and the profile would never go out. So `_submit` skips the queue
+when it is about to ask, and a test asserts the outbox is **empty while the
+profile screen is open**.
+
+### Send targets the survey on the card, not its source
+
+Found by the ground-truth audit, in this lane's file, and the most expensive
+thing in the round. `team_surveys_screen.dart` passed
+`survey.sourceSurveyId ?? survey.id` to `SendSurveyScreen`. Kotlin hands the
+**bound exam** straight through: `listener?.sendSurvey(current.exam)`
+(`SurveysAdapter:63-66`) → `b.putString("surveyId", current?.id)`
+(`DashboardActivity:1008-1014`) → `sendSurveyToUsers` →
+`createBulkSurveySubmissions`.
+
+An adopted team survey always has a `sourceSurveyId`, so every Send from the
+team tab created the members' pending sheets against the **un-adopted
+original**: `parentId = <source>`, answers filed against the source, and the
+team's own copy — which is what `submissionsForTeam` and the adoptable list read
+— showing zero submissions forever. `surveys_screen.dart:118` already passed
+`row.id`; **the two screens disagreeing was the tell.** The port's `adoptSurvey`
+copies the questions onto the clone (`surveys_repository.dart:96-135`), so there
+was no lookup reason for the old value either.
+
+Worth recording so nobody re-litigates the severity: Kotlin's own Send button is
+**invisible** — `SurveysAdapter` sets `sendSurvey.visibility = View.GONE` in the
+view holder's `init` (`:62`) and never sets it visible. The port's button is a
+surplus affordance. Which id its handler passes is still the Kotlin's answer to
+the question, and the port's feature is live.
+
+## Defects, each demonstrated failing first
+
+Pre-fix run kept at `prefix_evidence.txt` in the session scratchpad:
+
+```
+DEFECT 1: the team surveys tab opens the survey with no team
+  reached the survey route: true
+  Expected teamId: team-1
+    Actual teamId: null
+DEFECT 2: the public survey sheet stores no team
+  submissions written: 1
+  Expected teamId: team-1
+    Actual teamId: null
+```
+
+and, on the same tree, the four that needed the new parameters to exist before
+they could be written:
+
+* `a team survey asks the respondent who they are` — failed (no
+  `UserInformationScreen` anywhere in the flow);
+* `Send targets the survey on the card, not its source` — failed with
+  `'s1'` where `'s1_team-1'` was expected;
+* `cancel still queues the team survey for upload` — failed (nothing queued);
+* `a team-less sheet is not queued at all` — failed (queued anyway).
+
+## Tests
+
+`test/ui/surveys/survey_team_context_test.dart`, 12 new tests, plus 4 in
+`user_information_screen_test.dart`, 1 in `team_surveys_screen_test.dart` and 2
+in `public_survey_screen_test.dart`.
+
+They exercise the **chain**, not its halves, because every link here already
+passed alone while the whole was broken:
+
+* the location the team tab actually pushes;
+* that location fed to the **real route table** — `routerProvider`'s own
+  `findMatch`, then the matched `GoRoute`'s builder — so the route's parameter
+  reading is under test rather than a hand-written repetition of it. The test
+  takes the location *from the screen* rather than writing one out, so there is
+  no third copy of the key to agree with neither side;
+* the row the real repository writes, over a real in-memory database;
+* the payload the real uploader enqueues (`team: {_id: 'team-1'}` and the
+  respondent's `age`), which is the document Planet receives;
+* and one test that walks the whole journey — team tab → real
+  `TakeSurveyScreen` → profile → back on the tab.
+
+**Mutation-tested: thirteen injected, thirteen killed**, each by a test that names
+it. Dropping the query parameter; renaming the route's read to `team`; dropping
+the forward at each of the two repository hops; dropping the public screen's id;
+re-seeding the Phase 106 pop gate; never asking who the respondent is; ignoring
+`isFromNation`; going to the submission detail instead of popping back; queueing
+before the profile step; not queueing on Cancel; dropping the team gate on the
+queue; and deferring `_queueUpload`'s `ref` reads past its first `await`.
+
+The twelfth is the one worth the note: **queueing before the profile step
+passed at first.** `enqueue` refreshes an open row's payload, so the end state
+was identical and only the timing differed. The assertion that the outbox is
+empty *while the profile screen is open* is what turned a reasoned invariant
+into a checked one — Phase 122's "make the test able to fail", arrived at from
+the other direction.
+
+Two fixture problems surfaced while writing these, and both are the same
+mistake this project keeps naming:
+
+* **`user_information_screen_test.dart`'s seed cannot produce the row the
+  screen actually receives.** It seeds `status: 'pending', isUpdated: false`;
+  every real sheet arrives from `createSurveyDraft` as
+  `status: 'complete', isUpdated: true` (Kotlin marks it in `saveExamAnswer`
+  before the dialog opens, `:546-551`), and `pendingUploads` selects on
+  `isUpdated`. My cancel test asserted against the seed at first and failed
+  against correct code. The new tests put the row into its real state; the 21
+  existing tests are left alone — see *Reported, not fixed*.
+* **`take_survey_screen_test.dart` runs every submit into its own failure
+  branch.** `_submit` reads `serverConfigProvider` *inside* its `try`, that
+  notifier reads `planetPrefs`, and `planetPrefs` is `UnimplementedError` in
+  the widget harness — so the screen writes the row and then shows "Could not
+  save your answers". The existing tests assert only on the row, so nothing
+  saw it. The new tests override the provider; a production handset has real
+  prefs, so this is a harness artefact rather than a defect.
+
+## One file outside this lane's set, named here rather than buried
+
+**`flutter/lib/repository/surveys_repository.dart`** — one additive optional
+named parameter on `submitResponse`, forwarded verbatim to `createSurveyDraft`.
+
+The brief listed `submissions_repository.dart` as link 3 and told me to verify
+for myself. Verified: `createSurveyDraft` does live there (the brief is right
+about that, and Phase 129's notes were wrong), **but the method
+`TakeSurveyScreen` calls is `SurveysRepository.submitResponse`**, which is the
+only thing between the screen and the writer — so Phase 129 named the right file
+for the wrong reason, and the brief corrected a claim that happened to be true.
+
+The two ways to stay strictly inside the file set were both worse:
+
+* have the screen call `createSurveyDraft` directly — it does hold the survey
+  row and questions from the providers it watches, so no lookup is duplicated,
+  but `submitResponse` then has **no production caller at all**, and creating
+  dead code to close a dead-code gap is self-defeating;
+* stop and report — which leaves `teamId` plumbed as far as
+  `TakeSurveyScreen` and then dropped, reproducing precisely the
+  declared-and-never-read symptom this phase exists to remove.
+
+So the edit is made. No other lane owns the file this round (Lane A: the
+resources/notifications repositories, `app_database.dart`, the dashboard and
+notification UI; Lane C: `app/` and `docs/`), the change is additive and
+forwarding-only, and every other edit is inside the set. Flagged on the PR too.
 
 ## Reported, not fixed
 
-_(pending)_
+### Adopt is gated on team leadership; Kotlin gates on guest
+
+`team_surveys_screen.dart:32,78` — `canAdopt = membership?.isLeader == true`.
+Kotlin has **no role gate**: `SurveysAdapter:83-90` routes any tap to
+`onAdoptSurvey`, and the only visibility rule is
+`if (userId?.startsWith("guest") == true) startSurvey.visibility = View.GONE`
+(`:105-107`). So an ordinary member sees a disabled Adopt button where Kotlin
+adopts, and a guest sees an enabled Start affordance on **both** survey screens
+where Kotlin hides it. Same shape as Phase 99's manage-gate finding.
+
+In this lane's file, and left alone deliberately: it is an **authorization**
+change rather than team-context plumbing, and the current gate is pinned by an
+existing test (`'a non-leader sees the adopt button disabled'`), so some earlier
+round chose it. Changing a pinned gate deserves its own decision and its own
+diff. The fix is two edits — `canAdopt` becomes `userId?.startsWith('guest') !=
+true`, and the same predicate hides the start/tap affordance on both
+`team_surveys_screen.dart` and `surveys_screen.dart` (the latter is outside this
+set).
+
+### No incremental answer persistence, and therefore no resume
+
+Kotlin writes each answer as the respondent passes it: `updateAnsDb()` from
+`btnBack` (`:189-195`), `btnNext` (`:196-206`), the submit path (`:640-641`)
+and `onDestroyView` under `NonCancellable` (`:830-837`).
+`take_survey_screen.dart` holds everything in widget state and writes once in
+`_submit`. Kill the app on question 8 of 10: Kotlin has 7 answers and a
+resumable `pending` row, the port has nothing. Pre-existing, on this trail, and
+the reason the port has no resume-or-restart dialog to port. It is a
+`take_survey_screen.dart` change (mine) but a structural one — the screen would
+have to create the sheet at open time, as Kotlin does — so it wants a phase, not
+a corner of this one.
+
+### Opening and abandoning a team survey does not mark it taken
+
+Kotlin's `recreate = isTeam` (`ExamTakingFragment:150-153`) creates a **new**
+`pending` row every time a team survey is opened and never resumes. Two live
+readers are status-blind — `getSurveyFormState:344-347`
+(`getByParentIdsAndTeamId`) and `getTeamSubmissionExamIds:273-276`
+(`getByTeamId`) — so in Kotlin, opening a `teamShareAllowed` survey and pressing
+Back moves it out of the adoptable list and into the team's own. The port,
+creating the sheet at submit time, does neither. The port's readers match Kotlin
+(`_teamSubmissionSurveyIds`, no status filter); it is the writer's timing that
+differs, so this is the same root as the item above.
+
+### Nothing on screen shows what the team id now buys
+
+Kotlin binds `tvNoSubmissions`/`tvDateCompleted`/`tvDate` from `SurveyInfo`
+(`SurveysAdapter:109-112`, computed team-scoped in `getSurveyInfos:288-335` via
+`getByTeamId`). No `SurveyInfo` analogue exists in `lib/`, and neither survey
+screen renders any of it. Said out loud because this phase's win is in the
+uploaded document, not on the display: after it, the team is written, carried
+and uploaded correctly, and the screen looks the same.
+
+Related and visible: Kotlin's radio toggle shows one list at a time while
+`team_surveys_screen.dart:45-102` stacks both sections, so a team's own
+`teamShareAllowed` survey renders **twice** — tappable under *Team surveys* and
+again with an Adopt button under *Adoptable*.
+
+### `SurveyMapper` reads `isFromNation`; Kotlin derives it and always gets false
+
+`survey_mapper.dart:85` and `exam_mapper.dart:64` both do
+`JsonUtils.getBool('isFromNation', doc)`. Kotlin's only writer is
+`!parentId.isNullOrEmpty()` with `parentId` always `""`, so the field is false
+for every row in the Android app. If a Planet `exams` document carries the key,
+the port's rows diverge — and this phase has just made that field decide
+whether a team survey asks its respondent anything, so the divergence now has a
+consequence. Both mappers are outside this set. Someone should decide whether
+the port derives the field or trusts the document; trusting it is arguably
+better, but it should be a decision.
+
+### The adoption marker carries a `teamId` Kotlin never writes
+
+`surveys_repository.dart:177` passes `teamId: isTeam ? teamId : null` into
+`createSurveyAdoptionSubmission`. Kotlin's `createMappedSubmission:205-241` sets
+only the `@Ignore`d `membershipDoc`, so nothing persists. Combined with the
+port's `pendingUploads` gating on `isUpdated` where Kotlin's
+`getPendingSubmissions` requires `status = 'complete'`, the port **uploads an
+adoption document Kotlin never uploads**. Phase 129 recorded the divergence;
+it is still not in `docs/kotlin-to-flutter-migration.md`'s deviations list
+(Lane C owns that file this round).
+
+### `user_information_screen_test.dart`'s shared seed
+
+As above: `status: 'pending', isUpdated: false` is a state no caller of that
+screen can produce. Twenty-one existing tests assert against it, several
+explicitly (`expect(row?.status, 'pending')`), so correcting the seed means
+re-reading each of those expectations — worth doing, too large to bundle here.
+The two new tests set the row up themselves and say why.
+
+### `Routes.userInfo` still has no pusher
+
+`router.dart:127,315-321` registers `/exam/user-info/:submissionId`, already
+parsing `?teamId=`, and nothing navigates to it — it sits in
+`route_reachability_test`'s `allowed` map. This phase did **not** change that:
+`take_survey_screen` pushes the screen with `Navigator.push`, matching
+`public_survey_screen` and matching Kotlin, where it is a dialog over the
+survey rather than a destination. Either the route should be removed or a
+caller should use it; leaving a parsed-but-unreachable route is how the
+`teamId` this phase just wired sat unread in the first place.
+
+### Kotlin's degenerate team survey has no guard, and the port inherits none
+
+`TeamPagerAdapter` is handed `team?._id`, and `TeamDetailFragment` can reach
+`setupViewPager` with a null team (`newInstance` puts no `"id"`, so
+`shouldQueryRealm("")` is false and the early return at `:134-141` is skipped).
+Result in Kotlin: `isTeam = true, teamId = null` — the sheet is team-less, the
+profile dialog still opens, and `onDismiss` then returns early, so there is no
+upload, no toast and no pop, leaving the respondent stranded. The port cannot
+reproduce the *stranding* (its pop is unconditional), and a null `teamId` here
+simply means "no team", which is the same sheet Kotlin writes. Noted because
+anyone porting the team detail's tab pager should not reproduce the missing
+guard.
+
+### Kotlin's dead `isFromNation` arm navigates somewhere the port does not
+
+`navigateToSurveyList` replaces the container with a bare `SurveyFragment()` —
+the *individual* list, losing the team context — and inside
+`PublicSurveyActivity` it would strand the answers entirely, because
+`replaceFragment(..., addToBackStack = false)` leaves `backStackEntryCount` at
+1, so neither the back-stack listener nor `onFragmentDetached` fires and nothing
+is POSTed. The port's nation-survey arm goes to the submission detail instead.
+Since the arm is dead in Kotlin and its Kotlin behaviour is partly broken,
+matching it would be porting a bug; recorded rather than copied.

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -117,11 +117,13 @@ class SubmissionsRepository {
   /// belongs here as much as on [startExamSession], with the same
   /// blank-guarded, unconditional write.
   ///
-  /// **No caller passes it yet** — see [startExamSession] and
-  /// `PHASE_129_NOTES.md` for the chain that has to carry it
-  /// (`TeamSurveysScreen` -> the survey route -> `TakeSurveyScreen` ->
-  /// `SurveysRepository.submitResponse`), and for the second site,
-  /// `public_survey_screen`, which already holds the team id it does not pass.
+  /// **Two callers pass it, one per Kotlin site** (Phase 132, which closed the
+  /// gap Phase 129 recorded here): `TeamSurveysScreen` -> the survey route's
+  /// `?teamId=` -> `TakeSurveyScreen` -> `SurveysRepository.submitResponse`
+  /// -> here, and `public_survey_screen` for the deep link. Every other caller
+  /// of this method is team-less in Kotlin too — the individual survey list,
+  /// the dashboard's pending-survey prompt and a course step all pass
+  /// `isTeam = false` — so a null here is a positive answer, not a hole.
   Future<String> createSurveyDraft({
     required SurveyRow survey,
     required List<SurveyQuestionRow> questions,
@@ -303,12 +305,14 @@ class SubmissionsRepository {
   /// team reaches is [createSurveyDraft], and that is where the port's gap
   /// actually is.
   ///
-  /// **Nothing in the port passes it on either arm yet, and that is a named
-  /// gap, not a finished feature.** `TeamSurveysScreen` pushes
-  /// `'${Routes.surveys}/${survey.id}'` with no team, so the port's answer
-  /// sheets are all team-less where Kotlin's carry the team. Closing it is
-  /// four edits outside this repository, all recorded in
-  /// `PHASE_129_NOTES.md`.
+  /// **The survey arm now has its callers** (Phase 132: the team surveys tab
+  /// and the public-survey deep link, the two sites Kotlin sets `isTeam` at).
+  /// **This one still has none, and that is the answer rather than the gap** —
+  /// the port's only exam route is `/courses/exam/:examId`, reached from a
+  /// course step, where no team context exists or can, exactly as in Kotlin.
+  /// So a `null` arriving here is a fact about the journey, not a value
+  /// somebody forgot to thread; see `PHASE_132_NOTES.md` for the six Kotlin
+  /// journeys and which two carry a team.
   Future<String> startExamSession({
     required ExamRow exam,
     required List<ExamQuestionRow> questions,

--- a/flutter/lib/repository/surveys_repository.dart
+++ b/flutter/lib/repository/surveys_repository.dart
@@ -199,11 +199,18 @@ class SurveysRepository {
     }
   }
 
+  /// [teamId] is the team the sheet is being answered for, forwarded verbatim
+  /// to `createSurveyDraft` — which blank-guards it, as
+  /// `createExamSubmission:440` does. This is the single link between
+  /// `TakeSurveyScreen` and the writer, so a team survey's attribution either
+  /// travels through here or is lost; `TakeSurveyScreen.teamId` documents where
+  /// the value comes from and why the resume path has none.
   Future<String?> submitResponse(
     String surveyId,
     String userId,
-    Map<String, SubmissionDraftAnswer> answers,
-  ) async {
+    Map<String, SubmissionDraftAnswer> answers, {
+    String? teamId,
+  }) async {
     final survey = await _dao.getById(surveyId);
     if (survey == null) return null;
     final questions = await _dao.questionsFor(surveyId);
@@ -212,6 +219,7 @@ class SurveysRepository {
       questions: questions,
       userId: userId,
       answers: answers,
+      teamId: teamId,
     );
   }
 

--- a/flutter/lib/ui/exam/user_information_screen.dart
+++ b/flutter/lib/ui/exam/user_information_screen.dart
@@ -90,155 +90,170 @@ class _UserInformationScreenState extends ConsumerState<UserInformationScreen> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Scaffold(
-      appBar: AppBar(title: Text(l10n.yourInformation)),
-      body: Form(
-        key: _formKey,
-        child: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            if (!widget.showAdditionalFields) ...[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: OutlinedButton(
-                  onPressed: () {
-                    setState(() {
-                      _showAdditionalFields = !_showAdditionalFields;
-                      if (!_showAdditionalFields) {
-                        _fnameController.clear();
-                        _mnameController.clear();
-                        _lnameController.clear();
-                        _emailController.clear();
-                        _phoneController.clear();
-                        _dateOfBirth = null;
-                      } else {
-                        _yobController.clear();
-                      }
-                    });
-                  },
-                  child: Text(
-                    _showAdditionalFields
-                        ? l10n.hideAdditionalFields
-                        : l10n.showAdditionalFields,
-                  ),
-                ),
-              ),
-            ],
-
-            // Year of birth (simplified mode)
-            if (_showAdditionalFields) ...[
-              // No validator: `createUserProfile` requires nothing but the
-              // year of birth, so a respondent who gives no name still
-              // completes the survey.
-              _buildTextField(
-                controller: _fnameController,
-                label: l10n.firstName,
-              ),
-              _buildTextField(
-                controller: _mnameController,
-                label: l10n.middleName,
-              ),
-              _buildTextField(
-                controller: _lnameController,
-                label: l10n.lastName,
-              ),
-              _buildTextField(
-                controller: _emailController,
-                label: l10n.email,
-                keyboardType: TextInputType.emailAddress,
-              ),
-              _buildDropdown(
-                value: _selectedLanguage,
-                label: l10n.language,
-                items: memberLanguages,
-                onChanged: (v) => setState(() => _selectedLanguage = v),
-              ),
-              _buildTextField(
-                controller: _phoneController,
-                label: l10n.phoneNumber,
-                keyboardType: TextInputType.phone,
-              ),
-              _buildDateField(context, l10n),
-            ] else ...[
-              _buildTextField(
-                controller: _yobController,
-                label: l10n.yearOfBirth,
-                keyboardType: TextInputType.number,
-                inputFormatters: [
-                  FilteringTextInputFormatter.digitsOnly,
-                  LengthLimitingTextInputFormatter(4),
-                ],
-                validator: _validateYearOfBirth,
-              ),
-            ],
-
-            // Gender
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              child: Text(
-                l10n.gender,
-                style: Theme.of(context).textTheme.titleSmall,
-              ),
-            ),
-            RadioGroup<String?>(
-              groupValue: _selectedGender,
-              onChanged: (v) => setState(() => _selectedGender = v),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: RadioListTile<String?>(
-                      title: Text(l10n.male),
-                      value: 'male',
-                      contentPadding: EdgeInsets.zero,
-                    ),
-                  ),
-                  Expanded(
-                    child: RadioListTile<String?>(
-                      title: Text(l10n.female),
-                      value: 'female',
-                      contentPadding: EdgeInsets.zero,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-
-            // Level (for additional fields mode)
-            if (_showAdditionalFields) ...[
-              _buildDropdown(
-                value: _selectedLevel,
-                label: l10n.level,
-                items: memberLevels,
-                onChanged: (v) => setState(() => _selectedLevel = v),
-              ),
-            ],
-
-            const SizedBox(height: 24),
-
-            // Action buttons
-            Row(
-              children: [
-                Expanded(
+    // `onDismiss` is not the Cancel handler — it is *every* dismissal (Save,
+    // Cancel, an outside tap, the system back button), which is why the queue
+    // hangs off the pop rather than off the two buttons. Wiring the buttons
+    // only left the back button as a silent third exit that saved nothing and
+    // sent nothing. It also puts the order where Kotlin has it: the queue runs
+    // after `markSubmissionComplete`, so the payload carries the profile.
+    //
+    // `enqueue` dedupes on (uploadType, itemId), so a path that pops twice
+    // cannot double-post.
+    return PopScope(
+      canPop: true,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) _queueUpload();
+      },
+      child: Scaffold(
+        appBar: AppBar(title: Text(l10n.yourInformation)),
+        body: Form(
+          key: _formKey,
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (!widget.showAdditionalFields) ...[
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
                   child: OutlinedButton(
-                    onPressed: _isSubmitting ? null : () => _cancel(context),
-                    child: Text(l10n.cancel),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: FilledButton(
-                    onPressed: _isSubmitting ? null : () => _submit(context),
-                    child: _isSubmitting
-                        ? const SizedBox.square(
-                            dimension: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Text(l10n.save),
+                    onPressed: () {
+                      setState(() {
+                        _showAdditionalFields = !_showAdditionalFields;
+                        if (!_showAdditionalFields) {
+                          _fnameController.clear();
+                          _mnameController.clear();
+                          _lnameController.clear();
+                          _emailController.clear();
+                          _phoneController.clear();
+                          _dateOfBirth = null;
+                        } else {
+                          _yobController.clear();
+                        }
+                      });
+                    },
+                    child: Text(
+                      _showAdditionalFields
+                          ? l10n.hideAdditionalFields
+                          : l10n.showAdditionalFields,
+                    ),
                   ),
                 ),
               ],
-            ),
-          ],
+
+              // Year of birth (simplified mode)
+              if (_showAdditionalFields) ...[
+                // No validator: `createUserProfile` requires nothing but the
+                // year of birth, so a respondent who gives no name still
+                // completes the survey.
+                _buildTextField(
+                  controller: _fnameController,
+                  label: l10n.firstName,
+                ),
+                _buildTextField(
+                  controller: _mnameController,
+                  label: l10n.middleName,
+                ),
+                _buildTextField(
+                  controller: _lnameController,
+                  label: l10n.lastName,
+                ),
+                _buildTextField(
+                  controller: _emailController,
+                  label: l10n.email,
+                  keyboardType: TextInputType.emailAddress,
+                ),
+                _buildDropdown(
+                  value: _selectedLanguage,
+                  label: l10n.language,
+                  items: memberLanguages,
+                  onChanged: (v) => setState(() => _selectedLanguage = v),
+                ),
+                _buildTextField(
+                  controller: _phoneController,
+                  label: l10n.phoneNumber,
+                  keyboardType: TextInputType.phone,
+                ),
+                _buildDateField(context, l10n),
+              ] else ...[
+                _buildTextField(
+                  controller: _yobController,
+                  label: l10n.yearOfBirth,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [
+                    FilteringTextInputFormatter.digitsOnly,
+                    LengthLimitingTextInputFormatter(4),
+                  ],
+                  validator: _validateYearOfBirth,
+                ),
+              ],
+
+              // Gender
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Text(
+                  l10n.gender,
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+              RadioGroup<String?>(
+                groupValue: _selectedGender,
+                onChanged: (v) => setState(() => _selectedGender = v),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: RadioListTile<String?>(
+                        title: Text(l10n.male),
+                        value: 'male',
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                    ),
+                    Expanded(
+                      child: RadioListTile<String?>(
+                        title: Text(l10n.female),
+                        value: 'female',
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Level (for additional fields mode)
+              if (_showAdditionalFields) ...[
+                _buildDropdown(
+                  value: _selectedLevel,
+                  label: l10n.level,
+                  items: memberLevels,
+                  onChanged: (v) => setState(() => _selectedLevel = v),
+                ),
+              ],
+
+              const SizedBox(height: 24),
+
+              // Action buttons
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: _isSubmitting ? null : () => _cancel(context),
+                      child: Text(l10n.cancel),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: FilledButton(
+                      onPressed: _isSubmitting ? null : () => _submit(context),
+                      child: _isSubmitting
+                          ? const SizedBox.square(
+                              dimension: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Text(l10n.save),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -350,12 +365,10 @@ class _UserInformationScreenState extends ConsumerState<UserInformationScreen> {
   /// `user` object from the body.
   Future<void> _cancel(BuildContext context) async {
     // Kotlin's `onDismiss` runs on Cancel too, so declining the profile is
-    // still what sends a team survey — see [_queueUpload]. Queued before the
-    // pop, and not awaited into the navigation: the drain is best-effort and
-    // the respondent should not wait on it to leave.
-    final queued = _queueUpload();
+    // still what sends a team survey — but the queue hangs off the pop (see
+    // the `PopScope` in [build]) rather than being called here, so that the
+    // back button takes the same path.
     Navigator.of(context).pop(false);
-    await queued;
   }
 
   Future<void> _submit(BuildContext context) async {
@@ -390,7 +403,8 @@ class _UserInformationScreenState extends ConsumerState<UserInformationScreen> {
       await ref
           .read(submissionsRepositoryProvider)
           .markSubmissionComplete(widget.submissionId, profile);
-      await _queueUpload();
+      // No `_queueUpload()` here: the pop below runs it, after this write, so
+      // the enqueued payload carries the profile — Kotlin's order exactly.
       if (context.mounted) {
         ScaffoldMessenger.of(
           context,

--- a/flutter/lib/ui/exam/user_information_screen.dart
+++ b/flutter/lib/ui/exam/user_information_screen.dart
@@ -349,7 +349,13 @@ class _UserInformationScreenState extends ConsumerState<UserInformationScreen> {
   /// Cancel writes nothing at all (`:112-118`). Declining only omits the
   /// `user` object from the body.
   Future<void> _cancel(BuildContext context) async {
+    // Kotlin's `onDismiss` runs on Cancel too, so declining the profile is
+    // still what sends a team survey — see [_queueUpload]. Queued before the
+    // pop, and not awaited into the navigation: the drain is best-effort and
+    // the respondent should not wait on it to leave.
+    final queued = _queueUpload();
     Navigator.of(context).pop(false);
+    await queued;
   }
 
   Future<void> _submit(BuildContext context) async {
@@ -407,19 +413,48 @@ class _UserInformationScreenState extends ConsumerState<UserInformationScreen> {
   /// The Kotlin's `onDismiss` hands a team survey to
   /// `submissionsUploader.checkAvailableServer`; here the outbox carries it.
   ///
+  /// **[UserInformationScreen.teamId] is the gate**, which is what that
+  /// parameter is for and why it sat unread for so long.
+  /// `UserInformationFragment.onDismiss` (`:293-311`) reads it, returns
+  /// outright when it is empty, and otherwise uploads — on **every**
+  /// dismissal, Save and Cancel alike, because the sheet was already
+  /// `complete` before this screen opened (`saveExamAnswer` marks it on the
+  /// last question, `SubmissionsRepositoryImpl.kt:546-551`). Its other read,
+  /// `submitForm:151-174`, routes the profile onto the submission rather than
+  /// onto the signed-in user's own document — and that branch is inert here,
+  /// because this screen requires a `submissionId` and so always takes
+  /// Kotlin's `saveSubmission` arm anyway.
+  ///
+  /// The toast and `popBackStack` Kotlin gates on the same value are
+  /// deliberately **not** ported to this gate: each port screen owns its own
+  /// messaging, `PublicSurveyScreen` already thanks the respondent after its
+  /// POST, and duplicating the dialog's toast here would queue two identical
+  /// snackbars on the one path that reaches this screen today.
+  ///
   /// Swallowed on purpose, and awaited on the session's **future** rather than
   /// its `valueOrNull`: a screen that only reads `sessionProvider` sees it
   /// still loading, and a failure to queue is not a failure to save — the
   /// submission is already complete, and the next sync picks it up.
+  ///
+  /// **Every `ref` read is synchronous, ahead of the first `await`, and that is
+  /// load-bearing on the Cancel path**: `_cancel` pops before this finishes, so
+  /// this `State` can be disposed while the session future is still pending —
+  /// and a `ref` read after disposal throws, straight into the `catch` below,
+  /// which would silently skip the upload this gate exists to perform. The
+  /// swallowing that makes a failed queue harmless is exactly what would have
+  /// hidden that. Capturing the uploader and the session's future up front
+  /// keeps the rule that the `await` stays inside the `try` while owing
+  /// nothing to `ref` afterwards.
   Future<void> _queueUpload() async {
+    if ((widget.teamId ?? '').trim().isEmpty) return;
     try {
       final config = ref.read(serverConfigProvider);
       if (config == null) return;
-      final user = await ref.read(sessionProvider.future);
+      final session = ref.read(sessionProvider.future);
+      final uploader = ref.read(submissionsUploaderProvider);
+      final user = await session;
       if (user == null) return;
-      await ref
-          .read(submissionsUploaderProvider)
-          .queuePending(config: config, userId: user.id);
+      await uploader.queuePending(config: config, userId: user.id);
     } catch (_) {
       // See above.
     }

--- a/flutter/lib/ui/router.dart
+++ b/flutter/lib/ui/router.dart
@@ -469,9 +469,21 @@ final routerProvider = Provider<GoRouter>((ref) {
                     routes: [
                       GoRoute(
                         path: ':surveyId',
+                        // `teamId` is the port of the `isTeam`/`teamId`
+                        // fragment-argument pair `TeamPagerAdapter` injects
+                        // into the team's surveys tab (`:89-93`) and
+                        // `BaseExamFragment` reads (`:77-78`). Kotlin keeps two
+                        // arguments and stamps `if (isTeam) teamId else null`;
+                        // one nullable parameter says the same thing, because
+                        // the only site that sets the flag also sets the id.
+                        // A survey opened from anywhere else — the personal
+                        // list, the dashboard prompt, a course step — carries
+                        // no team, exactly as `openSurvey(..., false, "")`
+                        // does at those Kotlin call sites.
                         builder: (context, state) => TakeSurveyScreen(
                           surveyId: state.pathParameters['surveyId']!,
                           submissionId: state.uri.queryParameters['submission'],
+                          teamId: state.uri.queryParameters['teamId'],
                         ),
                       ),
                     ],

--- a/flutter/lib/ui/surveys/public_survey_screen.dart
+++ b/flutter/lib/ui/surveys/public_survey_screen.dart
@@ -262,6 +262,16 @@ class _PublicSurveyScreenState extends ConsumerState<PublicSurveyScreen> {
           );
 
       if (!mounted) return;
+      // Unconditionally, where `take_survey_screen` gates the same push on
+      // `survey?.isFromNation != true` — and the asymmetry is deliberate.
+      // Kotlin's else arm for a nation survey is `navigateToSurveyList`
+      // (`BaseExamFragment:167-174`), which inside `PublicSurveyActivity`
+      // replaces the container with `addToBackStack = false`: neither the
+      // back-stack listener (`:65-69`) nor `onFragmentDetached` (`:74-80`)
+      // then fires, so the answers are never POSTed at all. Porting the gate
+      // here would mean porting that, and the deep link's whole purpose is to
+      // deliver the answers. The team path has no such coupling, so it takes
+      // the arm as written.
       await Navigator.of(context).push(
         MaterialPageRoute<void>(
           builder: (_) => UserInformationScreen(

--- a/flutter/lib/ui/surveys/public_survey_screen.dart
+++ b/flutter/lib/ui/surveys/public_survey_screen.dart
@@ -251,6 +251,14 @@ class _PublicSurveyScreenState extends ConsumerState<PublicSurveyScreen> {
             questions: questions,
             userId: userId,
             answers: answers,
+            // `PublicSurveyActivity` launches the sheet with
+            // `isTeam = true` and the link's team id (`:99-107`), so
+            // `createExamSubmission` stamps the column here too — this is the
+            // second of Kotlin's two team-carrying sites, not an extra. The
+            // id was already in hand two statements from the call, and
+            // `UserInformationScreen(teamId: …)` below has been passing it
+            // all along.
+            teamId: widget.teamId,
           );
 
       if (!mounted) return;

--- a/flutter/lib/ui/surveys/take_survey_screen.dart
+++ b/flutter/lib/ui/surveys/take_survey_screen.dart
@@ -9,6 +9,7 @@ import '../../providers/app_providers.dart';
 import '../../providers/session_provider.dart';
 import '../../providers/surveys_provider.dart';
 import '../../repository/submissions_repository.dart';
+import '../exam/user_information_screen.dart';
 import '../router.dart';
 
 /// Offline survey-taking form, replacing the survey mode of
@@ -197,6 +198,7 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
     // the form permanently unusable with no message — the user's answers are
     // still on screen but there is no way to send them.
     String? id;
+    var askWhoTheyAre = false;
     try {
       // `ref.read(sessionProvider).valueOrNull` is null until something else
       // resolves that provider, and this screen never watches it: the early
@@ -209,6 +211,23 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
       // the failure path rather than reintroducing the silence.
       final user = await ref.read(sessionProvider.future);
       if (user == null) throw StateError('no signed-in user');
+      // `BaseExamFragment.continueExam:127-131` sends the last question of a
+      // *team* survey to `showUserInfoDialog` instead of the thank-you
+      // dialog, and `showUserInfoDialog:153-164` opens the respondent form
+      // unless the survey came from the nation — in which case it marks the
+      // sheet complete and leaves. `exam?.isFromNation != true` is reproduced
+      // literally, null included: a survey row that has not loaded takes the
+      // ask-them branch there too.
+      //
+      // Awaited rather than read off the `AsyncValue` this screen watches:
+      // the title falls back to a label while the survey loads, so the form
+      // can be submitted before it resolves, and `.valueOrNull` would read
+      // null and decide the gate on a value it does not have yet. The await
+      // is inside the `try` because the future can reject.
+      final survey = await ref.read(surveyProvider(widget.surveyId).future);
+      askWhoTheyAre =
+          (widget.teamId ?? '').trim().isNotEmpty &&
+          survey?.isFromNation != true;
       final repo = ref.read(surveysRepositoryProvider);
       id = widget.submissionId != null
           ? await repo.updateSurveyResponse(
@@ -222,7 +241,14 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
               teamId: widget.teamId,
             );
       final config = ref.read(serverConfigProvider);
-      if (id != null && config != null) {
+      // Not before the profile step, which is the order Kotlin uses: the
+      // upload is `UserInformationFragment.onDismiss`'s job, *after* the
+      // dialog. Queueing here as well would enqueue a payload serialized
+      // before `markSubmissionComplete` wrote the respondent's answers into
+      // the row, and if the outbox drained in between, `markUploaded` would
+      // take the sheet out of `pendingUploads` and the profile would never go
+      // out at all.
+      if (id != null && config != null && !askWhoTheyAre) {
         await ref
             .read(submissionsUploaderProvider)
             .queuePending(config: config, userId: user.id);
@@ -237,7 +263,43 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
     }
     if (!mounted) return;
     setState(() => submitting = false);
-    if (id != null) context.go('${Routes.submissions}/$id');
+    if (id == null) return;
+    if (askWhoTheyAre) {
+      // Kotlin shows this over the exhausted question screen
+      // (`childFragmentManager`) and, when it dismisses — Save or Cancel
+      // alike — `onDismiss` uploads, thanks the respondent and pops the
+      // survey off the back stack. The screen owns the first two; this owns
+      // the pop, so the respondent lands back on the team's surveys tab
+      // rather than on a submission detail they did not ask for.
+      //
+      // `Navigator.push` rather than the `Routes.userInfo` route, matching
+      // `public_survey_screen`: Kotlin's is a dialog over this screen, not a
+      // destination, and pushing a location would put it in the history.
+      await Navigator.of(context).push(
+        MaterialPageRoute<bool>(
+          builder: (_) => UserInformationScreen(
+            submissionId: id!,
+            teamId: widget.teamId,
+            // Kotlin's `shouldHideElements` is `exam?.isFromNation != true`,
+            // which this branch has already established is true, and this
+            // parameter is its negation.
+            showAdditionalFields: false,
+          ),
+        ),
+      );
+      if (!mounted) return;
+      // `FragmentNavigator.popBackStack`. A team survey is always reached by
+      // a push from the team's surveys tab, so there is something to pop;
+      // the fallback covers a `go` — Kotlin's own dead `isFromNation` arm
+      // lands on the survey list too (`navigateToSurveyList`).
+      if (context.canPop()) {
+        context.pop();
+      } else {
+        context.go(Routes.surveys);
+      }
+      return;
+    }
+    context.go('${Routes.submissions}/$id');
   }
 }
 

--- a/flutter/lib/ui/surveys/take_survey_screen.dart
+++ b/flutter/lib/ui/surveys/take_survey_screen.dart
@@ -225,7 +225,16 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
       // null and decide the gate on a value it does not have yet. The await
       // is inside the `try` because the future can reject.
       final survey = await ref.read(surveyProvider(widget.surveyId).future);
+      // `!isMySurvey && exam?.isFromNation != true` (`:154-155`) — both
+      // halves. A resumed sheet is Kotlin's `isMySurvey`, and it takes the
+      // else arm: mark complete and leave, without asking. No pusher produces
+      // a `?submission=` *and* a `?teamId=` today, so this half is latent —
+      // but a gate that is a line-for-line port cannot drift into the case
+      // later, and `updateSurveyResponse` deliberately carries no team, so
+      // without it a resumed sheet would be asked for a profile it could not
+      // attribute.
       askWhoTheyAre =
+          widget.submissionId == null &&
           (widget.teamId ?? '').trim().isNotEmpty &&
           survey?.isFromNation != true;
       final repo = ref.read(surveysRepositoryProvider);
@@ -243,11 +252,26 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
       final config = ref.read(serverConfigProvider);
       // Not before the profile step, which is the order Kotlin uses: the
       // upload is `UserInformationFragment.onDismiss`'s job, *after* the
-      // dialog. Queueing here as well would enqueue a payload serialized
-      // before `markSubmissionComplete` wrote the respondent's answers into
-      // the row, and if the outbox drained in between, `markUploaded` would
-      // take the sheet out of `pendingUploads` and the profile would never go
-      // out at all.
+      // dialog.
+      //
+      // The reason that always holds is duplication, not loss, and an
+      // earlier draft of this comment had it the other way round. Queueing
+      // here enqueues a payload serialized before `markSubmissionComplete`
+      // writes the profile; if the outbox drains before the respondent
+      // saves — an app background/foreground cycle mid-form is enough — the
+      // sheet is POSTed once without the profile, `markComplete` then puts
+      // the row back in `pendingUploads` (`app_database.dart`'s
+      // `markComplete` sets `uploaded: false, isUpdated: true`, and says so),
+      // and the pop's queue POSTs it **again**. Two documents on the server
+      // for one answer sheet, where Kotlin posts one. That is worse for a
+      // survey's results than a late delivery, which is what the old comment
+      // wrongly claimed was at stake here.
+      //
+      // The cost of this order is recorded in `PHASE_132_NOTES.md` under
+      // *Reported, not fixed*: nothing in the port sweeps `pendingUploads` on
+      // sync, so a sheet whose profile step is interrupted by process death
+      // waits for the user's next submission. Kotlin's safety net is
+      // `uploadSubmissions()` running unconditionally from `AutoSyncWorker`.
       if (id != null && config != null && !askWhoTheyAre) {
         await ref
             .read(submissionsUploaderProvider)

--- a/flutter/lib/ui/surveys/take_survey_screen.dart
+++ b/flutter/lib/ui/surveys/take_survey_screen.dart
@@ -17,10 +17,32 @@ class TakeSurveyScreen extends ConsumerStatefulWidget {
   const TakeSurveyScreen({
     required this.surveyId,
     this.submissionId,
+    this.teamId,
     super.key,
   });
   final String surveyId;
   final String? submissionId;
+
+  /// The team this sheet is being answered for, or null for a personal one.
+  ///
+  /// Kotlin's pair of fragment arguments (`isTeam` plus the id, read at
+  /// `BaseExamFragment:77-78`) collapses to one nullable value here, and
+  /// `ExamTakingFragment` hands it to `CreateExamSubmissionRequest` as
+  /// `if (isTeam) teamId else null` (`:151-152`) — so a null or blank value
+  /// means "no team", and the repository's own blank guard is what enforces
+  /// that rather than a check here.
+  ///
+  /// Only `${Routes.surveys}/:surveyId?teamId=` fills it, from
+  /// `TeamSurveysScreen`. It is deliberately **not** carried into the resume
+  /// path (`updateSurveyResponse`), and Kotlin agrees twice over: with a team
+  /// it never resumes at all — `if (sub == null || isTeam)` recreates the
+  /// sheet (`ExamTakingFragment:150-153`, `recreate = isTeam`) and the
+  /// resume-or-restart branch below it is unreachable while `isTeam` is true —
+  /// and every site that opens a *pending* sheet passes
+  /// `isMySurvey = true, isTeam = false, teamId = ""`
+  /// (`BellDashboardFragment:256`, `SubmissionsAdapter:98`). A resumed row
+  /// already carries whatever team it was created with.
+  final String? teamId;
 
   @override
   ConsumerState<TakeSurveyScreen> createState() => _TakeSurveyScreenState();
@@ -193,7 +215,12 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
               widget.submissionId!,
               answers: answers,
             )
-          : await repo.submitResponse(widget.surveyId, user.id, answers);
+          : await repo.submitResponse(
+              widget.surveyId,
+              user.id,
+              answers,
+              teamId: widget.teamId,
+            );
       final config = ref.read(serverConfigProvider);
       if (id != null && config != null) {
         await ref

--- a/flutter/lib/ui/teams/team_surveys_screen.dart
+++ b/flutter/lib/ui/teams/team_surveys_screen.dart
@@ -64,7 +64,23 @@ class TeamSurveysScreen extends ConsumerWidget {
                     const Icon(Icons.chevron_right),
                   ],
                 ),
-                onTap: () => context.push('${Routes.surveys}/${survey.id}'),
+                // The team travels with the tap. `TeamPagerAdapter` puts
+                // `isTeam`/`teamId` into the surveys tab's arguments
+                // (`:89-93`) and every sheet opened from it is attributed to
+                // the team; the port pushed the bare survey route, so the
+                // whole chain below — route, screen, `createSurveyDraft` —
+                // had a `teamId` nothing ever filled.
+                //
+                // Written as a literal rather than through a helper on
+                // purpose: `route_reachability_test`'s scanner reads
+                // `'${Routes.x}/…'` literals out of `lib/` and skips
+                // `router.dart`, so moving this into a builder there would
+                // make the one navigation this phase adds the one navigation
+                // that guard cannot see.
+                onTap: () => context.push(
+                  '${Routes.surveys}/${survey.id}'
+                  '?teamId=${Uri.encodeQueryComponent(teamId)}',
+                ),
               ),
             ),
             const SizedBox(height: 16),

--- a/flutter/lib/ui/teams/team_surveys_screen.dart
+++ b/flutter/lib/ui/teams/team_surveys_screen.dart
@@ -56,9 +56,23 @@ class TeamSurveysScreen extends ConsumerWidget {
                       icon: const Icon(Icons.send),
                       onPressed: () => showDialog<void>(
                         context: context,
-                        builder: (context) => SendSurveyScreen(
-                          surveyId: survey.sourceSurveyId ?? survey.id,
-                        ),
+                        // The survey on the card, never its source. Kotlin
+                        // hands the bound exam straight through —
+                        // `listener?.sendSurvey(current.exam)`
+                        // (`SurveysAdapter:63-66`) ->
+                        // `b.putString("surveyId", current?.id)`
+                        // (`DashboardActivity:1008-1014`) ->
+                        // `createBulkSurveySubmissions` — and an adopted team
+                        // survey always has a `sourceSurveyId`, so preferring
+                        // it sent every member a sheet keyed to the
+                        // *un-adopted original*. Their answers then filed
+                        // against the source, where neither
+                        // `submissionsForTeam` nor the adoptable list looks,
+                        // so the team's own copy read zero submissions
+                        // forever. `surveys_screen.dart` already passes
+                        // `row.id`.
+                        builder: (context) =>
+                            SendSurveyScreen(surveyId: survey.id),
                       ),
                     ),
                     const Icon(Icons.chevron_right),

--- a/flutter/lib/ui/teams/team_surveys_screen.dart
+++ b/flutter/lib/ui/teams/team_surveys_screen.dart
@@ -65,12 +65,23 @@ class TeamSurveysScreen extends ConsumerWidget {
                         // `createBulkSurveySubmissions` — and an adopted team
                         // survey always has a `sourceSurveyId`, so preferring
                         // it sent every member a sheet keyed to the
-                        // *un-adopted original*. Their answers then filed
-                        // against the source, where neither
-                        // `submissionsForTeam` nor the adoptable list looks,
-                        // so the team's own copy read zero submissions
-                        // forever. `surveys_screen.dart` already passes
-                        // `row.id`.
+                        // *un-adopted original*, so their answers filed
+                        // against the source survey rather than against the
+                        // team's own copy — mis-attributed at the parent id,
+                        // which is what identifies a survey's responses.
+                        // `surveys_screen.dart` already passes `row.id`.
+                        //
+                        // Note what this does *not* fix, because an earlier
+                        // draft of this comment claimed it did:
+                        // `getOrCreateSurveySubmission` writes neither a
+                        // `teamId` column nor a `parent` document
+                        // (`submissions_repository.dart:683-695`), and the
+                        // team's two readers need one or the other —
+                        // `submissionsForTeam` is `byTeam` on the column and
+                        // `_teamSubmissionSurveyIds` reads `parent._id`. So a
+                        // bulk-created sheet is invisible to both under
+                        // either id. This is right because Kotlin does it,
+                        // not because it makes those readers work.
                         builder: (context) =>
                             SendSurveyScreen(surveyId: survey.id),
                       ),

--- a/flutter/test/ui/exam/user_information_screen_test.dart
+++ b/flutter/test/ui/exam/user_information_screen_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:drift/drift.dart' show Value;
@@ -42,6 +43,15 @@ class _TestSessionNotifier extends SessionNotifier {
 
   @override
   Future<UserRow?> build() async => user;
+}
+
+/// A session whose future is still pending until the test completes it, so
+/// the widget can be disposed while `_queueUpload` is mid-flight.
+class _PendingSessionNotifier extends SessionNotifier {
+  static Completer<UserRow?>? completer;
+
+  @override
+  Future<UserRow?> build() => (completer ??= Completer<UserRow?>()).future;
 }
 
 /// A session whose future rejects — the shape Phase 100 found on the exam
@@ -163,6 +173,7 @@ void main() {
     UserRow? session,
     bool anonymous = false,
     bool failingSession = false,
+    bool pendingSession = false,
     ServerConfig? config = server,
     String? teamId = 'team-1',
   }) async {
@@ -182,6 +193,8 @@ void main() {
           sessionProvider.overrideWith(
             failingSession
                 ? _FailingSessionNotifier.new
+                : pendingSession
+                ? _PendingSessionNotifier.new
                 : () => _TestSessionNotifier(
                     anonymous ? null : (session ?? user),
                   ),
@@ -455,6 +468,113 @@ void main() {
       final row = await db.submissionDao.getById(submissionId);
       expect(row?.status, 'pending');
       expect(find.text('ROOT_PAGE'), findsOneWidget);
+    });
+
+    testWidgets('cancel still queues the team survey for upload', (
+      tester,
+    ) async {
+      // `UserInformationFragment.onDismiss` (`:293-311`) fires on **every**
+      // dismissal — Save, Cancel, an outside tap, the back button — and when
+      // the team id is non-empty it calls
+      // `submissionsUploader.checkAvailableServer`. So in Kotlin declining the
+      // profile is what *sends* the sheet, which was already `complete` before
+      // this screen opened; the port queued on Save only, and a respondent who
+      // skipped the questions about themselves left their answers sitting
+      // until some later sync happened to run.
+      //
+      // The row has to be in the state a real one is in first. This file's
+      // seed is `status: 'pending', isUpdated: false`, which **no caller of
+      // this screen can produce**: the sheet arrives from `createSurveyDraft`,
+      // which writes `status: 'complete', isUpdated: true` (as Kotlin's
+      // `saveExamAnswer` does before the dialog opens), and `pendingUploads`
+      // selects on `isUpdated`. Asserting against the seed instead would have
+      // pinned the fixture rather than the behaviour.
+      await (db.update(
+        db.submissions,
+      )..where((row) => row.id.equals(submissionId))).write(
+        const SubmissionsCompanion(
+          status: Value('complete'),
+          isUpdated: Value(true),
+        ),
+      );
+      await pumpScreen(tester);
+
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Cancel'));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final queued = await db.outboxDao.findOpen(
+        SubmissionsUploader.type,
+        submissionId,
+      );
+      expect(queued, isNotNull);
+      // And nothing was written to the row — Cancel saves no profile.
+      expect(await savedProfile(), isNull);
+    });
+
+    testWidgets('a team-less sheet is not queued at all', (tester) async {
+      // The other half of the same `onDismiss` gate: `if (safeTeamId == "")
+      // return`, before the upload. The port queued unconditionally. Nothing
+      // in the port reaches this screen without a team today — the public
+      // path always has one and `Routes.userInfo` has no pusher — so this is
+      // the specification being pinned before a caller arrives, not a live
+      // defect.
+      await pumpScreen(tester, teamId: null);
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Year of birth'),
+        '1990',
+      );
+      await tapSave(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // The profile still saves: that half of `submitForm` is reached with or
+      // without a team once a submission id is present (`:155-174`).
+      expect(await savedProfile(), isNotNull);
+      final queued = await db.outboxDao.findOpen(
+        SubmissionsUploader.type,
+        submissionId,
+      );
+      expect(queued, isNull);
+    });
+
+    testWidgets('cancel queues even after the screen is gone', (tester) async {
+      // The hazard the Cancel path introduces, and it is invisible without
+      // this: `_cancel` pops before the queue finishes, so this `State` can be
+      // disposed while the session future is pending. A `ref` read after
+      // disposal throws — into a `catch` that exists to make a failed queue
+      // harmless — so the upload would be skipped silently, which is the one
+      // failure mode this whole gate is meant to remove. Every `ref` read is
+      // therefore taken synchronously, before the first `await`.
+      //
+      // The session is held pending until after `pumpAndSettle` has disposed
+      // the route, which is what makes the window real rather than incidental;
+      // with the reads deferred, this test fails.
+      _PendingSessionNotifier.completer = Completer<UserRow?>();
+      addTearDown(() => _PendingSessionNotifier.completer = null);
+      await (db.update(
+        db.submissions,
+      )..where((row) => row.id.equals(submissionId))).write(
+        const SubmissionsCompanion(
+          status: Value('complete'),
+          isUpdated: Value(true),
+        ),
+      );
+      await pumpScreen(tester, pendingSession: true);
+
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Cancel'));
+      await tester.pumpAndSettle();
+      expect(find.text('ROOT_PAGE'), findsOneWidget);
+
+      _PendingSessionNotifier.completer!.complete(user);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final queued = await db.outboxDao.findOpen(
+        SubmissionsUploader.type,
+        submissionId,
+      );
+      expect(queued, isNotNull);
     });
 
     testWidgets('cancel pops false', (tester) async {

--- a/flutter/test/ui/exam/user_information_screen_test.dart
+++ b/flutter/test/ui/exam/user_information_screen_test.dart
@@ -577,6 +577,34 @@ void main() {
       expect(queued, isNotNull);
     });
 
+    testWidgets('the back button queues it too', (tester) async {
+      // `onDismiss` is not the Cancel handler — it is *every* dismissal:
+      // Save, Cancel, an outside tap, and the system back button. Wiring only
+      // the two buttons left the back button as a silent third exit that
+      // saved nothing and sent nothing, which is the same defect the Cancel
+      // path had, in the same method.
+      await (db.update(
+        db.submissions,
+      )..where((row) => row.id.equals(submissionId))).write(
+        const SubmissionsCompanion(
+          status: Value('complete'),
+          isUpdated: Value(true),
+        ),
+      );
+      await pumpScreen(tester);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('ROOT_PAGE'), findsOneWidget);
+      final queued = await db.outboxDao.findOpen(
+        SubmissionsUploader.type,
+        submissionId,
+      );
+      expect(queued, isNotNull);
+    });
+
     testWidgets('cancel pops false', (tester) async {
       // Reports that nothing was saved. It must NOT be read as "do not
       // post": Kotlin uploads from `onFragmentDetached` on both the save and

--- a/flutter/test/ui/public_survey_screen_test.dart
+++ b/flutter/test/ui/public_survey_screen_test.dart
@@ -339,17 +339,20 @@ void main() {
   });
 
   group('submitting', () {
-    /// Answers the one text question, submits, and dismisses the respondent
-    /// information screen the way a respondent who declines it would.
     /// Answers the one question, submits, and completes the respondent
-    /// profile step the way a respondent does.
+    /// profile step the way a respondent who fills it in does.
     ///
-    /// The profile step has to be *saved*, not backed out of: a dismissed
-    /// dialog leaves `uploadCompletedSubmission` nothing to POST, which is why
-    /// the screen returns early on anything but a `true` pop. Backing out —
-    /// which this helper used to do — therefore stopped sending the answer
-    /// sheet at all, and the five tests that go through here have been failing
-    /// on it. Never `pumpAndSettle` after Save: the button holds a
+    /// **The screen does not read the pop result**, and this comment used to
+    /// say it did — the Phase 106 rationale, surviving here after the code it
+    /// justified was reverted. `PublicSurveyActivity` uploads from
+    /// `onFragmentDetached` (`:74-80`) with no save-vs-cancel test, and the
+    /// sheet is already `status = "complete"` before the profile step opens.
+    /// Declining only omits the `user` object. So these tests save because
+    /// saving is the path with a profile to assert on, not because backing out
+    /// would stop the post; `'declining the profile step still posts the
+    /// answers'` covers the other half.
+    ///
+    /// Never `pumpAndSettle` after Save: the button holds a
     /// `CircularProgressIndicator` while it works.
     Future<void> completeProfileStep(WidgetTester tester) async {
       expect(find.text('Your information'), findsOneWidget);
@@ -371,6 +374,60 @@ void main() {
       await tapSubmit(tester);
       await completeProfileStep(tester);
     }
+
+    testWidgets('the answer sheet carries the link\'s team', (tester) async {
+      // Phase 132. `PublicSurveyActivity` launches the sheet with
+      // `isTeam = true` and the deep link's team id (`:99-107`), so
+      // `createExamSubmission` stamps `teamId`; the port had the value in
+      // `widget.teamId` two statements from the `createSurveyDraft` call and
+      // passed it only to the profile screen. Planet attributes a submission
+      // by its team, so an unstamped sheet is filed against nobody.
+      stubPost(succeeds: true);
+      stubFetch(surveyDoc([textQuestion('q1', 'What do you need?')]));
+      await pumpScreen(tester);
+
+      await answerAndSubmit(tester);
+
+      final submission = (await db.select(db.submissions).get()).single;
+      expect(submission.teamId, 'team-1');
+    });
+
+    testWidgets('declining the profile step still posts the answers', (
+      tester,
+    ) async {
+      // The Phase 106 regression, pinned. Gating the POST on the profile
+      // screen popping `true` lost the answers permanently —
+      // `PublicSurveyUploader.queue` had that one caller and nothing rescans
+      // unsent submissions. Kotlin uploads from `onFragmentDetached`
+      // (`PublicSurveyActivity:74-80`) with no save-vs-cancel test, and Cancel
+      // writes nothing at all (`UserInformationFragment:112-118`). The revert
+      // left no test behind, so nothing but a comment stopped it coming back.
+      stubPost(succeeds: true);
+      stubFetch(surveyDoc([textQuestion('q1', 'What do you need?')]));
+      await pumpScreen(tester);
+
+      await tester.enterText(find.byType(TextField), 'Clean water');
+      await tester.pump();
+      await tapSubmit(tester);
+
+      expect(find.text('Your information'), findsOneWidget);
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Cancel'));
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final submission = (await db.select(db.submissions).get()).single;
+      expect(
+        submission.uploaded,
+        isTrue,
+        reason:
+            'the answers were never sent after the profile step was '
+            'declined',
+      );
+      // And the sheet still carries the team it was answered for.
+      expect(submission.teamId, 'team-1');
+    });
 
     testWidgets('a delivered answer sheet is thanked for and marked sent', (
       tester,

--- a/flutter/test/ui/route_reachability_test.dart
+++ b/flutter/test/ui/route_reachability_test.dart
@@ -129,11 +129,17 @@ void main() {
       // test below.
       '/survey/:teamId/:surveyId': 'deep-link entry point',
       // Kotlin shows the respondent profile as a dialog over the survey and the
-      // port keeps that shape, so `PublicSurveyScreen` builds the screen with
-      // `Navigator.push` and there is no location to navigate to. The route is
-      // a spare entry point kept for a future in-app caller.
+      // port keeps that shape, so its callers build the screen with
+      // `Navigator.push` and there is no location to navigate to. There are
+      // **two** of them since Phase 132 — `PublicSurveyScreen` for a deep
+      // link and `TakeSurveyScreen` for a team survey, which is the pair
+      // Kotlin's `showUserInfoDialog` serves — so the route is still spare,
+      // and now spare with two live builders rather than one. Either give it
+      // a caller or delete it: a parsed-but-unreachable route is how the
+      // `teamId` it reads sat unread for three phases.
       '/exam/user-info/:submissionId':
-          'PublicSurveyScreen builds it with Navigator.push',
+          'PublicSurveyScreen and TakeSurveyScreen build it with '
+          'Navigator.push',
     };
 
     final reached = _navigationSites().map((s) => s.location).toSet();

--- a/flutter/test/ui/surveys/survey_team_context_test.dart
+++ b/flutter/test/ui/surveys/survey_team_context_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -299,9 +300,27 @@ void main() {
   });
 
   group('the answer sheet the port writes carries the team', () {
+    /// A pending sheet the resume path can reopen.
+    Future<String> seedPendingSheet() async {
+      const id = 'sub-resume';
+      await db.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: id,
+          parentId: const Value('s1'),
+          parent: Value(jsonEncode({'_id': 's1', 'name': 'Water access'})),
+          userId: const Value('user-a'),
+          type: const Value('survey'),
+          status: const Value('pending'),
+          uploaded: const Value(false),
+        ),
+      ]);
+      return id;
+    }
+
     Future<void> pumpTakeSurvey(
       WidgetTester tester, {
       String? teamId,
+      String? submissionId,
       ServerConfig? config,
     }) async {
       tester.view.physicalSize = const Size(1000, 3000);
@@ -310,7 +329,11 @@ void main() {
 
       await tester.pumpWidget(
         wrapScreen(
-          TakeSurveyScreen(surveyId: 's1', teamId: teamId),
+          TakeSurveyScreen(
+            surveyId: 's1',
+            teamId: teamId,
+            submissionId: submissionId,
+          ),
           pushTargets: {
             '/life/submissions/:id': (_) =>
                 const Scaffold(body: Text('SUBMISSION_PAGE')),
@@ -484,6 +507,26 @@ void main() {
       final payload = jsonDecode(queued!.payload) as Map<String, dynamic>;
       expect(payload['team'], {'_id': 'team-1'});
       expect((payload['user'] as Map<String, dynamic>)['age'], isNotNull);
+    });
+
+    testWidgets('a resumed sheet is not asked for a profile', (tester) async {
+      // `showUserInfoDialog`'s gate is `!isMySurvey && exam?.isFromNation !=
+      // true` (`BaseExamFragment:154-155`) — a resumed sheet takes the else
+      // arm and is never asked. Latent, since no pusher pairs `?submission=`
+      // with `?teamId=`; pinned so the gate stays a line-for-line port,
+      // because `updateSurveyResponse` carries no team and a profile asked
+      // for here could not be attributed to one.
+      await seedSurvey();
+      final existing = await seedPendingSheet();
+      await pumpTakeSurvey(tester, teamId: 'team-1', submissionId: existing);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UserInformationScreen), findsNothing);
+      // And the submit really ran, rather than the gate passing because
+      // nothing happened: the resumed row now holds the typed answer.
+      final answers = await db.select(db.submissionAnswers).get();
+      expect(answers.single.value, '2 km');
+      expect((await submissions()).single.id, existing);
     });
 
     testWidgets('a blank team id is stored as no team at all', (tester) async {

--- a/flutter/test/ui/surveys/survey_team_context_test.dart
+++ b/flutter/test/ui/surveys/survey_team_context_test.dart
@@ -1,8 +1,12 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/system/device_identity.dart';
 import 'package:myplanet/core/prefs/planet_prefs.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
@@ -11,6 +15,8 @@ import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/providers/team_surveys_provider.dart';
 import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/repository/submissions_uploader.dart';
+import 'package:myplanet/ui/exam/user_information_screen.dart';
 import 'package:myplanet/ui/router.dart';
 import 'package:myplanet/ui/surveys/take_survey_screen.dart';
 import 'package:myplanet/ui/teams/team_surveys_screen.dart';
@@ -19,6 +25,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../support/widget_harness.dart';
 
 class _MockPlanetApi extends Mock implements PlanetApi {}
+
+class _StubServerConfig extends ServerConfigNotifier {
+  _StubServerConfig(this.config);
+  final ServerConfig? config;
+  @override
+  ServerConfig? build() => config;
+}
 
 class _StubSession extends SessionNotifier {
   _StubSession(this.user);
@@ -41,6 +54,12 @@ class _StubSession extends SessionNotifier {
 /// These tests exercise the chain rather than its halves — the team screen's
 /// push, the real route table's read, and the row the repository actually
 /// writes — because each half was already green while the whole was broken.
+const _server = ServerConfig(
+  serverUrl: 'https://planet.example',
+  pin: '1234',
+  couchDbUrl: 'https://planet.example/db',
+);
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -61,11 +80,12 @@ void main() {
         teamShareAllowed: false,
       );
 
-  Future<void> seedSurvey({String id = 's1'}) async {
+  Future<void> seedSurvey({String id = 's1', bool fromNation = false}) async {
     final mapping = SurveyMapper.fromDoc({
       '_id': id,
       'type': 'surveys',
       'name': 'Water access',
+      'isFromNation': fromNation,
       'questions': [
         {'id': 'q1', 'body': 'How far is the nearest tap?', 'type': 'input'},
       ],
@@ -184,8 +204,106 @@ void main() {
     });
   });
 
+  testWidgets('the whole journey: team tab -> survey -> profile -> back', (
+    tester,
+  ) async {
+    // One test that walks it end to end, because every earlier round's
+    // reachability defect was a chain whose links each passed alone. The team
+    // tab's tap opens the real `TakeSurveyScreen` here — not a stub — so the
+    // team id crosses the navigation for real, and Kotlin's landing is
+    // asserted too: `UserInformationFragment.onDismiss` pops the survey off
+    // the back stack, so the respondent ends on the team's surveys tab rather
+    // than on a submission detail.
+    tester.view.physicalSize = const Size(1000, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await seedSurvey();
+
+    final overrides = [
+      appDatabaseProvider.overrideWith((ref) {
+        ref.onDispose(db.close);
+        return db;
+      }),
+      planetApiProvider.overrideWithValue(_MockPlanetApi()),
+      teamOwnedSurveysProvider(
+        'team-1',
+      ).overrideWith((ref) async => [survey()]),
+      teamAdoptableSurveysProvider(
+        'team-1',
+      ).overrideWith((ref) async => const []),
+      teamProvider('team-1').overrideWith((ref) async => null),
+      sessionProvider.overrideWith(
+        () => _StubSession(buildUserRow(id: 'user-a', name: 'jane')),
+      ),
+      teamMembershipsProvider.overrideWith(
+        (ref) => Stream.value(const <String, TeamRow>{}),
+      ),
+      serverConfigProvider.overrideWith(() => _StubServerConfig(_server)),
+      deviceIdentitySourceProvider.overrideWithValue(
+        const FixedDeviceIdentitySource(
+          DeviceIdentity(
+            androidId: 'android-1',
+            deviceName: 'Pixel',
+            customDeviceName: 'ada-phone',
+          ),
+        ),
+      ),
+    ];
+
+    await tester.pumpWidget(
+      wrapScreen(
+        const TeamSurveysScreen(teamId: 'team-1'),
+        pushTargets: {
+          '/life/surveys/:surveyId': (context) => TakeSurveyScreen(
+            surveyId: GoRouterState.of(context).pathParameters['surveyId']!,
+            teamId: GoRouterState.of(context).uri.queryParameters['teamId'],
+          ),
+        },
+        overrides: overrides,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Water access'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '2 km');
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Submit survey'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Your information'), findsOneWidget);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Year of birth'),
+      '1990',
+    );
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    for (var i = 0; i < 12; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await tester.pumpAndSettle();
+
+    // Back on the team's surveys tab: both pushed pages are gone. (The tab
+    // itself was never unmounted — it sits under the pushed routes — so its
+    // presence alone would prove nothing.)
+    expect(find.byType(TakeSurveyScreen), findsNothing);
+    expect(find.byType(UserInformationScreen), findsNothing);
+    expect(find.byType(TeamSurveysScreen), findsOneWidget);
+
+    final row = (await db.select(db.submissions).get()).single;
+    expect(row.teamId, 'team-1');
+    expect(row.user, isNotNull);
+  });
+
   group('the answer sheet the port writes carries the team', () {
-    Future<void> pumpTakeSurvey(WidgetTester tester, {String? teamId}) async {
+    Future<void> pumpTakeSurvey(
+      WidgetTester tester, {
+      String? teamId,
+      ServerConfig? config,
+    }) async {
       tester.view.physicalSize = const Size(1000, 3000);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);
@@ -205,6 +323,26 @@ void main() {
             planetApiProvider.overrideWithValue(_MockPlanetApi()),
             sessionProvider.overrideWith(
               () => _StubSession(buildUserRow(id: 'user-a', name: 'jane')),
+            ),
+            // Overridden because the real notifier reads `planetPrefs`, which
+            // is `UnimplementedError` in this harness — and `_submit` reads it
+            // *inside* its `try`, so without this the screen writes the row
+            // and then shows "Could not save your answers". The existing
+            // tests in `take_survey_screen_test.dart` assert only on the row,
+            // so they never saw the failure branch they were leaving the
+            // screen in. A null config skips the queue step, which is what
+            // an offline handset does anyway.
+            serverConfigProvider.overrideWith(() => _StubServerConfig(config)),
+            // The real source reads `planetPrefs`; the uploader reads this at
+            // queue time.
+            deviceIdentitySourceProvider.overrideWithValue(
+              const FixedDeviceIdentitySource(
+                DeviceIdentity(
+                  androidId: 'android-1',
+                  deviceName: 'Pixel',
+                  customDeviceName: 'ada-phone',
+                ),
+              ),
             ),
           ],
         ),
@@ -238,6 +376,114 @@ void main() {
       final rows = await submissions();
       expect(rows, hasLength(1));
       expect(rows.single.teamId, isNull);
+    });
+
+    testWidgets('a team survey asks the respondent who they are', (
+      tester,
+    ) async {
+      // `BaseExamFragment.continueExam:127-131` — the last question of a team
+      // survey goes to `showUserInfoDialog`, not to the thank-you dialog — and
+      // `showUserInfoDialog:153-164` opens `UserInformationFragment` for every
+      // live case (`isMySurvey` is false at both team entry points, and
+      // `isFromNation` has no writer that can make it true in Kotlin). The
+      // port completed a team survey in one tap and collected nothing, so the
+      // demographic a team survey exists to gather was never asked for and
+      // `UserInformationScreen.teamId` had no caller to be read by.
+      await seedSurvey();
+      await pumpTakeSurvey(tester, teamId: 'team-1');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UserInformationScreen), findsOneWidget);
+      final profile = tester.widget<UserInformationScreen>(
+        find.byType(UserInformationScreen),
+      );
+      expect(profile.teamId, 'team-1');
+      // `shouldHideElements = exam?.isFromNation != true`, which the arm's own
+      // predicate makes `true` — so the compact year-of-birth form, whose
+      // negation is `showAdditionalFields: false`.
+      expect(profile.showAdditionalFields, isFalse);
+      expect(profile.submissionId, (await submissions()).single.id);
+    });
+
+    testWidgets('a personal survey goes straight to the submission', (
+      tester,
+    ) async {
+      // The other side of the same gate: Kotlin reaches `showUserInfoDialog`
+      // only under `isTeam`, so a personal sheet must not acquire a profile
+      // step it never had.
+      await seedSurvey();
+      await pumpTakeSurvey(tester);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UserInformationScreen), findsNothing);
+      expect(find.text('SUBMISSION_PAGE'), findsOneWidget);
+    });
+
+    testWidgets('a nation survey skips the profile step', (tester) async {
+      // `showUserInfoDialog`'s else arm: `exam?.isFromNation == true` marks
+      // the sheet complete and leaves without asking. Dead in Kotlin — its
+      // only writer is `!parentId.isNullOrEmpty()` with `parentId` always `""`
+      // — but *live here*, because `SurveyMapper` reads `isFromNation` off the
+      // document, so a server that sends the key reaches this arm.
+      await seedSurvey(fromNation: true);
+      await pumpTakeSurvey(tester, teamId: 'team-1');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UserInformationScreen), findsNothing);
+      // The team is still on the row: the arm changes who is asked what, not
+      // what the sheet is attributed to.
+      expect((await submissions()).single.teamId, 'team-1');
+    });
+
+    testWidgets('the uploaded document carries both the team and the '
+        'respondent', (tester) async {
+      // The end of the chain, across both screens and the real uploader: what
+      // Planet actually receives. `resolveTeamJson` sends `{_id}` alone when
+      // the team document is not on this handset — which is the normal state
+      // of a handset that has not finished syncing — and the respondent's
+      // answers about themselves ride in the same document.
+      //
+      // Kotlin's order is what makes this hold: the sheet is queued by
+      // `onDismiss`, *after* `markSubmissionComplete` writes the profile. A
+      // port that queued at submit time would serialize the row before that
+      // write, and `pendingUploads` would have nothing left to re-queue once
+      // the outbox drained.
+      await seedSurvey();
+      await pumpTakeSurvey(tester, teamId: 'team-1', config: _server);
+      await tester.pumpAndSettle();
+
+      // Nothing is queued yet, and that is the ordering under test rather
+      // than an incidental observation: an enqueue here would carry a payload
+      // serialized before the profile exists, and a drain landing between the
+      // two would `markUploaded` the row out of `pendingUploads` for good.
+      expect(
+        await db.outboxDao.findOpen(
+          SubmissionsUploader.type,
+          (await submissions()).single.id,
+        ),
+        isNull,
+        reason: 'the sheet was queued before the respondent was asked',
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Year of birth'),
+        '1990',
+      );
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      final submissionId = (await submissions()).single.id;
+      final queued = await db.outboxDao.findOpen(
+        SubmissionsUploader.type,
+        submissionId,
+      );
+      expect(queued, isNotNull, reason: 'the team sheet was never queued');
+      final payload = jsonDecode(queued!.payload) as Map<String, dynamic>;
+      expect(payload['team'], {'_id': 'team-1'});
+      expect((payload['user'] as Map<String, dynamic>)['age'], isNotNull);
     });
 
     testWidgets('a blank team id is stored as no team at all', (tester) async {

--- a/flutter/test/ui/surveys/survey_team_context_test.dart
+++ b/flutter/test/ui/surveys/survey_team_context_test.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/team_surveys_provider.dart';
+import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/ui/router.dart';
+import 'package:myplanet/ui/surveys/take_survey_screen.dart';
+import 'package:myplanet/ui/teams/team_surveys_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/widget_harness.dart';
+
+class _MockPlanetApi extends Mock implements PlanetApi {}
+
+class _StubSession extends SessionNotifier {
+  _StubSession(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+/// Phase 132 — the team context an answer sheet is written with.
+///
+/// `SubmissionsRepository.createSurveyDraft(teamId:)` landed in Phase 129 with
+/// **no caller**, which is the reachability failure class this project keeps
+/// re-finding: the writer is correct, its tests are green, and no live journey
+/// hands it a value. Kotlin carries the team as fragment arguments
+/// (`TeamPagerAdapter` `putBoolean("isTeam", true)` + the id ->
+/// `BaseExamFragment:77-78` -> `ExamTakingFragment:124-125,151-152`), so a team
+/// survey's submission is attributable to the team; the port dropped it at the
+/// navigation and every answer sheet it wrote was team-less.
+///
+/// These tests exercise the chain rather than its halves — the team screen's
+/// push, the real route table's read, and the row the repository actually
+/// writes — because each half was already green while the whole was broken.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase.memory());
+  tearDown(() => db.close());
+
+  SurveyRow survey({String id = 's1', String? name = 'Water access'}) =>
+      SurveyRow(
+        id: id,
+        name: name,
+        createdDate: 0,
+        updatedDate: 0,
+        adoptionDate: 0,
+        totalMarks: 0,
+        isFromNation: false,
+        teamShareAllowed: false,
+      );
+
+  Future<void> seedSurvey({String id = 's1'}) async {
+    final mapping = SurveyMapper.fromDoc({
+      '_id': id,
+      'type': 'surveys',
+      'name': 'Water access',
+      'questions': [
+        {'id': 'q1', 'body': 'How far is the nearest tap?', 'type': 'input'},
+      ],
+    })!;
+    await db.surveyDao.upsertAll([mapping.survey], {id: mapping.questions});
+  }
+
+  Future<List<SubmissionRow>> submissions() => db.select(db.submissions).get();
+
+  /// Taps the first owned survey in the team's surveys tab and returns the
+  /// location the screen pushed.
+  Future<Uri> tapOwnedSurvey(WidgetTester tester) async {
+    Uri? pushed;
+
+    await tester.pumpWidget(
+      wrapScreen(
+        const TeamSurveysScreen(teamId: 'team-1'),
+        pushTargets: {
+          '/life/surveys/:surveyId': (context) {
+            pushed = GoRouterState.of(context).uri;
+            return const Scaffold(body: Text('TAKE_SURVEY'));
+          },
+        },
+        overrides: [
+          teamOwnedSurveysProvider(
+            'team-1',
+          ).overrideWith((ref) async => [survey()]),
+          teamAdoptableSurveysProvider(
+            'team-1',
+          ).overrideWith((ref) async => const []),
+          teamProvider('team-1').overrideWith((ref) async => null),
+          sessionProvider.overrideWith(() => _StubSession(null)),
+          teamMembershipsProvider.overrideWith(
+            (ref) => Stream.value(const <String, TeamRow>{}),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Water access'));
+    await tester.pumpAndSettle();
+
+    expect(pushed, isNotNull, reason: 'the survey route was not reached');
+    return pushed!;
+  }
+
+  group('the team surveys screen sends the team it is showing', () {
+    testWidgets('tapping an owned survey pushes a location carrying the team', (
+      tester,
+    ) async {
+      // `TeamSurveysScreen` pushed `'${Routes.surveys}/${survey.id}'` and
+      // dropped the team on the floor, which is where the whole chain died.
+      final pushed = await tapOwnedSurvey(tester);
+
+      expect(pushed.path, '/life/surveys/s1');
+      expect(pushed.queryParameters['teamId'], 'team-1');
+    });
+  });
+
+  group('the survey route carries the team to the screen', () {
+    late ProviderContainer container;
+    late GoRouter router;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+      container = ProviderContainer(
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          appDatabaseProvider.overrideWithValue(db),
+        ],
+      );
+      addTearDown(container.dispose);
+      router = container.read(routerProvider);
+    });
+
+    testWidgets('the location the team tab pushes builds a screen holding '
+        'the team', (tester) async {
+      // The pair test, and the reason it takes the location from the *screen*
+      // rather than writing one out: a route reading `team` where the push
+      // writes `teamId` is the Phase 74/100 shape — each half passes its own
+      // test, only the pair is wrong — and a hand-written location in this
+      // test would be a third copy of the key that agrees with neither.
+      final pushed = await tapOwnedSurvey(tester);
+      final built = await _buildFromRouter(tester, router, pushed.toString());
+
+      expect(built, isA<TakeSurveyScreen>());
+      expect((built as TakeSurveyScreen).surveyId, 's1');
+      expect(built.teamId, 'team-1');
+    });
+
+    testWidgets('a personal survey location builds a team-less screen', (
+      tester,
+    ) async {
+      final built = await _buildFromRouter(tester, router, '/life/surveys/s1');
+
+      expect((built as TakeSurveyScreen).teamId, isNull);
+    });
+
+    testWidgets('the resume query parameter still reaches the screen', (
+      tester,
+    ) async {
+      // `?submission=` and `?teamId=` share the query string now; reading one
+      // must not have cost the other.
+      final built =
+          await _buildFromRouter(
+                tester,
+                router,
+                '/life/surveys/s1?submission=sub-9',
+              )
+              as TakeSurveyScreen;
+
+      expect(built.submissionId, 'sub-9');
+      expect(built.teamId, isNull);
+    });
+  });
+
+  group('the answer sheet the port writes carries the team', () {
+    Future<void> pumpTakeSurvey(WidgetTester tester, {String? teamId}) async {
+      tester.view.physicalSize = const Size(1000, 3000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        wrapScreen(
+          TakeSurveyScreen(surveyId: 's1', teamId: teamId),
+          pushTargets: {
+            '/life/submissions/:id': (_) =>
+                const Scaffold(body: Text('SUBMISSION_PAGE')),
+          },
+          overrides: [
+            appDatabaseProvider.overrideWith((ref) {
+              ref.onDispose(db.close);
+              return db;
+            }),
+            planetApiProvider.overrideWithValue(_MockPlanetApi()),
+            sessionProvider.overrideWith(
+              () => _StubSession(buildUserRow(id: 'user-a', name: 'jane')),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '2 km');
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Submit survey'));
+      // Never pumpAndSettle after Submit: the button holds an indefinite
+      // CircularProgressIndicator while `submitting` is true.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+    }
+
+    testWidgets('a team survey stores the team on the submission', (
+      tester,
+    ) async {
+      await seedSurvey();
+      await pumpTakeSurvey(tester, teamId: 'team-1');
+
+      final rows = await submissions();
+      expect(rows, hasLength(1));
+      expect(rows.single.teamId, 'team-1');
+    });
+
+    testWidgets('a personal survey stores no team', (tester) async {
+      await seedSurvey();
+      await pumpTakeSurvey(tester);
+
+      final rows = await submissions();
+      expect(rows, hasLength(1));
+      expect(rows.single.teamId, isNull);
+    });
+
+    testWidgets('a blank team id is stored as no team at all', (tester) async {
+      // `teamId?.takeIf { it.isNotBlank() }` (`createExamSubmission:440`). A
+      // query parameter is a string, so `?teamId=` arrives as `''` rather than
+      // as absent, and the blank guard is what keeps that out of the column.
+      await seedSurvey();
+      await pumpTakeSurvey(tester, teamId: '   ');
+
+      final rows = await submissions();
+      expect(rows.single.teamId, isNull);
+    });
+  });
+}
+
+/// Builds the widget the **real** route table produces for [location].
+///
+/// The screen tests elsewhere construct their screen directly, which is
+/// precisely why an unreachable screen stayed green for three phases. This
+/// walks the router's own match so the route's parameter reading is what is
+/// under test, not a hand-written repetition of it.
+Future<Widget> _buildFromRouter(
+  WidgetTester tester,
+  GoRouter router,
+  String location,
+) async {
+  final uri = Uri.parse(location);
+  final matchList = router.configuration.findMatch(uri);
+  expect(matchList.isError, isFalse, reason: 'no route matches $location');
+  final leaf = _leafMatch(matchList.matches.last);
+  final route = leaf.route;
+
+  late Widget built;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) {
+          built = route.builder!(
+            context,
+            GoRouterState(
+              router.configuration,
+              uri: uri,
+              matchedLocation: leaf.matchedLocation,
+              fullPath: matchList.fullPath,
+              pathParameters: matchList.pathParameters,
+              pageKey: const ValueKey('phase-132'),
+            ),
+          );
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  );
+  return built;
+}
+
+/// The leaf of a match: the survey route sits under the dashboard's shell, so
+/// `matches.last` is the shell rather than the `GoRoute` that builds a screen.
+RouteMatch _leafMatch(RouteMatchBase match) => match is ShellRouteMatch
+    ? _leafMatch(match.matches.last)
+    : match as RouteMatch;

--- a/flutter/test/ui/team_surveys_screen_test.dart
+++ b/flutter/test/ui/team_surveys_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/providers/team_surveys_provider.dart';
 import 'package:myplanet/providers/teams_provider.dart';
 import 'package:myplanet/repository/surveys_repository.dart';
+import 'package:myplanet/ui/surveys/send_survey_screen.dart';
 import 'package:myplanet/ui/teams/team_surveys_screen.dart';
 
 import '../support/widget_harness.dart';
@@ -20,18 +21,23 @@ class _TestSessionNotifier extends SessionNotifier {
   Future<UserRow?> build() async => user;
 }
 
-SurveyRow _survey({String id = 's1', String? name, String? description}) =>
-    SurveyRow(
-      id: id,
-      name: name,
-      description: description,
-      createdDate: 0,
-      updatedDate: 0,
-      adoptionDate: 0,
-      totalMarks: 0,
-      isFromNation: false,
-      teamShareAllowed: false,
-    );
+SurveyRow _survey({
+  String id = 's1',
+  String? name,
+  String? description,
+  String? sourceSurveyId,
+}) => SurveyRow(
+  id: id,
+  name: name,
+  description: description,
+  sourceSurveyId: sourceSurveyId,
+  createdDate: 0,
+  updatedDate: 0,
+  adoptionDate: 0,
+  totalMarks: 0,
+  isFromNation: false,
+  teamShareAllowed: false,
+);
 
 UserRow _user() => UserRow(
   id: 'user-1',
@@ -123,6 +129,56 @@ void main() {
     expect(find.text('Untitled survey'), findsOneWidget);
     expect(find.byIcon(Icons.send), findsNWidgets(2));
     expect(find.byIcon(Icons.chevron_right), findsNWidgets(2));
+  });
+
+  testWidgets('Send targets the survey on the card, not its source', (
+    tester,
+  ) async {
+    // Phase 132. Kotlin sends the id of the exam the row is bound to —
+    // `listener?.sendSurvey(current.exam)` (`SurveysAdapter:63-66`) ->
+    // `b.putString("surveyId", current?.id)` (`DashboardActivity:1008-1014`)
+    // -> `sendSurveyToUsers` -> `createBulkSurveySubmissions`. An adopted team
+    // survey always carries a `sourceSurveyId`, so preferring it sent the
+    // *un-adopted original*: each member got a pending sheet keyed
+    // `parentId = <source>`, their answers filed against the source, and the
+    // team's own copy — which is what `submissionsForTeam` and the adoptable
+    // list read — showed no submissions at all, permanently.
+    //
+    // `surveys_screen.dart:118` already passes `row.id`; the two screens
+    // disagreeing is the tell.
+    final adopted = _survey(
+      id: 's1_team-1',
+      name: 'Water access - Blue',
+      sourceSurveyId: 's1',
+    );
+
+    await tester.pumpWidget(
+      wrapScreen(
+        const TeamSurveysScreen(teamId: 'team-1'),
+        overrides: [
+          teamOwnedSurveysProvider(
+            'team-1',
+          ).overrideWith((ref) async => [adopted]),
+          teamAdoptableSurveysProvider(
+            'team-1',
+          ).overrideWith((ref) async => const []),
+          teamProvider('team-1').overrideWith((ref) async => null),
+          sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
+          teamMembershipsProvider.overrideWith(
+            (ref) => Stream.value(const <String, TeamRow>{}),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    final dialog = tester.widget<SendSurveyScreen>(
+      find.byType(SendSurveyScreen),
+    );
+    expect(dialog.surveyId, 's1_team-1');
   });
 
   testWidgets('a non-leader sees the adopt button disabled', (tester) async {

--- a/flutter/test/ui/team_surveys_screen_test.dart
+++ b/flutter/test/ui/team_surveys_screen_test.dart
@@ -140,9 +140,13 @@ void main() {
     // -> `sendSurveyToUsers` -> `createBulkSurveySubmissions`. An adopted team
     // survey always carries a `sourceSurveyId`, so preferring it sent the
     // *un-adopted original*: each member got a pending sheet keyed
-    // `parentId = <source>`, their answers filed against the source, and the
-    // team's own copy — which is what `submissionsForTeam` and the adoptable
-    // list read — showed no submissions at all, permanently.
+    // `parentId = <source>`, so their answers filed against the source survey
+    // rather than against the team's own copy. Not because it repairs the
+    // team's readers — `getOrCreateSurveySubmission` writes neither a `teamId`
+    // column nor a `parent`, so a bulk-created sheet is invisible to
+    // `submissionsForTeam` and `_teamSubmissionSurveyIds` under either id —
+    // but because the parent id is what identifies a survey's responses, and
+    // Kotlin keys them to the survey the card shows.
     //
     // `surveys_screen.dart:118` already passes `row.id`; the two screens
     // disagreeing is the tell.


### PR DESCRIPTION
Lane B of a three-lane parallel round. Full write-up in `flutter/PHASE_132_NOTES.md`.

## What this closes

Phase 129 added `createSurveyDraft(teamId:)` / `startExamSession(teamId:)` and recorded that **no caller passes a team** — the reachability failure class: correct, tested, green, dead. Kotlin carries the team as fragment arguments (`TeamPagerAdapter:89-94` → `BaseExamFragment:77-78` → `ExamTakingFragment:151-152`).

**A correction to the brief's premise, from the ground-truth audit:** Kotlin has **seven** survey journeys and only **two** carry a team (the team detail's Surveys tab, and a public-survey deep link). The other five — the individual list, the my-surveys row, the dashboard prompt, `surveyNavigationEvent`, a course step — are team-less in Kotlin too, so those port paths were already at parity. The exam arm is confirmed unreachable with a team.

## The chain

`TeamSurveysScreen` pushes `?teamId=` → the survey route reads it (the same key `addResource` and `userInfo` already use) → `TakeSurveyScreen.teamId` → `submitResponse` → `createSurveyDraft`, which blank-guards it as `createExamSubmission:440` does. Plus `PublicSurveyScreen`, Kotlin's second site, where the id was already in hand.

## Three further defects, found by the audits, all in this lane's files

- **A team survey collected nothing about its respondent.** `continueExam:127-131` sends the last question of a team survey to `showUserInfoDialog`, which the port never opened — the reason `UserInformationScreen.teamId` was declared and never read. Now ported, gate included: `!isMySurvey && exam?.isFromNation != true`, both halves.
- **Declining the profile step didn't send the sheet.** `onDismiss:293-311` fires on *every* dismissal — Save, Cancel, an outside tap, the back button — and returns early on an empty team id. The port queued on Save only, and queued unconditionally. The queue now hangs off the screen's `PopScope`, which is the one hook that covers all three exits and puts the order where Kotlin has it (after `markSubmissionComplete`, so the payload carries the profile).
- **Send targeted the wrong survey.** The team screen preferred `sourceSurveyId`, so every Send created members' sheets against the un-adopted original, and their answers filed against the source rather than the team's own copy — mis-attributed at the parent id. `surveys_screen.dart` already passed `row.id`; the two screens disagreeing was the tell.

## ⚠️ Two things to read before merging

**1. A cost my own reordering introduced — reported, not fixed.** Moving the team sheet's enqueue to the profile step's pop is the Kotlin order and avoids POSTing the sheet twice, but the port has **no `queuePending` sweep in any sync or background path**, where Kotlin runs `uploadSubmissions()` unconditionally from `AutoSyncWorker`. Force-stop the app on "Your information" and a complete team sheet has no outbox row until the user's next submission. The fix belongs in `dashboard_sync_provider.dart` / `background_entrypoint.dart` — outside this lane's set, and the gap is port-wide. Notes: *Nothing sweeps `pendingUploads`, and this phase leans on that*. **This is the round's highest-value follow-up.**

**2. One file outside this lane's declared set.** `flutter/lib/repository/surveys_repository.dart` — one additive optional named parameter on `submitResponse`, forwarded verbatim to `createSurveyDraft`. The brief named `submissions_repository.dart` and told me to verify: `createSurveyDraft` does live there, but the method `TakeSurveyScreen` calls is `SurveysRepository.submitResponse`, the only thing between the screen and the writer. Both in-set alternatives were worse — calling the writer directly leaves `submitResponse` with no production caller (dead code to close a dead-code gap), and stopping leaves `teamId` plumbed to the screen and dropped there, reproducing the exact symptom this phase removes. No other lane owns the file this round.

Also: **review `user_information_screen.dart` with `git diff -w`** — wrapping the returned `Scaffold` re-indents the build method, so 292 changed lines carry 28 real ones.

## Verification

- Every defect demonstrated failing first; pre-fix output in the notes.
- **15 mutations injected, 15 killed** by a test that names each. Two are worth noting: queueing before the profile step passed at first (the outbox refreshes payloads, so only the timing differed, and a test now pins the timing), and re-reading my own `_cancel` found it reading `ref` after the pop, straight into a swallowing catch.
- The implementation audit independently ran 16 more on a scratchpad copy, including one this set had not covered (breaking the pushed path, which `route_reachability_test` kills). None survived.
- Tests drive the chain, not its halves: the tap's location, the **real route table's** read of it, the row the repository writes, the payload the uploader enqueues, and one walk of the whole journey.
- `dart format --set-exit-if-changed`, `flutter analyze`, `flutter test` — clean, 2366 tests. CI green on `9e002b0`.

Both required `parity-auditor` passes ran at `effort: max`. The second rejected two of my own rationales and my journey count; those are corrected where the reasoning lives (code comments and tests), not only in the notes, since a wrong reason is what re-seeds the mistake. **Eleven items** sit in *Reported, not fixed*, headed by the sweep above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQCWMdNGANdU7pFmGh8Xgs