### PR TITLE
fix(flutter): scope exam grading to the exam-taker, and escape the LIKE user patterns

### DIFF
--- a/flutter/PHASE_135_NOTES.md
+++ b/flutter/PHASE_135_NOTES.md
@@ -263,14 +263,20 @@ reads as coverage without being any.
 ## Gate
 
 `dart format --set-exit-if-changed lib test` clean, `flutter analyze` clean,
-`flutter test` **2418 passing** (2405 before this lane's 13 new repository and
-screen tests; the 7 `LIKE` tests are inside the 2405 because they were written
-and run first). Codegen (`dart run build_runner build`) run before analyzing,
-per the stale-generated-sources rule — the Drift DAO signature changed.
+`flutter test` **2430 passing** on the final tree, against 2405 on the base —
+25 new tests across the two jobs and the second audit's fixes. Codegen
+(`dart run build_runner build`) run before analyzing, per the
+stale-generated-sources rule, since the Drift DAO signature changed.
+
+An intermediate count of 2418/2419 appears in the audit narrative below and in
+the earlier commit messages; those were taken before the second audit's fixes
+added their tests, and before the `take_course_screen_test.dart` repair. The
+number to trust is the one measured last.
 
 ## What the second audit found in this lane's own finished code
 
-Six defects in code that was formatted, analyzer-clean and 2419-tests green.
+Six defects in code that was formatted, analyzer-clean and green at the time
+(2419 tests).
 Phases 110, 113, 116 and 119 each found more in their second pass; this is the
 fifth. Two of the six are in the work this phase added, and the worst of them
 made the phase's own headline change a no-op.

--- a/flutter/PHASE_135_NOTES.md
+++ b/flutter/PHASE_135_NOTES.md
@@ -1,0 +1,19 @@
+# Phase 135 — DAO predicates: user-scoped exam grading, and five unescaped `LIKE`s
+
+Lane B of a four-lane round. Branch `claude/dao-predicates-q5w9`, off
+`claude/kotlin-flutter-dart-migration-d3gmrd`. Sole owner of
+`lib/data/local/app_database.dart` this round, which is why the two jobs are
+one lane: **one file, one owner.**
+
+Two jobs, two commits:
+
+1. Port `ed5609f` — `AND userId IS :userId` on
+   `CourseProgressDao.updatePassedByCourseAndStep`, threaded through
+   `updateCourseProgress`, and wire the caller the port never had.
+2. Escape the five interpolated `LIKE` patterns Phase 131 listed.
+
+*(In progress — findings below are filled in as they are established.)*
+
+## Reported, not fixed
+
+*(to be filled in)*

--- a/flutter/PHASE_135_NOTES.md
+++ b/flutter/PHASE_135_NOTES.md
@@ -1,19 +1,318 @@
 # Phase 135 — DAO predicates: user-scoped exam grading, and five unescaped `LIKE`s
 
 Lane B of a four-lane round. Branch `claude/dao-predicates-q5w9`, off
-`claude/kotlin-flutter-dart-migration-d3gmrd`. Sole owner of
-`lib/data/local/app_database.dart` this round, which is why the two jobs are
-one lane: **one file, one owner.**
+`claude/kotlin-flutter-dart-migration-d3gmrd`. PR #16939.
 
-Two jobs, two commits:
+Sole owner of `lib/data/local/app_database.dart` this round, which is why the
+two jobs are one lane: **one file, one owner.** Two jobs, two separable
+commits — `88b2fee` (the `LIKE` escaping) and `5bff98b` (`ed5609f` plus its
+missing caller). `88b2fee` is committed first and stands alone, so it can be
+reverted without touching Job 1.
 
-1. Port `ed5609f` — `AND userId IS :userId` on
-   `CourseProgressDao.updatePassedByCourseAndStep`, threaded through
-   `updateCourseProgress`, and wire the caller the port never had.
-2. Escape the five interpolated `LIKE` patterns Phase 131 listed.
+Both briefs came from a previous round's *Reported, not fixed* list — Phase
+133's item 1 and Phase 131's items 1–3 — which is the fifth consecutive round
+where that list was the highest-yield source of work.
 
-*(In progress — findings below are filled in as they are established.)*
+## Result in one paragraph
+
+The `LIKE` escaping was exactly as reported and is fixed at all five sites,
+with one test per site. Job 1 is the interesting half: the port of `ed5609f`
+is small and the missing caller is real, but **the consequence Phase 133
+attached to it is overturned.** "An exam-bearing course can never complete in
+the port" is true, and it is equally true of the Kotlin app, because neither
+app grades an exam step locally — so it was never a port defect. What the port
+was actually missing is the *clearing* direction, and that is what `ed5609f`
+scopes. Wiring the caller then turned three latent defects in the uncalled code
+into live ones, which is the part worth remembering.
+
+## Method
+
+1. Read `ed5609f`'s diff, then the Kotlin call chain by hand:
+   `BaseExamFragment.continueExam` → `saveCourseProgress` →
+   `CoursesRepositoryImpl.updateCourseProgress` → the DAO, plus
+   `CourseStepFragment.launchSaveCourseProgress`, `CoursesPagerAdapter`,
+   `SubmissionsRepositoryImpl.saveExamAnswer`/`startExamSession` and
+   `ProgressRepositoryImpl.getCompletedCourses`.
+2. A `parity-auditor` pass at `effort: max` on that reading, **before** any
+   Dart — eight numbered claims and three implementation questions.
+3. Implement, with every defect demonstrated failing first.
+4. A second `parity-auditor` pass at `effort: max` aimed at the finished,
+   already-green code.
+
+The first pass corrected two things and added three defects I had not seen;
+they are recorded below rather than quietly folded in.
+
+## What the ground-truth audit corrected
+
+### `sub?.status == "graded"` is not unreachable — it is inert
+
+My claim was that the string `"graded"` appears exactly once in the whole
+Kotlin tree (the comparison itself), that no local writer produces it
+(`saveExamAnswer` writes `pending` / `complete` / `requires grading`), and that
+the exam branch of `startExamSession` always recreates the attempt — so the
+comparison is *never* true.
+
+The first two hold. The absolute does not. `startExamSession` is not the only
+writer of `sub`: `BaseExamFragment.kt:88` does
+`sub = submissionsRepository.getSubmissionById(it)` with **no status filter**,
+and `SubmissionViewModel`'s survey list filters on `userId` and `type` with no
+status predicate either — so a survey submission the server sent back as
+`graded` is listed, tappable, and reaches the comparison on the my-surveys
+resume path. It is inert there for a different reason: that path carries no
+`"stepNum"` argument, `BaseExamFragment.kt:75` reads it out of the Bundle with
+a default of 0, and `WHERE stepNum = 0` matches no row a course step ever
+wrote.
+
+The implementation is unaffected — the exam screen's attempt is always
+recreated, so reading the row back is correct — but the *reason* in the doc
+comment was wrong, and a wrong rationale is a defect here. Both comments now
+say which path can produce `graded` and why it does not matter.
+
+### `ed5609f` does not close the self case, and that quirk is ported
+
+One user, one device: Planet grades step 3, the pull writes `passed = true`,
+the learner retakes that step's exam, and the now-correctly-scoped `UPDATE`
+writes `false` back over their own pass — the completed-course star goes dark
+until Planet grades the new attempt. Upstream leaves this alone, so the port
+does too, with a test named for it. Worth recording because it looks exactly
+like a bug to fix.
+
+## Job 1 — `ed5609f`, and the caller that never existed
+
+The commit itself is four lines of behaviour: `AND userId IS :userId` on
+`CourseProgressDao.updatePassedByCourseAndStep`, threaded through
+`CoursesRepository.updateCourseProgress` and the abstract
+`BaseExamFragment.saveCourseProgress`. Before it, passing an exam for step *N*
+rewrote `passed` for **every** row at `(courseId, stepNum)` whatever its owner.
+No DDL, so no schema bump — the port needed none either.
+
+The port reproduced the old behaviour *and documented it as intentional*
+("an exam result is not per-user", in two places). Upstream has repudiated that
+rationale, so it is deleted along with the behaviour.
+
+### What the missing caller actually cost
+
+`updateCourseProgress` had **zero callers** in `lib/` or `test/`. Phase 133
+read the consequence chain correctly and drew the wrong conclusion from it:
+
+- `take_course_screen.dart` writes `passed: exams.isEmpty ? true : null`, so a
+  step *with* an exam is deliberately left unpassed
+  (`CourseStepFragment.kt:96`, verbatim).
+- Nothing then graded it.
+- `completedCourseIds` requires **every** step passed.
+
+⇒ "an exam-bearing course can never complete in the port". True. But follow the
+Kotlin the same distance: its exam finish passes `sub?.status == "graded"`,
+which on the exam path is always false, so **Kotlin writes `passed = false`
+too.** In both apps a step exam becomes passed only when Planet's own grading
+arrives in the `courses_progress` document — `ProgressRepositoryImpl`'s
+`if (passed != true) passed = getBoolean("passed", act) || localPassed`, which
+the port mirrors in `CourseProgressMapper.fromDoc` and pulls in
+`syncCourseProgress` from `CourseSyncNotifier`. That route is live and
+reachable, and two tests now pin the pair:
+
+| | expectation |
+|---|---|
+| finishing the exam | `completedCourseIds` is empty — in either app |
+| the graded `courses_progress` document arrives | `completedCourseIds` is `{course-1}` |
+
+The second one **passed before any of this phase's production changes**, which
+is the evidence that the "most expensive reachability row yet" framing was
+wrong. The row the port was genuinely missing is the narrow one: the reset.
+
+**The general lesson, since this is the second time a reachability finding has
+been over-read:** a chain that ends "so the port cannot do X" is only a defect
+once you have walked the *same* chain in the Kotlin and found that it can. Both
+apps are allowed to depend on the server.
+
+### The caller, and the step number
+
+Wired where Kotlin has it — `BaseExamFragment.continueExam:133`, after the last
+answer and before the thank-you dialog — as `TakeExamScreen._recordExamProgress`.
+
+Two decisions worth their reasons:
+
+* **`courseId` comes from the exam document, not the route.** Kotlin passes
+  `exam?.courseId` and never consults the fragment arguments here. It also
+  avoids a trap the audit found: both port entry points build their query
+  string as `courseId=${step.courseId ?? ''}` against a nullable column, so
+  `widget.courseId` can be the empty string — and `'' ?? exam.courseId` does
+  not fall back.
+* **`stepNum` is derived, not passed.** Kotlin threads it through fragment
+  arguments (`CoursesPagerAdapter` sets `stepNumber = position` where page 0 is
+  the course cover, so step *i* carries *i+1*; `CourseStepFragment` forwards it
+  as `"stepNum"`). This route carries `stepId` and not `stepNum`, and the same
+  number is the step's index in `CourseDao.getSteps` plus one — *the same
+  ordering* `take_course_screen._recordProgress` counts to write
+  `stepNum: index + 1`. So the writer and the reader of that column agree by
+  construction rather than by two independent conventions, which is the
+  property the writer/reader-key-disagreement class keeps violating. The
+  alternative — adding a `?stepNum=` parameter — is the closer port but only
+  one of the two pushers is in this lane's file set, and a parameter half the
+  callers set is worse than a derivation both share.
+
+An unresolvable step (no `stepId`, empty `courseId`, or a `stepId` the course
+does not list) skips the write rather than writing `stepNum: 0`. Kotlin reaches
+the same outcome by a different route — its default *is* 0, and no real row
+carries it.
+
+### Three defects wiring it turned live
+
+All three sat in code with no callers, which is why nothing had caught them.
+
+1. **The insert branch was an invention, and its key omitted the user.**
+   `updateCourseProgress` used to insert a row when the `UPDATE` matched
+   nothing; Kotlin runs the guard plus one statement and nothing else. The row
+   id was `'${courseId}_$stepNum'` — no user in it — and `upsert` is
+   `insertOnConflictUpdate`, so a second learner taking the same step's exam
+   would have overwritten the first learner's whole row *and rewritten its
+   `userId`*. That is strictly worse than the pre-`ed5609f` bug it imitated:
+   that one reset a flag, this reassigns ownership. Removed.
+2. **The same insert wrote `createdOn` from `parentCode`** where Kotlin writes
+   `planetCode`. The row has `couchId: null`, so `getPendingUploads` picks it
+   up and the uploader sends `createdOn` verbatim — the wrong planet code
+   reaching CouchDB. Removed with the branch; `parentCode` was that branch's
+   only reader, so the parameter went too, which also matches Kotlin's
+   four-argument signature.
+3. **No empty-`courseId` guard**, where Kotlin has
+   `if (courseId.isNullOrEmpty()) return`. Added, and tested.
+
+A fourth, found by reading the DAO around the method I was changing: **four
+user-scoped reads were `equals(userId ?? '')` where the Kotlin `@Query` is
+`userId IS :userId`** (`getByUserAndCourseIds`, `getByUserAndCourse`,
+`getByUser`, `findByCourseUserAndStep`). Coercing a null argument to the empty
+string matches rows whose `userId` is literally `''` and **no** row whose
+`userId` is NULL, where Kotlin matches exactly the NULL rows — and a synced
+document that omits `userId` writes one of those, since
+`CourseProgressMapper.fromDoc` passes `getStringOrNull`. Fixed with
+`equalsNullable`, drift's spelling of `IS`. Not in the brief; it is the same
+defect class as the job (null-safe user predicates in the very DAO being
+changed) and needs no schema bump.
+
+## Job 2 — five unescaped `LIKE` interpolations
+
+Exactly as Phase 131 described. `my_library.user_id` and `courses.user_id`
+hold a JSON list and shelf membership is the substring `"<userId>"` inside it;
+Kotlin builds the pattern with `ResourcesRepositoryImpl.userIdPattern` and
+`CoursesRepositoryImpl.userIdPattern` — verified character-for-character
+identical, which is why one Dart helper serves both tables — and pairs every
+DAO query with `ESCAPE '\'`.
+
+Five sites interpolated the raw id, leaving LIKE's metacharacters live:
+
+| site | |
+|---|---|
+| `MyLibraryDao.watchResources`, shelf arm | fixed |
+| `MyLibraryDao.watchResources`, catalog arm (`.not()`) | fixed |
+| `MyLibraryDao.resourcesOnShelf` | fixed |
+| `CourseDao.watchCourses` | fixed |
+| `CourseDao.coursesOnShelf` | fixed |
+
+The `_` case is the sharp one and it is **two** failures from one cause: a
+shelf query for `u_1` returned `ux1`'s rows, *and* the catalog arm — the same
+predicate negated — dropped them from the catalog at the same moment, so the
+resource was missing from both views at once. `%` is coarser: one id claims
+almost every shelf.
+
+All five now route through a `_shelfMembership` helper over the existing
+`likeEscapedUserPattern`, with drift's `escapeChar` writing the `ESCAPE` clause
+and the pattern bound as a variable. Seven tests, one per site plus the `%`
+case, each with ids that differ **only** at the escaped character (`u_1` vs
+`ux1`) so a pass cannot come from anything but the wildcard.
+
+### The rationale that sent Phase 131 to raw SQL is false
+
+`watchResourcesNeedingUpdateCount` says it uses `customSelect` because
+"drift's `like()` takes no `ESCAPE`". It does:
+`like(String regex, {String? escapeChar})` has been there all along
+(drift 2.34.3, `expressions/text.dart:10`), and it binds the pattern as a
+variable rather than splicing it in. The raw SQL stays — `IS NOT` has no
+query-builder spelling and reading the statement beside its `@Query` is worth
+something — but the comment is corrected, because the next person to need an
+escaped `LIKE` would have believed it and reached for raw SQL too.
+
+## Failing-first and mutation evidence
+
+Every production change was demonstrated failing first:
+
+* the seven `LIKE` tests: all 7 red before the fix;
+* `updateCourseProgress` scoping: 2 red before, including the peer-clearing one;
+* the `IS` semantics on the update: **mutation-checked** — swapping
+  `equalsNullable(userId)` back to `equals(userId ?? '')` turns **exactly one**
+  test red, the one written for it;
+* the new caller: **mutation-checked twice** — deleting the
+  `_recordExamProgress` call, and an off-by-one in the step-number derivation
+  (`index` for `index + 1`), each turn a screen test red.
+
+Following Phase 122's practice: a migration or predicate test that cannot fail
+reads as coverage without being any.
+
+## Gate
+
+`dart format --set-exit-if-changed lib test` clean, `flutter analyze` clean,
+`flutter test` **2418 passing** (2405 before this lane's 13 new repository and
+screen tests; the 7 `LIKE` tests are inside the 2405 because they were written
+and run first). Codegen (`dart run build_runner build`) run before analyzing,
+per the stale-generated-sources rule — the Drift DAO signature changed.
 
 ## Reported, not fixed
 
