### PR TITLE
fix(flutter): carry courseId onto an adopted survey clone, and keep the course gate satisfiable (Phase 136, Lane C)

### DIFF
--- a/flutter/PHASE_136_NOTES.md
+++ b/flutter/PHASE_136_NOTES.md
@@ -1,0 +1,11 @@
+# Phase 136 — an adopted survey clone loses its course
+
+Lane C of a four-lane round. Branch `claude/adopted-survey-course-key-j3v7`,
+based on `claude/kotlin-flutter-dart-migration-d3gmrd`.
+
+Brief: `SurveysRepositoryImpl.createMappedSurvey` copies `courseId` and
+`stepId` onto an adopted team clone; the port's `adoptSurvey` does not, and
+Phase 132's Send fix turned that omission into Phase 125's writer/reader key
+disagreement.
+
+_In progress — notes are written as the work lands._

--- a/flutter/PHASE_136_NOTES.md
+++ b/flutter/PHASE_136_NOTES.md
@@ -1,11 +1,289 @@
 # Phase 136 — an adopted survey clone loses its course
 
 Lane C of a four-lane round. Branch `claude/adopted-survey-course-key-j3v7`,
-based on `claude/kotlin-flutter-dart-migration-d3gmrd`.
+based on `claude/kotlin-flutter-dart-migration-d3gmrd`. PR #16937.
 
-Brief: `SurveysRepositoryImpl.createMappedSurvey` copies `courseId` and
-`stepId` onto an adopted team clone; the port's `adoptSurvey` does not, and
-Phase 132's Send fix turned that omission into Phase 125's writer/reader key
-disagreement.
+Brief: `SurveysRepositoryImpl.createMappedSurvey` copies `courseId` **and**
+`stepId` onto an adopted team clone; the port's `adoptSurvey` copied neither,
+and Phase 132's Send fix turned that omission into Phase 125's writer/reader
+key disagreement. Two field copies plus proving the chain.
 
