### PR TITLE
Phase 134 (Lane A): the submissions safety-net sweep in both sync paths

### DIFF
--- a/flutter/PHASE_134_NOTES.md
+++ b/flutter/PHASE_134_NOTES.md
@@ -50,7 +50,7 @@ pre-fix code it came back `uploaded == false`.
 * **`background_entrypoint.dart`** — top-level `submissionsPushStep(...)`, wired
   into `syncSteps` after `shelf_push` and **before** the pulls.
 * **`submissions_uploader.dart`** — `queuePending`'s `userId` is now nullable.
-* **`test/providers/pending_submissions_sweep_test.dart`** — 10 tests.
+* **`test/providers/pending_submissions_sweep_test.dart`** — 11 tests.
 
 ### Five decisions, each a reading of the Kotlin
 
@@ -98,11 +98,26 @@ runs. That is a Kotlin weakness rather than a behaviour to reproduce;
 pull is not in the full sync at all — it lives in `HeavyTableSyncWorker`
 (`HeavyTableSyncWorker:39-41`), which `startFullSync` only *schedules* at its
 end (`SyncManager:209`), while the sweep runs during the pass. The port's
-headless path does have a `'submissions'` pull step, and
-`SubmissionsRepository.upsertDocuments` writes `isUpdated: false` over rows it
-touches (as `bulkInsertFromSync` does, `SubmissionsRepositoryImpl:686`), so
-sweep-then-pull is the safe order as well as the faithful one. Both port paths
-agree on it, and a source-reading test pins the order in the headless list.
+headless path does have a `'submissions'` pull step, so sweep-then-pull is the
+safe order as well as the faithful one; both port paths agree on it, and a
+source-reading test pins the order in the headless list.
+
+**The first version of that reasoning was wrong, and it was mine.** Both doc
+comments said a pull "would take a locally edited sheet out of
+`pendingUploads`", full stop. `upsertDocuments` keys every row on the server
+`_id` (`submissions_repository.dart:1670-1672`, `id: id`), so a **locally
+authored** sheet — sha1 local id — has a pulled document land *beside* it as a
+separate row, touching nothing. Kotlin does exactly the same
+(`SubmissionsRepositoryImpl:669-670`), at the cost of two rows per logical
+submission after upload-then-pull. What the order actually protects is the
+narrower case of a sheet that **arrived from the server and was then edited
+locally**: survey resume's `markComplete` sets `uploaded: false,
+isUpdated: true` on a row whose primary key *is* the server `_id`, so a pull
+running first overwrites both and the edit never uploads. The claim is now
+stated in that narrower form and pinned by its own test (*a pull clears the
+local edit on a server-originated sheet*) rather than asserted in prose — a
+justification nothing exercises is how the four misread-Kotlin findings got
+in.
 
 ### Drained, not merely queued
 

--- a/flutter/PHASE_134_NOTES.md
+++ b/flutter/PHASE_134_NOTES.md
@@ -1,0 +1,10 @@
+# Phase 134 — the submissions safety-net sweep
+
+Lane A of a four-lane round. Branch `claude/pending-uploads-sweep-h8n2`.
+
+Closes the gap Phase 132's implementation audit called the round's
+highest-value item: **the port has no `queuePending` sweep in any sync or
+background path**, so a completed answer sheet that misses its one write-time
+enqueue call sits on the handset indefinitely.
+
+*(In progress — this file is written as the work lands.)*

--- a/flutter/PHASE_134_NOTES.md
+++ b/flutter/PHASE_134_NOTES.md
@@ -21,9 +21,10 @@ profile dialog's dismissal (`UserInformationFragment:303` →
 run with no precondition on the sheet, the user or the pull. A missed dismissal
 costs nothing there.
 
-The port had only *write-time* call sites — `take_survey_screen:278`,
-`user_information_screen:471`, `take_exam_screen:544`,
-`submissions_screen:190`, `teams_screen:202`. `background_entrypoint`'s
+The port had only *write-time* call sites — `take_survey_screen:276-278`,
+`user_information_screen:471`, `take_exam_screen:542-547` and
+`submissions_screen:186-193`. (Four, not five: `teams_screen:200-202` is
+`teamLogUploaderProvider.queuePending`, a different uploader.) `background_entrypoint`'s
 `'submissions'` step is the **pull**, and `OutboxDrainScope` only drains rows
 that already exist. So a sheet whose one enqueue call never ran sat on the
 handset as a `complete, isUpdated, !uploaded` row **with no outbox row**, and
@@ -46,11 +47,17 @@ pre-fix code it came back `uploaded == false`.
 ## What landed
 
 * **`dashboard_sync_provider.dart`** — `DashboardSyncNotifier.queuePendingSubmissions()`,
-  called from `syncAll()` immediately after `pushCurrentUserShelf()`.
-* **`background_entrypoint.dart`** — top-level `submissionsPushStep(...)`, wired
-  into `syncSteps` after `shelf_push` and **before** the pulls.
-* **`submissions_uploader.dart`** — `queuePending`'s `userId` is now nullable.
-* **`test/providers/pending_submissions_sweep_test.dart`** — 11 tests.
+  called from `syncAll()` after the shelf push and the challenge write, ahead
+  of every area. Queues, then drains the whole queue.
+* **`background_entrypoint.dart`** — top-level `sweepPendingSubmissions(...)`,
+  called from the runner's `drainOutbox` closure, ahead of the drain that
+  carries it and ahead of the pulls.
+* **`submissions_uploader.dart`** — `queuePending`'s `userId` is now nullable,
+  and it skips an item whose send is already on the wire.
+* **`outbox_repository.dart`** — `isInFlight`, which is what that skip asks.
+* **`test/providers/pending_submissions_sweep_test.dart`** — 14 tests, plus the
+  two `planetPrefsProvider`/`deviceIdentitySourceProvider` overrides
+  `dashboard_sync_provider_test.dart` now needs.
 
 ### Five decisions, each a reading of the Kotlin
 
@@ -78,13 +85,32 @@ stranded on it, and a shared handset is the normal deployment for this app.
 Nothing reads `OutboxEntries.userId` back (`tables.dart:368`), so a null tag
 costs the row nothing.
 
-**Ungated.** Unlike the two telemetry steps beside it, this does *not* wait for
-`successCount > 0`. Kotlin's manual sweep runs concurrently with the pull and
-inspects nothing about it, and `ServerReachabilityWorker` sweeps with **no pull
-at all**. A failed pull pass is not a reason to leave a finished sheet on the
-device. This is also why the test that pins it is worth having: in the widget
-harness every one of the sixteen areas fails, so a `successCount` gate would
-have made the sweep look correct and never run.
+**Ungated — and the first cut got half of that wrong.** Unlike the two telemetry
+steps beside it, the foreground sweep does *not* wait for `successCount > 0`:
+Kotlin's manual sweep runs concurrently with the pull and inspects nothing about
+it, and `ServerReachabilityWorker` sweeps with **no pull at all**. A failed pull
+pass is not a reason to leave a finished sheet on the device. The test that pins
+this is worth having because in the widget harness every one of the sixteen
+areas fails, so a `successCount` gate would have made the sweep look correct and
+never run.
+
+The **headless** half was gated, though, and only the implementation audit
+caught it. Put in `syncSteps` beside `shelf_push`, it sat behind three
+conditions `BackgroundTaskRunner.run` applies before it reaches the steps
+(`background_task_runner.dart:102-136`): the task must not be `maintenance`,
+`autoSyncEnabled` must be true, and the interval must be due. And
+`BackgroundWorkCoordinator` cancels the `autoSync` job outright when the user
+turns auto-sync off (`background_work_coordinator.dart:27-30`), so **for that
+user only `maintenance` ever fires and the step would never have run at all** —
+their safety net would have been "open the sync centre and press Sync", which
+is not a net. Kotlin's closest sweeper is `ServerReachabilityWorker`, scheduled
+by `NetworkMonitorWorker.start` from `MainApplication:520-522` with no reference
+to any sync setting or cadence, sweeping on **network reconnection**: precisely
+the case this exists for, the handset offline when the sheet was finished and
+the network back later. The sweep moved to the `drainOutbox` closure, which runs
+ahead of all three gates and on every invocation. Citing that worker as the
+authority for *ungated* and then filing the code behind the port's own cadence
+gate is the kind of contradiction a doc comment makes easy and a test does not.
 
 **Its own `try`, not a shared one — deliberately unlike Kotlin.**
 `AutoSyncWorker:121-138` runs the sweep as the sixteenth statement of one
@@ -99,8 +125,9 @@ pull is not in the full sync at all — it lives in `HeavyTableSyncWorker`
 (`HeavyTableSyncWorker:39-41`), which `startFullSync` only *schedules* at its
 end (`SyncManager:209`), while the sweep runs during the pass. The port's
 headless path does have a `'submissions'` pull step, so sweep-then-pull is the
-safe order as well as the faithful one; both port paths agree on it, and a
-source-reading test pins the order in the headless list.
+safe order as well as the faithful one, and it survives the move into
+`drainOutbox` — which the runner also calls before the steps. A source-reading
+test pins it.
 
 **The first version of that reasoning was wrong, and it was mine.** Both doc
 comments said a pull "would take a locally edited sheet out of
@@ -119,7 +146,7 @@ local edit on a server-originated sheet*) rather than asserted in prose — a
 justification nothing exercises is how the four misread-Kotlin findings got
 in.
 
-### Drained, not merely queued
+### Drained, not merely queued, and drained whole
 
 The one place the port cannot copy Kotlin's shape verbatim: Kotlin's sweep
 *posts*, while `queuePending` only enqueues, and the drain trigger is app
@@ -127,15 +154,28 @@ resume or the next headless invocation. Without a drain the fix would convert
 "deferred until the user finishes another submission" into "deferred until the
 next resume" — better, bounded, and still not what Kotlin does.
 
-So each sweep is followed by `drain(onlyTypes: {SubmissionsUploader.type})`.
-Every write-time call site already pairs the two (`submissions_screen:186-193`);
-the `onlyTypes` scope is what keeps a sweep from turning into a whole-queue
-flush nothing asked for. In the headless path this also fixes an ordering the
-runner imposes: `BackgroundTaskRunner` drains **before** it runs the steps
-(`background_task_runner.dart:100`), so a row swept in a step would otherwise
-wait for the next invocation.
+The first cut scoped that drain to `SubmissionsUploader.type`, reasoning that a
+sweep should not become a whole-queue flush nothing asked for. **The
+implementation audit showed that was wrong twice over.** `OutboxDrainer.drain`
+satisfies a *joining* caller without doing its work
+(`outbox_drainer.dart:79-82`, `return existing.then((_) => const [])`), and
+`outboxDrainerProvider` is a cached provider, so `_inFlight` is app-wide: a
+resume drain arriving during a submissions-only pass would return having sent
+nothing, and every queued health record, rating and team write would wait for
+the *next* resume. And the premise was false anyway — Kotlin's manual sync **is**
+a whole-queue flush, `UserDataWorker`'s `UPLOAD_TYPE_BULK` running eleven upload
+arms of which `uploadSubmissions()` is one. Both paths now drain unscoped: the
+foreground explicitly, the headless one by leaning on the drain the runner
+already makes. A test pins it by queueing an unrelated `uploadType` before the
+sync and asserting it left.
 
-### Why it cannot double-post
+In the headless path this also fixes an ordering the runner imposes:
+`BackgroundTaskRunner` drains **before** it runs the steps
+(`background_task_runner.dart:100`), so a row swept in a step would otherwise
+wait for the next invocation. Sweeping inside `drainOutbox` puts the queue write
+immediately before the drain that carries it.
+
+### Why it cannot double-post — and the one way it could
 
 The brief was right that a double POST is worse than a deferred one, and the
 ground-truth pass established what actually protects Kotlin: **nothing but the
@@ -150,36 +190,75 @@ table. **Kotlin therefore really can double-post**, and the auditor named the
 input: answer a team survey's last question, dismiss the profile dialog, and
 tap the dashboard sync button inside that probe window.
 
-The port inherits the same protection and adds one Kotlin lacks:
-`SubmissionsUploader.handler`'s `markUploaded` is the port of that UPDATE, and
-`OutboxRepository.enqueue` keys on `(uploadType, itemId)`, so a sweep over an
-already-queued row refreshes it instead of adding a second — with
-`OutboxDrainer`'s single-flight guard and its status-scoped claim keeping two
-drains off one row. The test drives the write-time enqueue *and* the sweep over
-one submission and asserts one row, one POST, and a second sweep that posts
-nothing.
+The port inherits that protection (`markUploaded` is the port of the same
+UPDATE) and adds one Kotlin lacks: `OutboxRepository.enqueue` keys on
+`(uploadType, itemId)`, so a sweep over an already-queued row refreshes it
+instead of adding a second.
+
+**And the implementation audit found a way through it anyway — the most
+valuable thing this phase produced.** `enqueue` puts an `in_progress` row back
+to `pending`, deliberately, so a payload edited mid-flight is not lost with the
+row `markCompleted` deletes; and `markCompleted` is `deleteIfInProgress`. So the
+send that succeeds moments later deletes **nothing**, the row survives as
+`pending` carrying the same body, and the next drain posts it again. Planet ends
+up with two answer sheets and the orphan carries a `_rev` no device knows.
+
+That reset is correct for *derived state* — the shelf, whose handler rebuilds
+from the database, so a replay re-sends current truth. A submission is an
+**append** (`submissions_uploader.dart:10` says so) and replaying an append is a
+duplicate, not an edit. The distinction was already written down in
+`OutboxHandler`'s doc comment; nothing had acted on it.
+
+It was newly reachable because of this phase: before, no credentialed path
+paired an enqueue with a drain except `submissions_screen`'s modal, which
+nothing races. Putting a drain in `syncAll` means the pair now runs on every
+sync while the app is interactive — tap Sync, then finish a survey while the
+POST is on the wire, and `take_survey_screen` calls the same `queuePending`.
+Demonstrated failing first (`posts = 2`), then fixed: `queuePending` skips an
+item whose send is in flight, via a new `OutboxRepository.isInFlight`.
+
+The cost is the narrow window where the sheet is edited *while* its POST is in
+flight: `markUploaded` clears `isUpdated` on success, so that edit leaves the
+pending set. Kotlin loses it identically — `SubmissionDao:44` clears `isUpdated`
+in the same statement — and a later edit is a `_rev`-carrying PUT rather than a
+new document, so a lost update is recoverable where a duplicate document is not.
+
+Because every enqueue of `uploadType = 'submissions'` goes through
+`queuePending`, the fix covers all four write-time sites as well as both sweeps.
 
 ## Every test was mutation-tested
 
-Phase 122's practice, and worth the ten minutes: a migration test that cannot
-fail reads as coverage. Five mutations, each failing exactly the tests that
-should notice and no others:
+Phase 122's practice, and it earned its keep: the first pass found one claim
+(the sweep sitting behind the challenge write) that **no test pinned at all**,
+so a test was added for it. Nine mutations, each failing exactly the tests that
+should notice:
 
 | mutation | test that failed |
 |---|---|
 | drop `queuePendingSubmissions()` from `syncAll` | the three foreground delivery/ordering tests |
-| the headless step returns `false` on throw | *a throwing push step does not request an OS retry* |
-| remove `submissionsPushStep` from `syncSteps` | *the headless path builds the step…* |
-| move the step after the `'submissions'` pull | *the headless path builds the step…* |
-| re-scope `queuePending` with `.where((r) => r.userId == userId)` | *the push step sweeps with no signed-in user* |
+| drop the in-flight skip in `queuePending` | *a re-enqueue mid-flight does not post a second document* |
+| move the sweep from `drainOutbox` into `syncSteps` | *the headless path calls the sweep from drainOutbox* |
+| the headless sweep rethrows | *a throwing sweep does not escape* |
+| re-scope the sync's drain to `submissions` | *the sync drains the whole queue, not just submissions* |
+| scope `pendingUploads` to one user in SQL | *delivers another user's sheet…*, *the sweep runs with no signed-in user* |
+| re-scope `queuePending` with a Dart `.where` on `userId` | *the sweep runs with no signed-in user* |
+| remove `recordSyncChallengeAction` from `syncAll` | *the sweep runs before the first table pull* |
+| move the sweep after the `'submissions'` pull | *the headless path calls the sweep from drainOutbox* |
 
-The reachability test is the one worth explaining. `submissionsPushStep` is
-exercised directly, which is precisely the Phase 113 shape: ported, tested,
-green and possibly built by nobody. `executeBackgroundTask` needs a Flutter
-binding, real preferences and a WorkManager engine, so its `syncSteps` list
-cannot be constructed in a unit test — the test reads
-`lib/background_entrypoint.dart` instead and asserts the step is built *and*
-built before the pull, the way `version_parity_test` reads `app/build.gradle`.
+Three test weaknesses the audit named and this pass fixed. The reachability
+test's "nothing calls the sweep" assertion was **vacuous**: it searched from
+`syncSteps:` to end of file, which includes the function's own declaration, so
+the name always occurred. It is now bounded to the runner's argument list and
+asserts the *call site* — before the drain, before the pull, and before
+`syncSteps:` so a future move back into the gated step list fails. The two
+throwing-sweep tests asserted nothing about the throw actually happening —
+`_ThrowingIdentitySource` only throws when `pendingUploads()` returned rows, so
+a fixture that stopped setting `isUpdated` would have left them green; it counts
+its reads now and the tests assert the count. And **nothing tested the
+cross-user handset**, which is the entire case the unscoped design exists for:
+a `pendingUploads()` re-scoped to the session in SQL would have left every other
+test passing. There is now a test that seeds member B's sheet, syncs as member
+A, and asserts both the delivery and that the document is attributed to B.
 
 ## A harness trap, arriving through a new door
 
@@ -192,6 +271,29 @@ overridden with `PlanetPrefs(await SharedPreferences.getInstance())`, the shape
 `leaders_screen_test` already uses. Same family as Phase 75's, and the reason
 it is worth writing down again: a swallowed exception plus an
 `UnimplementedError` provider is indistinguishable from a broken fix.
+
+**And it bit the sibling file silently.** `dashboard_sync_provider_test.dart`
+builds its containers without that override, so once `syncAll` gained the
+sweep its two `syncAll` tests were running a `queuePendingSubmissions` that
+threw `UnimplementedError` and was swallowed — still green, no longer covering
+the second half of the pass. Both overrides are added there with a comment
+saying why. **Adding a step to a shared entry point silently narrows every
+existing test of it**; the tests that break are the honest case.
+
+## What the two audit passes cost and returned
+
+Worth recording as evidence for the standing rule, since it is now four rounds
+of it. The **ground-truth** pass changed three decisions before any code
+existed: the foreground placement's real justification (`UserDataWorker:48` is
+reached from the dashboard sync button, not from `startFullSync`, which sweeps
+nothing), the ungated shape, and the deliberate departure from Kotlin's shared
+sequential `try`. The **implementation** pass, aimed at code that was already
+green with eleven passing tests, found a duplicate CouchDB document, a headless
+half that never ran for anyone with auto-sync off, a drain scope that would
+starve the resume drain, three false citations in my own doc comments, a
+vacuous assertion in my own reachability test, two tests that could pass without
+the thing they tested happening, and the absence of any test for the design's
+central claim. **None of that was visible from a green suite.**
 
 ## Reported, not fixed
 
@@ -230,6 +332,76 @@ the exam arm's own condition while excluding `''` and `pending` — one method i
 `app_database.dart` (**Lane B's this round**) with a matching read of
 `submissions_repository.dart` (**Lane C's**). Not editable from here, and it is
 a behaviour decision rather than an obvious repair.
+
+### A permanently refused sheet accretes one `abandoned` outbox row per sweep
+
+Found by the implementation audit, pre-existing, and now once per sync rather
+than once per user write. `OutboxDao.findOpen` deliberately ignores an
+`abandoned` row so a fresh enqueue is never blocked by one
+(`app_database.dart:2062-2065`), so each sweep **inserts a new row** with a new
+id and five fresh attempts. `clearAbandoned` has one caller in the whole tree
+(`health_uploader.dart:78`) and `cleanup()` has none, and `outbox` is in
+`localAuthorityTables`, so a schema bump does not clear it either. The auditor
+demonstrated five sweeps producing five `abandoned` rows and five doomed POSTs.
+
+The request count is at parity — Kotlin re-POSTs once per sweep too, since its
+row still matches the predicate — so what is port-only is the unbounded table.
+**Not fixed here, deliberately.** The fix is a policy call about the failure
+record (clear an item's abandoned rows on re-enqueue and lose the diagnostic, or
+bound the table in `cleanup()` and give it a caller), it applies to all fifteen
+uploaders rather than submissions, and doing it inside `queuePending` alone
+would fix one of them while leaving the shape everywhere else. It wants its own
+diff.
+
+The most likely trigger is worth naming because it is a **port-only document
+shape**: `createDraft` (`submissions_repository.dart:67-106`) is the submissions
+list's own New-submission button, which `collapseSubmissionsByParent`'s comment
+(`:1938-1941`) states has no Kotlin writer, and it produces `parentId: ''`,
+`parent` as a bare string, `status: 'pending'`. If Planet refuses that shape,
+any 4xx is classified `permanent` (`outbox_drainer.dart:163`) and the device
+writes one dead row and makes one doomed POST per sync for the life of the
+install — silently, because `pendingUploadCountProvider` counts only `pending`.
+
+### Kotlin sends a half-finished exam attempt; the port does not
+
+The direction of the predicate divergence the notes above missed, and the
+audit's correction to it. Kotlin's *second* sweep config, `ExamResults`
+(`SubmissionDao:40`), has **no status and no `isUpdated` test** —
+`type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND (_id IS NULL
+OR _id = '')` — so a half-finished exam attempt goes up on every Kotlin sweep.
+The port sets `isUpdated: false` at `_openExamSession`
+(`submissions_repository.dart:399-401`) and only flips it at `requires grading`
+(`:579`). Start a course exam, answer two of five questions, close the app: the
+Kotlin handset's next sweep POSTs a `pending` submission carrying those two
+answers and it appears in Planet's course report; the port posts nothing.
+
+The port's own comment at `:568-579` argues for this and calls it deliberate —
+but `docs/kotlin-to-flutter-migration.md`'s *Deliberate deviations* section does
+not list it, and by this project's rules an undocumented improvement is a
+finding. That section is also missing the two divergences above and the retry
+one below. Lane C owns `docs/`-adjacent work this round; whoever holds the
+deviations list should take all four.
+
+Relatedly, **the port's sweep is one arm of three.** `UserDataWorker` sweeps
+`uploadSubmissions()` at `:48`, `uploadExamResult` (the `ExamResults` config) at
+`:70-78`, and `uploadSubmitPhotos` at `:93-101`. The port has ported the first.
+`submitPhotosUploaderProvider.queuePending` still has exactly one caller,
+`take_exam_screen.dart:546`, so the certified-exam verification photo has no
+safety net at all — the same gap submissions had, in a smaller place.
+Deliberately not bundled: photos are a different upload config with a two-step
+POST-then-attach handler, and one `uploadType` per phase is how this stayed
+reviewable.
+
+### The port sends the adoption marker Kotlin never sends, and not the adopted survey Kotlin does
+
+An inversion worth naming as a pair. `SubmissionsUploader.kt:83-84` runs
+`uploadAdoptedSurveys()` **immediately before** the `uploadSubmissions()` this
+phase ports, and `UploadConfigs.kt:186-195` POSTs the `StepExam` to `exams`. The
+port's `SurveysRepository.adoptSurvey` (`surveys_repository.dart:78-138`) writes
+the adopted `Surveys` row locally and enqueues nothing; there is no `exams`
+uploader in the tree. So an adopted team survey exists only on the adopting
+handset — while a `submissions` document with `status: ''`, which no Kotlin
+config selects, reaches the server. `surveys_repository.dart` is Lane C's.
 
 ### Kotlin's retry queue re-POSTs; the port does not, and that is undocumented
 

--- a/flutter/PHASE_134_NOTES.md
+++ b/flutter/PHASE_134_NOTES.md
@@ -1,10 +1,289 @@
 # Phase 134 — the submissions safety-net sweep
 
-Lane A of a four-lane round. Branch `claude/pending-uploads-sweep-h8n2`.
+Lane A of a four-lane round. Branch `claude/pending-uploads-sweep-h8n2`, PR
+#16936.
 
-Closes the gap Phase 132's implementation audit called the round's
-highest-value item: **the port has no `queuePending` sweep in any sync or
-background path**, so a completed answer sheet that misses its one write-time
-enqueue call sits on the handset indefinitely.
+Closes what Phase 132's implementation audit called the round's highest-value
+item: **the port had no `queuePending` sweep in any sync or background path**.
 
-*(In progress — this file is written as the work lands.)*
+Two `parity-auditor` passes at `effort: max` ran per the standing rule — one on
+the Kotlin ground truth before any code, one aimed at this lane's own finished,
+already-green code. The ground-truth pass changed three decisions in this
+phase and corrected one claim in my brief; both are folded in below rather than
+appended.
+
+## The gap, and why green tests could not see it
+
+Kotlin reaches the server for a finished answer sheet **twice**: from the
+profile dialog's dismissal (`UserInformationFragment:303` →
+`SubmissionsUploader:84`) and from `uploadManager.uploadSubmissions()`, which
+`AutoSyncWorker:136`, `UserDataWorker:48` and `ServerReachabilityWorker:196`
+run with no precondition on the sheet, the user or the pull. A missed dismissal
+costs nothing there.
+
+The port had only *write-time* call sites — `take_survey_screen:278`,
+`user_information_screen:471`, `take_exam_screen:544`,
+`submissions_screen:190`, `teams_screen:202`. `background_entrypoint`'s
+`'submissions'` step is the **pull**, and `OutboxDrainScope` only drains rows
+that already exist. So a sheet whose one enqueue call never ran sat on the
+handset as a `complete, isUpdated, !uploaded` row **with no outbox row**, and
+stayed there until the same user happened to finish some *other* submission —
+because `queuePending` is an unscoped sweep that then rescues it incidentally.
+
+Reproduce it by answering a team survey, tapping Submit, and force-stopping the
+app on "Your information". Phase 132 made two such windows reachable for team
+surveys (process death with the profile screen open; the `if (!mounted) return`
+before the push), but the gap is pre-existing and port-wide: it applies equally
+to an exam attempt whose queue call throws.
+
+Every layer had passing tests. `submissions_uploader_test` drove `queuePending`
+directly; `dashboard_sync_provider_test` drove `syncAll`; nothing asked whether
+the second knew about the first. **The failing test written first here is the
+whole phase in one line:** seed a `complete, !uploaded` submission with no
+outbox row, run `syncAll()`, and assert the sheet reached the server. On the
+pre-fix code it came back `uploaded == false`.
+
+## What landed
+
+* **`dashboard_sync_provider.dart`** — `DashboardSyncNotifier.queuePendingSubmissions()`,
+  called from `syncAll()` immediately after `pushCurrentUserShelf()`.
+* **`background_entrypoint.dart`** — top-level `submissionsPushStep(...)`, wired
+  into `syncSteps` after `shelf_push` and **before** the pulls.
+* **`submissions_uploader.dart`** — `queuePending`'s `userId` is now nullable.
+* **`test/providers/pending_submissions_sweep_test.dart`** — 10 tests.
+
+### Five decisions, each a reading of the Kotlin
+
+**Both paths, and the foreground one is not a guess.** `SyncManager.startFullSync`
+sweeps nothing — its only push steps are `pushCurrentUserShelf()`
+(`SyncManager:155`) and `syncNotificationReads()` (`:200`). The reason the
+foreground sync centre gets the step anyway is `UserDataWorker:48`, which is
+*not* a background job in the sense its name suggests: the dashboard sync
+button reaches `SyncActivity.continueSyncProcess` with `forceSync`, which fires
+`isServerReachable(url, "upload")` **and** `startUpload("")`
+(`SyncActivity:813-815`) — the pull and, through `uploadBulkData()` →
+`enqueueUserDataUpload(UPLOAD_TYPE_BULK)`, that worker. So Kotlin's manual sync
+launches pull and sweep as siblings, which is exactly the relation
+`queuePendingSubmissions()` has to the areas. The port had already made this
+call twice before, for the same reason: `_uploadMyPlanetActivities` and
+`_queueSearchActivities` are `AutoSyncWorker`/`UserDataWorker` calls living in
+this notifier, and say so in their own doc comments.
+
+**Unscoped.** `SubmissionDao.getPendingSubmissions` (`SubmissionDao:41`) carries
+no `userId` predicate, and `uploadSubmissions()` takes no user — the owner is
+resolved per row (`UploadConfigs:258`), from the row. So the port's `userId` is
+only the outbox row's session tag, and it became nullable: a handset whose
+session has gone is precisely the one with somebody else's finished sheet
+stranded on it, and a shared handset is the normal deployment for this app.
+Nothing reads `OutboxEntries.userId` back (`tables.dart:368`), so a null tag
+costs the row nothing.
+
+**Ungated.** Unlike the two telemetry steps beside it, this does *not* wait for
+`successCount > 0`. Kotlin's manual sweep runs concurrently with the pull and
+inspects nothing about it, and `ServerReachabilityWorker` sweeps with **no pull
+at all**. A failed pull pass is not a reason to leave a finished sheet on the
+device. This is also why the test that pins it is worth having: in the widget
+harness every one of the sixteen areas fails, so a `successCount` gate would
+have made the sweep look correct and never run.
+
+**Its own `try`, not a shared one — deliberately unlike Kotlin.**
+`AutoSyncWorker:121-138` runs the sweep as the sixteenth statement of one
+sequential `try`, and three predecessors can throw out of it
+(`uploadAchievement`, `uploadNews`, `uploadTeams` each fetch outside their own
+guard). When one does, `:136` never runs *and* `setLastSync` at `:138` never
+runs. That is a Kotlin weakness rather than a behaviour to reproduce;
+`UserDataWorker`'s per-step `runCatching` is the shape followed here.
+
+**Ahead of the pulls, and Kotlin agrees by construction.** Kotlin's submissions
+pull is not in the full sync at all — it lives in `HeavyTableSyncWorker`
+(`HeavyTableSyncWorker:39-41`), which `startFullSync` only *schedules* at its
+end (`SyncManager:209`), while the sweep runs during the pass. The port's
+headless path does have a `'submissions'` pull step, and
+`SubmissionsRepository.upsertDocuments` writes `isUpdated: false` over rows it
+touches (as `bulkInsertFromSync` does, `SubmissionsRepositoryImpl:686`), so
+sweep-then-pull is the safe order as well as the faithful one. Both port paths
+agree on it, and a source-reading test pins the order in the headless list.
+
+### Drained, not merely queued
+
+The one place the port cannot copy Kotlin's shape verbatim: Kotlin's sweep
+*posts*, while `queuePending` only enqueues, and the drain trigger is app
+resume or the next headless invocation. Without a drain the fix would convert
+"deferred until the user finishes another submission" into "deferred until the
+next resume" — better, bounded, and still not what Kotlin does.
+
+So each sweep is followed by `drain(onlyTypes: {SubmissionsUploader.type})`.
+Every write-time call site already pairs the two (`submissions_screen:186-193`);
+the `onlyTypes` scope is what keeps a sweep from turning into a whole-queue
+flush nothing asked for. In the headless path this also fixes an ordering the
+runner imposes: `BackgroundTaskRunner` drains **before** it runs the steps
+(`background_task_runner.dart:100`), so a row swept in a step would otherwise
+wait for the next invocation.
+
+### Why it cannot double-post
+
+The brief was right that a double POST is worse than a deferred one, and the
+ground-truth pass established what actually protects Kotlin: **nothing but the
+query predicate and one UPDATE.** `SubmissionDao:44` sets `_id`, `_rev` and
+`isUpdated = 0` after a successful send, which drops the row out of
+`status = 'complete' AND (isUpdated = 1 OR _id IS NULL OR _id = '')`. There is
+no lock, no lease and no dedup key; the single `MainApplication.isSyncRunning`
+flag covers only the `AutoSyncWorker` ↔ `ServerReachabilityWorker` pair, and
+`SubmissionsUploader.checkAvailableServer` — the dismissal path — neither sets
+nor reads it while it spends up to 15 seconds probing URLs before it reads the
+table. **Kotlin therefore really can double-post**, and the auditor named the
+input: answer a team survey's last question, dismiss the profile dialog, and
+tap the dashboard sync button inside that probe window.
+
+The port inherits the same protection and adds one Kotlin lacks:
+`SubmissionsUploader.handler`'s `markUploaded` is the port of that UPDATE, and
+`OutboxRepository.enqueue` keys on `(uploadType, itemId)`, so a sweep over an
+already-queued row refreshes it instead of adding a second — with
+`OutboxDrainer`'s single-flight guard and its status-scoped claim keeping two
+drains off one row. The test drives the write-time enqueue *and* the sweep over
+one submission and asserts one row, one POST, and a second sweep that posts
+nothing.
+
+## Every test was mutation-tested
+
+Phase 122's practice, and worth the ten minutes: a migration test that cannot
+fail reads as coverage. Five mutations, each failing exactly the tests that
+should notice and no others:
+
+| mutation | test that failed |
+|---|---|
+| drop `queuePendingSubmissions()` from `syncAll` | the three foreground delivery/ordering tests |
+| the headless step returns `false` on throw | *a throwing push step does not request an OS retry* |
+| remove `submissionsPushStep` from `syncSteps` | *the headless path builds the step…* |
+| move the step after the `'submissions'` pull | *the headless path builds the step…* |
+| re-scope `queuePending` with `.where((r) => r.userId == userId)` | *the push step sweeps with no signed-in user* |
+
+The reachability test is the one worth explaining. `submissionsPushStep` is
+exercised directly, which is precisely the Phase 113 shape: ported, tested,
+green and possibly built by nobody. `executeBackgroundTask` needs a Flutter
+binding, real preferences and a WorkManager engine, so its `syncSteps` list
+cannot be constructed in a unit test — the test reads
+`lib/background_entrypoint.dart` instead and asserts the step is built *and*
+built before the pull, the way `version_parity_test` reads `app/build.gradle`.
+
+## A harness trap, arriving through a new door
+
+`outboxDrainerProvider` builds every registered handler, and several of those
+uploaders reach `planetPrefsProvider`, which is `UnimplementedError` by
+default. The first cut of these tests therefore had the sweep's drain throw,
+its own `catch` swallow it, and the test report the gap as **unfixed** — five
+failures that looked like the fix not working. `planetPrefsProvider` is
+overridden with `PlanetPrefs(await SharedPreferences.getInstance())`, the shape
+`leaders_screen_test` already uses. Same family as Phase 75's, and the reason
+it is worth writing down again: a swallowed exception plus an
+`UnimplementedError` provider is indistinguishable from a broken fix.
+
+## Reported, not fixed
+
+### The sweep now runs `pendingUploads` on every sync, and that predicate is not Kotlin's
+
+The single most important consequence of this change, and the item the next
+round should take. Kotlin's sweep query is
+`status = 'complete' AND (isUpdated = 1 OR _id IS NULL OR _id = '')`
+(`SubmissionDao:41`). The port's `SubmissionDao.pendingUploads`
+(`app_database.dart:2438`) is `isUpdated = true` minus a guest-exam arm minus
+the `public_%` arm — **there is no status test at all**, deliberately, because
+the port merges Kotlin's two upload configs into one uploader and an exam
+finishes at `requires grading` rather than `complete`.
+
+That was a defensible trade while `pendingUploads` only ever ran from four
+deliberate write-time sites. It now runs on every sync, for every row on the
+device, so two rows the Kotlin sweep never sends are sent sooner and more
+reliably:
+
+* **the adoption marker** — `createSurveyAdoptionSubmission`
+  (`submissions_repository.dart:736,743`) writes `status: ''` with
+  `isUpdated: true`, so the port uploads a document Kotlin has no sweep for.
+  Phase 129 recorded the divergence and Phase 132 repeated it; it is still not
+  in `docs/kotlin-to-flutter-migration.md`'s deviations list.
+* **a `pending` free-form draft** — `createDraft`
+  (`submissions_repository.dart:87,89`) writes `status: 'pending'` with
+  `isUpdated: true`.
+
+Neither is *new*: both were already uploaded by the next write-time
+`queuePending` call, since that sweep was already unscoped. What changed is
+**when**, not **what** — the set of documents that eventually reach the server
+is identical. But it is now systematic rather than incidental, so if the port
+should not be sending them, this is the round to decide it. The fix is a status
+predicate in `pendingUploads` that admits `complete`, `requires grading` and
+the exam arm's own condition while excluding `''` and `pending` — one method in
+`app_database.dart` (**Lane B's this round**) with a matching read of
+`submissions_repository.dart` (**Lane C's**). Not editable from here, and it is
+a behaviour decision rather than an obvious repair.
+
+### Kotlin's retry queue re-POSTs; the port does not, and that is undocumented
+
+`RetryQueueWorker.processOperationInternal` re-POSTs a queued payload and on
+success calls only `retryQueue.markCompleted(operation.id)`
+(`RetryQueueWorker:231`, `RetryQueue:64-67`) — the `submissions` row still has
+`_id = NULL` and `isUpdated = 1`, so **the next Kotlin sweep POSTs it again**.
+Concrete input: a survey POST that gets a 502, a successful retry drain, then
+any sync — two CouchDB documents. The port's `SubmissionsUploader.handler`
+calls `markUploaded` on every successful send including a retried one, so it
+does not have this bug. That is the port being *better* than Kotlin, which by
+this project's own rules is a documented-deviation decision, not a silent
+improvement. It belongs in `docs/kotlin-to-flutter-migration.md` (outside this
+lane's set).
+
+### The foreground sync centre has no `submissions` pull at all
+
+`DashboardSyncArea` has sixteen areas and none of them pulls `submissions`,
+while the headless path has had a `'submissions'` step since it was written.
+This is the Phase 119 class — a walk one path runs and the other does not — and
+it means a submission uploaded on handset A never reaches handset B through a
+manual sync, only through a background one. Adding an area is more than a
+one-line change: it needs a `SyncNotifier`, an entry in the enum's two
+`switch`es, and a label in the sync-centre UI, which is outside this set. Named
+here because I own `dashboard_sync_provider.dart` and deliberately did not
+widen this phase into it.
+
+For the same reason, the port has **no sweep for `submit_photos` either**. The
+certified-exam verification photo has one write-time site
+(`take_exam_screen:547`) and no safety net, exactly as submissions had. It is a
+smaller loss — Kotlin's `uploadSubmissions` does not carry photos either, they
+have their own `PhotoUploader` — and it wants the same treatment: find the
+Kotlin path that sweeps `Photos` and port it beside this one. Deliberately not
+bundled: `submit_photos` is a different upload config with a two-step
+POST-then-attach handler, and one uploadType per phase is how this stayed
+reviewable.
+
+### Two Kotlin oddities a future porter should not copy
+
+* **`UploadConfig.additionalUpdates` is dead code.** It is declared
+  (`UploadConfig:34`), assigned by the `Submissions` config alone
+  (`UploadConfigs:263-265`) and never invoked anywhere. Its body
+  (`submission.isUpdated = false`) happens to duplicate what
+  `SubmissionDao.markUploaded` does in SQL, so nothing is broken — but a port
+  that treats it as a second in-memory clearing step is porting a no-op.
+* **`SyncManager.start`'s `type` and `syncTables` parameters are never read**
+  (`SyncManager:89-98`). `"upload"` and `"sync"` produce the identical
+  `startFullSync()`. A port that branches on a sync "type" is inventing a
+  distinction the Kotlin does not have.
+
+### `hasPendingOfflineSubmissions` is wider than the query it guards
+
+`ServerReachabilityWorker:194` pre-checks
+`SELECT COUNT(*) FROM submissions WHERE (isUpdated = 1 OR _id IS NULL OR _id = '')`
+(`SubmissionDao:21`) — the upload predicate with the `status = 'complete'`
+conjunct dropped, so a strict superset. It can never suppress a needed upload,
+only trigger a sweep that finds nothing. Not ported here, and it should not be
+"tightened" if it ever is: that would be a behaviour change dressed as a fix,
+and inverting the relation would silently gate off real uploads. The sibling
+`hasPendingExamResults` (`SubmissionDao:22`) is mismatched with *its* config in
+the opposite direction — neither predicate is a subset of the other.
+
+### `PublicSurveyActivity` leaves an armed row in Kotlin
+
+It uploads through `surveysRepository.submitPublicSurvey`
+(`PublicSurveyActivity:136`) and never clears the local row, which
+`saveExamAnswer` left at `status = 'complete'`, `_id = NULL`. On a configured
+device Kotlin's next sweep POSTs it again, to the authenticated
+`/submissions`. The port cannot reproduce this — `markPublicSubmitted` clears
+`isUpdated`, and `pendingUploads` excludes the `public_%` owner besides — so
+this is recorded as a Kotlin defect the port already avoids rather than
+anything to port.

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -246,14 +246,24 @@ Future<bool> executeBackgroundTask(String taskName) async {
 /// reading this step is built on.
 ///
 /// Placed **before** the `submissions` pull below rather than after it, and the
-/// order is load-bearing here in a way it is not in the sync centre:
+/// order is load-bearing here in a way it is not in the sync centre.
 /// `SubmissionsRepository.upsertDocuments` writes `isUpdated: false` over every
-/// row it touches — as Kotlin's `bulkInsertFromSync` does
-/// (`SubmissionsRepositoryImpl:686`) — so a pull that ran first would take a
-/// locally edited sheet out of `pendingUploads` before the sweep could see it.
-/// Kotlin agrees by construction: its submissions pull lives in
-/// `HeavyTableSyncWorker`, which `startFullSync` only *schedules* at its end
-/// (`SyncManager:209`), while the sweep runs during the pass.
+/// row it writes — as Kotlin's `bulkInsertFromSync` does
+/// (`SubmissionsRepositoryImpl:686`) — and it keys each row on the server
+/// `_id` (`submissions_repository.dart:1670-1672`, `id: id`).
+///
+/// **That keying is why the window is narrower than it first looks, and the
+/// first version of this comment had it wrong.** A *locally authored* sheet
+/// carries a sha1 local id, so a pulled document lands beside it as a separate
+/// row and cannot touch its flags — Kotlin behaves identically
+/// (`SubmissionsRepositoryImpl:669-670`). What the order protects is a sheet
+/// that **arrived from the server and was then edited locally**: survey resume
+/// (`markComplete`) sets `uploaded: false, isUpdated: true` on a row whose
+/// primary key *is* the server `_id`, so a pull running first overwrites both
+/// and the edit never uploads. Kotlin agrees by construction anyway — its
+/// submissions pull lives in `HeavyTableSyncWorker`
+/// (`HeavyTableSyncWorker:39-41`), which `startFullSync` only *schedules* at
+/// its end (`SyncManager:209`), while the sweep runs during the pass.
 ///
 /// **Always `true`.** `BackgroundTaskRunner` adds a step that returns false or
 /// throws to `failedSteps`, which makes the whole task ask WorkManager for a

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -6,10 +6,12 @@ import 'core/background/background_task_runner.dart';
 import 'core/background/background_task_names.dart';
 import 'core/background/background_download_queue.dart';
 import 'core/network/network_result.dart';
+import 'core/config/server_config.dart';
 import 'core/prefs/planet_prefs.dart';
 import 'core/sync/sync_result.dart';
 import 'providers/app_providers.dart';
 import 'repository/personals_uploader.dart';
+import 'repository/submissions_uploader.dart';
 
 /// WorkManager launches this in a new isolate, so it must be a retained
 /// top-level entry point rather than a closure installed by the UI isolate.
@@ -110,6 +112,11 @@ Future<bool> executeBackgroundTask(String taskName) async {
                 }
                 return true;
               }),
+              submissionsPushStep(
+                container,
+                config: config,
+                userId: prefs.loggedInUserId,
+              ),
               BackgroundSyncStep(
                 'resources',
                 () async => completed(
@@ -233,3 +240,58 @@ Future<bool> executeBackgroundTask(String taskName) async {
     container.dispose();
   }
 }
+
+/// The headless half of the submissions safety net — see
+/// [DashboardSyncNotifier.queuePendingSubmissions], which carries the Kotlin
+/// reading this step is built on.
+///
+/// Placed **before** the `submissions` pull below rather than after it, and the
+/// order is load-bearing here in a way it is not in the sync centre:
+/// `SubmissionsRepository.upsertDocuments` writes `isUpdated: false` over every
+/// row it touches — as Kotlin's `bulkInsertFromSync` does
+/// (`SubmissionsRepositoryImpl:686`) — so a pull that ran first would take a
+/// locally edited sheet out of `pendingUploads` before the sweep could see it.
+/// Kotlin agrees by construction: its submissions pull lives in
+/// `HeavyTableSyncWorker`, which `startFullSync` only *schedules* at its end
+/// (`SyncManager:209`), while the sweep runs during the pass.
+///
+/// **Always `true`.** `BackgroundTaskRunner` adds a step that returns false or
+/// throws to `failedSteps`, which makes the whole task ask WorkManager for a
+/// retry. No Kotlin caller of `uploadSubmissions` does that:
+/// `UserDataWorker:48` wraps it in `runCatching` and still returns
+/// `Result.success()`, `AutoSyncWorker` logs and returns success, and
+/// `UploadManager:236-252` swallows the exception before either sees it. A
+/// sheet that cannot be sent must not re-run the pulls.
+///
+/// [userId] is nullable because Kotlin's sweep takes no user at all. A handset
+/// whose session has gone is precisely the one with somebody else's finished
+/// sheet stranded on it, and `SubmissionDao.getPendingSubmissions`
+/// (`SubmissionDao:41`) is handset-wide.
+///
+/// Exposed because `executeBackgroundTask` needs a Flutter binding, real
+/// preferences and a WorkManager engine, so a step body written inline in that
+/// closure is unreachable from a unit test.
+@visibleForTesting
+BackgroundSyncStep submissionsPushStep(
+  ProviderContainer container, {
+  required ServerConfig config,
+  required String? userId,
+}) => BackgroundSyncStep('submissions_push', () async {
+  try {
+    await container
+        .read(submissionsUploaderProvider)
+        .queuePending(config: config, userId: userId);
+    // Kotlin's sweep posts; `queuePending` only queues. The runner's own
+    // `drainOutbox` has already run by the time the steps do, so without this
+    // a sheet swept here would wait for the next invocation.
+    await container
+        .read(outboxDrainerProvider)
+        .drain(
+          authHeader: PersonalsUploader.authHeaderFor(config),
+          onlyTypes: const {SubmissionsUploader.type},
+        );
+  } catch (_) {
+    // Deliberately ignored — see above.
+  }
+  return true;
+});

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -5,13 +5,12 @@ import 'package:workmanager/workmanager.dart';
 import 'core/background/background_task_runner.dart';
 import 'core/background/background_task_names.dart';
 import 'core/background/background_download_queue.dart';
-import 'core/network/network_result.dart';
 import 'core/config/server_config.dart';
+import 'core/network/network_result.dart';
 import 'core/prefs/planet_prefs.dart';
 import 'core/sync/sync_result.dart';
 import 'providers/app_providers.dart';
 import 'repository/personals_uploader.dart';
-import 'repository/submissions_uploader.dart';
 
 /// WorkManager launches this in a new isolate, so it must be a retained
 /// top-level entry point rather than a closure installed by the UI isolate.
@@ -69,8 +68,17 @@ Future<bool> executeBackgroundTask(String taskName) async {
           ? null
           : DateTime.fromMillisecondsSinceEpoch(prefs.lastSync, isUtc: true),
       recoverOutbox: drainer.recoverStuck,
+      // The submissions safety net rides here rather than in `syncSteps`, and
+      // the placement is the whole point — see [sweepPendingSubmissions]. The
+      // drain that follows is unscoped, so the swept rows go out in this same
+      // invocation without the sweep needing a drain of its own.
       drainOutbox: () async {
         if (config == null) return;
+        await sweepPendingSubmissions(
+          container,
+          config: config,
+          userId: prefs.loggedInUserId,
+        );
         await drainer.drain(
           authHeader: PersonalsUploader.authHeaderFor(config),
         );
@@ -112,11 +120,6 @@ Future<bool> executeBackgroundTask(String taskName) async {
                 }
                 return true;
               }),
-              submissionsPushStep(
-                container,
-                config: config,
-                userId: prefs.loggedInUserId,
-              ),
               BackgroundSyncStep(
                 'resources',
                 () async => completed(
@@ -242,36 +245,45 @@ Future<bool> executeBackgroundTask(String taskName) async {
 }
 
 /// The headless half of the submissions safety net — see
-/// [DashboardSyncNotifier.queuePendingSubmissions], which carries the Kotlin
-/// reading this step is built on.
+/// `DashboardSyncNotifier.queuePendingSubmissions`, which carries the Kotlin
+/// reading this is built on.
 ///
-/// Placed **before** the `submissions` pull below rather than after it, and the
-/// order is load-bearing here in a way it is not in the sync centre.
-/// `SubmissionsRepository.upsertDocuments` writes `isUpdated: false` over every
-/// row it writes — as Kotlin's `bulkInsertFromSync` does
-/// (`SubmissionsRepositoryImpl:686`) — and it keys each row on the server
-/// `_id` (`submissions_repository.dart:1670-1672`, `id: id`).
+/// **Called from `drainOutbox`, deliberately not from `syncSteps`.** The first
+/// cut put it in the step list beside `shelf_push`, and the implementation
+/// audit found that this hides it behind three gates Kotlin's sweeper has none
+/// of: `BackgroundTaskRunner.run` returns before the steps for a `maintenance`
+/// task, when `autoSyncEnabled` is false, and when the interval is not yet due
+/// (`background_task_runner.dart:102-136`). Worse, `BackgroundWorkCoordinator`
+/// cancels the `autoSync` job outright when the user turns auto-sync off
+/// (`background_work_coordinator.dart:27-30`), so for that user only
+/// `maintenance` ever fires and a step in `syncSteps` would never run at all.
 ///
-/// **That keying is why the window is narrower than it first looks, and the
-/// first version of this comment had it wrong.** A *locally authored* sheet
+/// Kotlin's closest sweeper is `ServerReachabilityWorker`, scheduled by
+/// `NetworkMonitorWorker.start` from `MainApplication:520-522` with no
+/// reference to any sync setting or cadence, sweeping on **network
+/// reconnection** — which is exactly the case this net exists for: the handset
+/// was offline when the sheet was finished, and the network came back.
+/// `drainOutbox` runs ahead of all three gates and on every invocation, so it
+/// is the closest the port has to that worker.
+///
+/// Two properties survive the move. It is still ahead of the `'submissions'`
+/// pull, which matters because `SubmissionsRepository.upsertDocuments` writes
+/// `isUpdated: false` over every row it writes and keys each on the server
+/// `_id` (`submissions_repository.dart:1670-1672`): a *locally authored* sheet
 /// carries a sha1 local id, so a pulled document lands beside it as a separate
-/// row and cannot touch its flags — Kotlin behaves identically
-/// (`SubmissionsRepositoryImpl:669-670`). What the order protects is a sheet
-/// that **arrived from the server and was then edited locally**: survey resume
-/// (`markComplete`) sets `uploaded: false, isUpdated: true` on a row whose
-/// primary key *is* the server `_id`, so a pull running first overwrites both
-/// and the edit never uploads. Kotlin agrees by construction anyway — its
-/// submissions pull lives in `HeavyTableSyncWorker`
-/// (`HeavyTableSyncWorker:39-41`), which `startFullSync` only *schedules* at
-/// its end (`SyncManager:209`), while the sweep runs during the pass.
-///
-/// **Always `true`.** `BackgroundTaskRunner` adds a step that returns false or
-/// throws to `failedSteps`, which makes the whole task ask WorkManager for a
-/// retry. No Kotlin caller of `uploadSubmissions` does that:
-/// `UserDataWorker:48` wraps it in `runCatching` and still returns
-/// `Result.success()`, `AutoSyncWorker` logs and returns success, and
-/// `UploadManager:236-252` swallows the exception before either sees it. A
-/// sheet that cannot be sent must not re-run the pulls.
+/// row and cannot touch its flags — Kotlin identically
+/// (`SubmissionsRepositoryImpl:669-670`) — while a sheet that **arrived from
+/// the server and was then edited locally** (survey resume's `markComplete`)
+/// has the server `_id` for a primary key, so a pull running first overwrites
+/// the edit and it never uploads. And the sweep is swallowed rather than
+/// reported: a throwing `drainOutbox` adds `outboxDrain` to the runner's
+/// `failedSteps` and asks the OS to retry the task, and no Kotlin caller of
+/// `uploadSubmissions` does that — `UserDataWorker:48` wraps it in
+/// `runCatching` and still returns `Result.success()`, and
+/// `UploadManager:236-252` swallows the exception before either could see one.
+/// It is not hypothetical: `queuePending` reads device identity before it
+/// enqueues anything, and `PlatformDeviceIdentitySource.read` rethrows on a
+/// handset with no channel and no primed cache.
 ///
 /// [userId] is nullable because Kotlin's sweep takes no user at all. A handset
 /// whose session has gone is precisely the one with somebody else's finished
@@ -279,29 +291,19 @@ Future<bool> executeBackgroundTask(String taskName) async {
 /// (`SubmissionDao:41`) is handset-wide.
 ///
 /// Exposed because `executeBackgroundTask` needs a Flutter binding, real
-/// preferences and a WorkManager engine, so a step body written inline in that
+/// preferences and a WorkManager engine, so a body written inline in that
 /// closure is unreachable from a unit test.
 @visibleForTesting
-BackgroundSyncStep submissionsPushStep(
+Future<void> sweepPendingSubmissions(
   ProviderContainer container, {
   required ServerConfig config,
   required String? userId,
-}) => BackgroundSyncStep('submissions_push', () async {
+}) async {
   try {
     await container
         .read(submissionsUploaderProvider)
         .queuePending(config: config, userId: userId);
-    // Kotlin's sweep posts; `queuePending` only queues. The runner's own
-    // `drainOutbox` has already run by the time the steps do, so without this
-    // a sheet swept here would wait for the next invocation.
-    await container
-        .read(outboxDrainerProvider)
-        .drain(
-          authHeader: PersonalsUploader.authHeaderFor(config),
-          onlyTypes: const {SubmissionsUploader.type},
-        );
   } catch (_) {
     // Deliberately ignored — see above.
   }
-  return true;
-});
+}

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../repository/personals_uploader.dart';
-import '../repository/submissions_uploader.dart';
 import 'app_providers.dart';
 import 'activities_provider.dart';
 import 'session_provider.dart';
@@ -145,14 +144,16 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
     // null it would otherwise see on the first pass.
     await pushCurrentUserShelf();
 
-    // Beside the shelf push and for the same reason: a push belongs ahead of
-    // the pulls. See [queuePendingSubmissions].
-    await queuePendingSubmissions();
-
     // `DashboardElementActivity.logSyncInSharedPrefs` records the challenge
     // action right before the sync starts -- the challenge dialog's "sync"
-    // checkbox reads it via `hasUserCompletedSync`.
+    // checkbox reads it via `hasUserCompletedSync`. It stays ahead of the
+    // sweep below, which is unbounded network work: a user who taps Sync and
+    // backgrounds the app during it should still get the credit Kotlin gives
+    // them for pressing the button.
     await ref.read(activityLogProvider).recordSyncChallengeAction();
+
+    // With the shelf push, ahead of the pulls. See [queuePendingSubmissions].
+    await queuePendingSubmissions();
 
     for (final area in DashboardSyncArea.values) {
       await _syncArea(area);
@@ -221,9 +222,12 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
   /// the profile dialog's dismissal (`UserInformationFragment:303` →
   /// `SubmissionsUploader:84`), and once from
   /// `uploadManager.uploadSubmissions()`, which `AutoSyncWorker:136`,
-  /// `UserDataWorker:48` and `ServerReachabilityWorker:196` run with no
-  /// precondition on the sheet or the user. A missed dismissal therefore costs
-  /// nothing there: the next sync sweeps it up.
+  /// `UserDataWorker:48` and `ServerReachabilityWorker:196` run on a schedule
+  /// rather than off anything the sheet did. The first two call it bare;
+  /// `ServerReachabilityWorker` gates on `!isSyncRunning` and
+  /// `hasPendingOfflineSubmissions()` (`ServerReachabilityWorker:190-200`),
+  /// neither of which is a property of an individual sheet. A missed dismissal
+  /// therefore costs nothing there: the next sync sweeps it up.
   ///
   /// `UserDataWorker:48` is what puts this in *this* method rather than only in
   /// the headless path. It is not a background job in the sense the name
@@ -265,17 +269,26 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
   ///   Kotlin weakness rather than a behaviour to reproduce;
   ///   `UserDataWorker`'s per-step `runCatching` is the shape to follow, and
   ///   it is this one.
-  /// * **Ahead of the pulls.** Nothing in this pass pulls `submissions`, so
-  ///   ordering is free here — but the headless path does pull them, and
-  ///   Kotlin puts its submissions pull in `HeavyTableSyncWorker`
-  ///   (`HeavyTableSyncWorker:39-41`), which `startFullSync` only *schedules*
-  ///   at its end (`SyncManager:209`). Sweep-then-pull is therefore the Kotlin
-  ///   order as well as the safe one, and both port paths agree on it.
-  /// * **Drained, not merely queued.** Kotlin's sweep *posts*; `queuePending`
-  ///   only queues, and the drain trigger is app resume. Every write-time call
-  ///   site pairs the two (`submissions_screen:186-193`), so this does too —
-  ///   scoped to the one `uploadType` with `onlyTypes`, so a sweep cannot turn
-  ///   into a whole-queue flush that nothing asked for.
+  /// * **Ahead of the pulls.** Nothing in this pass pulls `submissions` at all
+  ///   (a gap of its own — see the phase notes), so ordering is free here; the
+  ///   headless path's is not, and `sweepPendingSubmissions` carries that
+  ///   reasoning. Kotlin agrees by construction either way: its submissions
+  ///   pull lives in `HeavyTableSyncWorker` (`HeavyTableSyncWorker:39-41`),
+  ///   which `startFullSync` only *schedules* at its end (`SyncManager:209`).
+  /// * **Drained, not merely queued, and drained whole.** Kotlin's sweep
+  ///   *posts*; `queuePending` only queues, and the drain trigger is otherwise
+  ///   app resume. `submissions_screen:186-193` is the one write-time site
+  ///   that pairs the two — the other three (`take_survey_screen:276-278`,
+  ///   `user_information_screen:471`, `take_exam_screen:542-547`) queue and
+  ///   leave — and it drains **unscoped**, which is what this does too.
+  ///   Scoping it to one `uploadType` was the first cut and was wrong twice
+  ///   over: `OutboxDrainer.drain` satisfies a *joining* caller without doing
+  ///   its work (`outbox_drainer.dart:79-82`), so a resume drain arriving
+  ///   during a scoped pass would return having sent nothing and every queued
+  ///   health record, rating and team write would wait for the next resume —
+  ///   and Kotlin's manual sync is a whole-queue flush anyway,
+  ///   `UserDataWorker`'s `UPLOAD_TYPE_BULK` running eleven upload arms of
+  ///   which `uploadSubmissions()` is one.
   ///
   /// **It cannot double-post, and the protection is not new.** Kotlin's only
   /// defence is exclusion from that same predicate: `SubmissionDao:44` sets
@@ -308,10 +321,7 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
           .queuePending(config: config, userId: user?.id);
       await ref
           .read(outboxDrainerProvider)
-          .drain(
-            authHeader: PersonalsUploader.authHeaderFor(config),
-            onlyTypes: const {SubmissionsUploader.type},
-          );
+          .drain(authHeader: PersonalsUploader.authHeaderFor(config));
     } catch (_) {
       // Deliberately ignored — see above.
     }

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../repository/personals_uploader.dart';
+import '../repository/submissions_uploader.dart';
 import 'app_providers.dart';
 import 'activities_provider.dart';
 import 'session_provider.dart';
@@ -143,6 +145,10 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
     // null it would otherwise see on the first pass.
     await pushCurrentUserShelf();
 
+    // Beside the shelf push and for the same reason: a push belongs ahead of
+    // the pulls. See [queuePendingSubmissions].
+    await queuePendingSubmissions();
+
     // `DashboardElementActivity.logSyncInSharedPrefs` records the challenge
     // action right before the sync starts -- the challenge dialog's "sync"
     // checkbox reads it via `hasUserCompletedSync`.
@@ -204,6 +210,108 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
       await ref
           .read(shelfRepositoryProvider)
           .upload(config: config, userId: user.id, shelfDocId: shelfDocId);
+    } catch (_) {
+      // Deliberately ignored — see above.
+    }
+  }
+
+  /// Port of `uploadManager.uploadSubmissions()` as the sync path's safety net.
+  ///
+  /// **Kotlin reaches the server for a finished answer sheet twice.** Once from
+  /// the profile dialog's dismissal (`UserInformationFragment:303` →
+  /// `SubmissionsUploader:84`), and once from
+  /// `uploadManager.uploadSubmissions()`, which `AutoSyncWorker:136`,
+  /// `UserDataWorker:48` and `ServerReachabilityWorker:196` run with no
+  /// precondition on the sheet or the user. A missed dismissal therefore costs
+  /// nothing there: the next sync sweeps it up.
+  ///
+  /// `UserDataWorker:48` is what puts this in *this* method rather than only in
+  /// the headless path. It is not a background job in the sense the name
+  /// suggests: the dashboard's sync button reaches
+  /// `SyncActivity.continueSyncProcess` with `forceSync`, which fires
+  /// `isServerReachable(url, "upload")` **and** `startUpload("")`
+  /// (`SyncActivity:813-815`) — the pull and, through `uploadBulkData()`, that
+  /// worker. `SyncManager.startFullSync` itself sweeps nothing; the manual
+  /// sweep is a sibling job launched beside it, which is exactly the relation
+  /// this method has to the areas below.
+  ///
+  /// The port had only *write-time* call sites, so it had no net at all. A
+  /// sheet whose one enqueue call never ran — process death on "Your
+  /// information", the `if (!mounted) return` before the push, a queue call
+  /// that threw on an exam attempt — stayed on the handset as a `complete`,
+  /// `isUpdated`, `!uploaded` row with no outbox row, and stayed there until
+  /// the same user happened to finish some *other* submission, because
+  /// `queuePending` is an unscoped sweep that then rescues it incidentally.
+  /// The answers were never lost, but for a field survey an indefinitely
+  /// deferred delivery is the same outcome.
+  ///
+  /// Five things about the shape, each a reading of the Kotlin rather than a
+  /// guess at it:
+  ///
+  /// * **Unscoped.** `SubmissionDao.getPendingSubmissions` (`SubmissionDao:41`)
+  ///   carries no `userId` predicate and `uploadSubmissions()` takes no user —
+  ///   the owner is resolved per row (`UploadConfigs:258`), so the session is
+  ///   only the outbox row's tag. Hence the nullable `userId`.
+  /// * **Ungated.** Unlike [_uploadMyPlanetActivities] and
+  ///   [_queueSearchActivities], this does *not* wait for `successCount > 0`.
+  ///   The manual sweep runs concurrently with the pull and inspects nothing
+  ///   about it, and `ServerReachabilityWorker` sweeps with no pull at all. A
+  ///   failed pull pass is not a reason to leave a finished sheet on the
+  ///   device.
+  /// * **Its own `try`, not a shared one.** `AutoSyncWorker:121-138` runs the
+  ///   sweep as the sixteenth statement of one sequential `try`, so an earlier
+  ///   upload throwing skips it silently — `uploadAchievement`, `uploadNews`
+  ///   and `uploadTeams` each fetch outside their own guard and can. That is a
+  ///   Kotlin weakness rather than a behaviour to reproduce;
+  ///   `UserDataWorker`'s per-step `runCatching` is the shape to follow, and
+  ///   it is this one.
+  /// * **Ahead of the pulls.** Nothing in this pass pulls `submissions`, so
+  ///   ordering is free here — but the headless path does pull them, and
+  ///   Kotlin puts its submissions pull in `HeavyTableSyncWorker`, which
+  ///   `startFullSync` only *schedules* at its end (`SyncManager:209`).
+  ///   Sweep-then-pull is therefore the Kotlin order as well as the safe one,
+  ///   and both port paths agree on it.
+  /// * **Drained, not merely queued.** Kotlin's sweep *posts*; `queuePending`
+  ///   only queues, and the drain trigger is app resume. Every write-time call
+  ///   site pairs the two (`submissions_screen:186-193`), so this does too —
+  ///   scoped to the one `uploadType` with `onlyTypes`, so a sweep cannot turn
+  ///   into a whole-queue flush that nothing asked for.
+  ///
+  /// **It cannot double-post, and the protection is not new.** Kotlin's only
+  /// defence is exclusion from that same predicate: `SubmissionDao:44` sets
+  /// `_id`, `_rev` and `isUpdated = 0` after a successful send, and
+  /// [SubmissionsUploader.handler]'s `markUploaded` is the port of exactly
+  /// that statement. The port adds one Kotlin lacks —
+  /// `OutboxRepository.enqueue` keys on `(uploadType, itemId)`, so a sweep
+  /// that overlaps a write-time enqueue refreshes the queued row instead of
+  /// adding a second one, and `OutboxDrainer`'s single-flight guard plus its
+  /// status-scoped claim keep two drains off one row.
+  ///
+  /// Swallowed for the reason the neighbouring steps are, and it is not
+  /// hypothetical: `queuePending` reads device identity before it enqueues
+  /// anything, and `PlatformDeviceIdentitySource.read` rethrows on a handset
+  /// with no channel and no primed cache. A sheet that cannot be queued must
+  /// not flip the sync to failed — no Kotlin caller of `uploadSubmissions`
+  /// reports a failure of it, and `UploadManager:236-252` swallows every
+  /// exception before they could see one.
+  Future<void> queuePendingSubmissions() async {
+    final config = ref.read(serverConfigProvider);
+    if (config == null) return;
+    try {
+      // Awaited rather than read: this notifier never watches
+      // `sessionProvider`, so `.valueOrNull` would be null on any pass that
+      // reached here first. The `await` is inside the `try` because the future
+      // can reject where `valueOrNull` could not.
+      final user = await ref.read(sessionProvider.future);
+      await ref
+          .read(submissionsUploaderProvider)
+          .queuePending(config: config, userId: user?.id);
+      await ref
+          .read(outboxDrainerProvider)
+          .drain(
+            authHeader: PersonalsUploader.authHeaderFor(config),
+            onlyTypes: const {SubmissionsUploader.type},
+          );
     } catch (_) {
       // Deliberately ignored — see above.
     }

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -267,10 +267,10 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
   ///   it is this one.
   /// * **Ahead of the pulls.** Nothing in this pass pulls `submissions`, so
   ///   ordering is free here — but the headless path does pull them, and
-  ///   Kotlin puts its submissions pull in `HeavyTableSyncWorker`, which
-  ///   `startFullSync` only *schedules* at its end (`SyncManager:209`).
-  ///   Sweep-then-pull is therefore the Kotlin order as well as the safe one,
-  ///   and both port paths agree on it.
+  ///   Kotlin puts its submissions pull in `HeavyTableSyncWorker`
+  ///   (`HeavyTableSyncWorker:39-41`), which `startFullSync` only *schedules*
+  ///   at its end (`SyncManager:209`). Sweep-then-pull is therefore the Kotlin
+  ///   order as well as the safe one, and both port paths agree on it.
   /// * **Drained, not merely queued.** Kotlin's sweep *posts*; `queuePending`
   ///   only queues, and the drain trigger is app resume. Every write-time call
   ///   site pairs the two (`submissions_screen:186-193`), so this does too —

--- a/flutter/lib/repository/outbox_repository.dart
+++ b/flutter/lib/repository/outbox_repository.dart
@@ -121,6 +121,24 @@ class OutboxRepository {
 
   Future<List<OutboxRow>> due() => _dao.due(_now().millisecondsSinceEpoch);
 
+  /// Whether a send for this item is on the wire right now.
+  ///
+  /// [enqueue] deliberately puts an `in_progress` row back to `pending` so a
+  /// payload edited mid-flight is not lost with the row `markCompleted`
+  /// deletes — and `markCompleted` is `deleteIfInProgress`, so the send that
+  /// just succeeded then deletes nothing and the row survives, `pending`, with
+  /// the same body. For *derived state* that is exactly right: the shelf's
+  /// handler rebuilds from the database, so a replay re-sends current truth.
+  ///
+  /// For an **append** it is a duplicate. A submission is an append, so its
+  /// uploader asks this first and leaves an in-flight row alone rather than
+  /// re-enqueueing over it. Kept here rather than as a bare `findOpen`
+  /// passthrough so the distinction that makes it necessary has one home; see
+  /// [OutboxHandler] for the append-versus-derived-state split it turns on.
+  Future<bool> isInFlight(String uploadType, String itemId) async =>
+      (await _dao.findOpen(uploadType, itemId))?.status ==
+      OutboxDao.statusInProgress;
+
   /// Withdraws a queued operation whose subject no longer exists.
   ///
   /// The Kotlin upload path has no equivalent because it reads the live table

--- a/flutter/lib/repository/submissions_uploader.dart
+++ b/flutter/lib/repository/submissions_uploader.dart
@@ -34,9 +34,18 @@ class SubmissionsUploader {
   /// the session's credentials the way `UploadCoordinator` sends them; each
   /// row's own owner rides in the document's `user` object, which is where
   /// Planet and the sync-in both read it from.
+  ///
+  /// It is nullable for the same reason it is not a filter. Kotlin's sweep
+  /// takes no user at all — `uploadManager.uploadSubmissions()` is a bare call
+  /// from `AutoSyncWorker:136`, `UserDataWorker:48` and
+  /// `ServerReachabilityWorker:196` — so the sync-path safety net has to be
+  /// able to run on a handset whose session has gone, which is precisely the
+  /// handset with somebody else's finished sheet stranded on it. The column is
+  /// nullable and nothing reads it back (`tables.dart:368`), so a null tag
+  /// costs the row nothing.
   Future<int> queuePending({
     required ServerConfig config,
-    required String userId,
+    required String? userId,
   }) async {
     final rows = await _submissions.pendingUploads();
     final identity = rows.isEmpty ? null : await _identity.read();

--- a/flutter/lib/repository/submissions_uploader.dart
+++ b/flutter/lib/repository/submissions_uploader.dart
@@ -49,7 +49,24 @@ class SubmissionsUploader {
   }) async {
     final rows = await _submissions.pendingUploads();
     final identity = rows.isEmpty ? null : await _identity.read();
+    var queued = 0;
     for (final row in rows) {
+      // A send already on the wire is left alone. `OutboxRepository.enqueue`
+      // would put it back to `pending` to preserve a mid-flight payload edit,
+      // and `markCompleted` only deletes an `in_progress` row — so the send
+      // that succeeds moments later deletes nothing, the row survives with the
+      // same body, and the next drain posts a **second** CouchDB document.
+      // That reset is right for derived state, whose handler rebuilds; a
+      // submission is an append and replaying it duplicates it.
+      //
+      // The cost is the narrow window where the sheet is edited while its POST
+      // is in flight: `markUploaded` clears `isUpdated` on success, so that
+      // edit leaves the pending set. Kotlin loses it identically —
+      // `SubmissionDao:44` clears `isUpdated` in the same statement — and a
+      // later edit is a `_rev`-carrying PUT rather than a new document, so an
+      // update is recoverable where a duplicate is not.
+      if (await _outbox.isInFlight(type, row.id)) continue;
+      queued++;
       await _outbox.enqueue(
         uploadType: type,
         itemId: row.id,
@@ -61,7 +78,7 @@ class SubmissionsUploader {
         userId: userId,
       );
     }
-    return rows.length;
+    return queued;
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {

--- a/flutter/test/providers/dashboard_sync_provider_test.dart
+++ b/flutter/test/providers/dashboard_sync_provider_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
 import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
@@ -12,6 +13,7 @@ import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/repository/shelf_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../repository/device_identity_fixture.dart';
 import '../support/widget_harness.dart';
 
 void main() {
@@ -173,9 +175,12 @@ void _shelfPushTests() {
 
   setUpAll(() => registerFallbackValue(config));
 
-  setUp(() {
+  late PlanetPrefs prefs;
+
+  setUp(() async {
     SharedPreferences.setMockInitialValues({});
     db = AppDatabase.memory();
+    prefs = PlanetPrefs(await SharedPreferences.getInstance());
   });
   tearDown(() => db.close());
 
@@ -188,6 +193,13 @@ void _shelfPushTests() {
       overrides: [
         appDatabaseProvider.overrideWithValue(db),
         planetApiProvider.overrideWithValue(_UnusablePlanetApi()),
+        // Phase 134: `syncAll` now sweeps pending submissions, and
+        // `outboxDrainerProvider` builds every registered handler — several of
+        // which reach `planetPrefsProvider`. Without this the sweep throws
+        // `UnimplementedError`, its own `catch` swallows it, and these two
+        // tests stop covering the second half of the pass while still passing.
+        planetPrefsProvider.overrideWithValue(prefs),
+        deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
         shelfRepositoryProvider.overrideWithValue(shelf),
         serverConfigProvider.overrideWith(
           () => _TestServerConfigNotifier(serverConfig),

--- a/flutter/test/providers/pending_submissions_sweep_test.dart
+++ b/flutter/test/providers/pending_submissions_sweep_test.dart
@@ -1,0 +1,458 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/background_entrypoint.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/system/device_identity.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/dashboard_sync_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/submissions_uploader.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+/// Phase 134. Kotlin reaches the server for a finished answer sheet **twice**:
+/// once from the profile dialog's dismissal (`UserInformationFragment:303`)
+/// and once from `uploadManager.uploadSubmissions()`, which
+/// `AutoSyncWorker:136`, `UserDataWorker:48` and
+/// `ServerReachabilityWorker:183,186` all run unconditionally. A missed
+/// dismissal therefore costs nothing there.
+///
+/// The port had only write-time call sites, so a sheet whose one enqueue call
+/// never ran — process death on "Your information", an `if (!mounted) return`,
+/// a throwing queue call on an exam attempt — stayed on the handset until the
+/// same user happened to finish some *other* submission, because
+/// `queuePending` is an unscoped sweep that then rescues it incidentally.
+///
+/// These tests drive the safety net from both sync paths.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  late AppDatabase db;
+  late MockPlanetApi api;
+
+  setUpAll(() {
+    registerFallbackValue(config);
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+  });
+  tearDown(() => db.close());
+
+  /// The reported state: `complete`, `isUpdated`, `!uploaded`, and **no**
+  /// outbox row — an answer sheet whose profile screen was force-stopped
+  /// between `markSubmissionComplete` and the push.
+  Future<String> seedStrandedSheet({
+    String userId = 'org.couchdb.user:ada',
+  }) async {
+    final repository = SubmissionsRepository(
+      api,
+      db.submissionDao,
+      db.submitPhotosDao,
+      db.surveyDao,
+      db.examDao,
+      teamDao: db.teamDao,
+    );
+    final id = await repository.createDraft(
+      userId: userId,
+      type: 'survey',
+      title: 'Water access',
+      answers: const [],
+    );
+    await repository.markSubmissionComplete(id, {'_id': userId, 'name': 'ada'});
+    return id;
+  }
+
+  /// `outboxDrainerProvider` builds every registered handler, and several of
+  /// those uploaders reach `planetPrefsProvider`, which is
+  /// `UnimplementedError` by default. Without this the sweep's drain throws,
+  /// its own `catch` swallows it, and the test would report the gap as
+  /// unfixed — the Phase 75 harness trap, arriving through a new door.
+  Future<PlanetPrefs> testPrefs() async =>
+      PlanetPrefs(await SharedPreferences.getInstance());
+
+  Future<ProviderContainer> containerFor({
+    DeviceIdentitySource identity = testDeviceIdentity,
+    String? couchId,
+  }) async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(await testPrefs()),
+        deviceIdentitySourceProvider.overrideWithValue(identity),
+        serverConfigProvider.overrideWith(
+          () => _TestServerConfigNotifier(config),
+        ),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(
+            buildUserRow(
+              id: 'org.couchdb.user:ada',
+            ).copyWith(couchId: Value(couchId)),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  void acceptOnePost() {
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'id': 'server-id',
+        'rev': '1-rev',
+      }),
+    );
+  }
+
+  group('foreground sync centre', () {
+    test('syncAll delivers an answer sheet nothing enqueued', () async {
+      final id = await seedStrandedSheet();
+      final container = await containerFor();
+      acceptOnePost();
+
+      // Nothing has queued it: this is the state the gap leaves behind.
+      expect(await db.outboxDao.forItem(SubmissionsUploader.type, id), isEmpty);
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      final row = await container
+          .read(submissionsRepositoryProvider)
+          .getById(id);
+      expect(
+        row?.uploaded,
+        isTrue,
+        reason:
+            'the sync path is the safety net; the sheet must reach the '
+            'server without a second submission being completed first',
+      );
+      expect(row?.couchId, 'server-id');
+      verify(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).called(1);
+    });
+
+    test('the sweep runs even when every table pull fails', () async {
+      // `ServerReachabilityWorker` sweeps with no pull at all and
+      // `UserDataWorker` sweeps inside its own `runCatching`, so the sweep is
+      // not conditional on a pull succeeding — unlike the telemetry uploads
+      // beside it, which are gated on `successCount`.
+      final id = await seedStrandedSheet();
+      final container = await containerFor();
+      acceptOnePost();
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(container.read(dashboardSyncProvider).successCount, 0);
+      expect(
+        (await container.read(submissionsRepositoryProvider).getById(id))
+            ?.uploaded,
+        isTrue,
+      );
+    });
+
+    test('the write-time enqueue and the sweep post one document', () async {
+      final id = await seedStrandedSheet();
+      final container = await containerFor();
+      acceptOnePost();
+      final uploader = container.read(submissionsUploaderProvider);
+
+      // The write-time call site, exactly as `user_information_screen:471`
+      // makes it.
+      await uploader.queuePending(
+        config: config,
+        userId: 'org.couchdb.user:ada',
+      );
+      expect(
+        await db.outboxDao.forItem(SubmissionsUploader.type, id),
+        hasLength(1),
+      );
+
+      // The sweep's own enqueue over the same still-undelivered row. This is
+      // the first of the two protections: `OutboxRepository.enqueue` keys on
+      // `(uploadType, itemId)`, so it refreshes the queued row rather than
+      // adding a second one. Kotlin has no equivalent — its only defence is
+      // the query predicate below — so the port cannot double-post here even
+      // where Kotlin's two paths race.
+      await uploader.queuePending(
+        config: config,
+        userId: 'org.couchdb.user:ada',
+      );
+      expect(
+        await db.outboxDao.forItem(SubmissionsUploader.type, id),
+        hasLength(1),
+        reason: 'a sweep over an already-queued submission must not add a row',
+      );
+
+      // Now let it go out.
+      await container
+          .read(dashboardSyncProvider.notifier)
+          .queuePendingSubmissions();
+      verify(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).called(1);
+      expect(
+        await db.outboxDao.forItem(SubmissionsUploader.type, id),
+        isEmpty,
+        reason: 'a delivered operation is dropped rather than marked completed',
+      );
+
+      // The second protection, and Kotlin's only one: `markUploaded` clears
+      // `isUpdated` and stamps `_id`/`_rev`, which takes the row out of
+      // `pendingUploads` — the port of `SubmissionDao:44`. A later sweep is a
+      // no-op, not a duplicate.
+      expect(
+        await container.read(submissionsRepositoryProvider).pendingUploads(),
+        isEmpty,
+      );
+      await container
+          .read(dashboardSyncProvider.notifier)
+          .queuePendingSubmissions();
+      verifyNoMoreInteractions(api);
+    });
+
+    test('a sweep that throws does not fail the sync', () async {
+      await seedStrandedSheet();
+      final container = await containerFor(
+        identity: const _ThrowingIdentitySource(),
+      );
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      final state = container.read(dashboardSyncProvider);
+      expect(state.running, isFalse);
+      expect(state.finishedAt, isNotNull);
+      expect(state.completedCount, DashboardSyncArea.values.length);
+    });
+
+    test('the sweep runs before the first table pull', () async {
+      // Same assertion shape as the shelf push's: every area still `waiting`
+      // when the POST goes out. Ordering is free in this pass (nothing here
+      // pulls `submissions`), but the headless path's is not, and the two must
+      // not disagree about which side of the pulls a push belongs on.
+      await seedStrandedSheet();
+      final container = await containerFor();
+      List<DashboardSyncStatus>? statusesAtPushTime;
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async {
+        statusesAtPushTime = container
+            .read(dashboardSyncProvider)
+            .items
+            .map((item) => item.status)
+            .toList(growable: false);
+        return const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'server-id',
+          'rev': '1-rev',
+        });
+      });
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(statusesAtPushTime, isNotNull, reason: 'nothing was posted');
+      expect(statusesAtPushTime, everyElement(DashboardSyncStatus.waiting));
+    });
+
+    test('no configured server means no sweep', () async {
+      final id = await seedStrandedSheet();
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          planetApiProvider.overrideWithValue(api),
+          planetPrefsProvider.overrideWithValue(await testPrefs()),
+          deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
+          serverConfigProvider.overrideWith(
+            () => _TestServerConfigNotifier(null),
+          ),
+          sessionProvider.overrideWith(
+            () =>
+                _TestSessionNotifier(buildUserRow(id: 'org.couchdb.user:ada')),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(dashboardSyncProvider.notifier)
+          .queuePendingSubmissions();
+
+      expect(await db.outboxDao.forItem(SubmissionsUploader.type, id), isEmpty);
+      verifyNever(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      );
+    });
+  });
+
+  group('headless path', () {
+    test('the push step queues and delivers a stranded sheet', () async {
+      final id = await seedStrandedSheet();
+      final container = await containerFor();
+      acceptOnePost();
+
+      final step = submissionsPushStep(
+        container,
+        config: config,
+        userId: 'org.couchdb.user:ada',
+      );
+
+      expect(step.name, 'submissions_push');
+      expect(await step.run(), isTrue);
+      expect(
+        (await container.read(submissionsRepositoryProvider).getById(id))
+            ?.uploaded,
+        isTrue,
+      );
+    });
+
+    test('the push step sweeps with no signed-in user', () async {
+      // Kotlin's sweep is unscoped and takes no user
+      // (`SubmissionDao.pendingUploads`); the port's `userId` is only the
+      // outbox row's session tag. A handset whose session is gone must still
+      // deliver the sheet left on it.
+      final id = await seedStrandedSheet();
+      final container = await containerFor();
+      acceptOnePost();
+
+      expect(
+        await submissionsPushStep(
+          container,
+          config: config,
+          userId: null,
+        ).run(),
+        isTrue,
+      );
+
+      expect(
+        (await container.read(submissionsRepositoryProvider).getById(id))
+            ?.uploaded,
+        isTrue,
+      );
+    });
+
+    test('a throwing push step does not request an OS retry', () async {
+      // `BackgroundTaskRunner` adds a step that throws or returns false to
+      // `failedSteps`, which makes `run` return false and WorkManager retry
+      // the whole task. Kotlin wraps its sweep in `runCatching`
+      // (`UserDataWorker:48`) and `AutoSyncWorker` always reports success, so
+      // an undeliverable sheet must not re-run the pulls.
+      await seedStrandedSheet();
+      final container = await containerFor(
+        identity: const _ThrowingIdentitySource(),
+      );
+
+      expect(
+        await submissionsPushStep(
+          container,
+          config: config,
+          userId: 'org.couchdb.user:ada',
+        ).run(),
+        isTrue,
+      );
+    });
+  });
+
+  /// **Reachability, not behaviour.** [submissionsPushStep] is exercised
+  /// directly above, which is exactly the shape Phase 113 warned about: a
+  /// step can be ported, tested and green while nothing in the app builds it.
+  /// `executeBackgroundTask` needs a Flutter binding, real preferences and a
+  /// WorkManager engine, so its `syncSteps` list cannot be built in a unit
+  /// test — the source is read instead, the way `version_parity_test` reads
+  /// `app/build.gradle`.
+  test('the headless path builds the step, ahead of the submissions pull', () {
+    final source = File('lib/background_entrypoint.dart').readAsStringSync();
+    final steps = source.substring(source.indexOf('syncSteps:'));
+
+    final built = steps.indexOf('submissionsPushStep(');
+    final pull = steps.indexOf(
+      "BackgroundSyncStep(\n                'submissions',",
+    );
+
+    expect(
+      built,
+      greaterThan(-1),
+      reason: 'nothing builds submissionsPushStep',
+    );
+    expect(pull, greaterThan(-1), reason: "the 'submissions' pull step moved");
+    expect(
+      built,
+      lessThan(pull),
+      reason:
+          'the sweep must precede the pull: `upsertDocuments` writes '
+          '`isUpdated: false` over every row it touches, which would take a '
+          'locally edited sheet out of `pendingUploads` first',
+    );
+  });
+}
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Reproduces the one failure `PlatformDeviceIdentitySource.read` really has:
+/// a headless WorkManager engine with no primed cache rethrows
+/// (`device_identity.dart:89`), and `SubmissionsUploader.queuePending` reads
+/// identity before it enqueues anything.
+class _ThrowingIdentitySource implements DeviceIdentitySource {
+  const _ThrowingIdentitySource();
+
+  @override
+  Future<DeviceIdentity> read() async =>
+      throw StateError('no platform channel and no primed cache');
+}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  _TestServerConfigNotifier(this._config);
+
+  final ServerConfig? _config;
+
+  @override
+  ServerConfig? build() => _config;
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this._user);
+
+  final UserRow? _user;
+
+  @override
+  Future<UserRow?> build() async => _user;
+}

--- a/flutter/test/providers/pending_submissions_sweep_test.dart
+++ b/flutter/test/providers/pending_submissions_sweep_test.dart
@@ -329,6 +329,7 @@ void main() {
       await seedStrandedSheet();
       final container = await containerFor();
       List<DashboardSyncStatus>? statusesAtPushTime;
+      bool? challengeRecordedFirst;
       when(
         () => api.postJsonObject(
           any(),
@@ -341,6 +342,9 @@ void main() {
             .items
             .map((item) => item.status)
             .toList(growable: false);
+        challengeRecordedFirst = await container
+            .read(activitiesRepositoryProvider)
+            .hasUserCompletedSync('org.couchdb.user:ada');
         return const NetworkSuccess<Map<String, dynamic>>({
           'id': 'server-id',
           'rev': '1-rev',
@@ -351,6 +355,16 @@ void main() {
 
       expect(statusesAtPushTime, isNotNull, reason: 'nothing was posted');
       expect(statusesAtPushTime, everyElement(DashboardSyncStatus.waiting));
+      // And behind the challenge write, which is local and instant. Kotlin
+      // records it "right before the sync starts"
+      // (`DashboardElementActivity.logSyncInSharedPrefs`); a user who taps Sync
+      // and backgrounds the app during the sweep's unbounded network work
+      // should still get the credit for pressing the button.
+      expect(
+        challengeRecordedFirst,
+        isTrue,
+        reason: 'the sweep overtook recordSyncChallengeAction',
+      );
     });
 
     test("delivers another user's sheet from this user's sync", () async {

--- a/flutter/test/providers/pending_submissions_sweep_test.dart
+++ b/flutter/test/providers/pending_submissions_sweep_test.dart
@@ -418,9 +418,69 @@ void main() {
       built,
       lessThan(pull),
       reason:
-          'the sweep must precede the pull: `upsertDocuments` writes '
-          '`isUpdated: false` over every row it touches, which would take a '
-          'locally edited sheet out of `pendingUploads` first',
+          'the sweep must precede the pull — see the test below for the '
+          'window that ordering closes',
+    );
+  });
+
+  /// Why the order above is load-bearing rather than tidy, and the narrow
+  /// shape of it. `upsertDocuments` keys each row on the server `_id`, so a
+  /// pulled document lands *beside* a locally authored sheet (sha1 local id)
+  /// and cannot touch its flags — Kotlin behaves the same way
+  /// (`SubmissionsRepositoryImpl:669-670`). The row it can clobber is one that
+  /// arrived from the server and was then edited locally, which survey resume
+  /// produces: `markComplete` sets `uploaded: false, isUpdated: true` on a row
+  /// whose primary key *is* the server `_id`.
+  test('a pull clears the local edit on a server-originated sheet', () async {
+    final db = AppDatabase.memory();
+    addTearDown(db.close);
+    final api = MockPlanetApi();
+    final repository = SubmissionsRepository(
+      api,
+      db.submissionDao,
+      db.submitPhotosDao,
+      db.surveyDao,
+      db.examDao,
+      teamDao: db.teamDao,
+    );
+
+    await repository.upsertDocuments([
+      {
+        '_id': 'server-1',
+        '_rev': '1-rev',
+        'parentId': 'survey-1',
+        'type': 'survey',
+        'status': 'pending',
+        'user': {'_id': 'org.couchdb.user:ada'},
+      },
+    ]);
+    // The local edit — the shape survey resume leaves behind.
+    await repository.markSubmissionComplete('server-1', {
+      '_id': 'org.couchdb.user:ada',
+    });
+    expect(
+      (await repository.pendingUploads()).map((row) => row.id),
+      contains('server-1'),
+    );
+
+    // The same document arrives again on the next walk.
+    await repository.upsertDocuments([
+      {
+        '_id': 'server-1',
+        '_rev': '2-rev',
+        'parentId': 'survey-1',
+        'type': 'survey',
+        'status': 'pending',
+        'user': {'_id': 'org.couchdb.user:ada'},
+      },
+    ]);
+
+    expect(
+      await repository.pendingUploads(),
+      isEmpty,
+      reason:
+          'the pull wrote isUpdated: false over the local edit, so a sweep '
+          'running after it would find nothing to send',
     );
   });
 }

--- a/flutter/test/providers/pending_submissions_sweep_test.dart
+++ b/flutter/test/providers/pending_submissions_sweep_test.dart
@@ -244,13 +244,76 @@ void main() {
       verifyNoMoreInteractions(api);
     });
 
+    test('a re-enqueue mid-flight does not post a second document', () async {
+      // The Phase 134 implementation audit found this, and it is the failure
+      // mode the phase most had to avoid. `OutboxRepository.enqueue` puts an
+      // `in_progress` row back to `pending` so a payload edited mid-flight is
+      // not lost, and `markCompleted` is `deleteIfInProgress` — so the send
+      // that just succeeded deletes nothing and the row survives, `pending`,
+      // with the same body. That is right for *derived state* (the shelf, whose
+      // handler rebuilds); a submission is an append (`submissions_uploader:10`)
+      // and replaying it is a second CouchDB document, not an edit.
+      //
+      // Reachable as soon as a sweep drains while the app is interactive:
+      // tapping Sync puts the POST on the wire, and the respondent finishing a
+      // survey during it calls the same `queuePending`.
+      final id = await seedStrandedSheet();
+      final container = await containerFor();
+      final uploader = container.read(submissionsUploaderProvider);
+      var posts = 0;
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async {
+        posts++;
+        // The interleaving: another write-time enqueue lands while this POST
+        // is on the wire.
+        await uploader.queuePending(
+          config: config,
+          userId: 'org.couchdb.user:ada',
+        );
+        return NetworkSuccess<Map<String, dynamic>>({
+          'id': 'server-id-$posts',
+          'rev': '$posts-rev',
+        });
+      });
+
+      await container
+          .read(dashboardSyncProvider.notifier)
+          .queuePendingSubmissions();
+      // Whatever the resume drain does next must not re-send it.
+      await container
+          .read(outboxDrainerProvider)
+          .drain(authHeader: 'Basic test');
+
+      expect(posts, 1, reason: 'the answer sheet was posted twice');
+      expect(
+        await db.outboxDao.forItem(SubmissionsUploader.type, id),
+        isEmpty,
+        reason: 'a delivered append must leave no replayable row behind',
+      );
+      expect(
+        (await container.read(submissionsRepositoryProvider).getById(id))
+            ?.couchId,
+        'server-id-1',
+      );
+    });
+
     test('a sweep that throws does not fail the sync', () async {
       await seedStrandedSheet();
-      final container = await containerFor(
-        identity: const _ThrowingIdentitySource(),
-      );
+      final identity = _ThrowingIdentitySource();
+      final container = await containerFor(identity: identity);
 
       await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(
+        identity.reads,
+        1,
+        reason: 'the sweep never got far enough to throw',
+      );
 
       final state = container.read(dashboardSyncProvider);
       expect(state.running, isFalse);
@@ -290,6 +353,87 @@ void main() {
       expect(statusesAtPushTime, everyElement(DashboardSyncStatus.waiting));
     });
 
+    test("delivers another user's sheet from this user's sync", () async {
+      // The shared handset, which is the normal deployment for this app and
+      // the case the unscoped design exists for: member B finishes a survey
+      // and signs out without syncing, member A signs in and syncs.
+      // `SubmissionDao.pendingUploads`' own doc comment names this flow, and
+      // until now nothing drove it through a sync — a `pendingUploads()`
+      // re-scoped to the session in SQL would have left every other test
+      // green.
+      final id = await seedStrandedSheet(userId: 'org.couchdb.user:bob');
+      final container = await containerFor();
+      Map<String, dynamic>? posted;
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((invocation) async {
+        posted = invocation.positionalArguments[1] as Map<String, dynamic>;
+        return const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'server-id',
+          'rev': '1-rev',
+        });
+      });
+
+      // Ada is the session (see `containerFor`).
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(
+        (await container.read(submissionsRepositoryProvider).getById(id))
+            ?.uploaded,
+        isTrue,
+        reason: "the signed-in learner's sync must carry the whole handset",
+      );
+      expect(
+        (posted?['user'] as Map<String, dynamic>?)?['_id'],
+        'org.couchdb.user:bob',
+        reason: 'each document is attributed to its own owner, not the session',
+      );
+    });
+
+    test('the sync drains the whole queue, not just submissions', () async {
+      // `drain(onlyTypes: …)` was the first cut and was wrong: a *joining*
+      // caller gets `const []` without doing its own work
+      // (`outbox_drainer.dart:79-82`), so a resume drain arriving during a
+      // submissions-only pass would return having sent nothing and starve
+      // every other queued write. Kotlin's manual sync is a whole-queue flush
+      // anyway (`UserDataWorker`'s `UPLOAD_TYPE_BULK`).
+      await seedStrandedSheet();
+      final container = await containerFor();
+      acceptOnePost();
+      when(
+        () => api.sendJsonObject(
+          any(),
+          body: any(named: 'body'),
+          method: any(named: 'method'),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async => const NetworkSuccess<Map<String, dynamic>>({'ok': true}),
+      );
+      // A row of some other type, queued before the sync and handler-less, so
+      // the drainer sends it through the generic path.
+      await container
+          .read(outboxRepositoryProvider)
+          .enqueue(
+            uploadType: 'audit_probe',
+            itemId: 'probe-1',
+            endpoint: 'https://planet.example.org/probe',
+            payload: const {'hello': 'world'},
+          );
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(
+        await db.outboxDao.forItem('audit_probe', 'probe-1'),
+        isEmpty,
+        reason: "the sync's drain left an unrelated queued write behind",
+      );
+    });
+
     test('no configured server means no sweep', () async {
       final id = await seedStrandedSheet();
       final container = ProviderContainer(
@@ -325,101 +469,119 @@ void main() {
   });
 
   group('headless path', () {
-    test('the push step queues and delivers a stranded sheet', () async {
+    test('the sweep queues a stranded sheet', () async {
       final id = await seedStrandedSheet();
       final container = await containerFor();
-      acceptOnePost();
 
-      final step = submissionsPushStep(
+      await sweepPendingSubmissions(
         container,
         config: config,
         userId: 'org.couchdb.user:ada',
       );
 
-      expect(step.name, 'submissions_push');
-      expect(await step.run(), isTrue);
       expect(
-        (await container.read(submissionsRepositoryProvider).getById(id))
-            ?.uploaded,
-        isTrue,
+        await db.outboxDao.forItem(SubmissionsUploader.type, id),
+        hasLength(1),
       );
     });
 
-    test('the push step sweeps with no signed-in user', () async {
+    test('the sweep runs with no signed-in user', () async {
       // Kotlin's sweep is unscoped and takes no user
-      // (`SubmissionDao.pendingUploads`); the port's `userId` is only the
-      // outbox row's session tag. A handset whose session is gone must still
-      // deliver the sheet left on it.
-      final id = await seedStrandedSheet();
+      // (`SubmissionDao.getPendingSubmissions`); the port's `userId` is only
+      // the outbox row's session tag. A handset whose session is gone must
+      // still deliver the sheet left on it.
+      final id = await seedStrandedSheet(userId: 'org.couchdb.user:bob');
       final container = await containerFor();
-      acceptOnePost();
 
-      expect(
-        await submissionsPushStep(
-          container,
-          config: config,
-          userId: null,
-        ).run(),
-        isTrue,
-      );
+      await sweepPendingSubmissions(container, config: config, userId: null);
 
-      expect(
-        (await container.read(submissionsRepositoryProvider).getById(id))
-            ?.uploaded,
-        isTrue,
-      );
+      final queued = await db.outboxDao.forItem(SubmissionsUploader.type, id);
+      expect(queued, hasLength(1));
+      expect(queued.single.userId, isNull);
     });
 
-    test('a throwing push step does not request an OS retry', () async {
-      // `BackgroundTaskRunner` adds a step that throws or returns false to
-      // `failedSteps`, which makes `run` return false and WorkManager retry
-      // the whole task. Kotlin wraps its sweep in `runCatching`
-      // (`UserDataWorker:48`) and `AutoSyncWorker` always reports success, so
-      // an undeliverable sheet must not re-run the pulls.
+    test('a throwing sweep does not escape', () async {
+      // `drainOutbox` throwing adds `outboxDrain` to the runner's
+      // `failedSteps`, which asks WorkManager to retry the whole task. Kotlin
+      // wraps its sweep in `runCatching` (`UserDataWorker:48`) and still
+      // returns `Result.success()`, so an undeliverable sheet must not re-run
+      // the pulls.
       await seedStrandedSheet();
-      final container = await containerFor(
-        identity: const _ThrowingIdentitySource(),
-      );
+      final identity = _ThrowingIdentitySource();
+      final container = await containerFor(identity: identity);
 
-      expect(
-        await submissionsPushStep(
+      await expectLater(
+        sweepPendingSubmissions(
           container,
           config: config,
           userId: 'org.couchdb.user:ada',
-        ).run(),
-        isTrue,
+        ),
+        completes,
+      );
+      expect(
+        identity.reads,
+        1,
+        reason:
+            'the test proves nothing unless the throw actually happened — '
+            '`queuePending` only reads identity when it has rows to queue',
       );
     });
   });
 
-  /// **Reachability, not behaviour.** [submissionsPushStep] is exercised
+  /// **Reachability, not behaviour.** [sweepPendingSubmissions] is exercised
   /// directly above, which is exactly the shape Phase 113 warned about: a
-  /// step can be ported, tested and green while nothing in the app builds it.
-  /// `executeBackgroundTask` needs a Flutter binding, real preferences and a
-  /// WorkManager engine, so its `syncSteps` list cannot be built in a unit
-  /// test — the source is read instead, the way `version_parity_test` reads
+  /// function can be ported, tested and green while nothing in the app calls
+  /// it. `executeBackgroundTask` needs a Flutter binding, real preferences and
+  /// a WorkManager engine, so its wiring cannot be built in a unit test — the
+  /// source is read instead, the way `version_parity_test` reads
   /// `app/build.gradle`.
-  test('the headless path builds the step, ahead of the submissions pull', () {
+  ///
+  /// It asserts the *call site*, not merely that the name occurs: the first cut
+  /// searched from `syncSteps:` to end of file, which includes the function's
+  /// own declaration, so its "nothing calls it" assertion could never fail.
+  test('the headless path calls the sweep from drainOutbox', () {
     final source = File('lib/background_entrypoint.dart').readAsStringSync();
-    final steps = source.substring(source.indexOf('syncSteps:'));
-
-    final built = steps.indexOf('submissionsPushStep(');
-    final pull = steps.indexOf(
-      "BackgroundSyncStep(\n                'submissions',",
+    // Bounded to the runner's argument list, which ends where the top-level
+    // declarations begin.
+    final wiring = source.substring(
+      source.indexOf('BackgroundTaskRunner('),
+      source.indexOf('@visibleForTesting'),
     );
 
     expect(
-      built,
-      greaterThan(-1),
-      reason: 'nothing builds submissionsPushStep',
+      wiring,
+      contains('sweepPendingSubmissions('),
+      reason: 'nothing in the headless path calls sweepPendingSubmissions',
     );
+
+    final swept = wiring.indexOf('sweepPendingSubmissions(');
+    final drained = wiring.indexOf('drainer.drain(');
+    final pull = wiring.indexOf("'submissions',");
+
+    expect(drained, greaterThan(-1), reason: 'drainer.drain moved');
     expect(pull, greaterThan(-1), reason: "the 'submissions' pull step moved");
     expect(
-      built,
+      swept,
+      lessThan(drained),
+      reason:
+          'the sweep must queue before the drain that carries it, or the rows '
+          'wait for the next invocation',
+    );
+    expect(
+      swept,
       lessThan(pull),
       reason:
           'the sweep must precede the pull — see the test below for the '
           'window that ordering closes',
+    );
+    expect(
+      swept,
+      lessThan(wiring.indexOf('syncSteps:')),
+      reason:
+          'the sweep must stay in drainOutbox rather than move into '
+          'syncSteps: those run only for an autoSync task, with auto-sync '
+          'enabled, and only when the interval is due — three gates Kotlin '
+          "ServerReachabilityWorker's network-reconnection sweep has none of",
     );
   });
 
@@ -492,11 +654,18 @@ class MockPlanetApi extends Mock implements PlanetApi {}
 /// (`device_identity.dart:89`), and `SubmissionsUploader.queuePending` reads
 /// identity before it enqueues anything.
 class _ThrowingIdentitySource implements DeviceIdentitySource {
-  const _ThrowingIdentitySource();
+  _ThrowingIdentitySource();
+
+  /// Counted so a test can prove the throw happened. `queuePending` reads
+  /// identity only when `pendingUploads()` returned rows, so a fixture that
+  /// stopped producing one would leave these tests passing vacuously.
+  int reads = 0;
 
   @override
-  Future<DeviceIdentity> read() async =>
-      throw StateError('no platform channel and no primed cache');
+  Future<DeviceIdentity> read() async {
+    reads++;
+    throw StateError('no platform channel and no primed cache');
+  }
 }
 
 class _TestServerConfigNotifier extends ServerConfigNotifier {


### PR DESCRIPTION
Lane A of the Phase 134 four-lane round. **Ready for the integrator** — gate green, pushed.

## The gap

Kotlin reaches the server for a finished answer sheet **twice**: from the profile dialog's dismissal (`UserInformationFragment:303` → `SubmissionsUploader:84`) and from `uploadManager.uploadSubmissions()`, which `AutoSyncWorker:136`, `UserDataWorker:48` and `ServerReachabilityWorker:196` run on a schedule. A missed dismissal costs nothing there.

The port had only *write-time* call sites, so a sheet whose one enqueue call never ran — process death on "Your information", the `if (!mounted) return` before the push, a queue call that threw on an exam attempt — sat on the handset as a `complete, isUpdated, !uploaded` row with **no outbox row** until the same user happened to finish some other submission. Phase 132's audit called closing this the round's highest-value item.

Demonstrated failing first: seed that row, run `syncAll()`, and it came back `uploaded == false`.

## What's here

| file | change |
|---|---|
| `providers/dashboard_sync_provider.dart` | `queuePendingSubmissions()`, called from `syncAll()` after the shelf push and challenge write, ahead of every area; queues then drains |
| `background_entrypoint.dart` | `sweepPendingSubmissions(...)`, called from the runner's `drainOutbox` closure — ahead of the drain that carries it and ahead of the pulls |
| `repository/submissions_uploader.dart` | `userId` nullable; skips an item whose send is in flight |
| `repository/outbox_repository.dart` | `isInFlight`, which that skip asks |
| `test/providers/pending_submissions_sweep_test.dart` | 14 tests; plus two overrides `dashboard_sync_provider_test.dart` now needs |

Unscoped, ungated, ahead of the pulls, drained whole, swallowed on failure — each a reading of the Kotlin recorded at the call site. `flutter/PHASE_134_NOTES.md` has the reasoning and the **Reported, not fixed** list.

## Both `parity-auditor` passes at `effort: max` found real things

**Ground truth**, before any code, changed three decisions: the foreground step's justification is `UserDataWorker:48` being reached from the *dashboard sync button* (`SyncActivity:813-815`), not `startFullSync`, which sweeps nothing; the sweep must be ungated because `ServerReachabilityWorker` sweeps with no pull at all; and Kotlin's own sweep sits in one shared sequential `try` that three predecessors can throw out of — a weakness not to reproduce.

**Implementation**, aimed at code already green with 11 passing tests, found:

- **A duplicate CouchDB document.** `enqueue` puts an `in_progress` row back to `pending` (deliberately, to preserve a mid-flight payload edit) and `markCompleted` is `deleteIfInProgress` — so a successful send deletes nothing, the row survives with the same body, and the next drain posts it again. Right for *derived state*, wrong for an **append**. Newly reachable because this phase drains during an interactive sync. Demonstrated at `posts = 2`, then fixed.
- **The headless half never ran for anyone with auto-sync off.** In `syncSteps` it sat behind three gates (`maintenance`, `autoSyncEnabled`, `isDue`), and `BackgroundWorkCoordinator` cancels the `autoSync` job outright when auto-sync is off. Kotlin's `ServerReachabilityWorker` is scheduled unconditionally and sweeps on network reconnection — the exact case the net exists for. Moved to `drainOutbox`.
- **The scoped drain would starve the resume drain**, because `OutboxDrainer.drain` satisfies a joining caller without doing its work. Now unscoped — which is Kotlin's manual sync anyway (`UPLOAD_TYPE_BULK`, eleven arms).
- Three false citations in my own doc comments, a **vacuous** assertion in my own reachability test, two tests that could pass without the throw they tested happening, and **no test for the design's central claim** (the cross-user handset). All fixed.

I also caught one of my own between passes: both comments claimed a pull clears a locally authored sheet's `isUpdated`. `upsertDocuments` keys on the server `_id`, so it lands as a separate row; the clobber is real but narrower (a sheet pulled then edited locally, which survey resume produces) and is now pinned by its own test.

## Gate

`dart format` clean · `flutter analyze` clean · **2412 tests pass**

Nine mutations, each failing exactly the tests that should notice — including one claim (the sweep sitting behind the challenge write) that no test pinned, so a test was added.

## For the integrator

- **No file outside this lane's set was edited.** `submissions_repository.dart` (Lane C) and `app_database.dart` (Lane B) are read only.
- **No `schemaVersion` bump**, and none needed.
- Two items in *Reported, not fixed* are **for Lane B/C or the next round**, not oversights: the port's `pendingUploads` predicate has no status test where Kotlin's has `status = 'complete'` (so the adoption marker and a `pending` draft go up sooner — same set of documents, different timing), and an `abandoned` outbox row now accretes once per sync for a permanently refused sheet. Both are policy calls in files this lane does not own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HR3VE8g8oyH2E8nk3skXP4