-*(to be filled in)*
+1. **The JSON/LIKE escaping mismatch — Phase 131's item 2 — is confirmed, and
+   its reasoning stands.** The column holds a JSON list, so a user id
+   containing a backslash is *stored* with that backslash doubled
+   (`jsonEncode([r'a\b'])` is `["a\\b"]`), while `userIdPattern` escapes it for
+   LIKE and `ESCAPE '\'` unescapes it again — so the pattern looks for a single
+   backslash and never matches what was written. Kotlin's Gson converter and
+   `ResourcesRepositoryImpl.userIdPattern` produce the identical mismatch, so
+   reproducing it is parity, and **fixing it in the port alone would make the
+   two apps disagree about shelf membership** for the affected ids. It needs
+   escaping against the stored JSON form in both apps at once. Unreachable
+   today — a CouchDB user id is `org.couchdb.user:<name>`. Phase 131's
+   existing test pins both halves; nothing here changes it.
+2. **`MyLibraryTable.userId` is non-nullable with a `'[]'` default — Phase
+   131's item 3 — so `watchResources`' catalog arm `r.userId.isNull() | …`
+   still has a branch that can never be true.** Kept deliberately: it is the
+   Kotlin condition, escaping it changed nothing about it, and removing it is a
+   schema question this round allocated no bump for. `'[]'` matches no
+   `%"x"%` pattern, so the surviving arm is correct on its own.
+3. **`completedCourseIds` omits Kotlin's non-blank id and title requirement,
+   and that is fine — the filter lives one layer up.** Recorded because I
+   nearly filed it as a defect and it is not one:
+   `ProgressRepositoryImpl.getCompletedCourses` drops a completion with a
+   blank id or title, and `progress_repository.dart`'s `completedCourseIds`
+   does not — but its **only** consumer,
+   `completedCoursesProvider` (`dashboard_providers.dart:172-182`), applies
+   exactly that filter after resolving the rows, and says so. The port splits
+   one Kotlin method across a repository and a provider, so a term missing
+   from one half is not missing from the pair. **Check the consumer before
+   filing a missing predicate**, in a port that folds Fragment + ViewModel
+   into different seams than the original.
+4. **The `?stepNum=` parameter is the closer port of the step number**, and
+   only one of the two pushers is in this lane's file set.
+   `take_course_screen.dart`'s `onTap` sits inside `_StepContent`, which
+   already holds the number, and `course_detail_screen.dart` has `number` in
+   scope. If a future round owns both files, passing it explicitly assumes
+   nothing about ordering; the derivation here is equivalent for every
+   reachable case but rests on `stepIndex`, whose column default of `0` makes
+   ties legal even though no current writer produces one.
+5. **`CourseStepDao`/`CourseStep` in Kotlin carry no order column**, so
+   Kotlin's `stepNum` is a position in an unordered read — the document's step
+   order *as first inserted*. An author who reorders a course's steps leaves
+   every Kotlin `stepNum` stale, because `@Upsert` keeps the rowids; the port
+   rewrites `stepIndex` from the new position on every pull and tracks the
+   reorder. A divergence in the port's favour, pre-existing, and now
+   load-bearing for a derivation — so it is named in the code rather than left
+   implied.
+6. **The survey path's `saveCourseProgress` call is not a port gap.** Kotlin's
+   `continueExam` fires it for the non-team survey path too, but that path
+   never sets the `"stepNum"` argument — `SubmissionsAdapter.openSurvey` does
+   not put the key and `CourseStepFragment.kt:280` is the only site in the tree
+   that does — so `stepNumber` is the Bundle default 0 and the `UPDATE` matches
+   nothing. `take_survey_screen.dart` (not this lane's file) therefore needs no
+   equivalent call. Recorded so nobody adds one, and because the same argument
+   is what makes the `graded`-status path above inert.
+7. **`CourseProgressDao.getByIds` matches `couchId` as well as `id`,** where
+   Kotlin's is `WHERE id IN (:ids)` only. It is not a defect — the port stores
+   `id: base?.id ?? docId`, so a locally-authored row keeps its local id and
+   carries the server id in `couchId`, and the sync-in look-up needs the second
+   arm. Recorded because it reads like an unexplained extension.

--- a/flutter/PHASE_135_NOTES.md
+++ b/flutter/PHASE_135_NOTES.md
@@ -182,12 +182,25 @@ user-scoped reads were `equals(userId ?? '')` where the Kotlin `@Query` is
 `userId IS :userId`** (`getByUserAndCourseIds`, `getByUserAndCourse`,
 `getByUser`, `findByCourseUserAndStep`). Coercing a null argument to the empty
 string matches rows whose `userId` is literally `''` and **no** row whose
-`userId` is NULL, where Kotlin matches exactly the NULL rows — and a synced
-document that omits `userId` writes one of those, since
-`CourseProgressMapper.fromDoc` passes `getStringOrNull`. Fixed with
-`equalsNullable`, drift's spelling of `IS`. Not in the brief; it is the same
-defect class as the job (null-safe user predicates in the very DAO being
-changed) and needs no schema bump.
+`userId` is NULL, where Kotlin matches exactly the NULL rows. Fixed with
+`equalsNullable`. Not in the brief; it is the same defect class as the job
+(null-safe user predicates in the very DAO being changed) and needs no schema
+bump.
+
+**The example I first justified it with was wrong, and the second audit caught
+it.** I wrote that a synced document omitting `userId` produces one of those
+NULL rows. It does *in the port* — `CourseProgressMapper.fromDoc` passes
+`getStringOrNull` — but **Kotlin stores `""` there**, because
+`ProgressRepositoryImpl.kt:260` uses `JsonUtils.getString`, which returns the
+empty string for a missing field. So on my own cited input the fix made the port
+**diverge**: a null-argument query returns nothing in Kotlin, nothing in the
+pre-fix port, and the row in the post-fix port. The predicate change is still
+the right port of the `@Query`; the defect my example describes belongs to the
+mapper (item 9), and the case that genuinely justifies `IS` is Kotlin's *local*
+writer at `ProgressRepositoryImpl.kt:234`, which does store NULL for a null
+argument. Two lessons, both already rules here: **cite the writer, not a
+plausible writer**, and a rationale that names the wrong mechanism is a defect
+even when the code is right.
 
 ## Job 2 — five unescaped `LIKE` interpolations
 
@@ -255,6 +268,146 @@ screen tests; the 7 `LIKE` tests are inside the 2405 because they were written
 and run first). Codegen (`dart run build_runner build`) run before analyzing,
 per the stale-generated-sources rule — the Drift DAO signature changed.
 
