### PR TITLE
login: smoother settings storage space dispatcher providing (fixes #16785)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7048
-        versionName = "0.70.48"
+        versionCode = 7049
+        versionName = "0.70.49"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -324,6 +324,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
             runBestEffort("SecurePrefs.warmUp") { SecurePrefs.warmUp(this@MainApplication) }
             runBestEffort("MarkdownUtils.warmUp") { MarkdownUtils.warmUp(this@MainApplication) }
             runBestEffort("Utilities.warmUp") { Utilities.warmUp() }
+            runBestEffort("defaultPref.warmUp") { defaultPref }
             runBestEffort("GifInfoHandle preload") { Class.forName("pl.droidsonroids.gif.GifInfoHandle") }
         }
         applicationScope.launch {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -19,10 +19,12 @@ import androidx.preference.Preference
 import androidx.preference.Preference.OnPreferenceChangeListener
 import androidx.preference.Preference.OnPreferenceClickListener
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceManager
 import androidx.preference.SwitchPreference
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.RetryOperation
@@ -34,6 +36,7 @@ import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.sync.SyncActivity.Companion.restartApp
 import org.ole.planet.myplanet.utils.DialogUtils
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
@@ -44,6 +47,8 @@ import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class SettingsActivity : AppCompatActivity() {
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
 
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(LocaleUtils.onAttach(base))
@@ -51,6 +56,9 @@ class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        lifecycleScope.launch(dispatcherProvider.io) {
+            PreferenceManager.getDefaultSharedPreferences(this@SettingsActivity)
+        }
         EdgeToEdgeUtils.setupEdgeToEdge(this, findViewById(android.R.id.content))
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         FragmentNavigator.replaceFragment(supportFragmentManager, android.R.id.content, SettingFragment())
@@ -84,6 +92,8 @@ class SettingsActivity : AppCompatActivity() {
         lateinit var sharedPrefManager: SharedPrefManager
         @Inject
         lateinit var timeProvider: TimeProvider
+        @Inject
+        lateinit var dispatcherProvider: DispatcherProvider
         var user: UserEntity? = null
         private var libraryList: List<MyLibrary>? = null
 
@@ -261,8 +271,14 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun refreshStorageBreakdownSummary() {
-            findPreference<Preference>("storage_breakdown")?.summary = getString(R.string.storage_breakdown_summary) +
-                " · ${getString(R.string.available_space_colon)} ${FileUtils.availableOverTotalMemoryFormattedString(requireContext())}"
+            val context = requireContext().applicationContext
+            lifecycleScope.launch {
+                val availableSpaceText = withContext(dispatcherProvider.io) {
+                    FileUtils.availableOverTotalMemoryFormattedString(context)
+                }
+                findPreference<Preference>("storage_breakdown")?.summary = getString(R.string.storage_breakdown_summary) +
+                    " · ${getString(R.string.available_space_colon)} $availableSpaceText"
+            }
         }
 
         private fun initRetryQueueDebug() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.settings
 
 import android.app.Dialog
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -175,13 +176,18 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
         binding.contentLayout.visibility = View.GONE
         binding.emptyText.visibility = View.GONE
 
-        loadJob = viewLifecycleOwner.lifecycleScope.launch {
-            val (availableSpaceText, result) = withContext(dispatcherProvider.io) {
-                FileUtils.availableOverTotalMemoryFormattedString(requireContext()) to scanStorage()
-            }
+        val context = requireContext().applicationContext
 
+        loadJob = viewLifecycleOwner.lifecycleScope.launch {
+            val availableSpaceText = withContext(dispatcherProvider.io) {
+                FileUtils.availableOverTotalMemoryFormattedString(context)
+            }
             binding.availableSpaceText.text = getString(R.string.available_space_colon) +
                 " " + availableSpaceText
+
+            val result = withContext(dispatcherProvider.io) {
+                scanStorage(context)
+            }
 
             categories.forEachIndexed { index, category ->
                 category.sizeBytes = result.sizes[index]
@@ -204,8 +210,8 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
 
     internal data class ScanResult(val totalBytes: Long, val sizes: LongArray, val counts: IntArray)
 
-    private fun scanStorage(): ScanResult {
-        return scanStorage(File(FileUtils.getOlePath(requireContext())))
+    private fun scanStorage(context: Context): ScanResult {
+        return scanStorage(File(FileUtils.getOlePath(context)))
     }
 
     internal fun scanStorage(oleDir: File): ScanResult {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
@@ -175,11 +175,13 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
         binding.contentLayout.visibility = View.GONE
         binding.emptyText.visibility = View.GONE
 
-        binding.availableSpaceText.text = getString(R.string.available_space_colon) +
-            " " + FileUtils.availableOverTotalMemoryFormattedString(requireContext())
-
         loadJob = viewLifecycleOwner.lifecycleScope.launch {
-            val result = withContext(dispatcherProvider.io) { scanStorage() }
+            val (availableSpaceText, result) = withContext(dispatcherProvider.io) {
+                FileUtils.availableOverTotalMemoryFormattedString(requireContext()) to scanStorage()
+            }
+
+            binding.availableSpaceText.text = getString(R.string.available_space_colon) +
+                " " + availableSpaceText
 
             categories.forEachIndexed { index, category ->
                 category.sizeBytes = result.sizes[index]


### PR DESCRIPTION
fixes #16785
Inject `DispatcherProvider` into `SettingsActivity` and compute available-space text in `dispatcherProvider.io` before updating the preference summary. `StorageBreakdownFragment` now fetches available-space text and scans storage together on the IO dispatcher, then updates UI on the main thread to avoid blocking during storage calculations.