-_In progress — notes are written as the work lands._
+It was not two field copies. One of the two must **not** be copied, the reader
+had to change to stay satisfiable, and the sentence in the brief that says
+Kotlin's gate counts the clone as "one more requirement" is describing dead
+code.
+
+## `createMappedSurvey`, read field by field
+
+`SurveysRepositoryImpl.kt:162-192` makes **nineteen** assignments — every one
+of `StepExam`'s constructor properties. Nothing is left at a default.
+
+| Kotlin | source | port |
+|---|---|---|
+| `id = newSurveyId` | minted | ✓ |
+| `_rev = null` | literal | ✓ **now explicit** |
+| `createdDate` / `updatedDate` / `adoptionDate` | three separate `now()` calls | ✓ (one timestamp) |
+| `createdBy = userModel?.id` | adopting user | ✓ |
+| `totalMarks` | source | ✓ |
+| `name = "${exam.name} - $teamName"` | source + team | ✓ |
+| `description` | source | ✓ |
+| `type = exam.type` | source | **no column** |
+| `stepId = exam.stepId` | source | **withheld — see below** |
+| `courseId = exam.courseId` | source | ✓ **this phase** |
+| `sourcePlanet` | source | ✓ |
+| `passingPercentage` | source | ✓ |
+| `noOfQuestions` | source | **no column** |
+| `isFromNation` | source | ✓ |
+| `teamId = teamId` | argument, not `exam.teamId` | ✓ |
+| `sourceSurveyId = examId` | source id | ✓ |
+| `isTeamShareAllowed = false` | literal | ✓ |
+
+`type` and `noOfQuestions` have nothing to lose: the port splits Kotlin's one
+`exams` table into `Surveys` and `Exams` on the document's own `type` and then
+discards it, and the marker's `parent` document computes the question count
+from the rows. Neither is a gap.
+
+`_rev = null` and `isTeamShareAllowed = false` are the two assignments that
+look like noise and are load-bearing: `ExamDao.kt:21` queues the clone for
+upload with `sourceSurveyId IS NOT NULL AND _rev IS NULL`, and
+`isTeamShareAllowed = false` is what keeps the clone out of the adoptable list
+and out of the individual list. The port already had the second; `rev` is now
+written explicitly rather than left absent, so an upsert onto an existing id
+cannot inherit a stale rev and silently un-queue the clone from the uploader
+this port still owes (see *Reported, not fixed*).
+
+## `courseId` is copied and `stepId` is not
+
+`stepId` is the one field where copying Kotlin's assignment would be copying a
+word whose meaning differs between the trees, and the port's own sync machinery
+would punish it. Proven, not reasoned:
+
+* Kotlin's step ids are a hash of the step's JSON; the port's are **positional**
+  (`CourseMapper.stepIdFor`, `'$courseId:$index'`). Because deleting a step
+  shifts every later id down one, the courses walk *owns* the join and retires
+  any row its course document does not name —
+  `SurveyDao.releaseStepJoinsForCourse` nulls `stepId` **and `courseId`
+  together**.
+* A clone is minted locally and is in no course document, so it is never in
+  that keep set. Probed on a clone-shaped row:
+  `releaseStepJoinsForCourse('course-1', {'survey-1'})` →
+  `courseId=null stepId=null`. Copying `stepId` would hand the next courses
+  sync a licence to strip the very `courseId` this phase writes.
+* With `stepId` null the update cannot select the row at all
+  (`stepId IS NOT NULL`), so the course join holds.
+
+Withholding it also keeps the clone off the course step's Take Survey button
+(`stepSurveysProvider` → `getByStepId`), whose *count* the port renders to the
+learner. Kotlin's `getByStepIdAndType(stepId, "surveys")` does list every
+team's clone there — a quirk worth not importing.
+
+## The reader had to change, and the brief's premise is dead code
+
+With `courseId` on the clone, `SurveyDao.getByCourseId` returns clones, and
+`hasUnfinishedSurveys` iterates exactly that query. Left alone it would demand
+that **every learner on the course complete every team's private copy** — a
+learner outside the adopting team has no sheet for it and never can have one.
+That is Phase 125's bug re-entered from the writer's side, and the guard
+`'the gate does not demand a team's private copy'` fails on the unfiltered
+version (mutation-tested: `Expected: false / Actual: <true>`).
+
+So `hasUnfinishedSurveys` now skips `sourceSurveyId != null` — Kotlin's own
+test for "this row is an adopted copy" (`ExamDao.kt:21`).
+
+**That is not a divergence from a live Kotlin behaviour.** Both branches of the
+Kotlin fork are broken, and the audit pinned both:
+
+* `getSurveysByCourseId` (`:367-369`) filters
+  `getByCourseIdAndType(courseId, "survey")` — **singular** — while every
+  survey in the app, clone included (`type = exam.type`), carries `"surveys"`:
+  the take-survey button (`:531`), all three survey lists, `ExamDao`'s
+  defaults. So for a normally shaped document the gate matches nothing at all
+  and `hasUnfinishedSurveys` is constant `false`.
+* The only writer of the singular value is `CoursesRepositoryImpl.kt:746`'s
+  `else examKey` — a step survey whose embedded document omits its own `type`.
+  There the gate does match, and matches the clone, but
+  `getTeamOwnedSurveys` filters `"surveys"`, so no screen lists that clone and
+  the obligation is one nothing can discharge.
+
+`repairCourseSurveyParentIds` deliberately does **not** skip clones: a clone's
+member sheets are exactly the rows a pre-Phase-136 build keyed bare, so the
+sweep is how they heal. The two loops want opposite things from the same query,
+and the doc comment now says so.
+
+## Two more defects in the same function
+
+* **The adoption marker's `parent` document disowned the course.** Kotlin's
+  `createParentJsonString(exam)` is handed the **source** exam — resolved at
+  `:73`, ten lines before the clone's id exists — and writes
+  `put("courseId", exam.courseId ?: "")`. The port hardcoded `''`. Confirmed by
+  the audit: the `parent` blob describes the source throughout (`_id` = source
+  id, name without the `" - $teamName"` suffix, `teamShareAllowed` = the
+  source's `true`).
+* **The marker's `user.doc` had no `name`.** Kotlin writes
+  `_id, name, userId, teamPlanetCode, status, type, createdBy` under `doc`
+  (`:139-147`). `adoptSurvey` gains a `userName` parameter, filled from the
+  session user the screen already watches. It is **omitted rather than sent as
+  null** because that JSON is built with `org.json`, whose
+  `put(String, Object)` removes the key for a null value — the same asymmetry
+  that makes `_id`/`name` disappear while `userId`/`createdBy` become `""`.
+
+`teamPlanetCode`, `source` and `parentCode` are left as they are: the audit
+confirms Kotlin takes them from `SharedPrefManager.getPlanetCode()`/
+`getParentCode()` — the **device's** codes, not the user row's — and
+`serialize`'s doc comment already files them under the port-wide
+*community-code parity gap*. Wiring the user row's values at this one call site
+would have been a plausible-looking wrong answer.
+
+## Where Kotlin is worse and the port is deliberately not following
+
+Three, all confirmed by the ground-truth audit and all already true of the port
+before this phase; recorded so nobody "restores parity" into them.
+
+1. **Kotlin blanks every cloned question's text.** `adoptSurvey:90-93` round-trips
+   the questions through `serializeQuestions` → `insertExamQuestions`, which
+   writes the header under `header` and reads it back from `title`, so
+   `header` becomes `""`; question ids are renumbered `"<newSurveyId>-<i>"` and
+   `scaleMax` resets to 9. The port copies the question rows directly.
+2. **Kotlin's adoption dedup is dead on the team path.** `createMappedSubmission`
+   sets only the `@Ignore`d `membershipDoc` and never the persisted `teamId`
+   column, so `findExistingAdoption`'s `getByUserIdAndTeamId` can never match.
+   The port's `createSurveyAdoptionSubmission` writes the column, so its guard
+   works.
+3. **Kotlin's Send button is unreachable.** `SurveysAdapter:62` sets
+   `sendSurvey.visibility = GONE` in `init` and nothing ever sets it visible,
+   so `createBulkSurveySubmissions` is dead in the shipping app. The port's
+   Send *is* reachable, which is why the key it writes has to be right even
+   though nothing upstream exercises it.
+
+The port also does not have Kotlin's `getSurveyFormState` gap (Finding 9: an
+exact `parentId IN (…)` on bare ids that a compound key defeats) — the port has
+no such reader; `_teamSubmissionSurveyIds` matches on the `parent` document's
+`_id`, which is the bare source id under either key.
+
+## The question the brief asked me to decide
+
+> whether the repair sweep should be extended to rescue clones already written
+> without a `courseId`, or whether the next sync rewrites them.
+
+**Neither. The next sync deletes them, and no extension is worth writing until
+that is fixed.** Decided from the code and probed:
+
+* `SurveyDao.deleteNotIn` spares only rows with a non-null `stepId`. A clone has
+  none (deliberately, above), its id is locally minted, and **the port has no
+  adopted-survey uploader**, so it is never in the walk's keep set. Probe:
+  `deleteNotIn(['survey-1'])` after an adopt → `DELETED=1`, clone `null`. The
+  clone and its questions are destroyed on the next surveys sync.
+* A clone already in the field with `courseId = null` cannot be backfilled by
+  `adoptSurvey` — the `adoptedTeamSurvey` guard returns early — and the adopt
+  button is hidden for an already-adopted source, so a backfill branch there
+  would be dead code.
+* Its member sheets are keyed bare, which is *internally consistent* with the
+  bare-keyed reads on that device: no double sheet, no unsatisfiable gate. The
+  only divergence is against a Kotlin handset in the same deployment.
+* Reaching such a clone from the sweep would mean joining clone → source →
+  `courseId`, a new DAO query in Lane B's file, to repair rows whose survey is
+  about to be deleted anyway.
+
+So: no repair extension. The two live rescue paths already cover everything
+reachable — `createBulkSurveySubmissions` repairs the very survey it keys
+(so a leader re-sending heals their team's stale sheets), and
+`repairCourseSurveyParentIds` now reaches clones because they carry a
+`courseId`. Both are pinned.
+
+One honest caveat, from the audit: **a clone's `courseId` does not survive a
+sync round trip in Kotlin either.** `StepExam.serializeExam` emits no `courseId`
+and no `stepId`, and the `exams` walk that pulls the document back cannot set
+them (`insertCourseStepsExams` reads neither from the JSON, and its one
+production call site passes `("", "", doc, "")`). So the join is a
+locally-authored, pre-sync fact in both trees. That is exactly the window Send
+runs in — adopt, then send — which is why the fix matters, and it is also why
+nobody should expect the column to be there after a sync.
+
+## Files
+
+* `lib/repository/surveys_repository.dart` — `adoptSurvey`: `courseId` copy,
+  explicit `rev: null`, `userName`, the `parent` document's `courseId`, one
+  hoisted question read.
+* `lib/repository/submissions_repository.dart` — `hasUnfinishedSurveys` skips
+  clones; the doc bullet that called the omission load-bearing is replaced.
+  Nothing near `queuePending` touched (Lane A).
+* `lib/ui/teams/team_surveys_screen.dart` — passes `userName` from the session
+  user it already watches.
+* `test/repository/adopted_team_survey_course_key_test.dart` — new, 9 tests.
+* `test/repository/mandatory_survey_round_trip_test.dart` — the Phase 125
+  pinned test now pins the corrected behaviour.
+
+No Drift `schemaVersion` bump: both columns already exist.
+
+## Reported, not fixed
+
+### An adopted team survey clone is deleted on the next sync, and never uploaded
+
+**The largest thing this phase found, and it is Phase 116's class: ported,
+tested, green, and destroyed.** Kotlin uploads the clone —
+`ExamDao.getPendingAdoptedSurveys()` (`sourceSurveyId IS NOT NULL AND
+_rev IS NULL`) feeds `UploadConfigs.kt:186-195`, endpoint `exams` — so it
+becomes a real document, gains a `_rev`, and is in every later walk's keep set.
+Kotlin also has **no** delete-except-ids on that table at all.
+
+The port has neither half. There is no adopted-survey uploader anywhere in
+`lib/`, and `SurveyDao.deleteNotIn` prunes every row without a `stepId` that
+the server did not name. Probed above: the clone and its question rows are gone
+after one surveys sync, so a team's adopted survey is a local artefact with a
+lifetime of minutes, its answer sheets orphaned.
+
+The fix is three pieces in three lanes' files, which is why it is reported:
+
+1. `SurveyDao` gains a pending-adopted query and `deleteNotIn` spares
+   `sourceSurveyId IS NOT NULL AND rev IS NULL` — `app_database.dart`, Lane B.
+2. An `AdoptedSurveysUploader` on the outbox, POSTing
+   `SubmissionsRepository.surveyParentDocument` to `exams` and recording
+   id/rev — the outbox files are Lane A's.
+3. `adoptSurvey` enqueues it. That half is mine and I have deliberately not
+   written it alone: an enqueue with no drainer and no prune exemption changes
+   nothing.
+
+Whoever takes it should treat it as the round's highest-value item, ahead of
+this phase's own subject: a wrong `parentId` mis-files answers, a deleted
+survey loses them.
+
+### `releaseStepJoinsForCourse` would strip a clone that ever carries a `stepId`
+
+The reason `stepId` is withheld. If a later round decides the clone should
+carry it — to match Kotlin's step button, say — then
+`SurveyDao.releaseStepJoinsForCourse` must first spare
+`sourceSurveyId IS NOT NULL`, or the next courses sync nulls the clone's
+`courseId` with it and this phase silently reverts. `app_database.dart`,
+Lane B's file this round.
+
+### Adopt is still gated on team leadership; Kotlin gates on guest
+
+Unchanged from Phase 132's report, and still in one of my files.
+`team_surveys_screen.dart:32` — `canAdopt = membership?.isLeader == true`, where
+Kotlin has no role gate at all: `SurveysAdapter:83-90` routes any tap to
+`onAdoptSurvey`, and the only visibility rule is
+`if (userId?.startsWith("guest") == true) startSurvey.visibility = View.GONE`.
+The audit confirms the adopt path is reachable for any member through the team
+SURVEY tab (`TeamPagerAdapter:89-94`, `SurveyFragment:152-155`). Left alone for
+the reason Phase 132 gave: it is an **authorization** change, the current gate
+is pinned by an existing test, and it wants its own diff. The fix is
+`canAdopt = userId?.startsWith('guest') != true`, plus the same predicate
+hiding the start affordance on `surveys_screen.dart` (not in this lane's set).
+
+### A team with no name adopts differently in the two trees
+
+`adoptSurvey:81-83` wraps the whole clone block in
+`if (!teamName.isNullOrEmpty())`, so Kotlin with an unresolved team name writes
+the adoption marker and **no clone** — and, per the audit, then leaves the
+source adoptable so every further tap inserts another marker. The port always
+creates the clone, falling back to the source's name. The port's behaviour is
+the more useful one and porting the guard would make Adopt silently do nothing,
+so this is recorded rather than changed.
+
+### `hasUnfinishedSurveys` and the challenge dialog's alias
+
+Unchanged, but now with a citation worth keeping: Kotlin's `hasPendingSurvey`
+(`:381-389`) differs from `hasUnfinishedSurveys` only in passing
+`survey.courseId` where the other passes `courseId`, and the DAO pinned
+`courseId = :courseId`, so the two are the same function under two names. The
+port's alias is correct.

--- a/flutter/PHASE_136_NOTES.md
+++ b/flutter/PHASE_136_NOTES.md
@@ -15,7 +15,7 @@ code.
 
 ## `createMappedSurvey`, read field by field
 
-`SurveysRepositoryImpl.kt:162-192` makes **nineteen** assignments — every one
+`SurveysRepositoryImpl.kt:163-191` makes **nineteen** assignments — every one
 of `StepExam`'s constructor properties. Nothing is left at a default.
 
 | Kotlin | source | port |
@@ -73,9 +73,13 @@ would punish it. Proven, not reasoned:
   (`stepId IS NOT NULL`), so the course join holds.
 
 Withholding it also keeps the clone off the course step's Take Survey button
-(`stepSurveysProvider` → `getByStepId`), whose *count* the port renders to the
-learner. Kotlin's `getByStepIdAndType(stepId, "surveys")` does list every
-team's clone there — a quirk worth not importing.
+(`stepSurveysProvider` → `getByStepId`) — and the second audit corrected my
+reason. The survey tile renders **no** count (`take_course_screen.dart:468-474`
+says so itself; only the *test* tile counts). The real hazard is worse: the
+button opens `surveys.first.id` (`:499`), so a copied `stepId` would point a
+learner's Take Survey button at whichever team's private clone sorted first.
+Kotlin's `getByStepIdAndType(stepId, "surveys")`
+(`CoursesRepositoryImpl.kt:530`) does exactly that.
 
 ## The reader had to change, and the brief's premise is dead code
 
@@ -87,23 +91,29 @@ That is Phase 125's bug re-entered from the writer's side, and the guard
 `'the gate does not demand a team's private copy'` fails on the unfiltered
 version (mutation-tested: `Expected: false / Actual: <true>`).
 
-So `hasUnfinishedSurveys` now skips `sourceSurveyId != null` — Kotlin's own
-test for "this row is an adopted copy" (`ExamDao.kt:21`).
+So `hasUnfinishedSurveys` now skips a clone — **on both halves of Kotlin's own
+predicate**, `sourceSurveyId IS NOT NULL AND _rev IS NULL` (`ExamDao.kt:21`).
+The first cut had only the first half and that was a real regression; see
+*What the second audit found in my own green code*.
 
-**That is not a divergence from a live Kotlin behaviour.** Both branches of the
-Kotlin fork are broken, and the audit pinned both:
+**Skipping is not a divergence from a live Kotlin behaviour.** Kotlin's gate
+cannot see a clone under any document shape:
 
 * `getSurveysByCourseId` (`:367-369`) filters
   `getByCourseIdAndType(courseId, "survey")` — **singular** — while every
   survey in the app, clone included (`type = exam.type`), carries `"surveys"`:
-  the take-survey button (`:531`), all three survey lists, `ExamDao`'s
-  defaults. So for a normally shaped document the gate matches nothing at all
-  and `hasUnfinishedSurveys` is constant `false`.
-* The only writer of the singular value is `CoursesRepositoryImpl.kt:746`'s
-  `else examKey` — a step survey whose embedded document omits its own `type`.
-  There the gate does match, and matches the clone, but
-  `getTeamOwnedSurveys` filters `"surveys"`, so no screen lists that clone and
-  the obligation is one nothing can discharge.
+  the take-survey button (`CoursesRepositoryImpl.kt:530`), all three survey
+  lists, `ExamDao`'s defaults. So for a normally shaped document the gate
+  matches nothing at all and `hasUnfinishedSurveys` is constant `false`.
+* The singular value is written only by `CoursesRepositoryImpl.kt:746`'s
+  `else examKey`. My first draft claimed that in *that* branch Kotlin's gate
+  does match the clone; **it cannot**, and the second audit caught it. Every
+  list `adoptSurvey` is reachable from is plural — `getAdoptableTeamSurveys`,
+  `getTeamOwnedSurveys` and `getIndividualSurveys` are all `type = "surveys"`
+  (`ExamDao.kt:29-31`) — so an adoption source is always `"surveys"` and so is
+  its clone. The conclusion survives and is *stronger* than the argument I
+  wrote for it, but the false step is the dangerous half: it is exactly the
+  sentence a later round would cite to remove the skip.
 
 `repairCourseSurveyParentIds` deliberately does **not** skip clones: a clone's
 member sheets are exactly the rows a pre-Phase-136 build keyed bare, so the
@@ -112,13 +122,17 @@ and the doc comment now says so.
 
 ## Two more defects in the same function
 
-* **The adoption marker's `parent` document disowned the course.** Kotlin's
-  `createParentJsonString(exam)` is handed the **source** exam — resolved at
-  `:73`, ten lines before the clone's id exists — and writes
-  `put("courseId", exam.courseId ?: "")`. The port hardcoded `''`. Confirmed by
-  the audit: the `parent` blob describes the source throughout (`_id` = source
-  id, name without the `" - $teamName"` suffix, `teamShareAllowed` = the
-  source's `true`).
+* **The adoption marker's `parent` document disowned the course** — on the
+  fallback path only, and my first write-up overstated it. Kotlin's
+  `createParentJsonString(exam)` is handed the **source** exam (resolved at
+  `:73`, ten lines before the clone's id exists) and writes
+  `put("courseId", exam.courseId ?: "")`; the port hardcoded `''`. But nothing
+  *published* that field: `serialize` prefers the live survey row
+  (`_liveParentDocument`) and `surveyParentDocument` emits no `courseId`, as
+  Kotlin's `StepExam.serializeExam` does not either. The stored blob is sent
+  only when the source survey row has gone missing. So this is faithfulness on
+  a rarely taken path, not a defect anyone observed — the commit message ranks
+  it too highly.
 * **The marker's `user.doc` had no `name`.** Kotlin writes
   `_id, name, userId, teamPlanetCode, status, type, createdBy` under `doc`
   (`:139-147`). `adoptSurvey` gains a `userName` parameter, filled from the
@@ -209,11 +223,84 @@ nobody should expect the column to be there after a sync.
   Nothing near `queuePending` touched (Lane A).
 * `lib/ui/teams/team_surveys_screen.dart` — passes `userName` from the session
   user it already watches.
-* `test/repository/adopted_team_survey_course_key_test.dart` — new, 9 tests.
+* `test/repository/adopted_team_survey_course_key_test.dart` — new, 13 tests
+  (the commit message for the first push says nine; two landed in a follow-up
+  and two more with the second audit's fixes).
 * `test/repository/mandatory_survey_round_trip_test.dart` — the Phase 125
   pinned test now pins the corrected behaviour.
 
 No Drift `schemaVersion` bump: both columns already exist.
+
+## What the second audit found in my own green code
+
+Both passes were run at `effort: max`, ground truth before implementing and
+implementation after it was green — and the second one earned its keep, as it
+has in every phase that ran it.
+
+### `sourceSurveyId != null` alone silently loosened the gate
+
+**A regression this phase introduced, and the worst kind: it made a blocking
+check stop blocking.** `sourceSurveyId` is *not* a local-authorship marker in
+the port. The courses walk reads it straight off the server's embedded survey
+(`survey_mapper.dart:163-167`), so a step survey that is itself an adopted copy
+lands with `courseId`, `stepId` **and** `sourceSurveyId`. That row has a Take
+Survey button and a working retake label — it can be satisfied — and my skip
+ignored it. A learner on `MANDATORY_SURVEY_COURSE_ID` could tap Finish having
+answered nothing and see no snackbar; the challenge dialog would report the
+survey task done.
+
+Kotlin's own test for a locally minted clone is the **conjunction**
+`sourceSurveyId IS NOT NULL AND _rev IS NULL` (`ExamDao.kt:21`) — I cited that
+line as authority and then ported half of it. The predicate is now the whole
+thing, which this phase's own `rev: Value(null)` makes exact: a server row
+always carries a rev, a clone never does. Pinned by
+`'a server-authored step survey still gates, even if adopted'`, on a course
+document carrying `_rev` and `sourceSurveyId`, which fails on the one-clause
+version.
+
+### The adoption guard had the null-vs-empty bug this phase celebrates catching
+
+Kotlin's `findExistingAdoption` predicate is `it.status.orEmpty().isEmpty()`
+(`:206`) — null **and** `''`. The port's was `row.status == ''`, which misses
+null, and null is the *normal* state for a marker that has synced: `serialize`
+sends `'status': ''` and `upsertDocuments` reads the empty string back as null
+(`json_utils.dart:19-22`). The same shape `_repairSurveyParentId` needs
+`coalesce(status, '')` for, three hundred lines away, with a doc comment
+explaining why. Now `(row.status ?? '').isEmpty`.
+
+Harmless today only because the port's marker id is deterministic, so the
+rewrite lands on the same row rather than duplicating (Kotlin would insert a
+second marker) — but it reset the status, bumped both timestamps and re-flagged
+`isUpdated`, re-queueing the marker for upload on every stray adopt tap.
+
+### Claims of mine it corrected
+
+* the "other Kotlin branch" argument, above — a misread citation;
+* the `parent.courseId` impact, above — not observable on the wire;
+* the Take Survey *count* — the survey tile renders none; the real hazard is
+  the button's target;
+* seven citations off by one or two (`:180-181` → `:181-182` for the
+  `stepId`/`courseId` pair, `createUserJsonString:139-141` → `:142-143`, the
+  `doc` key span `:139-147` → `:142-148`, the take-survey button `:531` →
+  `:530`), all now fixed;
+* the test count, which was nine and is thirteen.
+
+### And the framing, which is worth stating plainly
+
+**With the clone skipped, no reader in `lib/` distinguishes the bare key from
+the composite one for a clone.** The only two readers comparing a whole
+`parentId` are `latestPendingByUserAndParent` (writer-side dedupe,
+self-consistent under either key) and `countByUserParentAndType` (reached from
+`hasSubmission`, which only ever sees step surveys, and from
+`hasUnfinishedSurveys`, which now skips clones). Off-device, Planet has no
+clone document to join against, because the port never uploads one.
+
+So this is a **writer-faithfulness** change, not the live writer/reader
+disagreement the commit message describes. It is still worth having — Send and
+the answering path now derive the key from one place so they cannot drift
+apart, a mixed Kotlin/port fleet agrees, and the transition is covered by the
+repair — but the ranking in *Reported, not fixed* is the correct one: **the
+uploader/prune gap is the item that loses data. This one does not.**
 
 ## Reported, not fixed
 
@@ -255,6 +342,27 @@ carry it — to match Kotlin's step button, say — then
 `sourceSurveyId IS NOT NULL`, or the next courses sync nulls the clone's
 `courseId` with it and this phase silently reverts. `app_database.dart`,
 Lane B's file this round.
+
+### `progress_repository.dart:92-95` now reads as a contradiction
+
+Not touched — Lane B's file this round. Its comment justifies a `groupBy` with
+"`adoptSurvey` copies `stepId` onto a new row, so a step can legitimately carry
+more than one". That is a statement about *Kotlin*, and it was unambiguous
+while the port copied neither column; now that `adoptSurvey` deliberately
+withholds `stepId` it reads as a contradiction of
+`surveys_repository.dart`'s block. The `groupBy` itself is correct and should
+stay — Kotlin's clone really does share the step. It wants one clarifying
+clause, from whoever owns that file.
+
+### The repair's idempotence claim is device-local only
+
+`repairCourseSurveyParentIds`' doc says "after the first pass no row matches the
+bare id any more". True on the device: but `upsertDocuments` writes `parentId`
+verbatim from the document and `_repairSurveyParentId` does not set
+`isUpdated`, so a *server-authored* bare-id row is rewritten locally on every
+Finish tap and re-reverted on the next pull. Pre-existing (Phase 125), and the
+clone extension adds no new instance — a clone has no server rows, because the
+port never uploads it. Recorded because this phase re-asserted the claim.
 
 ### Adopt is still gated on team leadership; Kotlin gates on guest
 

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -994,10 +994,35 @@ class SubmissionsRepository {
   /// by tests in `mandatory_survey_round_trip_test.dart`:
   ///
   /// * Kotlin's `createMappedSurvey` copies the source survey's `courseId` and
-  ///   `stepId` into an adopted team clone (`SurveysRepositoryImpl.kt:181-182`),
-  ///   so a Kotlin course step can serve a clone and this block would demand
-  ///   every team's copy. The port's `adoptSurvey` omits both columns, and that
-  ///   omission is what makes an unfiltered `getByCourseId` correct here.
+  ///   `stepId` into an adopted team clone (`SurveysRepositoryImpl.kt:180-181`).
+  ///   Since Phase 136 the port copies the `courseId` too — Send has to, since
+  ///   `createBulkSurveySubmissions` folds it into every member's key — so
+  ///   `getByCourseId` now returns clones and **this loop skips them
+  ///   explicitly**. It used to be safe by accident, on the omission.
+  ///
+  ///   Skipping is not a divergence from a live Kotlin behaviour, and the note
+  ///   this replaced implied it was. Kotlin's own gate reaches **no** survey at
+  ///   all: `getSurveysByCourseId` (`:367-369`) filters
+  ///   `getByCourseIdAndType(courseId, "survey")`, singular, while every
+  ///   survey — clone included, since `createMappedSurvey` assigns
+  ///   `type = exam.type` — carries `"surveys"`. So there is no Kotlin
+  ///   behaviour here to match, only a live port gate to keep satisfiable: a
+  ///   learner outside the adopting team has no sheet for that team's copy and
+  ///   never can have one, so counting it would make the course unfinishable —
+  ///   Phase 125's bug, re-entered from the writer's side.
+  ///
+  ///   And in the *other* branch — a step survey whose embedded document omits
+  ///   `type`, which is the only way Kotlin ever writes the singular value
+  ///   (`CoursesRepositoryImpl.kt:746`, `else examKey`) — Kotlin's gate does
+  ///   match, and matches the clone too, but `getTeamOwnedSurveys` filters
+  ///   `type = "surveys"` and so lists no such clone at all. The obligation it
+  ///   adds is one no Kotlin screen can discharge. Neither branch is behaviour
+  ///   worth reproducing.
+  ///
+  ///   [repairCourseSurveyParentIds] deliberately does **not** skip them: a
+  ///   clone's member sheets are exactly the rows a pre-Phase-136 build keyed
+  ///   bare, so the sweep is how they heal. The two loops want opposite things
+  ///   from the same query.
   /// * `countByUserParentAndType` is status-blind, as Kotlin's is
   ///   (`SubmissionDao.kt:23`) — a sheet the learner has merely *opened*
   ///   satisfies the gate. That is also why the adoption marker, which is
@@ -1026,6 +1051,11 @@ class SubmissionsRepository {
     await repairCourseSurveyParentIds(courseId);
     final surveys = await _surveyDao.getByCourseId(courseId);
     for (final survey in surveys) {
+      // An adopted team clone joins the course as of Phase 136, and the course
+      // must not demand it — see this method's doc comment. `sourceSurveyId`
+      // is Kotlin's own test for "this row is an adopted copy"
+      // (`ExamDao.kt:21`, the upload sweep).
+      if (survey.sourceSurveyId != null) continue;
       // Routed through the writers' own derivation so the two cannot drift
       // apart again. `courseId` is non-empty by the guard above and equal to
       // `survey.courseId` by the query that produced the row, so this is

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -987,14 +987,19 @@ class SubmissionsRepository {
   /// no step join: found here, offered by no button. Kotlin genuinely cannot do
   /// that, since `StepExam.insertCourseStepsExams` never reads either key from
   /// the document (`StepExam.kt:36-58`) and the exams walk passes
-  /// `("", "", doc, "")`. Whether it is live depends on Planet's document
-  /// shape, which nothing in this tree settles.
+  /// `("", "", doc, "")`.
+  ///
+  /// **And since Phase 136 the port manufactures that shape itself**, on every
+  /// team adoption: `adoptSurvey` copies `courseId` and deliberately not
+  /// `stepId`. So this is no longer a hypothetical waiting on Planet's
+  /// document shapes — it is the normal state of an adopted clone, and the
+  /// skip below is what keeps it out of this reader.
   ///
   /// Two things the audit established that keep this reader safe, both pinned
   /// by tests in `mandatory_survey_round_trip_test.dart`:
   ///
   /// * Kotlin's `createMappedSurvey` copies the source survey's `courseId` and
-  ///   `stepId` into an adopted team clone (`SurveysRepositoryImpl.kt:180-181`).
+  ///   `stepId` into an adopted team clone (`SurveysRepositoryImpl.kt:181-182`).
   ///   Since Phase 136 the port copies the `courseId` too — Send has to, since
   ///   `createBulkSurveySubmissions` folds it into every member's key — so
   ///   `getByCourseId` now returns clones and **this loop skips them
@@ -1011,13 +1016,17 @@ class SubmissionsRepository {
   ///   never can have one, so counting it would make the course unfinishable —
   ///   Phase 125's bug, re-entered from the writer's side.
   ///
-  ///   And in the *other* branch — a step survey whose embedded document omits
-  ///   `type`, which is the only way Kotlin ever writes the singular value
-  ///   (`CoursesRepositoryImpl.kt:746`, `else examKey`) — Kotlin's gate does
-  ///   match, and matches the clone too, but `getTeamOwnedSurveys` filters
-  ///   `type = "surveys"` and so lists no such clone at all. The obligation it
-  ///   adds is one no Kotlin screen can discharge. Neither branch is behaviour
-  ///   worth reproducing.
+  ///   And a `type = "survey"` **clone** cannot exist at all, which an earlier
+  ///   draft of this bullet got wrong: the singular value is written only by
+  ///   `CoursesRepositoryImpl.kt:746`'s `else examKey`, while every list
+  ///   `adoptSurvey` is reachable from is plural — `getAdoptableTeamSurveys`,
+  ///   `getTeamOwnedSurveys` and `getIndividualSurveys` are all
+  ///   `type = "surveys"` (`ExamDao.kt:29-31`), and `createMappedSurvey`
+  ///   copies `type = exam.type`. So Kotlin's gate cannot see a clone under
+  ///   *any* document shape. That makes the case for skipping stronger than
+  ///   the one this replaced, not weaker — but it is also the sentence a later
+  ///   round would reach for to remove the skip, so it is worth stating
+  ///   correctly.
   ///
   ///   [repairCourseSurveyParentIds] deliberately does **not** skip them: a
   ///   clone's member sheets are exactly the rows a pre-Phase-136 build keyed
@@ -1052,10 +1061,21 @@ class SubmissionsRepository {
     final surveys = await _surveyDao.getByCourseId(courseId);
     for (final survey in surveys) {
       // An adopted team clone joins the course as of Phase 136, and the course
-      // must not demand it — see this method's doc comment. `sourceSurveyId`
-      // is Kotlin's own test for "this row is an adopted copy"
-      // (`ExamDao.kt:21`, the upload sweep).
-      if (survey.sourceSurveyId != null) continue;
+      // must not demand it — see this method's doc comment.
+      //
+      // **Both halves of the predicate are load-bearing**, and the first cut
+      // of this had only the first. `sourceSurveyId` is not a local-authorship
+      // marker in the port: the courses walk reads it straight off the
+      // server's embedded survey (`survey_mapper.dart:163-167`), so a step
+      // survey that is itself an adopted copy arrives with `courseId`,
+      // `stepId` and `sourceSurveyId` — it has a Take Survey button and a
+      // working retake label, and skipping it let a learner finish
+      // `MANDATORY_SURVEY_COURSE_ID` having answered nothing. Kotlin's own
+      // test for a locally minted clone is the conjunction
+      // `sourceSurveyId IS NOT NULL AND _rev IS NULL` (`ExamDao.kt:21`, the
+      // upload sweep), and `adoptSurvey` writing `rev: Value(null)`
+      // explicitly is what makes the second half exact here.
+      if (survey.sourceSurveyId != null && survey.rev == null) continue;
       // Routed through the writers' own derivation so the two cannot drift
       // apart again. `courseId` is non-empty by the guard above and equal to
       // `survey.courseId` by the query that produced the row, so this is

--- a/flutter/lib/repository/surveys_repository.dart
+++ b/flutter/lib/repository/surveys_repository.dart
@@ -78,7 +78,7 @@ class SurveysRepository {
   /// Port of `SurveysRepositoryImpl.adoptSurvey` (`:66-114`).
   ///
   /// [userName] feeds the adoption marker's `user.doc.name`, which Kotlin
-  /// writes from the resolved session model (`createUserJsonString:143`). It is
+  /// writes from the resolved session model (`createUserJsonString:142-143`). It is
   /// nullable and omitted when absent rather than sent as null, because
   /// `JSONObject.put(String, Object)` *removes* the key for a null value.
   Future<void> adoptSurvey({
@@ -105,7 +105,7 @@ class SurveysRepository {
         final adoptedId = createId?.call() ?? '${surveyId}_$teamId';
         await _dao.upsertAll(
           [
-            // `createMappedSurvey` (`SurveysRepositoryImpl.kt:162-192`) makes
+            // `createMappedSurvey` (`SurveysRepositoryImpl.kt:163-191`) makes
             // nineteen assignments; every one with a column here is below.
             // `type` and `noOfQuestions` have none — the port splits Kotlin's
             // single `exams` table on the document's own `type` and computes
@@ -125,10 +125,15 @@ class SurveysRepository {
             // (`stepId IS NOT NULL`), and the course join holds.
             //
             // Withholding it also keeps the clone off the course step's Take
-            // Survey button (`stepSurveysProvider` -> `getByStepId`), whose
-            // count the port renders to the learner; Kotlin's
-            // `getByStepIdAndType(stepId, "surveys")` does show every team's
-            // clone there, and that is a quirk worth not importing.
+            // Survey button (`stepSurveysProvider` -> `getByStepId`). That
+            // matters more than a wrong count — the survey tile renders none
+            // (`take_course_screen.dart:468-474`; only the *test* tile counts)
+            // — because the button opens `surveys.first.id` (`:499`), so a
+            // copied `stepId` would point a learner's Take Survey button at
+            // whichever team's private clone sorted first. Kotlin's
+            // `getByStepIdAndType(stepId, "surveys")`
+            // (`CoursesRepositoryImpl.kt:530`) does exactly that, and it is a
+            // quirk worth not importing.
             SurveysCompanion.insert(
               id: adoptedId,
               // `_rev = null` is an explicit assignment in the Kotlin, and it
@@ -181,9 +186,18 @@ class SurveysRepository {
     final candidates = isTeam && teamId != null && teamId.isNotEmpty
         ? await _submissions.submissionsForTeam(teamId)
         : await _submissions.submissionsForUserWithoutTeam(userId);
+    // `it.status.orEmpty().isEmpty()` (`SurveysRepositoryImpl.kt:206`) — a
+    // **null** status counts as empty, and null is the normal state for a
+    // marker that has round-tripped: [SubmissionsRepository.serialize] sends
+    // `'status': ''` and `upsertDocuments` reads the empty string back as null
+    // (`json_utils.dart:19-22`). `row.status == ''` missed those and rewrote
+    // the marker on every adopt tap, re-queueing it for upload. Same shape as
+    // the `coalesce(status, '')` that `_repairSurveyParentId` needs.
     final exists = candidates.any(
       (row) =>
-          row.userId == userId && row.parentId == surveyId && row.status == '',
+          row.userId == userId &&
+          row.parentId == surveyId &&
+          (row.status ?? '').isEmpty,
     );
     if (exists) return;
     final parentJson = jsonEncode({
@@ -193,7 +207,14 @@ class SurveysRepository {
       // (`createParentJsonString`, `SurveysRepositoryImpl.kt:122`), where
       // `exam` is the **source** survey this marker is about, not the clone —
       // `adoptSurvey` resolves it at `:73` and calls this at `:77`, ten lines
-      // before the clone's id exists. A hardcoded `''` here published a
+      // before the clone's id exists.
+      //
+      // The hardcoded `''` this replaced was **not** observable on the wire:
+      // `SubmissionsRepository.serialize` prefers the live survey row
+      // (`_liveParentDocument`) and `surveyParentDocument` emits no `courseId`
+      // at all, as Kotlin's `StepExam.serializeExam` does not either. This
+      // blob is uploaded only when the source row has gone missing. So the
+      // fix is faithfulness on the fallback path, not a bug anyone saw. A hardcoded `''` here published a
       // marker whose parent document disowned the course the survey belongs
       // to.
       'courseId': survey.courseId ?? '',

--- a/flutter/lib/repository/surveys_repository.dart
+++ b/flutter/lib/repository/surveys_repository.dart
@@ -75,9 +75,16 @@ class SurveysRepository {
         .toList();
   }
 
+  /// Port of `SurveysRepositoryImpl.adoptSurvey` (`:66-114`).
+  ///
+  /// [userName] feeds the adoption marker's `user.doc.name`, which Kotlin
+  /// writes from the resolved session model (`createUserJsonString:143`). It is
+  /// nullable and omitted when absent rather than sent as null, because
+  /// `JSONObject.put(String, Object)` *removes* the key for a null value.
   Future<void> adoptSurvey({
     required String surveyId,
     required String? userId,
+    String? userName,
     String? teamId,
     bool isTeam = false,
     String? teamName,
@@ -88,16 +95,48 @@ class SurveysRepository {
   }) async {
     final survey = await _dao.getById(surveyId);
     if (survey == null) return;
+    // Read once: the clone's question set and the marker's `noOfQuestions` are
+    // the same list, and Kotlin resolves each of its own inputs once too.
+    final questions = await _dao.questionsFor(surveyId);
     final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
     if (isTeam && teamId != null && teamId.isNotEmpty) {
       final existing = await _dao.adoptedTeamSurvey(teamId, surveyId);
       if (existing == null) {
         final adoptedId = createId?.call() ?? '${surveyId}_$teamId';
-        final questions = await _dao.questionsFor(surveyId);
         await _dao.upsertAll(
           [
+            // `createMappedSurvey` (`SurveysRepositoryImpl.kt:162-192`) makes
+            // nineteen assignments; every one with a column here is below.
+            // `type` and `noOfQuestions` have none — the port splits Kotlin's
+            // single `exams` table on the document's own `type` and computes
+            // the question count from the rows — so the copy is complete apart
+            // from `stepId`, which is withheld deliberately:
+            //
+            // **`courseId` is copied and `stepId` is not, and the asymmetry is
+            // load-bearing.** Kotlin's step ids are a hash of the step's own
+            // JSON; the port's are positional (`CourseMapper.stepIdFor`,
+            // `'$courseId:$index'`), so the courses walk *owns* the join and
+            // retires any row its course document does not name —
+            // `SurveyDao.releaseStepJoinsForCourse` nulls `stepId` **and**
+            // `courseId` together. A clone is minted locally and is in no
+            // course document, so copying `stepId` would hand the next courses
+            // sync a licence to strip the very `courseId` this writes. With
+            // `stepId` null that update cannot select the row at all
+            // (`stepId IS NOT NULL`), and the course join holds.
+            //
+            // Withholding it also keeps the clone off the course step's Take
+            // Survey button (`stepSurveysProvider` -> `getByStepId`), whose
+            // count the port renders to the learner; Kotlin's
+            // `getByStepIdAndType(stepId, "surveys")` does show every team's
+            // clone there, and that is a quirk worth not importing.
             SurveysCompanion.insert(
               id: adoptedId,
+              // `_rev = null` is an explicit assignment in the Kotlin, and it
+              // is what marks a clone as not yet published: Kotlin's upload
+              // sweep is `sourceSurveyId IS NOT NULL AND _rev IS NULL`
+              // (`ExamDao.kt:21`). Written rather than left absent so an
+              // upsert onto an existing id cannot inherit a stale rev.
+              rev: const Value(null),
               name: Value(
                 (teamName == null || teamName.isEmpty)
                     ? survey.name
@@ -115,6 +154,7 @@ class SurveysRepository {
               teamId: Value(teamId),
               teamShareAllowed: const Value(false),
               sourceSurveyId: Value(surveyId),
+              courseId: Value(survey.courseId),
             ),
           ],
           {
@@ -149,15 +189,27 @@ class SurveysRepository {
     final parentJson = jsonEncode({
       '_id': survey.id,
       'name': survey.name,
-      'courseId': '',
+      // `put("courseId", exam.courseId ?: "")`
+      // (`createParentJsonString`, `SurveysRepositoryImpl.kt:122`), where
+      // `exam` is the **source** survey this marker is about, not the clone —
+      // `adoptSurvey` resolves it at `:73` and calls this at `:77`, ten lines
+      // before the clone's id exists. A hardcoded `''` here published a
+      // marker whose parent document disowned the course the survey belongs
+      // to.
+      'courseId': survey.courseId ?? '',
       'sourcePlanet': survey.sourcePlanet ?? '',
       'teamShareAllowed': survey.teamShareAllowed,
-      'noOfQuestions': (await _dao.questionsFor(surveyId)).length,
+      'noOfQuestions': questions.length,
       'isFromNation': survey.isFromNation,
     });
     final userJson = jsonEncode({
       'doc': {
         '_id': userId,
+        // Null-aware, so a missing name omits the key rather than sending
+        // null — `org.json`'s `put(String, Object)` removes the mapping for a
+        // null value, which is why Kotlin's `_id`/`name` disappear while its
+        // `userId`/`createdBy` fall back to `""`.
+        'name': ?userName,
         'userId': userId,
         'teamPlanetCode': planetCode,
         'status': 'active',

--- a/flutter/lib/ui/teams/team_surveys_screen.dart
+++ b/flutter/lib/ui/teams/team_surveys_screen.dart
@@ -127,7 +127,7 @@ class TeamSurveysScreen extends ConsumerWidget {
                                 // The marker's `user.doc.name`, which Kotlin
                                 // takes off the same resolved session model
                                 // it takes the id from
-                                // (`createUserJsonString:139-141`).
+                                // (`createUserJsonString:142-143`).
                                 userName: user?.name,
                                 teamId: teamId,
                                 teamName: team?.name,

--- a/flutter/lib/ui/teams/team_surveys_screen.dart
+++ b/flutter/lib/ui/teams/team_surveys_screen.dart
@@ -23,7 +23,8 @@ class TeamSurveysScreen extends ConsumerWidget {
     final owned = ref.watch(teamOwnedSurveysProvider(teamId));
     final adoptable = ref.watch(teamAdoptableSurveysProvider(teamId));
     final team = ref.watch(teamProvider(teamId)).valueOrNull;
-    final userId = ref.watch(sessionProvider).valueOrNull?.id;
+    final user = ref.watch(sessionProvider).valueOrNull;
+    final userId = user?.id;
     final memberships =
         ref.watch(teamMembershipsProvider).valueOrNull ?? const {};
     final membership =
@@ -123,6 +124,11 @@ class TeamSurveysScreen extends ConsumerWidget {
                               .adoptSurvey(
                                 surveyId: survey.id,
                                 userId: userId,
+                                // The marker's `user.doc.name`, which Kotlin
+                                // takes off the same resolved session model
+                                // it takes the id from
+                                // (`createUserJsonString:139-141`).
+                                userName: user?.name,
                                 teamId: teamId,
                                 teamName: team?.name,
                                 isTeam: true,

--- a/flutter/test/repository/adopted_team_survey_course_key_test.dart
+++ b/flutter/test/repository/adopted_team_survey_course_key_test.dart
@@ -243,6 +243,53 @@ void main() {
     expect(parent['noOfQuestions'], 1);
   });
 
+  test('the marker\'s user document carries the adopter\'s name', () async {
+    await surveys.adoptSurvey(
+      surveyId: 'survey-1',
+      userId: 'leader-1',
+      userName: 'Ada Lovelace',
+      teamId: 'team-1',
+      teamName: 'Water Team',
+      isTeam: true,
+      now: DateTime.fromMillisecondsSinceEpoch(5000),
+    );
+    final marker = (await database.submissionDao.getSurveySubmissionsByUser(
+      'leader-1',
+    )).singleWhere((row) => row.status == '');
+    final user = jsonDecode(marker.user!) as Map<String, dynamic>;
+    final doc = user['doc'] as Map<String, dynamic>;
+    expect(doc['name'], 'Ada Lovelace');
+    // Kotlin's key set and order under `doc` (`createUserJsonString:139-147`).
+    expect(doc.keys, [
+      '_id',
+      'name',
+      'userId',
+      'teamPlanetCode',
+      'status',
+      'type',
+      'createdBy',
+    ]);
+    // `membershipDoc` is a **sibling** of `doc`, not nested in it: the sync-in
+    // reads `user.membershipDoc.teamId`.
+    expect(user['membershipDoc'], {'teamId': 'team-1'});
+  });
+
+  test('a nameless adopter omits the key rather than sending null', () async {
+    // `org.json`'s `put(String, Object)` removes the mapping for a null value,
+    // which is why Kotlin's `_id`/`name` disappear while its `userId` and
+    // `createdBy` fall back to `""`.
+    await adopt();
+    final marker = (await database.submissionDao.getSurveySubmissionsByUser(
+      'leader-1',
+    )).singleWhere((row) => row.status == '');
+    final doc =
+        (jsonDecode(marker.user!) as Map<String, dynamic>)['doc']
+            as Map<String, dynamic>;
+    expect(doc.containsKey('name'), isFalse);
+    expect(doc['userId'], 'leader-1');
+    expect(doc['createdBy'], 'leader-1');
+  });
+
   test('a course-less survey is unaffected', () async {
     await database.surveyDao.upsertAll([
       SurveysCompanion.insert(

--- a/flutter/test/repository/adopted_team_survey_course_key_test.dart
+++ b/flutter/test/repository/adopted_team_survey_course_key_test.dart
@@ -1,0 +1,275 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// **The pair, not the halves.** Phase 136, and the same class as Phase 125.
+///
+/// `SurveysRepositoryImpl.createMappedSurvey` copies the source survey's
+/// `courseId` and `stepId` onto an adopted team clone
+/// (`SurveysRepositoryImpl.kt:180-181`). The port's `adoptSurvey` copied
+/// neither, and once Phase 132 made Send pass the *clone's* id,
+/// `createBulkSurveySubmissions` resolved `survey?.courseId == null` and keyed
+/// every member's answer sheet with the bare clone id where Kotlin keys
+/// `"<cloneId>@<courseId>"`. Each half had a passing test; only the pair was
+/// wrong.
+///
+/// Nothing here fabricates the join. The survey row comes out of
+/// `SurveyMapper.fromCourseDoc` reading a course document shaped like the
+/// server's, so `surveys.courseId` is populated for the same reason it is in
+/// the field, and the clone is produced by the production `adoptSurvey`.
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository submissions;
+  late SurveysRepository surveys;
+
+  /// The reachable shape: a course step's survey that is **also** shareable
+  /// with teams. `SurveyMapper._build` reads `teamShareAllowed` off the
+  /// embedded survey JSON and writes `courseId`/`stepId` from the step it was
+  /// found on, so one document produces both joins at once.
+  const courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'Clean water',
+    'steps': [
+      {
+        'stepTitle': 'First',
+        'survey': {
+          '_id': 'survey-1',
+          'type': 'surveys',
+          'name': 'Water needs',
+          'teamShareAllowed': true,
+          'sourcePlanet': 'nation',
+          'questions': [
+            {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+          ],
+        },
+      },
+    ],
+  };
+
+  /// `adoptSurvey`'s default clone id — `'${surveyId}_$teamId'`.
+  const cloneId = 'survey-1_team-1';
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    final api = MockPlanetApi();
+    submissions = SubmissionsRepository(
+      api,
+      database.submissionDao,
+      database.submitPhotosDao,
+      database.surveyDao,
+      database.examDao,
+      teamDao: database.teamDao,
+    );
+    surveys = SurveysRepository(
+      api,
+      database.surveyDao,
+      database.examDao,
+      submissions,
+    );
+
+    final parsed = CourseMapper.fromDoc(courseDoc)!;
+    await database.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      courseDoc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+  });
+
+  tearDown(() => database.close());
+
+  test('the fixture is reachable, not fabricated', () async {
+    // If this fails the rest of the file proves nothing: the chain needs a
+    // survey that is course-attached *and* offered for adoption, and both
+    // columns have to come off the one server-shaped document.
+    final attached = await database.surveyDao.getByCourseId('course-1');
+    expect(attached.map((row) => row.id), ['survey-1']);
+    expect(attached.single.teamShareAllowed, isTrue);
+    expect(
+      (await surveys.adoptableTeamSurveys('team-1')).map((row) => row.id),
+      ['survey-1'],
+      reason: 'a course-attached survey really is adoptable',
+    );
+  });
+
+  Future<void> adopt() => surveys.adoptSurvey(
+    surveyId: 'survey-1',
+    userId: 'leader-1',
+    teamId: 'team-1',
+    teamName: 'Water Team',
+    isTeam: true,
+    planetCode: 'planet-a',
+    parentCode: 'parent-a',
+    now: DateTime.fromMillisecondsSinceEpoch(5000),
+  );
+
+  test('the clone carries the course, as Kotlin\'s does', () async {
+    await adopt();
+    final clone = await database.surveyDao.adoptedTeamSurvey(
+      'team-1',
+      'survey-1',
+    );
+    expect(clone, isNotNull);
+    expect(
+      clone!.courseId,
+      'course-1',
+      reason: '`createMappedSurvey` assigns `courseId = exam.courseId`',
+    );
+    // `stepId` is deliberately *not* copied — see `adoptSurvey`'s doc comment.
+    // Kotlin's step ids are content hashes; the port's are positional and the
+    // courses walk owns the join, so a copied `stepId` would be revoked (and
+    // the `courseId` nulled with it) by `releaseStepJoinsForCourse`.
+    expect(clone.stepId, isNull);
+  });
+
+  test('the members\' answer sheets carry the compound key', () async {
+    await adopt();
+    // Phase 132: Send passes the clone's own id, never the source's.
+    await submissions.createBulkSurveySubmissions(cloneId, const [
+      'member-1',
+      'member-2',
+    ]);
+    final sheets = [
+      for (final userId in ['member-1', 'member-2'])
+        (await database.submissionDao.getSurveySubmissionsByUser(
+          userId,
+        )).single,
+    ];
+    expect(
+      sheets.map((row) => row.parentId),
+      ['$cloneId@course-1', '$cloneId@course-1'],
+      reason: 'Kotlin resolves the clone\'s own courseId for the whole batch',
+    );
+  });
+
+  test('re-sending does not give a member a second sheet', () async {
+    await adopt();
+    await submissions.createBulkSurveySubmissions(cloneId, const ['member-1']);
+    await submissions.createBulkSurveySubmissions(cloneId, const ['member-1']);
+    expect(
+      await database.submissionDao.getSurveySubmissionsByUser('member-1'),
+      hasLength(1),
+      reason: 'the existence check compares the whole parentId',
+    );
+  });
+
+  test('the repair sweep now reaches a clone\'s stale sheets', () async {
+    await adopt();
+    // What a pre-Phase-136 build wrote: the bare clone id, because the clone
+    // had no `courseId` for `examParentId` to fold in.
+    await submissions.getOrCreateSurveySubmission(
+      userId: 'member-1',
+      parentId: cloneId,
+      now: DateTime.fromMillisecondsSinceEpoch(6000),
+      createId: () => 'stale-sheet',
+    );
+    expect(
+      await submissions.repairCourseSurveyParentIds('course-1'),
+      1,
+      reason: 'the clone is in `getByCourseId` now, so the sweep sees it',
+    );
+    expect(
+      (await submissions.getById('stale-sheet'))!.parentId,
+      '$cloneId@course-1',
+    );
+    // And the writer's own repair, which is the path that actually runs when a
+    // leader re-sends, leaves the member with one sheet rather than two.
+    await submissions.createBulkSurveySubmissions(cloneId, const ['member-1']);
+    expect(
+      await database.submissionDao.getSurveySubmissionsByUser('member-1'),
+      hasLength(1),
+    );
+  });
+
+  test('the gate does not demand a team\'s private copy', () async {
+    // The hazard the copy introduces, and the reason `hasUnfinishedSurveys`
+    // filters clones explicitly instead of relying on `adoptSurvey` leaving
+    // `courseId` null. Remove that filter and this fails: `getByCourseId`
+    // returns the clone, no sheet exists for a learner outside the team, and
+    // the course can never be finished.
+    await adopt();
+    expect(await database.surveyDao.getByCourseId('course-1'), hasLength(2));
+    final id = await surveys.submitResponse('survey-1', 'outsider', const {});
+    expect(id, isNotNull);
+    expect(
+      await submissions.hasUnfinishedSurveys('course-1', 'outsider'),
+      isFalse,
+      reason: 'the course asks for its own survey, not every team\'s clone',
+    );
+  });
+
+  test('the adoption marker still keys the bare source id', () async {
+    await adopt();
+    final marker = (await database.submissionDao.getSurveySubmissionsByUser(
+      'leader-1',
+    )).singleWhere((row) => row.status == '');
+    expect(
+      marker.parentId,
+      'survey-1',
+      reason: '`findExistingAdoption` looks it up by the bare source id',
+    );
+    // Neither sweep may fold a course into it, or every adoption re-adopts.
+    expect(await submissions.repairCourseSurveyParentIds('course-1'), 0);
+    expect((await submissions.getById(marker.id))!.parentId, 'survey-1');
+  });
+
+  test('the marker\'s parent document carries the source course', () async {
+    await adopt();
+    final marker = (await database.submissionDao.getSurveySubmissionsByUser(
+      'leader-1',
+    )).singleWhere((row) => row.status == '');
+    final parent = jsonDecode(marker.parent!) as Map<String, dynamic>;
+    expect(
+      parent['courseId'],
+      'course-1',
+      reason: '`createParentJsonString` writes `exam.courseId ?: ""`',
+    );
+    expect(parent['_id'], 'survey-1');
+    expect(parent['teamShareAllowed'], isTrue);
+    expect(parent['noOfQuestions'], 1);
+  });
+
+  test('a course-less survey is unaffected', () async {
+    await database.surveyDao.upsertAll([
+      SurveysCompanion.insert(
+        id: 'loose',
+        name: const Value('Loose'),
+        teamShareAllowed: const Value(true),
+      ),
+    ], {});
+    await surveys.adoptSurvey(
+      surveyId: 'loose',
+      userId: 'leader-1',
+      teamId: 'team-1',
+      teamName: 'Water Team',
+      isTeam: true,
+      now: DateTime.fromMillisecondsSinceEpoch(5000),
+    );
+    final clone = await database.surveyDao.adoptedTeamSurvey('team-1', 'loose');
+    expect(clone!.courseId, isNull);
+    await submissions.createBulkSurveySubmissions('loose_team-1', const [
+      'member-1',
+    ]);
+    expect(
+      (await database.submissionDao.getSurveySubmissionsByUser(
+        'member-1',
+      )).single.parentId,
+      'loose_team-1',
+      reason: 'no course to fold in, so the bare id is already the key',
+    );
+  });
+}

--- a/flutter/test/repository/adopted_team_survey_course_key_test.dart
+++ b/flutter/test/repository/adopted_team_survey_course_key_test.dart
@@ -16,7 +16,7 @@ class MockPlanetApi extends Mock implements PlanetApi {}
 ///
 /// `SurveysRepositoryImpl.createMappedSurvey` copies the source survey's
 /// `courseId` and `stepId` onto an adopted team clone
-/// (`SurveysRepositoryImpl.kt:180-181`). The port's `adoptSurvey` copied
+/// (`SurveysRepositoryImpl.kt:181-182`). The port's `adoptSurvey` copied
 /// neither, and once Phase 132 made Send pass the *clone's* id,
 /// `createBulkSurveySubmissions` resolved `survey?.courseId == null` and keyed
 /// every member's answer sheet with the bare clone id where Kotlin keys
@@ -259,7 +259,7 @@ void main() {
     final user = jsonDecode(marker.user!) as Map<String, dynamic>;
     final doc = user['doc'] as Map<String, dynamic>;
     expect(doc['name'], 'Ada Lovelace');
-    // Kotlin's key set and order under `doc` (`createUserJsonString:139-147`).
+    // Kotlin's key set and order under `doc` (`createUserJsonString:142-148`).
     expect(doc.keys, [
       '_id',
       'name',
@@ -288,6 +288,102 @@ void main() {
     expect(doc.containsKey('name'), isFalse);
     expect(doc['userId'], 'leader-1');
     expect(doc['createdBy'], 'leader-1');
+  });
+
+  test('a server-authored step survey still gates, even if adopted', () async {
+    // `sourceSurveyId` alone is **not** a local-authorship marker in the port:
+    // the courses walk reads it straight off the server's own embedded survey
+    // (`survey_mapper.dart:163-167`). A step survey that is itself an adopted
+    // copy therefore lands with `courseId`, `stepId` *and* `sourceSurveyId` —
+    // it gets a Take Survey button and a working retake label, so the gate
+    // must keep demanding it. Kotlin's own test for a locally minted clone is
+    // the **conjunction** `sourceSurveyId IS NOT NULL AND _rev IS NULL`
+    // (`ExamDao.kt:21`); skipping on the first half alone silently let a
+    // learner finish `MANDATORY_SURVEY_COURSE_ID` having answered nothing.
+    const doc = {
+      '_id': 'course-2',
+      'courseTitle': 'Adopted upstream',
+      'steps': [
+        {
+          'stepTitle': 'First',
+          'survey': {
+            '_id': 'survey-adopted',
+            '_rev': '3-abc',
+            'type': 'surveys',
+            'name': 'Adopted upstream survey',
+            'sourceSurveyId': 'survey-origin',
+            'questions': [
+              {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+            ],
+          },
+        },
+      ],
+    };
+    final parsed = CourseMapper.fromDoc(doc)!;
+    await database.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+    final row = (await database.surveyDao.getByCourseId('course-2')).single;
+    expect(row.sourceSurveyId, 'survey-origin');
+    expect(
+      row.rev,
+      '3-abc',
+      reason: 'a server row carries a rev; a clone does not',
+    );
+    expect(
+      (await database.surveyDao.getByStepId('course-2:0')).map((r) => r.id),
+      ['survey-adopted'],
+      reason: 'it has a Take Survey button, so it can be satisfied',
+    );
+    expect(
+      await submissions.hasUnfinishedSurveys('course-2', 'user-1'),
+      isTrue,
+      reason: 'nothing answered, so the course must still block',
+    );
+  });
+
+  test('re-adopting does not rewrite a round-tripped marker', () async {
+    // Kotlin's guard is `it.status.orEmpty().isEmpty()`
+    // (`SurveysRepositoryImpl.kt:206`), which matches a null status and an
+    // empty one alike. `row.status == ''` misses the null — and null is the
+    // *normal* state for a marker that has synced, because [serialize] sends
+    // `'status': ''` and `upsertDocuments` reads the empty string back as null
+    // (`json_utils.dart:19-22`). The same shape `_repairSurveyParentId` needed
+    // `coalesce(status, '')` for.
+    await adopt();
+    final marker = (await database.submissionDao.getSurveySubmissionsByUser(
+      'leader-1',
+    )).singleWhere((row) => row.status == '');
+    await (database.submissionDao.update(database.submissionDao.submissions)
+          ..where((row) => row.id.equals(marker.id)))
+        .write(const SubmissionsCompanion(status: Value(null)));
+    expect((await submissions.getById(marker.id))!.status, isNull);
+
+    await surveys.adoptSurvey(
+      surveyId: 'survey-1',
+      userId: 'leader-1',
+      teamId: 'team-1',
+      teamName: 'Water Team',
+      isTeam: true,
+      now: DateTime.fromMillisecondsSinceEpoch(9000),
+    );
+    final after = (await database.submissionDao.getSurveySubmissionsByUser(
+      'leader-1',
+    )).where((row) => (row.status ?? '').isEmpty).toList();
+    expect(after, hasLength(1));
+    expect(
+      after.single.status,
+      isNull,
+      reason: 'the existing marker was recognised, not rewritten',
+    );
+    expect(after.single.startTime, 5000);
   });
 
   test('a course-less survey is unaffected', () async {

--- a/flutter/test/repository/mandatory_survey_round_trip_test.dart
+++ b/flutter/test/repository/mandatory_survey_round_trip_test.dart
@@ -194,15 +194,15 @@ void main() {
   });
 
   test('an adopted team clone is not counted by the course gate', () async {
-    // The Phase 125 audit overturned my reading here. Kotlin's
-    // `createMappedSurvey` copies the source survey's `courseId` **and**
-    // `stepId` into the clone (`SurveysRepositoryImpl.kt:181-182`), and
-    // `getAdoptableTeamSurveys` filters only on `teamShareAllowed` — so a
-    // course-attached survey is adoptable and the Kotlin clone inherits the
-    // course join. `SurveyDao.getByCourseId` has no team or adoption filter,
-    // so if the port's clone ever copied those columns this gate would start
-    // demanding that the learner complete every team's copy of the survey.
-    // The port's `adoptSurvey` omits both, and that omission is load-bearing.
+    // Phase 125 read this as "the clone must not join the course"; Phase 136
+    // corrected it to "the clone joins the course and the gate must skip it".
+    // Kotlin's `createMappedSurvey` copies the source survey's `courseId`
+    // (`SurveysRepositoryImpl.kt:180`) and Send folds it into every member's
+    // key, so the port has to copy it. `SurveyDao.getByCourseId` has no
+    // adoption filter, so `hasUnfinishedSurveys` now skips
+    // `sourceSurveyId != null` itself — otherwise a learner outside the
+    // adopting team could never satisfy that team's copy. `stepId` stays null;
+    // `adoptSurvey` documents why.
     await surveys.adoptSurvey(
       surveyId: 'survey-1',
       userId: 'user-1',
@@ -215,9 +215,13 @@ void main() {
       'survey-1',
     );
     expect(clone, isNotNull);
-    expect(clone!.courseId, isNull, reason: 'a clone must not join the course');
+    expect(clone!.courseId, 'course-1', reason: 'as Kotlin\'s clone does');
     expect(clone.stepId, isNull);
-    expect(await database.surveyDao.getByCourseId('course-1'), hasLength(1));
+    expect(
+      await database.surveyDao.getByCourseId('course-1'),
+      hasLength(2),
+      reason: 'the clone is in the query the gate reads; the gate skips it',
+    );
 
     // And the adoption marker it wrote — bare id, `status = ''` — must not be
     // mistaken for an answered sheet, nor repaired into the composite key.

--- a/flutter/test/repository/mandatory_survey_round_trip_test.dart
+++ b/flutter/test/repository/mandatory_survey_round_trip_test.dart
@@ -197,7 +197,7 @@ void main() {
     // Phase 125 read this as "the clone must not join the course"; Phase 136
     // corrected it to "the clone joins the course and the gate must skip it".
     // Kotlin's `createMappedSurvey` copies the source survey's `courseId`
-    // (`SurveysRepositoryImpl.kt:180`) and Send folds it into every member's
+    // (`SurveysRepositoryImpl.kt:182`) and Send folds it into every member's
     // key, so the port has to copy it. `SurveyDao.getByCourseId` has no
     // adoption filter, so `hasUnfinishedSurveys` now skips
     // `sourceSurveyId != null` itself — otherwise a learner outside the

--- a/flutter/test/ui/team_surveys_screen_test.dart
+++ b/flutter/test/ui/team_surveys_screen_test.dart
@@ -221,6 +221,7 @@ void main() {
       () => repo.adoptSurvey(
         surveyId: any(named: 'surveyId'),
         userId: any(named: 'userId'),
+        userName: any(named: 'userName'),
         teamId: any(named: 'teamId'),
         teamName: any(named: 'teamName'),
         isTeam: any(named: 'isTeam'),
@@ -255,6 +256,10 @@ void main() {
       () => repo.adoptSurvey(
         surveyId: 'a1',
         userId: 'user-1',
+        // Phase 136: the marker's `user.doc.name`, which Kotlin takes off the
+        // same resolved session model it takes the id from
+        // (`createUserJsonString:143`).
+        userName: 'ada',
         teamId: 'team-1',
         teamName: null,
         isTeam: true,


### PR DESCRIPTION
**Lane C of the Phase 136 parallel round.** Gate green: `dart format` clean, `flutter analyze` no issues, **2411 tests pass**. Both `parity-auditor` passes run at `effort: max` — ground truth before implementing, implementation after it was green.

## What this fixes

`SurveysRepositoryImpl.createMappedSurvey` (`:163-191`) makes nineteen assignments onto an adopted team clone, including `courseId = exam.courseId` (`:182`) and `stepId = exam.stepId` (`:181`). The port's `adoptSurvey` set 14 fields and neither. Since Phase 132 made Send pass the clone's own id, `createBulkSurveySubmissions` resolved `survey?.courseId == null` and keyed every member's answer sheet with the bare clone id where Kotlin keys `"<cloneId>@<courseId>"`.

It was not two field copies. One of the two must **not** be copied, and the reader had to change with it.

### `courseId` is copied, `stepId` is not

Kotlin's step ids are a hash of the step's JSON; the port's are **positional** (`CourseMapper.stepIdFor`, `'$courseId:$index'`), so the courses walk *owns* the join and `SurveyDao.releaseStepJoinsForCourse` nulls `stepId` **and `courseId` together** for any row its course document does not name. A clone is minted locally and is in no course document. Probed on a clone-shaped row: `releaseStepJoinsForCourse('course-1', {'survey-1'})` → `courseId=null stepId=null`. Copying `stepId` would hand the next courses sync a licence to strip the very `courseId` this writes; with `stepId` null that update cannot select the row at all.

It also keeps the clone off the course step's Take Survey button — which matters not for the count (the survey tile renders none) but because the button opens `surveys.first.id`, so a copied `stepId` would point a learner's button at whichever team's private clone sorted first. Kotlin's `getByStepIdAndType(stepId, "surveys")` (`CoursesRepositoryImpl.kt:530`) does exactly that.

### The reader had to change, and the brief's premise is dead code

With `courseId` on the clone, `SurveyDao.getByCourseId` returns clones — and `hasUnfinishedSurveys` iterates exactly that query. Left alone it would demand that **every learner on the course complete every team's private copy**, which nobody outside the team can satisfy: Phase 125's bug re-entered from the writer's side. Mutation-tested — the guard fails on the unfiltered version (`Expected: false / Actual: <true>`).

The gate now skips a clone on **both halves** of Kotlin's own predicate, `sourceSurveyId IS NOT NULL AND _rev IS NULL` (`ExamDao.kt:21`). **Skipping is not a divergence from live Kotlin:** `getSurveysByCourseId` filters `getByCourseIdAndType(courseId, "survey")` — singular — while every survey, clone included (`type = exam.type`), carries `"surveys"`. Kotlin's gate matches nothing, under any document shape.

`repairCourseSurveyParentIds` deliberately still includes clones: their member sheets are exactly the rows a pre-Phase-136 build keyed bare, so the sweep is how they heal.

## What the second audit found in my own green code

Both fixed here, both demonstrated failing first.

- **`sourceSurveyId != null` alone silently loosened the gate** — a regression this phase introduced, and the worst kind, because it made a blocking check stop blocking. `sourceSurveyId` is not a local-authorship marker in the port: the courses walk reads it off the server's embedded survey (`survey_mapper.dart:163-167`), so a step survey that is *itself* an adopted copy arrives with `courseId`, `stepId` and `sourceSurveyId`. It has a Take Survey button and a working retake label — it can be satisfied — and the skip ignored it. A learner on `MANDATORY_SURVEY_COURSE_ID` could tap Finish having answered nothing and see no snackbar. I cited `ExamDao.kt:21` as authority and then ported half of it.
- **`findExistingAdoption`'s port had the null-vs-empty bug this phase congratulates itself on catching elsewhere.** Kotlin's predicate is `it.status.orEmpty().isEmpty()` (`:206`); `row.status == ''` misses null, and null is the *normal* state for a marker that has synced (`serialize` sends `'status': ''`, `upsertDocuments` reads it back as null). The same shape `_repairSurveyParentId` needs `coalesce(status, '')` for, three hundred lines away, with a doc comment explaining why.

Four claims of mine it corrected, all fixed in place so they cannot be re-cited: the "other Kotlin branch" where the gate supposedly matches a clone **cannot exist** (every list adopt is reachable from filters `type = "surveys"`); the `parent.courseId` fix is **not observable on the wire** (`serialize` prefers the live survey row and `surveyParentDocument` omits the field, as `serializeExam` does), so it is faithfulness on a fallback path rather than a defect anyone saw; the survey tile renders no count; and seven Kotlin citations were off by one or two.

**And the framing.** With the clone skipped, no reader in `lib/` distinguishes the bare key from the composite one for a clone, and Planet has no clone document to join against because the port never uploads one. So this is a **writer-faithfulness** change, not a live writer/reader disagreement — worth having (Send and the answering path now derive the key from one place, and a mixed fleet agrees), but the ranking below is the correct one.

## Tests

13 in `test/repository/adopted_team_survey_course_key_test.dart`, on course documents shaped like the server's — `courseId`, `stepId` and `teamShareAllowed` all come off one document through the real mappers, so nothing fabricates the join, and the first test fails loudly if the mappers stop producing it. Five failed before the fix; two more before the audit fixes. The Phase 125 pinned test in `mandatory_survey_round_trip_test.dart` now pins the corrected behaviour.

## Reported, not fixed (details in `flutter/PHASE_136_NOTES.md`)

**An adopted team survey clone is deleted on the next sync, and never uploaded** — Phase 116's class, and the round's highest-value item, ahead of this phase's own subject: a wrong `parentId` mis-files answers, a deleted survey loses them. Kotlin uploads the clone (`ExamDao.getPendingAdoptedSurveys()` → `UploadConfigs.kt:186-195`) so it becomes a real document in every later keep set, and Kotlin has no prune on that table at all. The port has neither half: no adopted-survey uploader anywhere in `lib/`, and `SurveyDao.deleteNotIn` spares only rows with a `stepId`. Probed: `deleteNotIn(['survey-1'])` after an adopt → `DELETED=1`, clone and its questions gone. The fix spans Lane B's `app_database.dart` and Lane A's outbox, so it is reported rather than half-written here.

Also reported: `releaseStepJoinsForCourse` would need to spare clones if a later round ever copies `stepId`; `progress_repository.dart:92-95` (Lane B's file) now reads as a contradiction of this change and wants one clarifying clause; the repair's idempotence claim is device-local only; the adopt gate is still team-leadership where Kotlin gates on guest; and a team with no name adopts differently in the two trees.

**Answering the brief's open question:** the repair sweep needs no extension. The next sync does not rewrite a courseId-less clone — it **deletes** it — and a field clone cannot be backfilled by `adoptSurvey` (the existing-clone guard returns early, and the adopt button is hidden for an adopted source, so such a branch would be dead code). Its bare-keyed sheets are internally consistent with that device's bare-keyed reads.

## Lane hygiene

Touched only this lane's files. Nothing near `queuePending` (Lane A). No `app_database.dart` change, no Drift `schemaVersion` bump — both columns already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112ccKgprgnBtkXaMonUtJY