+## What the second audit found in this lane's own finished code
+
+Six defects in code that was formatted, analyzer-clean and 2419-tests green.
+Phases 110, 113, 116 and 119 each found more in their second pass; this is the
+fifth. Two of the six are in the work this phase added, and the worst of them
+made the phase's own headline change a no-op.
+
+### The exam write was a no-op on the ordinary path (fixed)
+
+`_recordExamProgress` derives the right `stepNum` and issues the right
+`UPDATE` — against a row that does not exist. **Nothing in the port wrote a
+`course_progress` row for the step the learner lands on.**
+
+`_recordProgress` had one caller, `goToStep`, reached only from
+`PageView.onPageChanged` and the Previous/Next buttons — and `onPageChanged`
+never fires for the initial page. Kotlin's pager has a course-cover page at
+position 0, so its first *step* is always arrived at; the port's `PageView`
+opens directly on step 1. Kotlin also records the row twice over without any
+page change at all: `CourseStepFragment.onViewCreated`'s
+`withResumed { launchSaveCourseProgress() }` (`:168-172`) and
+`setMenuVisibility` (`:262-268`), both gated on `userHasCourse`.
+
+The blast radius is much wider than this phase's write:
+
+* `getCurrentProgress` and `courseProgressSummary` count rows ignoring
+  `passed`, so both under-reported by a step;
+* `completedCourseIds` requires `passed`, and **a one-step course could
+  therefore never complete** — the write that would pass its only step never
+  ran;
+* and the exam-finish `UPDATE` this phase added silently matched nothing.
+
+Fixed by making `_CourseContent` stateful and recording the step in view on
+mount and on change, gated on `isMyCourse` (Kotlin's `userHasCourse`), with
+`_recordedStep` making a rebuild not a re-visit.
+
+**The fix broke seven existing tests, and that is itself the finding.** They
+all failed with `planetPrefsProvider must be overridden` — the Phase 75 harness
+trap — because recording progress queues an outbox row, which reaches
+`serverConfigProvider` and through it `planetPrefs`. **No test in
+`take_course_screen_test.dart` had ever reached that code**, in a file of
+thirteen tests for this screen, because nothing in it changed pages. The
+harness trap was the proof of the defect: a screen whose progress write is
+unreachable also has an untouched provider graph behind it.
+
+**Why it survived a phase that was looking for exactly this.** Every one of my
+tests seeded the row it needed — the four widget tests with
+`courseProgressDao.upsert`, the repository tests with `saveCourseProgress`.
+Nothing drove `take_course_screen` → `take_exam_screen` end to end, so the
+fixture supplied what production did not. That is the "every fixture
+hand-faked the join" symptom verbatim, and I wrote it in this file's own
+method section while doing it. **Asking the three reachability questions is
+not the same as answering them; the answer has to come from a test that uses
+no fixture for the join.**
+
+The first cut of the fix *also* failed, and instructively: it gated
+`didUpdateWidget` on `currentStep` having changed, but `userId` comes from the
+parent's `ref.watch(sessionProvider).valueOrNull?.id` and so is null on the
+first frame — the membership gate bailed, and the rebuild carrying the
+resolved session did not change `currentStep`. The `.valueOrNull` shape again,
+in its rarest form: correctly *watched*, and still null when it mattered.
+
+### A failed progress write reported the exam as failed to submit (fixed)
+
+Kotlin's caller is `lifecycleScope.launch { … }` (`ExamTakingFragment.kt:846-850`)
+and `continueExam` builds its thank-you dialog on the next statement, so a
+failure there can neither suppress the dialog nor reach the learner. Awaited
+inside `_submitExam`'s own `try`, a throw took the `examSubmitFailed` branch:
+no dialog, no pop, and a learner told their exam failed when the attempt was
+already `requires grading` on disk and already queued — so they would retake a
+recorded exam. The realistic trigger is not a database fault but `ref` after
+dispose, which throws if the learner backs out during the awaited photo
+capture. Now contained in its own `try`, and documented as a deliberate
+exception to this project's rule against silent failure.
+
+### The call sat behind work Kotlin either does not await or does not have (fixed)
+
+Kotlin's `capturePhoto()` only *launches* the camera, and Kotlin has no
+upload-queue step at this point, so its progress write goes out before the
+shutter opens and nothing downstream can skip it. Mine sat after a camera
+round trip and two `queuePending` calls, making it skippable by any of them.
+Moved ahead of both. Textual placement was already Kotlin's; **temporal
+placement is the one that decides whether a write happens.**
+
+### A sixth unescaped `LIKE`, and this one Kotlin does not have at all (fixed)
+
+`CourseDao.watchCourses`' `courseTitleNormal.like('%$trimmed%')`. Kotlin's
+course search is not a `LIKE`: `CourseDao` has no title query and
+`CoursesRepositoryImpl.filterCourses` (`:304`) filters in memory with
+`courseTitle?.contains(searchText, ignoreCase = true)`, which is literal. So
+the port *invented* the `LIKE` — searching `intro_a` matched `IntroXA`, and a
+lone `%` matched every course. Escaped through a new `_literalContains`, kept
+separate from `_shelfMembership` because the two mean different things.
+
+### Two of my rationales named the wrong mechanism (fixed in place)
+
+The step-reorder claim was **inverted** — see *Reported, not fixed* item 5 —
+and the NULL-`userId` justification cited a writer that behaves differently in
+the two apps, see the Job 1 section above. Both are corrected where they were
+written rather than only here, since a wrong rationale is what re-seeds a
+mistake.
+
+### Also worth keeping
+
+* The `%`/`_` ids I tested with (`u_1`, `ux1`) are synthetic where the shipping
+  shape is not: Planet usernames explicitly permit `_`, `.` and `-`
+  (`UserRepositoryImpl.kt:827`) and a synced id is `org.couchdb.user:<name>`,
+  so **`mary_jane` and `mary-jane` on one handset is the real reproduction** —
+  as is any `guest_<name>`.
+* The escaping fix is **write-side too**, which I had not realised:
+  `shelf_repository.dart`'s `_localCourseIds`/`_localResourceIds` feed the
+  uploaded shelf document, so before it `mary_jane`'s shelf POST carried
+  `mary-jane`'s course and resource ids to CouchDB.
+* The test named for the step-number derivation passes under the off-by-one
+  mutation; the sibling test is what catches it. The claim "mutation-checked"
+  is true of the pair, but **the test that names a property should be the one
+  that fails for it**.
+
+## A parallel-lane hazard nobody had written down
+
+**An audit subagent's mutation check lands in the lane's own working tree.**
+The second `parity-auditor` pass reverted this phase's four `equalsNullable`
+reads to `equals(x ?? '')` to measure whether anything pinned them — the same
+technique this lane used deliberately — and left the file that way. It was
+caught only by the session's dirty-tree check on the way out; a reflexive
+"commit what's outstanding" would have silently un-shipped the fix its own
+commit message describes.
+
+Two rules follow, and they cost nothing:
+
+* **After an audit pass, `git status` is not a formality.** Diff the tree
+  against the commit you expect before touching it, and read any change you
+  did not make rather than staging it.
+* **An audit agent that mutates should restore.** Until an agent definition
+  enforces that, a lane must treat the tree as shared with whatever it
+  spawned — the same way it treats a file shared with another lane.
+
+The audit also reported it had run whole-suite passes with its own probe files
+in place, which is why its test counts and this file's differ by a test or two
+depending on when each was taken.
+
 ## Reported, not fixed
 
 1. **The JSON/LIKE escaping mismatch — Phase 131's item 2 — is confirmed, and
@@ -295,14 +448,23 @@ per the stale-generated-sources rule — the Drift DAO signature changed.
    nothing about ordering; the derivation here is equivalent for every
    reachable case but rests on `stepIndex`, whose column default of `0` makes
    ties legal even though no current writer produces one.
-5. **`CourseStepDao`/`CourseStep` in Kotlin carry no order column**, so
-   Kotlin's `stepNum` is a position in an unordered read — the document's step
-   order *as first inserted*. An author who reorders a course's steps leaves
-   every Kotlin `stepNum` stale, because `@Upsert` keeps the rowids; the port
-   rewrites `stepIndex` from the new position on every pull and tracks the
-   reorder. A divergence in the port's favour, pre-existing, and now
-   load-bearing for a derivation — so it is named in the code rather than left
-   implied.
+5. **A course-step reorder re-binds the port's step ids to different
+   content, and my first write-up of this had it exactly backwards.** Kotlin's
+   step id is content-derived — `Base64(stepElement.toString())`
+   (`CoursesRepositoryImpl.kt:681`) — so a reorder changes no id, `@Upsert`
+   updates in place, and every `course_progress.stepNum` keeps naming the same
+   step content; only Kotlin's *rendered* order lags, because its position
+   comes from an unordered read. The port's ids are `<courseId>:<index>` and
+   `stepIndex` is rewritten on every pull, so after a reorder step 1's id
+   points at what used to be step 2 while the learner's progress rows keep
+   their old `stepNum`s — finishing the new step 1's exam writes `passed` onto
+   the row that described the old one. **A divergence against the port, not in
+   its favour**, and it is now load-bearing for this phase's `stepNum`
+   derivation. Not fixed: changing how step ids are minted is a mapper and
+   migration question. Note `docs/kotlin-to-flutter-migration.md` calls the
+   port's position-derived ids "stable across syncs", which holds only while
+   the step order does not change — the two documents should be reconciled by
+   whoever takes this.
 6. **The survey path's `saveCourseProgress` call is not a port gap.** Kotlin's
    `continueExam` fires it for the non-team survey path too, but that path
    never sets the `"stepNum"` argument — `SubmissionsAdapter.openSurvey` does
@@ -311,7 +473,48 @@ per the stale-generated-sources rule — the Drift DAO signature changed.
    nothing. `take_survey_screen.dart` (not this lane's file) therefore needs no
    equivalent call. Recorded so nobody adds one, and because the same argument
    is what makes the `graded`-status path above inert.
-7. **`CourseProgressDao.getByIds` matches `couchId` as well as `id`,** where
+7. **The port's `CourseProgressMapper` stores NULL where Kotlin stores `''`.**
+   A synced `courses_progress` document omitting `userId` gives the port NULL
+   (`getStringOrNull`) and Kotlin the empty string
+   (`ProgressRepositoryImpl.kt:260` via `JsonUtils.getString`, which returns
+   `''` for a missing field). Aligning it is a one-word change in
+   `course_progress_mapper.dart`, which is not in this lane's file set. It
+   matters because this phase made the four user-scoped reads null-safe, so on
+   that input the apps now differ where before they agreed by accident. Planet
+   writes `userId` on every progress document, so it is not reachable today.
+8. **A course-step reorder re-binds the port's step ids to different content.**
+   Item 5 above carries the detail; it is listed twice deliberately, once as a
+   correction of my own claim and once as work for somebody. Fixing it means
+   changing how `CourseMapper` mints step ids, which is a migration question.
+9. **`take_course_screen._recordProgress` writes neither `planetCode` nor
+   `parentCode`.** Kotlin's `saveCourseProgress` sets
+   `createdOn = planetCode` and `parentCode = parentCode`
+   (`ProgressRepositoryImpl.kt:231-233`), and
+   `course_progress_uploader.dart:85,89` uploads both columns — so every
+   locally-authored progress row reaches CouchDB with both null. The insert
+   this phase deleted got `createdOn` wrong in a different way (it passed
+   `parentCode`); deleting it leaves `_recordProgress` as the only writer, and
+   it fills neither. Not fixed because the values come from the session user
+   and threading them through is a change to the screen's provider reads
+   rather than to this phase's subject.
+10. **The port's course search matches a folded column against an unfolded
+    query.** `watchCourses` compares `courseTitleNormal` (diacritic-folded by
+    `CourseMapper`) with `query.trim().toLowerCase()`, so searching "Café"
+    misses a course the Kotlin's `contains(ignoreCase = true)` finds. Escaping
+    the pattern (this phase) does not touch it. The fix is to fold the query
+    with `text_utils.normalizeText`, the single one — but the courses screen
+    also filters in Dart via `filterCourses`, so which layer should own the
+    match wants deciding rather than patching.
+11. **`NewsDao`'s team-voices predicate diverges two ways**, surfaced while
+    sweeping the `LIKE` class. Kotlin's `getTopLevelByTeamFlow` is
+    `viewIn LIKE '%"_id":"<teamId>"%' ESCAPE '\\' OR (viewableBy = 'teams' AND
+    viewableId = :teamId)`; the port filters `viewIn` with `jsonDecode` (more
+    precise than a `LIKE`, so not an escaping bug) but **drops the
+    `viewableBy`/`viewableId` arm** and **adds a `docType = 'message'` filter
+    Kotlin does not have**. A server-authored team post carrying
+    `viewableBy`/`viewableId` and no `viewIn` array is invisible in the port's
+    team voices. Not this lane's files.
+12. **`CourseProgressDao.getByIds` matches `couchId` as well as `id`,** where
    Kotlin's is `WHERE id IN (:ids)` only. It is not a defect — the port stores
    `id: base?.id ?? docId`, so a locally-authored row keeps its local id and
    carries the server id in `couchId`, and the sync-in look-up needs the second

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1026,7 +1026,9 @@ class UserDao extends DatabaseAccessor<AppDatabase> with _$UserDaoMixin {
 
 /// Port of `ResourcesRepositoryImpl.userIdPattern` (`:64-70`) — a user id as
 /// the `LIKE` pattern that finds it inside the serialized JSON list
-/// `my_library.user_id` holds.
+/// `my_library.user_id` holds. `CoursesRepositoryImpl.userIdPattern`
+/// (`:94-100`) is character-for-character the same function over
+/// `courses.user_id`, so both tables share this one.
 ///
 /// The three replacements are in the Kotlin's order, and the order matters:
 /// escaping `\` first means the backslashes this function itself introduces
@@ -1043,6 +1045,28 @@ String likeEscapedUserPattern(String userId) {
       .replaceAll('_', '\\_');
   return '%"$escaped"%';
 }
+
+/// Shelf membership: `user_id LIKE '%"<id>"%' ESCAPE '\'`, the predicate
+/// behind `MyLibraryDao.getForUserPattern` (`MyLibraryDao.kt:103`) and
+/// `CourseDao.getForUserPattern` (`CourseDao.kt:17`).
+///
+/// The `ESCAPE` clause is the whole point, and it is why this is a function
+/// rather than an inline `like()`. Five call sites interpolated the raw id
+/// into the pattern, which leaves LIKE's own metacharacters live: `_` matches
+/// any single character, so a shelf query for `u_1` also returned `ux1`'s
+/// rows — and the catalog arm, which is the same predicate negated, dropped
+/// them from the catalog at the same time, so the resource went missing from
+/// both views. `%` is worse: it matches any run, so one id could claim
+/// almost every shelf. Kotlin escapes at every one of these sites; the port
+/// escaped at exactly one, the count added in Phase 131.
+///
+/// [likeEscapedUserPattern] escapes the id and drift's `escapeChar` writes
+/// the matching `ESCAPE` clause, binding the pattern as a variable rather
+/// than splicing it into the SQL.
+Expression<bool> _shelfMembership(
+  GeneratedColumn<String> userIdColumn,
+  String userId,
+) => userIdColumn.like(likeEscapedUserPattern(userId), escapeChar: r'\');
 
 /// Port of `data/room/dao/MyLibraryDao.kt`.
 @DriftAccessor(tables: [MyLibraryTable])
@@ -1105,13 +1129,14 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
 
     if (myLibrary && shelfUserId != null && shelfUserId.isNotEmpty) {
       // `getMyLibrary` — the user's shelf, private team resources included.
-      statement.where((r) => r.userId.like('%"$shelfUserId"%'));
+      statement.where((r) => _shelfMembership(r.userId, shelfUserId));
     } else {
       // `getPublic` / `getPublicNotUserPattern` — the catalog.
       statement.where((r) => r.isPrivate.equals(false));
       if (shelfUserId != null && shelfUserId.isNotEmpty) {
         statement.where(
-          (r) => r.userId.isNull() | r.userId.like('%"$shelfUserId"%').not(),
+          (r) =>
+              r.userId.isNull() | _shelfMembership(r.userId, shelfUserId).not(),
         );
       }
     }
@@ -1131,7 +1156,7 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   /// query stream for a single value.
   Future<List<MyLibraryRow>> resourcesOnShelf(String userId) => (select(
     myLibraryTable,
-  )..where((r) => r.userId.like('%"$userId"%'))).get();
+  )..where((r) => _shelfMembership(r.userId, userId))).get();
 
   /// Port of `MyLibraryDao.countPublicNeedingUpdateForUserPattern`
   /// (`MyLibraryDao.kt:119-124`) — how many of the user's shelf resources are
@@ -1168,10 +1193,13 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   /// with `!=` it would be SQL NULL, hence false, and those rows would vanish
   /// from the count.
   ///
-  /// Raw SQL rather than the query builder for one reason: drift's `like()`
-  /// takes no `ESCAPE`, and the Kotlin pattern is escaped
-  /// ([likeEscapedUserPattern]). Keeping the statement verbatim also lets it be
-  /// read side by side with the `@Query` it ports.
+  /// Raw SQL rather than the query builder so the statement can be read side
+  /// by side with the `@Query` it ports — `IS NOT` in particular has no
+  /// query-builder spelling. The original reason given here was that "drift's
+  /// `like()` takes no `ESCAPE`", which is not true: it takes an `escapeChar`
+  /// and binds the pattern as a variable, which is how the five shelf
+  /// predicates escape theirs ([_shelfMembership]). The rationale is corrected
+  /// rather than the code, because the `IS NOT` reason stands on its own.
   Stream<int> watchResourcesNeedingUpdateCount(String userId) => customSelect(
     'SELECT COUNT(*) AS c FROM my_library '
     'WHERE is_private = 0 '
@@ -1420,7 +1448,7 @@ class CourseDao extends DatabaseAccessor<AppDatabase> with _$CourseDaoMixin {
       statement.where((c) => c.courseTitleNormal.like('%$trimmed%'));
     }
     if (shelfUserId != null && shelfUserId.isNotEmpty) {
-      statement.where((c) => c.userId.like('%"$shelfUserId"%'));
+      statement.where((c) => _shelfMembership(c.userId, shelfUserId));
     }
     if (gradeLevel != null && gradeLevel.isNotEmpty) {
       statement.where((c) => c.gradeLevel.equals(gradeLevel));
@@ -1476,7 +1504,7 @@ class CourseDao extends DatabaseAccessor<AppDatabase> with _$CourseDaoMixin {
 
   /// The user's shelf, read once — see [MyLibraryDao.resourcesOnShelf].
   Future<List<CourseRow>> coursesOnShelf(String userId) =>
-      (select(courses)..where((c) => c.userId.like('%"$userId"%'))).get();
+      (select(courses)..where((c) => _shelfMembership(c.userId, userId))).get();
 
   /// Port of `CoursesRepositoryImpl.isMyCourse`.
   Future<bool> isMyCourse(String courseId, String userId) async {

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -3402,6 +3402,16 @@ class CourseProgressDao extends DatabaseAccessor<AppDatabase>
     with _$CourseProgressDaoMixin {
   CourseProgressDao(super.db);
 
+  /// The four user-scoped reads below are `userId IS :userId` in the Kotlin
+  /// DAO (`CourseProgressDao.kt:10-20`), not `=`. The port had them as
+  /// `equals(userId ?? '')`, which coerces a null argument into the empty
+  /// string: it then matched rows whose `userId` is literally `''` and no row
+  /// whose `userId` is NULL — where Kotlin matches exactly the NULL rows. A
+  /// synced document that omits `userId` writes one of those NULL rows
+  /// (`CourseProgressMapper.fromDoc` passes `getStringOrNull`), so the two
+  /// apps disagreed about which rows a null-user query returns.
+  /// `equalsNullable` is drift's spelling of `IS`: `IS NULL` for a null
+  /// argument, `=` otherwise.
   Future<List<CourseProgressRow>> getByUserAndCourseIds(
     String? userId,
     List<String> courseIds,
@@ -3409,8 +3419,9 @@ class CourseProgressDao extends DatabaseAccessor<AppDatabase>
     if (courseIds.isEmpty) return const [];
     final rows = <CourseProgressRow>[];
     for (final chunk in _chunked(courseIds, _sqliteVariableChunk)) {
-      final stmt = select(courseProgress)
-        ..where((r) => r.userId.equals(userId ?? '') & r.courseId.isIn(chunk));
+      final stmt = select(
+        courseProgress,
+      )..where((r) => r.userId.equalsNullable(userId) & r.courseId.isIn(chunk));
       rows.addAll(await stmt.get());
     }
     return rows;
@@ -3422,14 +3433,14 @@ class CourseProgressDao extends DatabaseAccessor<AppDatabase>
   ) =>
       (select(courseProgress)..where(
             (r) =>
-                r.userId.equals(userId ?? '') &
-                r.courseId.equals(courseId ?? ''),
+                r.userId.equalsNullable(userId) &
+                r.courseId.equalsNullable(courseId),
           ))
           .get();
 
   Future<List<CourseProgressRow>> getByUser(String? userId) => (select(
     courseProgress,
-  )..where((r) => r.userId.equals(userId ?? ''))).get();
+  )..where((r) => r.userId.equalsNullable(userId))).get();
 
   Future<CourseProgressRow?> findByCourseUserAndStep(
     String? courseId,
@@ -3439,8 +3450,8 @@ class CourseProgressDao extends DatabaseAccessor<AppDatabase>
       (select(courseProgress)
             ..where(
               (r) =>
-                  r.courseId.equals(courseId ?? '') &
-                  r.userId.equals(userId ?? '') &
+                  r.courseId.equalsNullable(courseId) &
+                  r.userId.equalsNullable(userId) &
                   r.stepNum.equals(stepNum),
             )
             ..limit(1))
@@ -3505,16 +3516,33 @@ class CourseProgressDao extends DatabaseAccessor<AppDatabase>
         CourseProgressCompanion(couchId: Value(remoteId), rev: Value(rev)),
       );
 
-  /// Port of `CourseProgressDao.updatePassedByCourseAndStep`. Used by the exam
-  /// path (`CoursesRepository.updateCourseProgress`) to flip the `passed` flag
-  /// for every user who reached a step, since an exam result is not per-user.
+  /// Port of `CourseProgressDao.updatePassedByCourseAndStep`
+  /// (`CourseProgressDao.kt:34-35`) — the exam path's write, reached from
+  /// `ProgressRepository.updateCourseProgress`.
+  ///
+  /// `AND userId IS :userId` is upstream `ed5609f` (fixes #16695). Without it
+  /// the update hit **every** row on `(courseId, stepNum)` whatever its owner,
+  /// so on a shared handset one learner finishing an exam rewrote another
+  /// learner's flag for that step. The direction that actually bites is the
+  /// clearing one: the value written here is `sub?.status == "graded"`, which
+  /// no local writer can make true (see [ProgressRepository
+  /// .updateCourseProgress]), so the unscoped statement wrote `passed = 0`
+  /// over a peer's server-granted pass and un-completed their course.
+  ///
+  /// [userId] is nullable with `IS` semantics, exactly as the `@Query` has it:
+  /// a null argument matches the rows whose `userId` is NULL rather than
+  /// matching nothing.
   Future<int> updatePassedByCourseAndStep(
     String courseId,
     int stepNum,
     bool passed,
+    String? userId,
   ) =>
       (update(courseProgress)..where(
-            (r) => r.courseId.equals(courseId) & r.stepNum.equals(stepNum),
+            (r) =>
+                r.courseId.equals(courseId) &
+                r.stepNum.equals(stepNum) &
+                r.userId.equalsNullable(userId),
           ))
           .write(CourseProgressCompanion(passed: Value(passed)));
 

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1063,6 +1063,33 @@ String likeEscapedUserPattern(String userId) {
 /// [likeEscapedUserPattern] escapes the id and drift's `escapeChar` writes
 /// the matching `ESCAPE` clause, binding the pattern as a variable rather
 /// than splicing it into the SQL.
+/// A `LIKE '%<text>%'` that matches [text] **literally**, escaping LIKE's own
+/// metacharacters.
+///
+/// Kotlin's course search is not a `LIKE` at all: `CourseDao` carries no title
+/// query and `CoursesRepositoryImpl.filterCourses` (`:304`) filters in memory
+/// with `courseTitle?.contains(searchText, ignoreCase = true)`. `contains` is
+/// a literal substring test, so a learner typing `intro_a` in Kotlin matches
+/// only a course actually containing `intro_a`. The port pushed the filter
+/// into SQL and, unescaped, `_` became "any character" and `%` "anything at
+/// all" — so `intro_a` also matched `IntroXA`, and a lone `%` matched every
+/// course. This is the one site in the class where the port *invented* the
+/// `LIKE`, which is why matching Kotlin means escaping rather than copying an
+/// unescaped pattern.
+Expression<bool> _literalContains(
+  GeneratedColumn<String> column,
+  String text,
+) => column.like(likeEscapedLiteral(text), escapeChar: r'\');
+
+/// The escape half of [_literalContains], exposed for tests.
+String likeEscapedLiteral(String text) {
+  final escaped = text
+      .replaceAll('\\', '\\\\')
+      .replaceAll('%', '\\%')
+      .replaceAll('_', '\\_');
+  return '%$escaped%';
+}
+
 Expression<bool> _shelfMembership(
   GeneratedColumn<String> userIdColumn,
   String userId,
@@ -1445,7 +1472,7 @@ class CourseDao extends DatabaseAccessor<AppDatabase> with _$CourseDaoMixin {
 
     final trimmed = query?.trim().toLowerCase();
     if (trimmed != null && trimmed.isNotEmpty) {
-      statement.where((c) => c.courseTitleNormal.like('%$trimmed%'));
+      statement.where((c) => _literalContains(c.courseTitleNormal, trimmed));
     }
     if (shelfUserId != null && shelfUserId.isNotEmpty) {
       statement.where((c) => _shelfMembership(c.userId, shelfUserId));
@@ -3406,10 +3433,16 @@ class CourseProgressDao extends DatabaseAccessor<AppDatabase>
   /// DAO (`CourseProgressDao.kt:10-20`), not `=`. The port had them as
   /// `equals(userId ?? '')`, which coerces a null argument into the empty
   /// string: it then matched rows whose `userId` is literally `''` and no row
-  /// whose `userId` is NULL — where Kotlin matches exactly the NULL rows. A
-  /// synced document that omits `userId` writes one of those NULL rows
-  /// (`CourseProgressMapper.fromDoc` passes `getStringOrNull`), so the two
-  /// apps disagreed about which rows a null-user query returns.
+  /// whose `userId` is NULL — where Kotlin matches exactly the NULL rows.
+  /// `ProgressRepositoryImpl.saveCourseProgress` (`:234`) writes NULL for a
+  /// null argument, so those rows exist.
+  ///
+  /// Not to be justified by the *synced* case, which is where this comment
+  /// first pointed: a document omitting `userId` gives the port NULL
+  /// (`CourseProgressMapper.fromDoc` passes `getStringOrNull`) but gives
+  /// Kotlin `''` (`ProgressRepositoryImpl.kt:260` uses `JsonUtils.getString`),
+  /// so on that input `IS` makes the port *diverge* until the mapper is
+  /// aligned. Recorded in `PHASE_135_NOTES.md`.
   /// `equalsNullable` is drift's spelling of `IS`: `IS NULL` for a null
   /// argument, `=` otherwise.
   Future<List<CourseProgressRow>> getByUserAndCourseIds(

--- a/flutter/lib/repository/progress_repository.dart
+++ b/flutter/lib/repository/progress_repository.dart
@@ -418,45 +418,61 @@ class ProgressRepository {
     );
   }
 
-  /// Port of `CoursesRepositoryImpl.updateCourseProgress`.
+  /// Port of `CoursesRepositoryImpl.updateCourseProgress` (`:521-524`), the
+  /// write `BaseExamFragment.continueExam` makes when the learner answers the
+  /// last question of a step exam.
   ///
-  /// Flips `passed` to [passed] for every user's row on `(courseId, stepNum)`,
-  /// matching the Kotlin `updatePassedByCourseAndStep`. An exam result is not
-  /// per-user, so the row the take-course screen created for the current user
-  /// is updated in place; a row that does not exist yet (the exam was taken
-  /// before the step was opened) is created keyed by the current user.
+  /// **Scoped to [userId]** since upstream `ed5609f`. The old rationale here
+  /// read "an exam result is not per-user", and upstream has contradicted it:
+  /// the statement is `WHERE courseId = ? AND stepNum = ? AND userId IS ?`,
+  /// so it rewrites the taker's row and nobody else's.
+  ///
+  /// **What [passed] is actually worth knowing.** Kotlin passes
+  /// `sub?.status == "graded"` (`BaseExamFragment.kt:133`) — and `"graded"` is
+  /// a status no local writer in either app produces. `saveExamAnswer` writes
+  /// `pending`, `complete` or `requires grading`; the exam branch of
+  /// `startExamSession` always recreates the attempt, so the submission the
+  /// comparison reads is always freshly `pending`; and only the server ever
+  /// sends `graded`. So finishing an exam writes `passed = false`, in both
+  /// apps: **no local action grades an exam step.** (Kotlin can reach a
+  /// server-sent `graded` on one other path — `BaseExamFragment.kt:88` loads a
+  /// my-surveys submission by id with no status filter — but that path carries
+  /// no `stepNum`, so its update matches nothing. It does not reach the exam
+  /// screen, whose attempt is always recreated.) A step exam becomes passed
+  /// through the `courses_progress` pull instead
+  /// ([insertCourseProgressFromSync], whose merge adopts a server `true`),
+  /// which is Planet's grading arriving. Do not "fix" this to `true` — that
+  /// would complete a course the server has not graded.
+  ///
+  /// Which makes the *clearing* direction the one `ed5609f` matters for: on a
+  /// shared handset the unscoped statement wrote that `false` over a peer's
+  /// server-granted pass, un-completing their course. Note the commit does
+  /// **not** close the self case, and that quirk is ported rather than fixed:
+  /// retaking a step exam whose server-granted pass has already synced in
+  /// resets the taker's own flag and darkens their completed-course star until
+  /// Planet grades the new attempt.
+  ///
+  /// There is deliberately **no insert** when no row matches. Kotlin runs the
+  /// `UPDATE` and nothing else, and the port's extra insert was both an
+  /// invention and unsafe once this method had a caller: its row id was
+  /// `'${courseId}_$stepNum'` with no user in it, so a second learner on the
+  /// same handset would have overwritten the first learner's whole row on the
+  /// primary key. A missing row also means the learner never opened the step,
+  /// and `getCurrentProgress` counts rows *ignoring* `passed` — so inserting
+  /// one would have reported a step as reached that never was.
   Future<void> updateCourseProgress({
     required String courseId,
     required int stepNum,
     required bool passed,
     String? userId,
-    String? parentCode,
   }) async {
-    await _progressDao.updatePassedByCourseAndStep(courseId, stepNum, passed);
-    if (userId != null && userId.isNotEmpty) {
-      final existing = await _progressDao.findByCourseUserAndStep(
-        courseId,
-        userId,
-        stepNum,
-      );
-      if (existing == null) {
-        final now = DateTime.now().millisecondsSinceEpoch;
-        await _progressDao.upsert(
-          CourseProgressCompanion.insert(
-            id: '${courseId}_$stepNum',
-            couchId: const Value(null),
-            createdOn: Value(parentCode),
-            createdDate: Value(now),
-            updatedDate: Value(now),
-            stepNum: Value(stepNum),
-            passed: Value(passed),
-            userId: Value(userId),
-            courseId: Value(courseId),
-            parentCode: Value(parentCode),
-          ),
-        );
-      }
-    }
+    if (courseId.isEmpty) return;
+    await _progressDao.updatePassedByCourseAndStep(
+      courseId,
+      stepNum,
+      passed,
+      userId,
+    );
   }
 
   /// Port of `ProgressRepositoryImpl.insertCourseProgressFromSync`.

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -168,7 +168,7 @@ class _CourseContent extends ConsumerWidget {
     );
   }
 
-  /// Port of `CourseStepFragment.saveCourseProgress` — landing on a step
+  /// Port of `CourseStepFragment.launchSaveCourseProgress` — landing on a step
   /// records a `course_progress` row and queues it for upload. The row is keyed
   /// by `(courseId, userId, stepNum)`, so a re-visit upserts in place rather
   /// than creating duplicates.

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -107,7 +107,7 @@ class _TakeCourseScreenState extends ConsumerState<TakeCourseScreen> {
   }
 }
 
-class _CourseContent extends ConsumerWidget {
+class _CourseContent extends ConsumerStatefulWidget {
   const _CourseContent({
     required this.course,
     required this.steps,
@@ -125,12 +125,93 @@ class _CourseContent extends ConsumerWidget {
   final VoidCallback onCourseUpdated;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final isMyCourse = userId != null && course.userId.contains(userId!);
+  ConsumerState<_CourseContent> createState() => _CourseContentState();
+}
 
+class _CourseContentState extends ConsumerState<_CourseContent> {
+  /// The step index whose `course_progress` row has already been recorded for
+  /// this mount, so a rebuild is not a re-visit.
+  int? _recordedStep;
+
+  /// **Stateful for one reason: the step the learner *lands on* has to be
+  /// recorded, and a page-change callback never fires for it.**
+  ///
+  /// Kotlin records the row twice over, neither requiring a page change:
+  /// `CourseStepFragment.onViewCreated` runs `launchSaveCourseProgress()`
+  /// inside `withResumed` (`:168-172`), and `setMenuVisibility` runs it again
+  /// when the pager brings a step into view (`:262-268`). Both are gated on
+  /// `userHasCourse`, which is `isMyCourse(userId, step.courseId)`.
+  ///
+  /// The port drove `_recordProgress` from `goToStep` alone —
+  /// `PageView.onPageChanged` plus the Previous/Next buttons — and
+  /// `onPageChanged` does not fire for the initial page. Kotlin's pager has a
+  /// course-cover page at position 0, so its first *step* is always arrived
+  /// at; this `PageView` opens directly on step 1. Nothing recorded step 1
+  /// until the learner navigated away and back, which made three readers wrong
+  /// (`getCurrentProgress` and `courseProgressSummary` under-report by one
+  /// step, `completedCourseIds` cannot see the step at all) and meant a
+  /// **one-step course could never complete**, since the write that would pass
+  /// its only step never ran. It also silently no-op'd the exam-finish write
+  /// this phase added, whose `UPDATE` needs the row to exist.
+  @override
+  void initState() {
+    super.initState();
+    _recordCurrentStep();
+  }
+
+  /// Unconditional, not gated on `currentStep` having changed, and that is
+  /// load-bearing. `userId` comes from the parent's
+  /// `ref.watch(sessionProvider).valueOrNull?.id`, so it is **null on the
+  /// first frame** — `_isMyCourse` is false, `initState`'s attempt bails, and
+  /// the rebuild that carries the resolved session does not change
+  /// `currentStep`. A `currentStep`-only gate therefore recorded nothing at
+  /// all, which is how the first cut of this fix still failed its own test.
+  /// [_recordCurrentStep] is idempotent instead: it sets `_recordedStep` only
+  /// *after* the membership gate passes, so a bail leaves the attempt to be
+  /// retried on the next rebuild.
+  @override
+  void didUpdateWidget(_CourseContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _recordCurrentStep();
+  }
+
+  // The methods below this class's `build` were written against
+  // `_CourseContent`'s own fields; these keep them reading the same way now
+  // that the fields live on `widget`.
+  CourseRow get course => widget.course;
+  List<CourseStepRow> get steps => widget.steps;
+  String? get userId => widget.userId;
+  VoidCallback get onCourseUpdated => widget.onCourseUpdated;
+
+  bool get _isMyCourse =>
+      widget.userId != null && widget.course.userId.contains(widget.userId!);
+
+  void _recordCurrentStep() {
+    // `userHasCourse` gates both Kotlin triggers: browsing a course you have
+    // not joined leaves no progress rows behind.
+    if (!_isMyCourse) return;
+    final index = widget.currentStep;
+    if (index < 0 || index >= widget.steps.length) return;
+    if (_recordedStep == index) return;
+    _recordedStep = index;
+    // After the frame, like `withResumed` — `initState` is too early to touch
+    // providers, and the row is not needed to draw anything.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _recordProgress(ref, index);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentStep = widget.currentStep;
+    final onStepChanged = widget.onStepChanged;
+    final isMyCourse = _isMyCourse;
+
+    // The recording moved to [_recordCurrentStep], which covers this and the
+    // step the screen opens on alike.
     void goToStep(int index) {
       onStepChanged(index);
-      _recordProgress(ref, index);
     }
 
     return Column(

--- a/flutter/lib/ui/exam/take_exam_screen.dart
+++ b/flutter/lib/ui/exam/take_exam_screen.dart
@@ -535,6 +535,15 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
       // must not be reported as a failed save. The photo and the queueing are
       // what need a user; the record does not.
       final user = await ref.read(sessionProvider.future);
+
+      // Ahead of the photo and the two outbox writes, because Kotlin's
+      // progress write goes out before any of that: `capturePhoto()`
+      // (`ExamTakingFragment.kt:655-663`) only *launches* the camera and
+      // returns, and Kotlin has no upload-queue step here at all. Awaiting
+      // this after a camera round trip made it skippable by the camera, by
+      // `queuePending`, and by an unmount in between.
+      await _recordExamProgress(submissionId, exam, user?.id);
+
       final config = ref.read(serverConfigProvider);
       if (user != null) {
         await _captureVerificationPhoto(submissionId, exam, user.id);
@@ -547,13 +556,6 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
               .queuePending(config: config);
         }
       }
-      // `BaseExamFragment.continueExam` records the step's course progress
-      // before it shows the thank-you dialog (`:133`), so this sits in the
-      // same place. It is inside this `try` with the photo and the upload
-      // queueing because it is bookkeeping of the same kind: the attempt is
-      // already on disk, and a failure here is reported the same way theirs
-      // is.
-      await _recordExamProgress(submissionId, exam, user?.id);
       if (!mounted) return;
       await _showResult();
     } catch (_) {
@@ -609,14 +611,20 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   /// defaults to 0 there, and `WHERE stepNum = 0` matches no row a course step
   /// ever wrote.
   ///
-  /// One asymmetry worth naming since a derivation now rests on it. Kotlin's
-  /// number is a position in an unordered read (`CourseStepDao` has no
-  /// `ORDER BY` and `CourseStep` no order column), so it is the document's
-  /// step order as first inserted — and an author who *reorders* a course's
-  /// steps leaves Kotlin's `stepNum`s stale, because `@Upsert` keeps the
-  /// rowids. The port rewrites `stepIndex` from the new position on every
-  /// pull, so it tracks the reorder. That is a pre-existing difference in the
-  /// port's favour, not something introduced here.
+  /// One asymmetry worth naming since a derivation now rests on it, and it
+  /// runs **against** the port rather than for it. Kotlin's step id is
+  /// content-derived — `Base64(stepElement.toString())`
+  /// (`CoursesRepositoryImpl.kt:681`) — so reordering a course changes no
+  /// step's id, `@Upsert` updates each row in place, and every existing
+  /// `course_progress.stepNum` still names the same step content; only
+  /// Kotlin's *rendered* order lags the author's intent, because its position
+  /// comes from an unordered read. The port's ids are position-derived
+  /// (`<courseId>:<index>`) and `stepIndex` is rewritten from the new position
+  /// on every pull, so a reorder re-binds each id to different content while
+  /// existing progress rows keep their old `stepNum` — a step the learner
+  /// passed can end up describing a different step. Pre-existing, not
+  /// introduced here, and not fixable without changing how step ids are
+  /// minted; recorded because this derivation now rests on it.
   Future<void> _recordExamProgress(
     String submissionId,
     ExamRow exam,
@@ -624,30 +632,56 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   ) async {
     final courseId = exam.courseId;
     if (courseId == null || courseId.isEmpty) return;
-    final stepNum = await _resolveStepNum(courseId);
-    if (stepNum == null) return;
 
-    // `sub?.status == "graded"`, read back from the row rather than assumed.
+    // Contained, because Kotlin's caller is fire-and-forget:
+    // `ExamTakingFragment.kt:846-850` is a bare `lifecycleScope.launch`, and
+    // `continueExam` builds its thank-you dialog on the very next statement,
+    // so a failure in here can neither suppress that dialog nor tell the
+    // learner anything. Awaited inside `_submitExam`'s own `try` it did both —
+    // a throw took the `examSubmitFailed` branch, so there was no dialog, no
+    // pop, and a learner told their exam failed to submit when the attempt was
+    // already `requires grading` on disk and already queued. They would then
+    // retake a recorded exam. The realistic trigger is not a database fault
+    // but using `ref` after dispose, which throws if the learner backs out
+    // during the awaited photo capture.
     //
-    // It cannot be true here, and the reason is the attempt's provenance, not
-    // the vocabulary: `startExamSession`'s exam branch recreates the
-    // submission, so the row this screen wrote is `pending` and then
-    // `requires grading`. A `graded` status exists only on a submission the
-    // server sent, and Kotlin can reach one of those on a *different* path
-    // (`BaseExamFragment.kt:88` loads a my-surveys submission by id with no
-    // status filter) — inert there only because that path carries no
-    // `stepNum`. Reading the row keeps this tracking the status rather than
-    // hard-coding a verdict that holds for one path's reason.
-    final attempt = await ref.read(submissionDaoProvider).getById(submissionId);
+    // Swallowed rather than surfaced, deliberately and against this project's
+    // usual rule about silent failure: there is nothing the learner can do,
+    // the attempt is safe either way, the row is rewritten by the next
+    // `courses_progress` sync, and `lib/` has no logging seam to route it to.
+    try {
+      final stepNum = await _resolveStepNum(courseId);
+      if (stepNum == null) return;
 
-    await ref
-        .read(progressRepositoryProvider)
-        .updateCourseProgress(
-          courseId: courseId,
-          stepNum: stepNum,
-          passed: attempt?.status == 'graded',
-          userId: userId,
-        );
+      // `sub?.status == "graded"`, read back from the row rather than assumed.
+      //
+      // It cannot be true here, and the reason is the attempt's provenance,
+      // not the vocabulary: `startExamSession`'s exam branch recreates the
+      // submission, so the row this screen wrote is `pending` and then
+      // `requires grading`. A `graded` status exists only on a submission the
+      // server sent, and Kotlin can reach one of those through a different
+      // route into the same fragment (`BaseExamFragment.kt:88` loads a
+      // my-surveys submission by id with no status filter) — inert there only
+      // because that route carries no `stepNum`. Reading the row keeps this
+      // tracking the status rather than hard-coding a verdict that holds for
+      // one route's reason. Note Kotlin does *not* track it: its `sub` is the
+      // object captured at session start and never refreshed, so a
+      // `submissions` sync landing mid-exam would move this and not Kotlin.
+      final attempt = await ref
+          .read(submissionDaoProvider)
+          .getById(submissionId);
+
+      await ref
+          .read(progressRepositoryProvider)
+          .updateCourseProgress(
+            courseId: courseId,
+            stepNum: stepNum,
+            passed: attempt?.status == 'graded',
+            userId: userId,
+          );
+    } catch (_) {
+      // See above: the attempt is already recorded and already queued.
+    }
   }
 
   Future<int?> _resolveStepNum(String courseId) async {

--- a/flutter/lib/ui/exam/take_exam_screen.dart
+++ b/flutter/lib/ui/exam/take_exam_screen.dart
@@ -547,6 +547,13 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
               .queuePending(config: config);
         }
       }
+      // `BaseExamFragment.continueExam` records the step's course progress
+      // before it shows the thank-you dialog (`:133`), so this sits in the
+      // same place. It is inside this `try` with the photo and the upload
+      // queueing because it is bookkeeping of the same kind: the attempt is
+      // already on disk, and a failure here is reported the same way theirs
+      // is.
+      await _recordExamProgress(submissionId, exam, user?.id);
       if (!mounted) return;
       await _showResult();
     } catch (_) {
@@ -556,6 +563,99 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
       return;
     }
     if (mounted) setState(() => _isSubmitting = false);
+  }
+
+  /// Port of the `saveCourseProgress(exam?.courseId, stepNumber,
+  /// sub?.status == "graded", user?.id)` call in
+  /// `BaseExamFragment.continueExam` (`:133`) — reached, as here, once the
+  /// learner has answered the last question.
+  ///
+  /// **This call had no counterpart at all.** `ProgressRepository
+  /// .updateCourseProgress` was ported and then never called from anywhere in
+  /// `lib/` or `test/` — the "a Dart writer already sitting uncalled" shape
+  /// Phase 119 named. What it costs is narrower than it looks, and worth
+  /// stating precisely, because the missing caller reads like a
+  /// course-breaking bug: on this path the value written is always `false`, so
+  /// an exam step is left unpassed by *both* apps and only Planet's own
+  /// grading — arriving through the `courses_progress` pull — completes such a
+  /// course. The behaviour the port was missing is therefore the *clearing*
+  /// one: re-taking an exam after the server granted a pass resets the flag.
+  /// That quirk survives `ed5609f` for the taker's own row and is ported here
+  /// deliberately; what the commit removes is the reset landing on *other*
+  /// learners' rows on a shared handset.
+  ///
+  /// [ProgressRepository.updateCourseProgress] carries the whole argument.
+  ///
+  /// `courseId` is the **exam document's**, not the navigation argument's:
+  /// Kotlin passes `exam?.courseId` (`BaseExamFragment.kt:133`) and never
+  /// consults the fragment's own arguments here. Both port entry points build
+  /// their query string as `courseId=${step.courseId ?? ''}` against a
+  /// nullable column, so `widget.courseId` can be the empty string — reading
+  /// the exam avoids inheriting that.
+  ///
+  /// `stepNum` is derived rather than passed. Kotlin threads it through the
+  /// fragment arguments (`CourseStepFragment.kt:280` forwards the
+  /// `stepNumber` that `CoursesPagerAdapter.kt:49` set to the pager position,
+  /// where page 0 is the course cover — so step *i* carries *i+1*). This route
+  /// carries `stepId` and not `stepNum`, and the same 1-based number falls out
+  /// of the step's position in `CourseDao.getSteps`, which is the *same*
+  /// ordering `take_course_screen._recordProgress` counts to write
+  /// `stepNum: index + 1`. Both halves of the pair therefore agree by
+  /// construction rather than by two independent conventions.
+  ///
+  /// An unresolvable step (no `stepId`, an empty `courseId`, or a `stepId` the
+  /// course does not list) skips the write rather than writing `stepNum: 0`.
+  /// Kotlin reaches the same outcome by a different route: `stepNumber`
+  /// defaults to 0 there, and `WHERE stepNum = 0` matches no row a course step
+  /// ever wrote.
+  ///
+  /// One asymmetry worth naming since a derivation now rests on it. Kotlin's
+  /// number is a position in an unordered read (`CourseStepDao` has no
+  /// `ORDER BY` and `CourseStep` no order column), so it is the document's
+  /// step order as first inserted — and an author who *reorders* a course's
+  /// steps leaves Kotlin's `stepNum`s stale, because `@Upsert` keeps the
+  /// rowids. The port rewrites `stepIndex` from the new position on every
+  /// pull, so it tracks the reorder. That is a pre-existing difference in the
+  /// port's favour, not something introduced here.
+  Future<void> _recordExamProgress(
+    String submissionId,
+    ExamRow exam,
+    String? userId,
+  ) async {
+    final courseId = exam.courseId;
+    if (courseId == null || courseId.isEmpty) return;
+    final stepNum = await _resolveStepNum(courseId);
+    if (stepNum == null) return;
+
+    // `sub?.status == "graded"`, read back from the row rather than assumed.
+    //
+    // It cannot be true here, and the reason is the attempt's provenance, not
+    // the vocabulary: `startExamSession`'s exam branch recreates the
+    // submission, so the row this screen wrote is `pending` and then
+    // `requires grading`. A `graded` status exists only on a submission the
+    // server sent, and Kotlin can reach one of those on a *different* path
+    // (`BaseExamFragment.kt:88` loads a my-surveys submission by id with no
+    // status filter) — inert there only because that path carries no
+    // `stepNum`. Reading the row keeps this tracking the status rather than
+    // hard-coding a verdict that holds for one path's reason.
+    final attempt = await ref.read(submissionDaoProvider).getById(submissionId);
+
+    await ref
+        .read(progressRepositoryProvider)
+        .updateCourseProgress(
+          courseId: courseId,
+          stepNum: stepNum,
+          passed: attempt?.status == 'graded',
+          userId: userId,
+        );
+  }
+
+  Future<int?> _resolveStepNum(String courseId) async {
+    final stepId = widget.stepId;
+    if (stepId == null || stepId.isEmpty) return null;
+    final steps = await ref.read(courseDaoProvider).getSteps(courseId);
+    final index = steps.indexWhere((step) => step.id == stepId);
+    return index < 0 ? null : index + 1;
   }
 
   /// Captures a verification photo for a certified course exam, the port of

--- a/flutter/test/data/local/like_pattern_escaping_test.dart
+++ b/flutter/test/data/local/like_pattern_escaping_test.dart
@@ -90,6 +90,28 @@ void main() {
       },
     );
 
+    test('the catalog arm keeps its AND/OR grouping', () async {
+      // Kotlin is `isPrivate = 0 AND (userId IS NULL OR userId NOT LIKE …)`
+      // (`MyLibraryDao.kt:126-130`). Flattened to
+      // `isPrivate = 0 AND isNull OR NOT LIKE`, a *private* resource nobody
+      // put on this user's shelf would satisfy the trailing `OR` on its own
+      // and leak into the catalog. Escaping the pattern rewrote this
+      // expression, so the grouping is pinned rather than assumed.
+      await resource(
+        'private-other',
+        userId: const [collider],
+        isPrivate: true,
+      );
+      await resource('public-other', userId: const [collider]);
+      await resource('mine', userId: const [escaped]);
+
+      final rows = await db.myLibraryDao
+          .watchResources(shelfUserId: escaped)
+          .first;
+
+      expect(rows.map((r) => r.id), ['public-other']);
+    });
+
     test('resourcesOnShelf does not leak a colliding shelf', () async {
       await seedResources();
 

--- a/flutter/test/data/local/like_pattern_escaping_test.dart
+++ b/flutter/test/data/local/like_pattern_escaping_test.dart
@@ -43,15 +43,19 @@ void main() {
     ),
   ]);
 
-  Future<void> course(String id, {required List<String> userId}) =>
-      db.courseDao.upsertAll([
-        CoursesCompanion.insert(
-          id: id,
-          userId: Value(userId),
-          courseTitle: Value(id),
-          courseTitleNormal: Value(id),
-        ),
-      ], const []);
+  Future<void> course(
+    String id, {
+    required List<String> userId,
+    String? title,
+  }) => db.courseDao.upsertAll([
+    CoursesCompanion.insert(
+      id: id,
+      userId: Value(userId),
+      courseTitle: Value(title ?? id),
+      // `CourseMapper` writes the diacritic-folded, lowercased title here.
+      courseTitleNormal: Value((title ?? id).toLowerCase()),
+    ),
+  ], const []);
 
   Future<void> seedResources() async {
     await resource('mine', userId: const [escaped]);
@@ -128,6 +132,37 @@ void main() {
       expect((await db.myLibraryDao.resourcesOnShelf('a%')).map((r) => r.id), [
         'mine',
       ]);
+    });
+  });
+
+  group('the course title search', () {
+    // Kotlin's course search is not a `LIKE` at all: `CourseDao` has no title
+    // query and `CoursesRepositoryImpl.filterCourses` (`:304`) filters in
+    // memory with `courseTitle?.contains(searchText, ignoreCase = true)` — a
+    // literal substring test. The port pushed the filter into SQL, so it is
+    // the one site in this class where the port *invented* the `LIKE` and
+    // matching Kotlin means escaping rather than copying an unescaped pattern.
+    setUp(() async {
+      await course('underscore', userId: const [escaped], title: 'Intro_A');
+      await course('collider', userId: const [escaped], title: 'IntroXA');
+    });
+
+    Future<Iterable<String>> search(String query) async =>
+        (await db.courseDao.watchCourses(query: query).first).map((c) => c.id);
+
+    test(
+      'an underscore in the query is literal, as Kotlin\'s contains is',
+      () async {
+        expect(await search('intro_a'), ['underscore']);
+      },
+    );
+
+    test('a bare percent matches nothing rather than everything', () async {
+      expect(await search('%'), isEmpty);
+    });
+
+    test('an ordinary query still matches', () async {
+      expect((await search('intro')).length, 2);
     });
   });
 

--- a/flutter/test/data/local/like_pattern_escaping_test.dart
+++ b/flutter/test/data/local/like_pattern_escaping_test.dart
@@ -1,0 +1,138 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+
+/// The five shelf-membership `LIKE` predicates, one test per call site.
+///
+/// `my_library.user_id` and `courses.user_id` hold a JSON list, and shelf
+/// membership is the substring `"<userId>"` inside it. The Kotlin builds that
+/// pattern through `ResourcesRepositoryImpl.userIdPattern` (`:64-70`) and
+/// `CoursesRepositoryImpl.userIdPattern`, which escape `\`, `%` and `_` and
+/// pair the pattern with `ESCAPE '\'`. Interpolating the raw id instead leaves
+/// LIKE's own metacharacters live:
+///
+/// * `_` matches **any single character**, so `u_1` also matches `ux1` — one
+///   learner's shelf leaking another's rows, and the catalog arm losing rows
+///   it should show;
+/// * `%` matches any run of characters, so `a%` matches almost everything.
+///
+/// The ids used here are deliberately minimal (`u_1` / `ux1`) so that a match
+/// can only come from the wildcard: they differ at exactly the escaped
+/// character and nowhere else.
+void main() {
+  late AppDatabase db;
+
+  /// The escaped user, and a *different* user whose id the unescaped pattern
+  /// `%"u_1"%` matches because `_` is a wildcard.
+  const escaped = 'u_1';
+  const collider = 'ux1';
+
+  setUp(() => db = AppDatabase.memory());
+  tearDown(() => db.close());
+
+  Future<void> resource(
+    String id, {
+    required List<String> userId,
+    bool isPrivate = false,
+  }) => db.myLibraryDao.upsertAll([
+    MyLibraryTableCompanion.insert(
+      id: id,
+      userId: Value(userId),
+      isPrivate: Value(isPrivate),
+      titleNormal: Value(id),
+    ),
+  ]);
+
+  Future<void> course(String id, {required List<String> userId}) =>
+      db.courseDao.upsertAll([
+        CoursesCompanion.insert(
+          id: id,
+          userId: Value(userId),
+          courseTitle: Value(id),
+          courseTitleNormal: Value(id),
+        ),
+      ], const []);
+
+  Future<void> seedResources() async {
+    await resource('mine', userId: const [escaped]);
+    await resource('theirs', userId: const [collider]);
+  }
+
+  Future<void> seedCourses() async {
+    await course('mine', userId: const [escaped]);
+    await course('theirs', userId: const [collider]);
+  }
+
+  group('MyLibraryDao', () {
+    test('watchResources shelf arm does not leak a colliding shelf', () async {
+      await seedResources();
+
+      final rows = await db.myLibraryDao
+          .watchResources(shelfUserId: escaped, myLibrary: true)
+          .first;
+
+      expect(rows.map((r) => r.id), ['mine']);
+    });
+
+    test(
+      'watchResources catalog arm excludes only the signed-in user',
+      () async {
+        await seedResources();
+
+        final rows = await db.myLibraryDao
+            .watchResources(shelfUserId: escaped)
+            .first;
+
+        // `theirs` is public and not on this user's shelf, so the catalog shows
+        // it. Under the unescaped pattern the `.not()` arm excluded it too, and
+        // the resource became invisible in both views at once.
+        expect(rows.map((r) => r.id), ['theirs']);
+      },
+    );
+
+    test('resourcesOnShelf does not leak a colliding shelf', () async {
+      await seedResources();
+
+      expect(
+        (await db.myLibraryDao.resourcesOnShelf(escaped)).map((r) => r.id),
+        ['mine'],
+      );
+    });
+
+    test('a `%` in the user id does not match every shelf', () async {
+      await resource('mine', userId: const ['a%']);
+      await resource('theirs', userId: const ['ab']);
+
+      expect((await db.myLibraryDao.resourcesOnShelf('a%')).map((r) => r.id), [
+        'mine',
+      ]);
+    });
+  });
+
+  group('CourseDao', () {
+    test('watchCourses does not leak a colliding shelf', () async {
+      await seedCourses();
+
+      final rows = await db.courseDao.watchCourses(shelfUserId: escaped).first;
+
+      expect(rows.map((c) => c.id), ['mine']);
+    });
+
+    test('coursesOnShelf does not leak a colliding shelf', () async {
+      await seedCourses();
+
+      expect((await db.courseDao.coursesOnShelf(escaped)).map((c) => c.id), [
+        'mine',
+      ]);
+    });
+
+    test('a `%` in the user id does not match every shelf', () async {
+      await course('mine', userId: const ['a%']);
+      await course('theirs', userId: const ['ab']);
+
+      expect((await db.courseDao.coursesOnShelf('a%')).map((c) => c.id), [
+        'mine',
+      ]);
+    });
+  });
+}

--- a/flutter/test/repository/exam_progress_user_scoping_test.dart
+++ b/flutter/test/repository/exam_progress_user_scoping_test.dart
@@ -1,0 +1,294 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/progress_repository.dart';
+
+class _MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Port of `ed5609f` ("courses: smoother repository base exam progress user
+/// scoping", fixes #16695): `CourseProgressDao.updatePassedByCourseAndStep`
+/// gains `AND userId IS :userId`, and `CoursesRepositoryImpl
+/// .updateCourseProgress` threads the exam-taker's id into it.
+///
+/// The second group settles a claim rather than a defect — see the group's own
+/// comment.
+void main() {
+  late AppDatabase db;
+  late ProgressRepository repository;
+
+  setUp(() async {
+    db = AppDatabase.memory();
+    repository = ProgressRepository(
+      _MockPlanetApi(),
+      db.courseDao,
+      db.courseProgressDao,
+      db.examDao,
+      db.submissionDao,
+      db.certificationDao,
+    );
+  });
+
+  tearDown(() => db.close());
+
+  Future<void> seedCourse(
+    String courseId, {
+    required int stepCount,
+    List<String> shelfUserIds = const ['learner-a'],
+  }) => db.courseDao.upsertAll(
+    [
+      CoursesCompanion.insert(
+        id: courseId,
+        courseId: Value(courseId),
+        courseTitle: Value('Course $courseId'),
+        userId: Value(shelfUserIds),
+      ),
+    ],
+    [
+      for (var i = 0; i < stepCount; i++)
+        CourseStepsCompanion.insert(
+          id: '$courseId:$i',
+          courseId: Value(courseId),
+          stepIndex: Value(i),
+        ),
+    ],
+  );
+
+  Future<bool?> passedFor(String? userId, {int stepNum = 2}) async {
+    final row = await db.courseProgressDao.findByCourseUserAndStep(
+      'course-1',
+      userId,
+      stepNum,
+    );
+    return row?.passed;
+  }
+
+  group('updateCourseProgress is scoped to the exam-taker', () {
+    setUp(() async {
+      await seedCourse('course-1', stepCount: 3);
+      // Learner A's step 2 came back graded from Planet, so their row is
+      // passed. Learner B has reached the same step and has not passed it.
+      await repository.saveCourseProgress(
+        id: 'progress-a',
+        courseId: 'course-1',
+        userId: 'learner-a',
+        stepNum: 2,
+        passed: true,
+      );
+      await repository.saveCourseProgress(
+        id: 'progress-b',
+        courseId: 'course-1',
+        userId: 'learner-b',
+        stepNum: 2,
+        passed: false,
+      );
+    });
+
+    test('one learner taking the exam does not clear another learner\'s '
+        'pass', () async {
+      // B finishes the exam. `isGraded` is false — see the reachability group
+      // below — so the write is `passed = false`, and unscoped it wiped A's
+      // `true`: on a shared handset, B taking an exam un-completed A's course.
+      await repository.updateCourseProgress(
+        courseId: 'course-1',
+        stepNum: 2,
+        passed: false,
+        userId: 'learner-b',
+      );
+
+      expect(await passedFor('learner-a'), isTrue);
+      expect(await passedFor('learner-b'), isFalse);
+    });
+
+    test('the taker\'s own row is still written', () async {
+      await repository.updateCourseProgress(
+        courseId: 'course-1',
+        stepNum: 2,
+        passed: true,
+        userId: 'learner-b',
+      );
+
+      expect(await passedFor('learner-b'), isTrue);
+      expect(await passedFor('learner-a'), isTrue);
+    });
+
+    test('other steps of the same course are untouched', () async {
+      await repository.saveCourseProgress(
+        id: 'progress-b-1',
+        courseId: 'course-1',
+        userId: 'learner-b',
+        stepNum: 1,
+        passed: true,
+      );
+
+      await repository.updateCourseProgress(
+        courseId: 'course-1',
+        stepNum: 2,
+        passed: false,
+        userId: 'learner-b',
+      );
+
+      expect(await passedFor('learner-b', stepNum: 1), isTrue);
+    });
+
+    test('retaking your own exam still clears your own pass', () async {
+      // `ed5609f` deliberately does not close the self case, so this quirk is
+      // ported rather than fixed: A's step-2 pass came from Planet, A retakes
+      // the exam, and the write is `false` again — the star goes dark until
+      // Planet grades the new attempt.
+      await repository.updateCourseProgress(
+        courseId: 'course-1',
+        stepNum: 2,
+        passed: false,
+        userId: 'learner-a',
+      );
+
+      expect(await passedFor('learner-a'), isFalse);
+    });
+
+    test('an empty course id writes nothing', () async {
+      // `if (courseId.isNullOrEmpty()) return`
+      // (`CoursesRepositoryImpl.kt:522`).
+      await repository.updateCourseProgress(
+        courseId: '',
+        stepNum: 2,
+        passed: true,
+        userId: 'learner-b',
+      );
+
+      expect(await passedFor('learner-b'), isFalse);
+    });
+
+    test('no row for the taker means no row is created', () async {
+      // Kotlin runs the `UPDATE` and nothing else. The port used to insert
+      // here, under the user-less key `'${courseId}_$stepNum'` — so a second
+      // learner would have overwritten the first learner's row outright, and
+      // `getCurrentProgress`, which counts rows ignoring `passed`, would have
+      // reported a step as reached that was never opened.
+      await repository.updateCourseProgress(
+        courseId: 'course-1',
+        stepNum: 3,
+        passed: true,
+        userId: 'learner-c',
+      );
+
+      expect(await db.courseProgressDao.getByUser('learner-c'), isEmpty);
+      final steps = await db.courseDao.getSteps('course-1');
+      expect(
+        await repository.getCurrentProgress(steps, 'learner-c', 'course-1'),
+        0,
+      );
+    });
+
+    test('a null user id matches the null-user rows, not every row', () async {
+      // `userId IS :userId`, not `=`: SQLite's null-safe equality, so a null
+      // argument matches rows whose `userId` is NULL and only those. Written
+      // `=` it would match nothing at all.
+      await db.courseProgressDao.upsert(
+        CourseProgressCompanion.insert(
+          id: 'progress-null',
+          courseId: const Value('course-1'),
+          userId: const Value(null),
+          stepNum: const Value(2),
+          passed: const Value(false),
+        ),
+      );
+
+      await repository.updateCourseProgress(
+        courseId: 'course-1',
+        stepNum: 2,
+        passed: true,
+        userId: null,
+      );
+
+      expect(await passedFor(null), isTrue);
+      expect(await passedFor('learner-a'), isTrue);
+      expect(await passedFor('learner-b'), isFalse);
+    });
+  });
+
+  /// Phase 133 reported that "in the port a course containing any exam step
+  /// can never complete, and the completed-course stars can never light for
+  /// it", calling it possibly the most expensive reachability row found so
+  /// far. These two tests establish what is actually true, because the fix
+  /// depends on it: **neither app grades an exam step locally**, and the port
+  /// has the same server route to a passed step that Kotlin has.
+  group('how an exam step actually becomes passed', () {
+    setUp(() => seedCourse('course-1', stepCount: 2));
+
+    test(
+      'finishing the exam does not complete the course, in either app',
+      () async {
+        // The step-view write, `passed: exams.isEmpty ? true : null`
+        // (`CourseStepFragment.kt:96`): step 1 has no exam, step 2 has one.
+        await repository.saveCourseProgress(
+          id: 'p1',
+          courseId: 'course-1',
+          userId: 'learner-a',
+          stepNum: 1,
+          passed: true,
+        );
+        await repository.saveCourseProgress(
+          id: 'p2',
+          courseId: 'course-1',
+          userId: 'learner-a',
+          stepNum: 2,
+          passed: null,
+        );
+
+        // Kotlin's exam finish is `saveCourseProgress(courseId, stepNumber,
+        // sub?.status == "graded", user?.id)` — and `"graded"` is a status no
+        // local writer produces (`saveExamAnswer` writes `pending`, `complete`
+        // or `requires grading`), on a submission the exam branch always
+        // recreates. So the argument is false, and the step stays unpassed.
+        await repository.updateCourseProgress(
+          courseId: 'course-1',
+          stepNum: 2,
+          passed: false,
+          userId: 'learner-a',
+        );
+
+        expect(await repository.completedCourseIds('learner-a'), isEmpty);
+      },
+    );
+
+    test(
+      'the graded `courses_progress` document from Planet completes it',
+      () async {
+        await repository.saveCourseProgress(
+          id: 'p1',
+          courseId: 'course-1',
+          userId: 'learner-a',
+          stepNum: 1,
+          passed: true,
+        );
+        await repository.saveCourseProgress(
+          id: 'p2',
+          courseId: 'course-1',
+          userId: 'learner-a',
+          stepNum: 2,
+          passed: null,
+        );
+
+        // What `syncCourseProgress` hands `insertCourseProgressFromSync` — the
+        // walk `CourseSyncNotifier` runs on every course sync. `fromDoc` merges
+        // onto the local `(courseId, userId, stepNum)` row rather than creating
+        // a twin, so the server's `passed: true` lands on the step the learner
+        // already reached.
+        await repository.insertCourseProgressFromSync([
+          {
+            '_id': 'server-p2',
+            '_rev': '1-abc',
+            'courseId': 'course-1',
+            'userId': 'learner-a',
+            'stepNum': 2,
+            'passed': true,
+          },
+        ]);
+
+        expect(await repository.completedCourseIds('learner-a'), {'course-1'});
+      },
+    );
+  });
+}

--- a/flutter/test/repository/exam_progress_user_scoping_test.dart
+++ b/flutter/test/repository/exam_progress_user_scoping_test.dart
@@ -208,6 +208,67 @@ void main() {
     });
   });
 
+  /// The four user-scoped reads Kotlin spells `userId IS :userId`
+  /// (`CourseProgressDao.kt:10-20`). Reverting them to `equals(userId ?? '')`
+  /// left the whole suite green except for one test that only failed
+  /// incidentally, so nothing pinned them — these do.
+  ///
+  /// A NULL-`userId` row is what `ProgressRepositoryImpl.saveCourseProgress`
+  /// (`:234`) writes for a null argument.
+  group('the null-safe user predicates', () {
+    setUp(() async {
+      await seedCourse('course-1', stepCount: 2);
+      await db.courseProgressDao.upsert(
+        CourseProgressCompanion.insert(
+          id: 'nobody',
+          courseId: const Value('course-1'),
+          userId: const Value(null),
+          stepNum: const Value(1),
+        ),
+      );
+      await db.courseProgressDao.upsert(
+        CourseProgressCompanion.insert(
+          id: 'empty-string',
+          courseId: const Value('course-1'),
+          userId: const Value(''),
+          stepNum: const Value(2),
+        ),
+      );
+    });
+
+    test(
+      'getByUser(null) returns the NULL rows, not the empty-string ones',
+      () async {
+        final rows = await db.courseProgressDao.getByUser(null);
+        expect(rows.map((r) => r.id), ['nobody']);
+      },
+    );
+
+    test('getByUserAndCourse(null, …) is null-safe on both columns', () async {
+      final rows = await db.courseProgressDao.getByUserAndCourse(
+        null,
+        'course-1',
+      );
+      expect(rows.map((r) => r.id), ['nobody']);
+    });
+
+    test('getByUserAndCourseIds(null, …) is null-safe', () async {
+      final rows = await db.courseProgressDao.getByUserAndCourseIds(null, [
+        'course-1',
+      ]);
+      expect(rows.map((r) => r.id), ['nobody']);
+    });
+
+    test('findByCourseUserAndStep(…, null, …) is null-safe', () async {
+      final row = await db.courseProgressDao.findByCourseUserAndStep(
+        'course-1',
+        null,
+        1,
+      );
+      expect(row?.id, 'nobody');
+    });
+  });
+
   /// Phase 133 reported that "in the port a course containing any exam step
   /// can never complete, and the completed-course stars can never light for
   /// it", calling it possibly the most expensive reachability row found so

--- a/flutter/test/ui/courses/course_progress_on_open_test.dart
+++ b/flutter/test/ui/courses/course_progress_on_open_test.dart
@@ -1,0 +1,219 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:myplanet/repository/progress_repository.dart';
+import 'package:myplanet/ui/courses/take_course_screen.dart';
+
+import '../../support/widget_harness.dart';
+
+class _MockPlanetApi extends Mock implements PlanetApi {}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+UserRow _user() => UserRow(
+  id: 'user-1',
+  couchId: 'org.couchdb.user:ada',
+  rev: '1-a',
+  name: 'ada',
+  rolesList: const ['learner'],
+  userAdmin: false,
+  joinDate: 0,
+  isArchived: false,
+  isUpdated: false,
+);
+
+/// Does opening a course record progress for the step the learner **lands
+/// on**?
+///
+/// Kotlin records it twice over, neither requiring a page change:
+/// `CourseStepFragment.onViewCreated` runs `launchSaveCourseProgress()` inside
+/// `withResumed` (`:168-172`), and `setMenuVisibility` runs it again when the
+/// pager brings the step into view (`:262-268`). Both are gated on
+/// `userHasCourse` = `isMyCourse(userId, step.courseId)`.
+///
+/// The port drove `_recordProgress` from `goToStep` alone, which
+/// `PageView.onPageChanged` never fires for the initial page — and unlike
+/// Kotlin's pager there is no cover page at position 0, so the port opens
+/// *on* step 1. Nothing recorded step 1 until the learner navigated away and
+/// back.
+///
+/// It is a reachability defect of the shape this port keeps finding: a reader
+/// whose writer cannot produce the values it matches. Three readers are
+/// affected — `getCurrentProgress` and `courseProgressSummary` (which count
+/// rows ignoring `passed`) and `completedCourseIds` (which requires `passed`).
+/// A **one-step course therefore could never complete**, because the only
+/// write that would pass its single step never ran.
+void main() {
+  late AppDatabase db;
+
+  late PlanetPrefs prefs;
+
+  setUp(() async {
+    db = AppDatabase.memory();
+    // `_recordProgress` and `_logVisitOnce` both queue an outbox row, which
+    // reaches `serverConfigProvider` -> `planetPrefsProvider` — the harness
+    // trap that is `UnimplementedError` unless overridden. With no server
+    // configured the queueing is skipped, which is all these tests need.
+    SharedPreferences.setMockInitialValues({});
+    prefs = PlanetPrefs(await SharedPreferences.getInstance());
+  });
+  tearDown(() => db.close());
+
+  /// [shelfUserIds] decides `isMyCourse`, which is Kotlin's `userHasCourse`
+  /// gate on recording at all.
+  Future<void> seedCourse({
+    int stepCount = 2,
+    List<String> shelfUserIds = const ['user-1'],
+  }) => db.courseDao.upsertAll(
+    [
+      CoursesCompanion.insert(
+        id: 'course-1',
+        courseId: const Value('course-1'),
+        courseTitle: const Value('Algebra'),
+        userId: Value(shelfUserIds),
+      ),
+    ],
+    [
+      for (var i = 0; i < stepCount; i++)
+        CourseStepsCompanion.insert(
+          id: 'course-1:$i',
+          courseId: const Value('course-1'),
+          stepTitle: Value('Step ${i + 1}'),
+          stepIndex: Value(i),
+        ),
+    ],
+  );
+
+  /// `runAsync` yields wall-clock time so the real drift futures behind
+  /// `courseProvider` / `courseStepsProvider` complete — a widget test's zone
+  /// is fake-async, so they never progress otherwise. The trailing
+  /// `pumpAndSettle` is what clears the scroll-physics timer `PageView` leaves
+  /// behind, which the binding asserts on at teardown; it terminates here
+  /// because the loading spinners are gone by the time it runs.
+  Future<void> settle(WidgetTester tester) async {
+    for (var round = 0; round < 6; round++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 20)),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    await tester.pumpAndSettle();
+  }
+
+  /// Tears the tree down *inside* the test body.
+  ///
+  /// `TakeCourseScreen` builds its `PageController` in `build` and never
+  /// disposes it, so `PageView`'s scroll simulation leaves a timer pending and
+  /// the binding asserts `!timersPending` at the end of the test body —
+  /// before any `addTearDown` callback could clear it. Replacing the tree and
+  /// pumping past the simulation disposes the controller while the test can
+  /// still pump. (The undisposed controller is a pre-existing leak in the
+  /// screen, not something these tests introduce.)
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  Future<void> pumpCourse(WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') router.push('/take');
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (_) => const TakeCourseScreen(courseId: 'course-1'),
+        },
+        overrides: [
+          appDatabaseProvider.overrideWith((ref) => db),
+          planetPrefsProvider.overrideWithValue(prefs),
+          sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
+        ],
+      ),
+    );
+    await settle(tester);
+  }
+
+  Future<List<int>> recordedSteps() async {
+    final rows = await db.courseProgressDao.getByUser('user-1');
+    final steps = [for (final row in rows) row.stepNum]..sort();
+    return steps;
+  }
+
+  testWidgets('opening a course records progress for the step it opens on', (
+    tester,
+  ) async {
+    await seedCourse();
+    await pumpCourse(tester);
+
+    expect(await recordedSteps(), [1]);
+    await unmount(tester);
+  });
+
+  testWidgets('a one-step course with no exam is completable', (tester) async {
+    // The consequence that makes this more than bookkeeping. The step has no
+    // exam, so `passed: exams.isEmpty ? true : null` is `true` — but only if
+    // anything writes the row at all.
+    await seedCourse(stepCount: 1);
+    await pumpCourse(tester);
+
+    final progress = ProgressRepository(
+      _MockPlanetApi(),
+      db.courseDao,
+      db.courseProgressDao,
+      db.examDao,
+      db.submissionDao,
+      db.certificationDao,
+    );
+    expect(await progress.completedCourseIds('user-1'), {'course-1'});
+    await unmount(tester);
+  });
+
+  testWidgets('a course not on the learner\'s shelf records nothing', (
+    tester,
+  ) async {
+    // `userHasCourse` gates both Kotlin triggers, so browsing a course you
+    // have not joined leaves no progress rows behind.
+    await seedCourse(shelfUserIds: const ['someone-else']);
+    await pumpCourse(tester);
+
+    expect(await recordedSteps(), isEmpty);
+    await unmount(tester);
+  });
+
+  testWidgets('paging forward records the step paged to as well', (
+    tester,
+  ) async {
+    await seedCourse();
+    await pumpCourse(tester);
+
+    await tester.tap(find.text('Next'));
+    await settle(tester);
+
+    expect(await recordedSteps(), [1, 2]);
+    await unmount(tester);
+  });
+}

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -11,6 +11,8 @@ import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/courses_providers.dart';
 import 'package:myplanet/providers/ratings_provider.dart';
 import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:myplanet/repository/ratings_repository.dart';
 import 'package:myplanet/repository/submissions_repository.dart';
 import 'package:myplanet/repository/surveys_repository.dart';
@@ -40,6 +42,20 @@ UserRow _user() => UserRow(
   isArchived: false,
   isUpdated: false,
 );
+
+/// `TakeCourseScreen` records a `course_progress` row for the step it opens on
+/// (Kotlin's `withResumed { launchSaveCourseProgress() }`), and that queues an
+/// outbox row — which reaches `serverConfigProvider` and through it
+/// `planetPrefsProvider`, the harness trap that throws `UnimplementedError`
+/// unless overridden. Before the on-mount recording existed, no test here ever
+/// reached it. With no server configured the queueing is skipped, which is all
+/// these tests need.
+Future<Override> _prefsOverride() async {
+  SharedPreferences.setMockInitialValues({});
+  return planetPrefsProvider.overrideWithValue(
+    PlanetPrefs(await SharedPreferences.getInstance()),
+  );
+}
 
 void main() {
   /// Pushes the take-course screen onto a router so `context.pop()` (the finish
@@ -73,6 +89,7 @@ void main() {
           ...extraTargets,
         },
         overrides: [
+          await _prefsOverride(),
           sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
           courseProvider('course-1').overrideWith(
             (ref) => Stream.value(
@@ -102,6 +119,7 @@ void main() {
     await pumpScreen(
       tester,
       overrides: [
+        await _prefsOverride(),
         appDatabaseProvider.overrideWith((ref) {
           ref.onDispose(db.close);
           return db;
@@ -136,6 +154,7 @@ void main() {
     await pumpScreen(
       tester,
       overrides: [
+        await _prefsOverride(),
         appDatabaseProvider.overrideWith((ref) {
           ref.onDispose(db.close);
           return db;
@@ -171,6 +190,7 @@ void main() {
     await pumpScreen(
       tester,
       overrides: [
+        await _prefsOverride(),
         appDatabaseProvider.overrideWith((ref) {
           ref.onDispose(db.close);
           return db;
@@ -241,6 +261,7 @@ void main() {
               const TakeCourseScreen(courseId: mandatoryCourseId),
         },
         overrides: [
+          await _prefsOverride(),
           sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
           courseProvider(mandatoryCourseId).overrideWith(
             (ref) => Stream.value(
@@ -342,6 +363,7 @@ void main() {
               const TakeCourseScreen(courseId: mandatoryCourseId),
         },
         overrides: [
+          await _prefsOverride(),
           sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
           courseProvider(mandatoryCourseId).overrideWith(
             (ref) => Stream.value(
@@ -474,6 +496,7 @@ void main() {
         ),
       },
       overrides: [
+        await _prefsOverride(),
         appDatabaseProvider.overrideWithValue(db),
         courseProvider('course-1').overrideWith(
           (ref) => Stream.value(

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -283,6 +283,7 @@ void main() {
     WidgetTester tester, {
     String examId = 'exam-1',
     String? courseId,
+    String? stepId,
     UserRow? session,
     ServerConfig? config = server,
     List<Override> overrides = const [],
@@ -304,7 +305,11 @@ void main() {
           },
         ),
         pushTargets: {
-          '/exam': (_) => TakeExamScreen(examId: examId, courseId: courseId),
+          '/exam': (_) => TakeExamScreen(
+            examId: examId,
+            courseId: courseId,
+            stepId: stepId,
+          ),
         },
         overrides: [
           appDatabaseProvider.overrideWith((ref) => db),
@@ -889,6 +894,135 @@ void main() {
         find.widgetWithText(FilledButton, 'Submit exam'),
       );
       expect(button.onPressed, isNotNull);
+    });
+  });
+
+  /// The `saveCourseProgress` call in `BaseExamFragment.continueExam`
+  /// (`:133`), which the port had ported into `ProgressRepository
+  /// .updateCourseProgress` and then never called from anywhere — so these are
+  /// the reachability tests for a write that previously did not happen.
+  group('course progress on finish', () {
+    /// A two-step course whose step 2 carries the exam, plus progress rows for
+    /// two learners: `user-1` (this session) and `other-user`, whose step-2
+    /// pass came back graded from Planet.
+    Future<void> seedCourseWithGradedPeer() async {
+      await db.courseDao.upsertAll(
+        [
+          CoursesCompanion.insert(
+            id: 'course-1',
+            courseId: const Value('course-1'),
+            courseTitle: const Value('Algebra'),
+            userId: const Value(['user-1', 'other-user']),
+          ),
+        ],
+        [
+          CourseStepsCompanion.insert(
+            id: 'course-1:0',
+            courseId: const Value('course-1'),
+            stepIndex: const Value(0),
+          ),
+          CourseStepsCompanion.insert(
+            id: 'course-1:1',
+            courseId: const Value('course-1'),
+            stepIndex: const Value(1),
+          ),
+        ],
+      );
+      for (final owner in ['user-1', 'other-user']) {
+        await db.courseProgressDao.upsert(
+          CourseProgressCompanion.insert(
+            id: 'progress-$owner',
+            courseId: const Value('course-1'),
+            userId: Value(owner),
+            stepNum: const Value(2),
+            passed: const Value(true),
+          ),
+        );
+      }
+    }
+
+    Future<void> finishExam(WidgetTester tester) async {
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+      await tester.enterText(find.byType(TextField), 'Paris');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Submit exam'));
+      await settleExam(tester);
+    }
+
+    Future<bool?> passedFor(String userId) async {
+      final row = await db.courseProgressDao.findByCourseUserAndStep(
+        'course-1',
+        userId,
+        2,
+      );
+      return row?.passed;
+    }
+
+    testWidgets('finishing writes the taker\'s own step row and leaves a '
+        'peer\'s alone', (tester) async {
+      await seedTwoQuestionExam(courseId: 'course-1');
+      await seedCourseWithGradedPeer();
+      await pumpExam(tester, courseId: 'course-1', stepId: 'course-1:1');
+
+      await finishExam(tester);
+      expect(find.text('Exam Complete'), findsOneWidget);
+
+      // `sub?.status == "graded"` is false — the attempt this screen created
+      // is `requires grading` — so the write is `passed = false`. That reset
+      // is the behaviour the missing caller was costing.
+      expect(await passedFor('user-1'), isFalse);
+      // And `ed5609f`: unscoped, the same statement cleared this row too.
+      expect(await passedFor('other-user'), isTrue);
+    });
+
+    testWidgets('the step number comes from the step\'s position in the '
+        'course', (tester) async {
+      await seedTwoQuestionExam(courseId: 'course-1');
+      await seedCourseWithGradedPeer();
+      // Step 1 of the same course, so a write against the wrong step number
+      // would land on the step-2 rows instead.
+      await pumpExam(tester, courseId: 'course-1', stepId: 'course-1:0');
+
+      await finishExam(tester);
+
+      expect(await passedFor('user-1'), isTrue);
+      expect(await passedFor('other-user'), isTrue);
+      final step1 = await db.courseProgressDao.findByCourseUserAndStep(
+        'course-1',
+        'user-1',
+        1,
+      );
+      // Kotlin runs the `UPDATE` and inserts nothing, so a step the learner
+      // never opened still has no row.
+      expect(step1, isNull);
+    });
+
+    testWidgets('an exam with no course writes no progress', (tester) async {
+      await seedTwoQuestionExam();
+      await seedCourseWithGradedPeer();
+      // `BaseExamFragment` passes `exam?.courseId`, and this exam has none.
+      await pumpExam(tester, courseId: 'course-1', stepId: 'course-1:1');
+
+      await finishExam(tester);
+
+      expect(await passedFor('user-1'), isTrue);
+      expect(await passedFor('other-user'), isTrue);
+    });
+
+    testWidgets('a step id the course does not list writes no progress', (
+      tester,
+    ) async {
+      await seedTwoQuestionExam(courseId: 'course-1');
+      await seedCourseWithGradedPeer();
+      await pumpExam(tester, courseId: 'course-1', stepId: 'course-9:7');
+
+      await finishExam(tester);
+
+      expect(await passedFor('user-1'), isTrue);
+      expect(await passedFor('other-user'), isTrue);
     });
   });
 

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -982,22 +982,33 @@ void main() {
         'course', (tester) async {
       await seedTwoQuestionExam(courseId: 'course-1');
       await seedCourseWithGradedPeer();
-      // Step 1 of the same course, so a write against the wrong step number
-      // would land on the step-2 rows instead.
+      // A passed row on step **1** as well, so this test fails for the
+      // property it names rather than by accident. Asserting only that the
+      // step-2 rows are untouched would also hold if the derivation produced
+      // `0` — `WHERE stepNum = 0` matches nothing — so an off-by-one would
+      // slip through. It has to be observable that step 1 is the row written.
+      await db.courseProgressDao.upsert(
+        CourseProgressCompanion.insert(
+          id: 'progress-user-1-step-1',
+          courseId: const Value('course-1'),
+          userId: const Value('user-1'),
+          stepNum: const Value(1),
+          passed: const Value(true),
+        ),
+      );
       await pumpExam(tester, courseId: 'course-1', stepId: 'course-1:0');
 
       await finishExam(tester);
 
-      expect(await passedFor('user-1'), isTrue);
-      expect(await passedFor('other-user'), isTrue);
       final step1 = await db.courseProgressDao.findByCourseUserAndStep(
         'course-1',
         'user-1',
         1,
       );
-      // Kotlin runs the `UPDATE` and inserts nothing, so a step the learner
-      // never opened still has no row.
-      expect(step1, isNull);
+      expect(step1?.passed, isFalse);
+      // And the step-2 rows, which a wrong number would have hit.
+      expect(await passedFor('user-1'), isTrue);
+      expect(await passedFor('other-user'), isTrue);
     });
 
     testWidgets('an exam with no course writes no progress', (tester) async {


### PR DESCRIPTION
Lane B of a four-lane Phase 135 round. Sole owner of `flutter/lib/data/local/app_database.dart` this round, which is why the two jobs share a lane — **one file, one owner**.

Full write-up in `flutter/PHASE_135_NOTES.md`, with a **Reported, not fixed** section carrying 12 items.

**Note for the integrator: `d28089f` is broader than the brief.** It changes `take_course_screen.dart`'s widget lifecycle and touches seven existing tests. Reasons below — in short, without it this phase's headline change provably does nothing.

## Job 2 — unescaped `LIKE` interpolations — `88b2fee`, `1cd1e21`

`MyLibraryDao.watchResources` (shelf and negated catalog arms), `MyLibraryDao.resourcesOnShelf`, `CourseDao.watchCourses`, `CourseDao.coursesOnShelf` — the five Phase 131 listed — now route through one `_shelfMembership` helper using drift's `escapeChar`.

The `_` case is two failures from one cause: a shelf query for `u_1` returned `ux1`'s rows, *and* the catalog arm (the same predicate negated) dropped them at the same moment, so the resource was missing from both views at once. Realistic input is not synthetic: Planet usernames permit `_`, `.` and `-`, so **`mary_jane` and `mary-jane` on one handset** reproduces it, as does any `guest_<name>`. It is write-side too — `shelf_repository`'s id collection feeds the uploaded shelf document, so `mary_jane`'s POST carried `mary-jane`'s ids to CouchDB.

Also corrects a false rationale: `watchResourcesNeedingUpdateCount` claimed drift's `like()` takes no `ESCAPE`. It takes an `escapeChar`. Raw SQL stays for the `IS NOT` reason, which stands alone.

## Job 1 — port `ed5609f` (exam progress user scoping) — `5bff98b`

`CourseProgressDao.updatePassedByCourseAndStep` gains `AND userId IS :userId` (nullable, `IS` semantics), threaded through `ProgressRepository.updateCourseProgress`. No DDL, no schema bump. The port's comments asserted the rationale upstream repudiated ("an exam result is not per-user"); both copies deleted with the behaviour.

`updateCourseProgress` had **zero callers**. Now called where Kotlin has it (`BaseExamFragment.continueExam:133`).

Three latent defects that wiring a dead writer turned live: the invented insert branch keyed rows `'${courseId}_$stepNum'` with **no user in the key** (a second learner would have overwritten the first's whole row — worse than the bug it imitated); that insert wrote `createdOn` from `parentCode` where Kotlin writes `planetCode`, and the column uploads verbatim; and no empty-`courseId` guard. Plus four `CourseProgressDao` reads that were `equals(userId ?? '')` where the `@Query` is `userId IS :userId`.

## What the second audit changed about all of this — `d28089f`

An earlier revision of this description said the "exam-bearing course can never complete" finding "was never a port defect". **That was half wrong and is corrected here.** It is true that Kotlin also writes `passed = false` on exam finish, so neither app grades an exam step locally and both depend on Planet's graded `courses_progress` document. But the real port defect was one layer down, and neither Phase 133 nor my first pass looked there:

**Nothing in the port wrote a `course_progress` row for the step a learner lands on.** `_recordProgress` had one caller, `goToStep`, reached only from `PageView.onPageChanged` and Previous/Next — and `onPageChanged` never fires for the initial page. Kotlin's pager has a cover page at position 0 so its first step is always arrived at, and Kotlin records the row twice over without any page change (`CourseStepFragment.onViewCreated`'s `withResumed`, and `setMenuVisibility`), both gated on `userHasCourse`.

Consequences: `getCurrentProgress` and `courseProgressSummary` under-reported by a step, **a one-step course could never complete**, and Job 1's new `UPDATE` silently matched nothing. Fixed by making `_CourseContent` stateful and recording the step in view on mount and on change, gated on `isMyCourse`.

Also in that commit: a failed progress write was reporting a successfully-submitted exam as *failed* (Kotlin's caller is fire-and-forget and cannot suppress its dialog) — now contained and moved ahead of the awaited camera round trip and two outbox writes that Kotlin either doesn't await or doesn't have. And a **sixth** unescaped `LIKE`, this one with no Kotlin counterpart at all: `courseTitleNormal.like('%$trimmed%')`, where Kotlin's search is an in-memory literal `contains` — so `intro_a` matched `IntroXA` and a bare `%` matched every course.

Two of my own doc rationales named the wrong mechanism and are corrected where they were written: the step-reorder claim was **inverted** (Kotlin's content-derived step ids keep every `stepNum` bound to the same content; it is the *port* that re-binds ids on reorder), and the NULL-`userId` justification cited the synced case, where Kotlin stores `''` and only the port stores NULL.

## Why the defect survived a phase looking for exactly it

Every test I wrote seeded the row it needed. Nothing drove `take_course_screen` → `take_exam_screen` end to end, so the fixture supplied what production did not — the "every fixture hand-faked the join" symptom, which I reproduced while writing the reachability questions into my own notes. Corroboration: the fix broke seven tests with `planetPrefsProvider must be overridden`, because in a file of thirteen tests for that screen **none had ever reached the code behind its progress write**.

## Evidence

Every defect demonstrated failing first. Mutation-checked: the `IS` semantics, the step-number derivation (rewritten so the test that names the property is the one that fails for it), the escaping, and the new caller.

Two `parity-auditor` passes at `effort: max` — one on the Kotlin ground truth before any Dart, one on the finished green code. The first corrected two of my claims and found three defects; the second found six more, including the one above. Both are required, and this round is the fifth consecutive demonstration of why.

Gate: format clean, analyze clean, **`flutter test` 2430 passing** (2405 on the base), codegen run before analyzing since the Drift DAO signature changed. CI green on the head.

## Status

Complete, green, pushed. Left as a draft deliberately — the integrator merges these lane branches. This PR is the integrator's only inbound channel to this lane, so comment here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFrSLeH94tPguMNR6yxDVs