### PR TITLE
Phase 137 — pay down Flutter dependency drift (pubspec-only)

### DIFF
--- a/flutter/PHASE_137_NOTES.md
+++ b/flutter/PHASE_137_NOTES.md
@@ -158,18 +158,36 @@ Starting from versions 3.x of the `sqlite3` package, `sqlite3_flutter_libs` is
 no longer necessary. This version removes all code from this package."* The port
 is already on `sqlite3` 3.5.2, so on paper the migration applies.
 
-It resolves. It would almost certainly pass the gate. **That is the problem.**
-`flutter.yml` runs `analyze` and `test` and never builds an APK for the port,
-and `flutter test` runs on the Dart VM against the host's SQLite — so nothing in
-CI, and nothing in this container, exercises the Android native build this
-change is entirely about. A green run here would be evidence of nothing.
+It resolves, and it would pass this lane's gate. Refused anyway, and left at
+`^0.5.26` — but the reason needs stating carefully, because my first reading of
+it was wrong.
 
-This container has no Android SDK at all (`flutter doctor`: *"Unable to locate
-Android SDK"*), so I cannot produce the one piece of evidence that matters.
-Refused and left at `^0.5.26`. Whoever takes it needs `flutter build apk` to
-pass *and* the app to actually open a database on a device, before and after.
-Worth doing — it is the upstream-recommended direction and removes a build-script
-dependency — but not on analyze-and-test evidence.
+**Correction, recorded because the wrong version of this argument would mislead
+the next round.** An earlier draft of this file said `flutter.yml` never builds
+an APK. It does: the workflow has a second job, `build-android`, which runs
+`flutter build apk --debug` on every Flutter push. I had read only as far as the
+`analyze-and-test` job. So build-level evidence for this migration *is*
+available in CI, and the refusal cannot rest on "nothing would exercise it".
+
+What is still missing is the evidence that actually decides it. `sqlite3`'s
+`hook/build.dart` only emits a code asset when `input.config.buildCodeAssets` is
+true — that is, when code assets are active for that build; it then either
+downloads a prebuilt binary or compiles SQLite from source (both Android paths
+exist, including the `-lm` link). Dropping `sqlite3_flutter_libs` hands the
+Android app's entire SQLite provisioning to that hook. If code assets are *not*
+active for the Android APK build under Flutter 3.44.8, the hook contributes
+nothing, `flutter build apk --debug` still succeeds, and the app ships with no
+SQLite at all. **That is a green-CI-but-broken-app shape**, which is the failure
+class this project has a whole section about — and the payload here is the
+database, so the blast radius is the entire app.
+
+This container has no Android SDK (`flutter doctor`: *"Unable to locate Android
+SDK"*), so I cannot check it locally either. The concrete thing the next round
+must do before dropping this package: confirm the Android build actually emits
+`sqlite3`'s code asset — or just run the app and open a database — not merely
+that `build-android` went green. Worth doing; it is the upstream-recommended
+direction and removes a build-script dependency. Not worth doing on a green
+check mark.
 
 ### 3c. SDK-pinned — `build_runner`, `intl`, `meta`
 

--- a/flutter/PHASE_137_NOTES.md
+++ b/flutter/PHASE_137_NOTES.md
@@ -1,0 +1,7 @@
+# Phase 137 — dependency drift
+
+Lane D of a four-lane round. Scope: `pubspec.yaml` / `pubspec.lock` only.
+`flutter_riverpod`, `riverpod` and `go_router` are explicitly out of scope and
+are pinned so no transitive resolution can drag them.
+
+Work in progress — this file is the deliverable and is filled in as the lane runs.

--- a/flutter/PHASE_137_NOTES.md
+++ b/flutter/PHASE_137_NOTES.md
@@ -181,13 +181,56 @@ SQLite at all. **That is a green-CI-but-broken-app shape**, which is the failure
 class this project has a whole section about — and the payload here is the
 database, so the blast radius is the entire app.
 
-This container has no Android SDK (`flutter doctor`: *"Unable to locate Android
-SDK"*), so I cannot check it locally either. The concrete thing the next round
-must do before dropping this package: confirm the Android build actually emits
-`sqlite3`'s code asset — or just run the app and open a database — not merely
-that `build-android` went green. Worth doing; it is the upstream-recommended
-direction and removes a build-script dependency. Not worth doing on a green
-check mark.
+**And CI then answered it.** The `build-android` job on this branch's head
+(run 34239569599) is green, and its log settles the question:
+
+- `sqlite3_flutter_libs` 0.5.42's `android/build.gradle` is an AGP library
+  module whose whole job is one line — `implementation
+  "eu.simonbinder:sqlite3-native-library:3.52.0"`. That prebuilt AAR **is** how
+  the Android app gets SQLite today.
+- `sqlite3_flutter_libs` 0.6.0+eol contains exactly one file,
+  `lib/sqlite3_flutter_libs.dart`. There is **no `android/` directory at all**.
+  Upgrading deletes the module that pulls that AAR in.
+- The build log shows no native-assets or code-assets step anywhere between
+  `pub get` and `assembleDebug`, so `sqlite3`'s `hook/build.dart` is not running
+  for the Android build under Flutter 3.44.8 — nothing replaces the AAR.
+
+So the upgrade would remove the app's SQLite and `flutter build apk --debug`
+would still print `✓ Built app-debug.apk`. **Refused, and now on evidence rather
+than caution.** The precondition for the round that takes it is that
+`sqlite3`'s hook actually runs for Android — a Flutter version where native
+assets are on for Android builds, or the flag that enables them — verified by
+the app opening a database, not by a green check mark.
+
+One near-miss worth recording, since it is the same mistake as the flutter.yml
+one. The APK log installs CMake 3.22.1, and the obvious reading is "that is
+`sqlite3_flutter_libs` compiling SQLite" — it is the behaviour that package is
+known for. It is not: 0.5.42 uses a Maven AAR and no CMake, and the CMake
+install comes from `jni` (via `pdfx`). The conclusion above survived the check;
+the reason I first reached for did not. **Two errors in one lane from reading
+the plausible thing instead of the actual file.**
+
+### 3b-bis. A forward-looking Android break CI is already warning about
+
+Not a version gap, so `pub outdated` never mentions it, but it surfaced in the
+same log and belongs with the rest of this file:
+
+```
+WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP):
+  file_picker, package_info_plus, pdfx, workmanager_android
+Future versions of Flutter will fail to build if your app uses plugins that apply KGP.
+```
+
+This is not fixed by anything in this branch and is not fixed by the win32-6
+cluster either — checked directly: `package_info_plus` 10.2.1 still applies KGP,
+and `file_picker` 12 delegates its Android side to `android_file_picker` 1.1.0,
+which also applies KGP. `pdfx` 2.11.0 and `workmanager_android` 0.10.9 are the
+versions this branch already upgraded *to*, and both still apply it.
+
+So all four are upstream's problem, and the port's exposure is a future Flutter
+release, not a current one. Worth watching rather than acting on — but if a
+Flutter SDK bump is ever blocked by a hard KGP failure, this is the list, and
+the fix is upstream migration or replacing the plugin, not a constraint change.
 
 ### 3c. SDK-pinned — `build_runner`, `intl`, `meta`
 

--- a/flutter/PHASE_137_NOTES.md
+++ b/flutter/PHASE_137_NOTES.md
@@ -1,7 +1,307 @@
 # Phase 137 — dependency drift
 
-Lane D of a four-lane round. Scope: `pubspec.yaml` / `pubspec.lock` only.
-`flutter_riverpod`, `riverpod` and `go_router` are explicitly out of scope and
-are pinned so no transitive resolution can drag them.
+Lane D of a four-lane round. **Scope: `pubspec.yaml` and `pubspec.lock` only.**
+Nothing under `lib/` or `test/` is touched, which is what makes this lane safe
+to run beside three lanes editing providers, repositories, screens and the Drift
+DAO. Where an upgrade needed a source change, the package was pinned back and
+the required change written down here instead.
 
-Work in progress — this file is the deliverable and is filled in as the lane runs.
+`flutter_riverpod`, `riverpod` and `go_router` were out of scope by instruction
+and are now pinned exactly, so no resolution — direct or transitive — can drag
+them. The brief for the round that does take them is at the end of this file.
+
+---
+
+## 1. What "89 packages behind" actually decomposes into
+
+`CLAUDE.md` has quoted a raw count for several rounds ("84 a few rounds ago",
+"89 now") without decomposing it. The raw count answers a question nobody is
+asking. `flutter pub outdated` reports three genuinely different situations, and
+only one of them is work anybody can do today.
+
+**Before this phase — 89 behind latest:**
+
+| Bucket | Count | What it means |
+|---|---:|---|
+| **Locked, but upgradable now** | 53 | `pubspec.lock` is behind what the *existing* constraints already allow. `flutter pub upgrade` takes them. No pubspec edit, no code change, no decision. |
+| **Constrained below a resolvable version** | 18 | Needs a `pubspec.yaml` constraint change. This is the bucket that contains actual judgement — majors, coupled clusters, API breaks. |
+| **Not reachable at any constraint** | 18 | The newest release needs a newer Dart/Flutter SDK than the pinned 3.44.8, or is held there by a parent that is itself blocked. No constraint you can write reaches it. |
+
+**After this phase — 38 behind latest:**
+
+| Bucket | Count | Change |
+|---|---:|---|
+| Locked, but upgradable now | **0** | All 53 taken. |
+| Constrained below a resolvable version | **13** | 5 of the 18 closed; the remaining 13 are documented below with a reason each. |
+| Not reachable at any constraint | **25** | Grew by 7 — see the next paragraph, this is not a regression. |
+
+**Why the third bucket grew, and why that is correct.** Taking a lock-only
+upgrade frequently just moves a package from bucket 1 to bucket 3. `analyzer`
+was "locked at 10.0.1, upgradable to 13.0.0, latest 14.3.0": taking 13.0.0 moved
+it out of bucket 1 and into bucket 3, because 14.3.0 needs an SDK this repo
+cannot have. Same for `dart_style` (3.1.7 → 3.1.9, latest 3.1.13) and five
+others.
+
+The practical consequence, which is the useful thing to take away: **on a pinned
+Flutter SDK the headline number has a floor, and 38 is close to it.** 25 of the
+remaining 38 are unreachable until `flutter.yml` and
+`.claude/hooks/session-start.sh` move off 3.44.8 together, and 2 of those 25
+(`js`, `flutter_secure_storage_macos`) are discontinued packages that will never
+move at all. Quoting the raw number as debt overstates it by roughly a factor of
+three. The number worth tracking is **bucket 2**, which is 13.
+
+---
+
+## 2. What was taken
+
+One commit per upgrade or coherent group, so a bisect can attribute a
+regression. The gate — `dart run build_runner build`, `dart format
+--output=none --set-exit-if-changed lib test`, `flutter analyze`, `flutter test`
+— was run to completion after **every** one of these, and was green each time:
+462 files formatted with 0 changed, no analyzer issues, 2398 tests passing.
+
+| Commit | What | Kind |
+|---|---|---|
+| `a52e007` | pin `flutter_riverpod` 2.6.1, `go_router` 14.8.1 | pubspec |
+| `9dbaae8` | 33 runtime dependencies | lock only |
+| `3197c37` | `drift` 2.34.3 → 2.34.4, `sqlite3` 3.5.0 → 3.5.2 | lock only |
+| `c1dd525` | build/analysis toolchain, 19 packages | lock only |
+| `8bb58f2` | `package_info_plus` ^8.1.1 → ^9.0.0 | **major**, pubspec |
+| `a6fc8ae` | `flutter_map` ^7.0.2 → ^8.3.2, `latlong2` ^0.9.1 → ^0.10.1 | **major**, pubspec |
+| `9f8c18e` | `proj4dart` 3.0.0, `mgrs_dart` 3.0.0, `unicode` 1.1.9 | **major**, lock only |
+
+Three of these deserve a note.
+
+**The toolchain commit (`c1dd525`) was the risky one.** `dart_style` and
+`drift_dev` between them decide the layout of every generated file under `lib/`,
+and CI gates on `dart format --set-exit-if-changed lib test`, which does not
+exclude generated output. `analyzer` 10 → 13 (with `_fe_analyzer_shared` 93 →
+100) and `dart_style` 3.1.7 → 3.1.9 could therefore have produced a tree-wide
+reformat that looks like a correct commit and is not. It was verified by
+deleting `.dart_tool/build`, regenerating from scratch, and formatting: 462
+files, 0 changed. This also takes `build_daemon` off 4.1.3, which is a
+**retracted** version. `drift_dev` could not move on its own — it wanted the
+`analyzer` bump first, which is why it is here rather than with the drift
+runtime commit.
+
+**`schemaVersion` is untouched, still 46.** No lane was allocated a bump this
+round. `drift` 2.34.3 → 2.34.4 is a patch: no DDL change, no migration step, and
+regenerating confirms the output still matches.
+
+**`sqlite3` 3.5.0 → 3.5.2 moves the download.** Its build hook fetches a
+prebuilt binary and verifies a sha256 with no retry of its own, and the expected
+hash table lives inside the package and moves with the version. Nothing in this
+repo pins those hashes, so this is a version move only — but if a future CI run
+goes red with a hash mismatch (as run `34129995451` did on 3.5.0, where the
+fetched bytes hashed to `8e8052a0…`, matching no released version), that is the
+download, not the commit. Re-run it.
+
+**`flutter_map` 8 has no test behind it.** There is no widget test for
+`lib/ui/maps/offline_maps_screen.dart` — it is the one upgrade in this branch
+whose only evidence is `flutter analyze` rather than analyze *plus* a passing
+test. Analyze does type-check the entire surface the screen uses (`FlutterMap`,
+`MapOptions.initialCenter` / `initialZoom` / `onPositionChanged`, `TileLayer`,
+`MapController`), so this is not blind, but it is thinner than everything else
+here and worth a manual look the next time anyone runs the app.
+
+---
+
+## 3. What was not taken, and why
+
+### 3a. The win32-6 cluster — blocked on four `lib/` files
+
+`file_picker` 12, `flutter_secure_storage` 11 and `package_info_plus` 10 are
+**one upgrade, not three.** All three sit on `win32 ^6`, and every package still
+on `win32 ^5` blocks all of them:
+
+```
+package_info_plus >=10.0.0        -> win32 ^6.0.0
+file_picker 11.0.2                -> win32 ^5.9.0
+flutter_secure_storage 9.x        -> flutter_secure_storage_windows 3.1.2 -> win32 ^5
+```
+
+This is why `package_info_plus` stops at 9 in this branch: 9.0.1 is the highest
+version that does not require `win32 ^6`. Resolving all three together succeeds,
+and `flutter analyze` then reports exactly these errors:
+
+| File | Line | Error | Cause |
+|---|---:|---|---|
+| `lib/core/prefs/planet_prefs.dart` | 33 | `The named parameter 'encryptedSharedPreferences' isn't defined` | `AndroidOptions.encryptedSharedPreferences` removed in `flutter_secure_storage` 10; the encrypted implementation became the only one. |
+| `lib/core/system/file_pick.dart` | 45–50 | `The getter 'files' isn't defined for the type 'List<PlatformFile>'` (×2) | `FilePicker.pickFiles` returns `List<PlatformFile>` in v12, not `FilePickerResult?`. `.files` and the null check are both gone. |
+| `lib/ui/personals/personals_screen.dart` | 312–317 | same, ×2 | same |
+| `lib/ui/resources/add_resource_screen.dart` | 107–109 | `The getter 'paths' isn't defined for the type 'List<PlatformFile>'` (×2) | same, via `.paths` |
+
+Plus two deprecation infos: `allowMultiple` is deprecated in favour of a
+separate `pickFile` for the single-file case
+(`lib/core/system/file_pick.dart:47`, `lib/ui/personals/personals_screen.dart:314`).
+
+`lib/ui/teams/team_reports_screen.dart` uses `FilePicker.saveFile` and is
+**unaffected** — that API did not change.
+
+So the whole cluster is four files and roughly a dozen lines, all of it
+mechanical. It is out of scope here only because it is source, not pubspec. It
+is a good candidate for a small follow-up lane on its own, and it closes five of
+the thirteen remaining bucket-2 entries plus `win32` and four
+`flutter_secure_storage_*` transitives — nine of the thirteen, in one change.
+
+One caution for whoever takes it: the secure-storage change is not just a
+parameter deletion. `PlanetPrefs` is where the server PIN, the derived key and
+the user's password live, and Phase 56 already has a scar from a credential
+column being wiped. Confirm that dropping `encryptedSharedPreferences: true`
+reads back values written by the 9.x implementation, or that the failure mode is
+"prompt for the password again" rather than "locked out of offline login".
+
+### 3b. `sqlite3_flutter_libs` 0.6.0+eol — refused, and this one is a trap
+
+`0.6.0+eol` is not a normal release. Its changelog: *"Deprecate this package.
+Starting from versions 3.x of the `sqlite3` package, `sqlite3_flutter_libs` is
+no longer necessary. This version removes all code from this package."* The port
+is already on `sqlite3` 3.5.2, so on paper the migration applies.
+
+It resolves. It would almost certainly pass the gate. **That is the problem.**
+`flutter.yml` runs `analyze` and `test` and never builds an APK for the port,
+and `flutter test` runs on the Dart VM against the host's SQLite — so nothing in
+CI, and nothing in this container, exercises the Android native build this
+change is entirely about. A green run here would be evidence of nothing.
+
+This container has no Android SDK at all (`flutter doctor`: *"Unable to locate
+Android SDK"*), so I cannot produce the one piece of evidence that matters.
+Refused and left at `^0.5.26`. Whoever takes it needs `flutter build apk` to
+pass *and* the app to actually open a database on a device, before and after.
+Worth doing — it is the upstream-recommended direction and removes a build-script
+dependency — but not on analyze-and-test evidence.
+
+### 3c. SDK-pinned — `build_runner`, `intl`, `meta`
+
+```
+build_runner >=2.15.2 -> analyzer >=13.3.0 -> meta ^1.18.3
+flutter_test from sdk -> meta 1.18.0
+```
+
+Flutter 3.44.8 pins `meta` at 1.18.0, so `build_runner` stops at 2.15.1 and
+`intl` at 0.20.2. Nothing to do at the constraint level; these move when the SDK
+moves, and the SDK is pinned in two places that must change together
+(`.github/workflows/flutter.yml` `flutter-version:` and
+`.claude/hooks/session-start.sh`). The same pin is why 25 packages sit in bucket
+3.
+
+### 3d. The two pinned by instruction
+
+`flutter_riverpod` and `go_router` — section 4.
+
+---
+
+## 4. Brief for the solo round: Riverpod 3 and go_router 18
+
+Both were measured, not guessed: each was resolved in this container, analyzed,
+and (for go_router) run against the full suite, then reverted. Neither is
+committed.
+
+### go_router 14.8.1 → 18.0.1 — **this is a one-line change**
+
+The finding that matters, and it contradicts how `CLAUDE.md` frames this:
+
+```
+flutter analyze  -> No issues found!
+flutter test     -> All tests passed!  (2398)
+```
+
+Zero source changes. Zero test changes. Zero failures. The constraint edit is
+the entire diff.
+
+Why it is that cheap, from the changelogs against the port's actual usage:
+
+- **18.0.0** raises the floor to Flutter 3.44 / Dart 3.12 — which is *exactly*
+  what is pinned here (3.44.8 / Dart 3.12.2). It migrates to the `material_ui`
+  and `cupertino_ui` packages and breaks no routing API.
+- **17.0.0** makes `ShellRoute` navigator changes notify `GoRouter`'s observers
+  by default, adding `notifyRootObserver`. The port registers no router
+  observer, so the changed default is unobservable here.
+- **16.0.0** changes `GoRouteData` method signatures and **requires
+  `go_router_builder >= 3.0.0`** — the port has no `go_router_builder` and zero
+  `TypedGoRoute` (confirmed by grep), so this whole breaking change misses it.
+- **15.0.0** makes URLs case-sensitive by default (`caseSensitive`, default
+  `true`). Every one of the port's 78 `GoRoute` paths is lowercase and every
+  navigation goes through `context.go`/`push` with those same literals, so the
+  new default changes nothing. **This is the one to re-check if a route is ever
+  added with a capital letter in it.**
+
+Port surface, for the record: 78 `GoRoute`, 4 `ShellRoute`, 3
+`StatefulShellRoute`, 1 `redirect`, 1 `refreshListenable`, 9 `GoRouterState`,
+29 `state.pathParameters`, 18 `state.uri`, 1 `state.extra`, 24 `context.go`,
+86 `context.push`, 19 `context.pop`, in a 683-line `lib/ui/router.dart`.
+
+**Recommendation: take it.** It does not need a solo round, it does not need to
+wait for Riverpod, and it does not need to be bundled with anything. It was left
+out of this branch only because the lane brief named it out of scope, and a lane
+that quietly relitigates its own boundary is worse than a lane that leaves an
+easy win on the table with the evidence attached. Any integrator can apply it in
+one line and re-run the gate.
+
+### flutter_riverpod 2.6.1 → 3.4.3 — **261 analyzer errors across 81 files**
+
+Resolved and analyzed in this container. `261` errors, `81` files (61 under
+`lib/`, 20 under `test/`), and they account for themselves exactly:
+
+| Errors | Cause | Fix |
+|---:|---|---|
+| **164** | `AsyncValue.valueOrNull` is gone; renamed to `.value` | search-and-replace |
+| **78** | `StateProvider` (20), `StateNotifierProvider` (4), `StateNotifier` base class, and the `state` / `mounted` / `dispose` members that come with it moved to `package:riverpod/legacy.dart` | add one import per file |
+| **14** | `Override` is no longer exported from `riverpod.dart`; it lives in `package:riverpod/misc.dart` | add one import per file |
+| **2** | `Ref` is now a `sealed class` and cannot be implemented outside its library — `test/ui/notification_tap_scope_test.dart:233` (`_NoRef`) and `test/providers/challenge_provider_test.dart:170` (`_DummyRef`) | rewrite both fakes |
+| **2** | `AsyncValue` is sealed, so a `switch` over it must be exhaustive — `lib/providers/events_provider.dart:34`, `lib/providers/surveys_provider.dart:34` | add a wildcard or the missing case |
+| **1** | `double` where `int` is expected — `lib/ui/user/profile_screen.dart:347` | one line |
+
+Concentration: `lib/providers/health_provider.dart` alone carries 40 (it holds
+the port's only `StateNotifier` subclasses), then `lib/ui/dashboard/home_screen.dart`
+16, `test/providers/health_provider_test.dart` 10,
+`lib/providers/notifications_provider.dart` 10, `lib/providers/teams_provider.dart` 9.
+
+Scale of the surface being migrated: **262 top-level provider declarations**
+across 38 files (254 of them in `lib/providers/`), 521 `ref.watch`, 388
+`ref.read`, 5 `ref.listen`, 23 `ref.invalidate`, 22 `ref.onDispose`, 71
+`ConsumerWidget` and 42 `ConsumerStatefulWidget`, and — the number that decides
+how long this takes — **627 `overrideWith` and 121 `overrideWithValue`** across
+the test tree. The port uses no `riverpod_generator` and no `@riverpod`
+annotations, so there is no codegen migration; every provider is hand-declared,
+which makes the work tedious rather than subtle.
+
+**The compile errors are the easy part. Four things will not show up in
+`flutter analyze` and are where the round will actually be spent:**
+
+1. **Providers now retry on failure automatically**, with exponential backoff
+   (200ms initial, up to 6.4s), configurable per container or per provider via
+   `retry`. This port has its own deliberate retry semantics in several places —
+   `RetryQueue`, the outbox drainer, `saveKeyIv`'s explicit 3 attempts, and the
+   sync walks' `hadBatchFailure` rule that decides whether a `deleteNotIn`
+   cleanup is safe to run. A silent framework retry underneath any of those
+   changes behaviour that four separate phases were spent getting right.
+   **Decide the `retry` policy explicitly, per provider, rather than inheriting
+   the default.**
+2. **Errors are wrapped in `ProviderException`.** Only 6 `throwsA` sites in the
+   test tree, so the blast radius looks small — but the port's failure paths
+   mostly branch on a caught error rather than assert on a thrown one, and those
+   `catch` blocks will now see a wrapper.
+3. **Refs and Notifiers cannot be touched after disposal**, and `Ref.mounted`
+   is the new guard. The port has 98 `await …future` sites and a documented
+   habit (four phases' worth) of awaiting a provider inside a screen's `try`.
+   Every one of those is an async gap that now needs a mounted check.
+4. **Subscriptions pause when the widget is not visible** (via `TickerMode`).
+   The dashboard's sync-center providers and the notification bell are watched
+   from tabs that are frequently off-screen.
+
+Also worth flagging, because it cuts against a rule this project relies on:
+renaming `valueOrNull` → `value` **destroys the grep signal** behind
+`CLAUDE.md`'s own rule — *"when you touch a screen, grep it for `.valueOrNull`
+before anything else"*. That rule exists because five separate defects were a
+screen reading a provider it never watches. After the rename, the tell is
+`.value`, which is far noisier. Update the rule in `CLAUDE.md` in the same round,
+or the next instance of that bug gets harder to find, not easier.
+
+**Recommendation: still a solo round, and still not urgent.** Nothing is broken
+at 2.6.1. But the two-line summary for whoever schedules it is: *the mechanical
+part is 261 errors that decompose into four search-and-replaces, and the real
+work is auditing 262 providers against automatic retry, error wrapping, stricter
+disposal and visibility-based pausing.* Take go_router first and separately — it
+is free, and bundling it into the Riverpod round only makes that round's bisect
+worse.

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      sha256: f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+4"
+    version: "0.3.5+5"
   crypto:
     dependency: "direct main"
     description:
@@ -261,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
+      sha256: a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.13"
+    version: "0.7.15"
   diacritic:
     dependency: "direct main"
     description:
@@ -277,18 +277,18 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
+      sha256: "852ec3b48cc431ac04fff978413c541502b67ffc3e26921e74e3d994694192c1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.0"
+    version: "5.11.1"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
+      sha256: "3a1b2cd7be71086f38504956e3ebcd2837288d231ff454bafa78021244102bfc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   drift:
     dependency: "direct main"
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: extension
-      sha256: be3a6b7f8adad2f6e2e8c63c895d19811fcf203e23466c6296267941d0ff4f24
+      sha256: "1d6cc5a2d173407284780b68fd94f2b547184d4190ca7dbf6d0bf43eb43c29d8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "1.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -349,18 +349,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      sha256: da76400e7872ce7637ffdce12749ec24169c25f6195c28372208e65a24bcd2ab
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.9.4+1"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      sha256: d57c62362766b5e7ae739448650b66c6aab7a68ba7ecc65e04018652645ae0f4
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.5"
+    version: "0.9.5+1"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -373,10 +373,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      sha256: fbefc5fb92c6d3cbe8d284a2cd971b593bb07d2cd6da8557b81a862250b4acec
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+5"
+    version: "0.9.3+6"
   fixnum:
     dependency: transitive
     description:
@@ -577,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: html
-      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      sha256: "43b67b8f43321ab066817dfac5619596c98bb1b61624e77203bb4351785f9699"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.6"
+    version: "0.15.7"
   http:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      sha256: "1c0c38790306fda4ed774095620444333e56a2b6bc8fc98f3a35c9398781cf54"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+19"
+    version: "0.8.13+22"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -641,10 +641,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      sha256: ee3885b6fcd71958fbc79770dd194c63371439d536d69c47b279171a486482ae
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+6"
+    version: "0.8.13+7"
   image_picker_linux:
     dependency: transitive
     description:
@@ -705,10 +705,10 @@ packages:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
+      sha256: b2310cdd4c18c65c081ab141a41efa94aa26c65431803703ece51996f174f351
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   jni_util:
     dependency: transitive
     description:
@@ -785,10 +785,10 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
+      sha256: "2a0dc097e7b01d942475bdd552356db2d0f768b05540bd4b2b53f1840f2239a7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.8.0"
   logging:
     dependency: transitive
     description:
@@ -841,10 +841,10 @@ packages:
     dependency: "direct main"
     description:
       name: mime
-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      sha256: bd47de35f07e27267e69c8c8b22edf9473bfee170a60d60fcc93730c5144b7f6
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -969,10 +969,10 @@ packages:
     dependency: "direct main"
     description:
       name: pdfx
-      sha256: "29db9b71d46bf2335e001f91693f2c3fbbf0760e4c2eb596bf4bafab211471c1"
+      sha256: "83bcd2b971fc2f6ee4299659c96d7d66b2ba4807748571a8a4889f1cde14b754"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.2"
+    version: "2.11.0"
   petitparser:
     dependency: transitive
     description:
@@ -1112,18 +1112,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      sha256: "1e12aafe408aa50da80edfd679a2a6bf63ba7ab37c7fa98286da459a757b3399"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.23"
+    version: "2.4.28"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      sha256: "2ec3934efa51e46117f23031cc141b8fc878e8525b94ec1ea4f7f586cf1b47ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6"
+    version: "2.5.7"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1269,18 +1269,18 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423"
+      sha256: "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1+1"
+    version: "3.4.1+2"
   table_calendar:
     dependency: "direct main"
     description:
       name: table_calendar
-      sha256: "0c0c6219878b363a2d5f40c7afb159d845f253d061dc3c822aa0d5fe0f721982"
+      sha256: f276347cad425ef837a41e8d9ad43f3ee7d59227aa4c36d7430607a5a18fa3b3
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1341,34 +1341,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      sha256: "611e87fb320b70d1dd721dc46af89c98aceccea9b31fde49e084591414e0c610"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.32"
+    version: "6.3.33"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      sha256: "8faa1aab294f1ab4040b43660c887b0418d5fa4f0cffef76a484e6aa1092eb4a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.4.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      sha256: "10f86fef4c2c43563fa6c211ff9cf757adf4d3ab762c56bd430664a947d70cd0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      sha256: "5e835a3b869c2d70325349c81c5a45c28e20791265b67b2669da6b08c5cd5201"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.5"
+    version: "3.2.6"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1389,10 +1389,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      sha256: "6c5ad3f22cd4c38e089b81963b3cd7bb83b111b2df5dce008bb066162f42e429"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   uuid:
     dependency: transitive
     description:
@@ -1413,26 +1413,26 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
+      sha256: "8c837b570dccb9ae6ff73d2e0b03c7e708bfefd3bd1194faa7f3e7f200dfc399"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: e229676f8fade3e0124482495aaa2b548872cc4018b6268adfca4868be16aa74
+      sha256: d27054dea34d748a44f06d433a57005d2aac69944485b0abbaed3303dbcfa3f1
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.12.2"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
+      sha256: "2fc56e537324a19eb649fca991aa308ac961b5406292876fa657b062de461fd8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   video_player_platform_interface:
     dependency: transitive
     description:
@@ -1501,10 +1501,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: b98656fa4461f8cc05c48a778b4d4883e60ec63e1778348f363f9bb9a477745d
+      sha256: "4de8b3d1ff4ebe1bdb42e68a5e4f809194a3cb0117a8f495f590004f00da3964"
       url: "https://pub.dev"
     source: hosted
-    version: "4.14.0"
+    version: "4.14.1"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1517,10 +1517,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: c879dd64b87c452aa84381b244d5469da57ba7e8cca6884c7b1e0d406372c12d
+      sha256: fe359c7fac1002124b5b9e2ba3a41906bbb9b2d029ccb4a0067404d8f3704730
       url: "https://pub.dev"
     source: hosted
-    version: "3.26.0"
+    version: "3.26.1"
   win32:
     dependency: transitive
     description:
@@ -1541,26 +1541,26 @@ packages:
     dependency: "direct main"
     description:
       name: workmanager
-      sha256: "06fc5bdd83e2da35f33b682e25167245d0ccb8b56e9a9ada5bfa079fa3af4b9c"
+      sha256: "96b09a4a852ec487d29371f27031dab80ce2e260911e2dbe0f904951e22a3956"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.7"
+    version: "0.10.10"
   workmanager_android:
     dependency: transitive
     description:
       name: workmanager_android
-      sha256: f89029cbcf0695c772287aa8fbbd7af776f1ea63bc95b60a00617f69468ddaa0
+      sha256: ffe8aa061885370c9363f7ae2d2196d31855217c58e7b15899d915d36c768c4a
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.6"
+    version: "0.10.9"
   workmanager_apple:
     dependency: transitive
     description:
       name: workmanager_apple
-      sha256: "15558fb54415a010910c3529eaf8f61f94d23903dac620331895c472602d6f6e"
+      sha256: "9e0ca0b857df986b37ca964ffa3b21990e1bc0f7935356a9706b47e5b71a7524"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.10"
+    version: "0.9.11"
   workmanager_linux:
     dependency: transitive
     description:
@@ -1573,10 +1573,10 @@ packages:
     dependency: transitive
     description:
       name: workmanager_platform_interface
-      sha256: "378b392db15ee88cd878ab983d3a0b4b1e460cfbb0f096ff74fda2614b1ba172"
+      sha256: a1022dca1284d64ba8bbe046edc9089cc5158b3d0e2cf9f68c7cde2fbf89746c
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.4"
+    version: "0.10.5"
   workmanager_web:
     dependency: transitive
     description:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "3a3f1f6f905037d7426e4c445854139fd6a3d592135f7c96d7931682b73d16f4"
+      sha256: bab55d542d63765f6250ee3e2c62e11bfa1145d4ec2ffa05353c8fb4e10b52c1
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.3"
+    version: "2.34.4"
   drift_dev:
     dependency: "direct dev"
     description:
@@ -1205,10 +1205,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
+      sha256: "4c7fe79840389aaeaf05fd093f795b631b5a98e2bd28d54e555c100f4a9c7a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.2"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -881,10 +881,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  dart_polylabel2:
+    dependency: transitive
+    description:
+      name: dart_polylabel2
+      sha256: "7eeab15ce72894e4bdba6a8765712231fc81be0bd95247de4ad9966abc57adc6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -447,10 +455,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_map
-      sha256: "2ecb34619a4be19df6f40c2f8dce1591675b4eff7a6857bd8f533706977385da"
+      sha256: "9bbe5472f66ae648d2ca2efbce97fcaa04e71261fabd3e062f26728222d7f767"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "8.3.2"
   flutter_markdown_plus:
     dependency: "direct main"
     description:
@@ -737,10 +745,10 @@ packages:
     dependency: "direct main"
     description:
       name: latlong2
-      sha256: "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe"
+      sha256: "84b776b100a84a684a0aaa3fa4dc2c9b1931c658de533701ee4e09bfa991f8dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1"
+    version: "0.10.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -781,14 +789,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  logger:
-    dependency: transitive
-    description:
-      name: logger
-      sha256: "2a0dc097e7b01d942475bdd552356db2d0f768b05540bd4b2b53f1840f2239a7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.8.0"
   logging:
     dependency: transitive
     description:
@@ -1020,14 +1020,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  polylabel:
-    dependency: transitive
-    description:
-      name: polylabel
-      sha256: "41b9099afb2aa6c1730bdd8a0fab1400d287694ec7615dd8516935fa3144214b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   pool:
     dependency: transitive
     description:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -781,14 +781,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  lists:
-    dependency: transitive
-    description:
-      name: lists
-      sha256: "4ca5c19ae4350de036a7e996cdd1ee39c93ac0a2b840f4915459b7d0a7d4ab27"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -833,10 +825,10 @@ packages:
     dependency: transitive
     description:
       name: mgrs_dart
-      sha256: fb89ae62f05fa0bb90f70c31fc870bcbcfd516c843fb554452ab3396f78586f7
+      sha256: "385e7168ecc77eb545220223c49eef8ab249da7bf57f22781c40a04d23fb196f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   mime:
     dependency: "direct main"
     description:
@@ -1040,10 +1032,10 @@ packages:
     dependency: transitive
     description:
       name: proj4dart
-      sha256: c8a659ac9b6864aa47c171e78d41bbe6f5e1d7bd790a5814249e6b68bc44324e
+      sha256: ddcedc1f7876e62717de43ab3491e2829bdad0b028261805f94aa080967e5859
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   pub_semver:
     dependency: transitive
     description:
@@ -1172,6 +1164,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
+  simple_sparse_list:
+    dependency: transitive
+    description:
+      name: simple_sparse_list
+      sha256: aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1309,10 +1309,10 @@ packages:
     dependency: transitive
     description:
       name: unicode
-      sha256: "0f69e46593d65245774d4f17125c6084d2c20b4e473a983f6e21b7d7762218f1"
+      sha256: a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "1.1.9"
   universal_platform:
     dependency: transitive
     description:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "100.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "13.0.0"
   app_links:
     dependency: "direct main"
     description:
@@ -109,18 +109,18 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
+      sha256: d466ed2dc9c6cd1d169948879b84ee061eb5e22c64a7c6089879c6296d272a8d
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712"
+      sha256: e1d40ef3f7934986d5da2271b1ba07794921ce263e44d622fb6c406d76589e33
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.3"
+    version: "4.1.6"
   build_runner:
     dependency: "direct dev"
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      sha256: f87ea98192116f7093cb214551ce1929caae0681fdba282b3d8b4462adee7bb7
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.6"
+    version: "8.13.0"
   characters:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      sha256: "71e43f1976c3eae2d9468a5b4d6600bf8cae61508b87f27fa1799228935d48ab"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.2"
   clock:
     dependency: transitive
     description:
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
+      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.9"
   dbus:
     dependency: transitive
     description:
@@ -301,10 +301,10 @@ packages:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
+      sha256: aa824b21ac7c43e417e1e481d114c60546ec4b585dcc0f98e7a556d1d0adb476
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.0"
+    version: "2.34.6"
   extension:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      sha256: "218aeb56050c714f62a3182775320dfa04602b55074873e24e31bbd39bda96fb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   go_router:
     dependency: "direct main"
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: transitive
     description:
       name: io
-      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      sha256: "2635216ca6a737e60de577ffa1a48a0bec76ca8a62917cfc1bb88c14c570646f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   jni:
     dependency: transitive
     description:
@@ -1000,10 +1000,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      sha256: a36d119c13416516a7b5913fbe8af8531e11633d784c550b2125f76c758524ec
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.2.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -1032,10 +1032,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
+      sha256: "4177f68c237ea2128d1bee66ac17b2ce05ba3dbaafcbdd54c5d40a39d0b6b11c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.2"
+    version: "1.5.3"
   posix:
     dependency: transitive
     description:
@@ -1056,18 +1056,18 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      sha256: "261236774e8b1d69cfc6b9eabbc96c40f25e7a2d6b171f3385d4f65d5734fb24"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      sha256: c38b81cbf34450b67e0265d73433569d12e34782e30ed769c9cc99c9d5f2e796
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   qr:
     dependency: transitive
     description:
@@ -1221,10 +1221,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
+      sha256: "772bb2f6f5bce0631a60f26b57d6e8882e1105c22345b05c163ee6ee5d7ba32d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.44.5"
+    version: "0.45.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1253,10 +1253,10 @@ packages:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      sha256: a00e5f18bffc764f923e7dec1038527f7fe7a1791361a7117f0358193f13d53a
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -1453,10 +1453,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   watcher:
     dependency: transitive
     description:
@@ -1605,10 +1605,18 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      sha256: f67cdd8e07d3c6329146aaef1ba043542b3134c12489f553ca9a7435d1068aea
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
 sdks:
   dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.44.0"

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -80,8 +80,8 @@ dependencies:
   # the same local file via `WebViewController.loadFile`.
   webview_flutter: ^4.10.0
   # Offline maps — replaces OSMDroid.
-  flutter_map: ^7.0.2
-  latlong2: ^0.9.1
+  flutter_map: ^8.3.2
+  latlong2: ^0.10.1
   # Calendar widget — replaces applandeo/materialcalendarview for team calendar.
   table_calendar: ^3.1.3
   # Profile photo selection — replaces the `Intent.ACTION_GET_CONTENT` +

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -108,7 +108,7 @@ dependencies:
   # `BuildConfig.VERSION_CODE` for the About and Settings version lines. The
   # port had been hardcoding `0.62.97` / `Build 6297`, which drifts from the
   # pubspec version on every release.
-  package_info_plus: ^8.1.1
+  package_info_plus: "^9.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -19,7 +19,11 @@ dependencies:
   cupertino_icons: ^1.0.8
 
   # State management — replaces Hilt + ViewModel/StateFlow.
-  flutter_riverpod: ^2.6.1
+  # Phase 137 pin. Riverpod 3 is a rewrite of the provider surface (203 provider
+  # declarations across 152 files here) and wants a round with no other lane
+  # running; see PHASE_137_NOTES.md. The exact pin stops any resolution — direct
+  # or transitive — from moving it while that round is unscheduled.
+  flutter_riverpod: 2.6.1
 
   # Networking — replaces Retrofit + OkHttp.
   dio: ^5.7.0
@@ -33,7 +37,10 @@ dependencies:
   mime: ^2.0.0
 
   # Navigation — replaces the Activity/Fragment + FragmentNavigator stack.
-  go_router: ^14.6.2
+  # Phase 137 pin, same reasoning as flutter_riverpod above: four majors behind,
+  # and the upgrade is coupled to the Riverpod one through the router's
+  # `ref.listen(sessionProvider, …)`. See PHASE_137_NOTES.md.
+  go_router: 14.8.1
 
   # Deep links — replaces reading `Intent.getData()` in `OnboardingActivity`.
   # The engine's own handling hands go_router a location that may carry no


### PR DESCRIPTION
Lane D of the four-lane Phase 137 round. **Diff against the base is three files: `flutter/pubspec.yaml`, `flutter/pubspec.lock`, `flutter/PHASE_137_NOTES.md`.** Nothing under `lib/` or `test/` is touched, so this merges cleanly beside the lanes editing providers, repositories, screens and the Drift DAO. The base has moved on since the branch point and touches neither pubspec file.

Gate run to completion after **every** commit — `dart run build_runner build`, `dart format --output=none --set-exit-if-changed lib test`, `flutter analyze`, `flutter test` — green each time: 462 files formatted / 0 changed, no analyzer issues, **2398 tests passing**. CI agrees on the head: `Analyze and test` ✅, `Build Android APK` ✅.

### Result

`flutter pub outdated` went from **89 packages behind latest to 38**, and the useful decomposition is in the notes:

| Bucket | Before | After |
|---|---:|---:|
| Locked, but upgradable within existing constraints | 53 | **0** |
| Constrained below a resolvable version (real work) | 18 | **13** |
| Not reachable at any constraint (SDK-pinned or discontinued) | 18 | **25** |

The third bucket grew because taking a lock-only upgrade usually just moves a package into it — `analyzer` 10 → 13 with latest 14.3.0 needs an SDK we cannot have. On a pinned Flutter 3.44.8 the headline number has a floor near 25, two of which are discontinued packages that will never move. **The number worth tracking is 13, not 38.**

### Taken — one commit each, so a bisect can attribute a regression

- 33 runtime dependencies (pdfx 2.9.2 → 2.11.0, video_player, workmanager 0.10.7 → 0.10.10, dio, mime, plugin patches)
- drift 2.34.3 → 2.34.4 and sqlite3 3.5.0 → 3.5.2 — **`schemaVersion` stays at 46**
- the build/analysis toolchain: analyzer 10 → 13, drift_dev 2.34.0 → 2.34.6, dart_style 3.1.7 → 3.1.9, and off the **retracted** build_daemon 4.1.3
- package_info_plus ^8 → ^9 (major)
- flutter_map ^7 → ^8 with latlong2 ^0.9 → ^0.10 (coupled majors), plus proj4dart/mgrs_dart/unicode

The toolchain commit is the one to look at: `dart_style` and `drift_dev` decide the layout of every generated file under `lib/`, and CI gates on `--set-exit-if-changed` without excluding generated output. Verified by regenerating from scratch — 0 files changed.

### Refused, each with a reason

- **file_picker 12 + flutter_secure_storage 11 + package_info_plus 10 are one upgrade, not three** — all three need `win32 ^6`. Resolving them together leaves exactly 7 errors in 4 files (`planet_prefs.dart`'s removed `encryptedSharedPreferences`, and `FilePicker.pickFiles` now returning `List<PlatformFile>` in `file_pick.dart`, `personals_screen.dart`, `add_resource_screen.dart`). Roughly a dozen mechanical lines that would close 9 of the 13 remaining entries — a good small follow-up lane.
- **sqlite3_flutter_libs 0.6.0+eol — refused on evidence.** It resolves and would pass the gate; that is the trap. 0.5.42's Android module exists to pull one prebuilt AAR (`eu.simonbinder:sqlite3-native-library:3.52.0`) — that *is* how the Android app gets SQLite. 0.6.0+eol ships a single Dart file with **no `android/` directory at all**, and the APK build log shows no native-assets step, so `sqlite3`'s own hook is not running for Android under Flutter 3.44.8 and nothing replaces the AAR. The upgrade would remove the app's database while `flutter build apk --debug` still prints `✓ Built app-debug.apk`.
- **build_runner 2.16.1 / intl / meta** — Flutter 3.44.8 pins `meta` at 1.18.0 via `flutter_test`; `build_runner >= 2.15.2` wants `meta ^1.18.3`.

### One finding `pub outdated` structurally cannot see

The APK build warns: *"Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): `file_picker`, `package_info_plus`, `pdfx`, `workmanager_android`. Future versions of Flutter will fail to build if your app uses plugins that apply KGP."* Not fixed by this branch, and **not fixed by the win32-6 cluster either** — checked directly: `package_info_plus` 10.2.1 still applies KGP, and `file_picker` 12 delegates to `android_file_picker` 1.1.0, which also does. Upstream's problem and a future-SDK exposure, but this is the list to consult if a Flutter bump is ever blocked.

### The brief for the solo round

Both out-of-scope upgrades were **measured** in this container, then reverted:

**go_router 14.8.1 → 18.0.1 analyzes clean and passes all 2398 tests with a zero-line source diff.** 18.0.0's floor is Flutter 3.44/Dart 3.12 — exactly what is pinned. 16.0.0's breaking change needs `go_router_builder`, which the port does not use (0 `TypedGoRoute`). 15.0.0's case-sensitivity default is inert because all 78 routes are lowercase. It does not need a solo round and does not need to wait for Riverpod. Left out only because the lane brief named it out of scope — **any integrator can take it in one line**; the evidence is in the notes.

**flutter_riverpod 2.6.1 → 3.4.3 is 261 analyzer errors across 81 files**, which decompose exactly: 164 `valueOrNull` → `value`, 78 from `StateProvider`/`StateNotifier` moving to `riverpod/legacy.dart`, 14 from `Override` moving to `riverpod/misc.dart`, 2 test fakes that implement the now-sealed `Ref`, 2 non-exhaustive switches, 1 type error. Against 262 provider declarations and 748 test overrides. The mechanical part is four search-and-replaces; the real work is auditing those providers against Riverpod 3's automatic retry, `ProviderException` wrapping, stricter post-disposal access and visibility-based subscription pausing — none of which `flutter analyze` can see, and automatic retry in particular collides with the port's own deliberate retry semantics in `RetryQueue`, the outbox, and the `hadBatchFailure` rule. Also flagged: the `valueOrNull` → `value` rename destroys the grep signal behind `CLAUDE.md`'s own "grep a screen for `.valueOrNull` first" rule, which exists because five separate defects were a screen reading a provider it never watches.

### Two corrections this lane made to itself, recorded in the notes

Both were reading the plausible thing instead of the actual file, and both are written down rather than quietly fixed. First: I claimed `flutter.yml` never builds an APK — it does, in a `build-android` job I had not read as far as. Second: the APK log installs CMake 3.22.1, which reads as `sqlite3_flutter_libs` compiling SQLite and is not — 0.5.42 uses a Maven AAR, and the CMake comes from `jni` via `pdfx`. The sqlite3 conclusion survived the check; the reason I first reached for did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vKuHyUCkQ7pWw2Zyr3hpm