### PR TITLE
Phase 138 (Lane A): the adopted survey clone's lifecycle, and pendingUploads' missing status test

### DIFF
--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -886,6 +886,73 @@ Deliberate *deviations*, all flagged in code:
   while the only two type literals the tree does write are the singular `"exam"` and `"survey"`
   fallbacks, which no Kotlin query ever selects on.
 
+- **An adopted team survey's upload records the CouchDB rev; Kotlin's records nothing.**
+  `UploadConfigs.AdoptedSurveys` (`UploadConfigs.kt:186-195`) declares no
+  `responseHandler` and no `markUploaded` — unlike `Meetups` five lines above it, which has
+  both — so the local row keeps `_rev = NULL`, stays in
+  `ExamDao.getPendingAdoptedSurveys()` for the life of the install, and is re-POSTed on
+  every sweep; `serializeExam` always writes `_id` (`StepExam.kt:73`), so CouchDB answers
+  the second POST with a 409 and every one after it, silently.
+  `AdoptedSurveysUploader.handler` calls `SurveyDao.markUploaded` instead. The rev is also
+  what scopes the port's prune exemption: Kotlin never deletes from `exams` at all
+  (`bulkInsertExamsFromSync` upserts, and `ExamDao.deleteById` has zero production callers),
+  while the port's `SurveyDao.deleteNotIn` has to spare an unpublished clone explicitly —
+  and only an unpublished one, so a document the server has stopped naming is still pruned.
+
+- **`hasUnfinishedSurveys` skips an adopted team clone; Kotlin's gate has no such rule
+  because it cannot see one.** `getSurveysByCourseId` filters
+  `getByCourseIdAndType(courseId, "survey")` — **singular**
+  (`SubmissionsRepositoryImpl.kt:367-379`) — while a clone copies the source's `type`
+  (`SurveysRepositoryImpl.kt:180`) and every list adoption is reachable from queries
+  `type = "surveys"` (`ExamDao.kt:29-31`). The port's table split *is* the type, so its
+  `getByCourseId` returns the clone and the guard is a port-invented one on port-invented
+  breadth. It is keyed on `stepId == null` — does the courses walk own this row's course
+  join? — and deliberately **not** on `rev == null`: that read was exact only while nothing
+  published a clone, and Phase 138 publishes it, at which point the gate would demand a
+  team's private copy of every learner on the course and make
+  `MANDATORY_SURVEY_COURSE_ID` uncompletable for outsiders.
+
+- **The team-adoption marker is not uploaded; everything else with an `isUpdated` flag
+  still is.** Kotlin's sweeps are
+  `status = 'complete' AND (isUpdated = 1 OR _id IS NULL OR _id = '')` (`SubmissionDao:41`)
+  and, for exams, `type = 'exam' AND … AND (_id IS NULL OR _id = '')` (`:40`). The port
+  merges the two configs into one uploader and gates on `isUpdated`, because an exam finishes
+  at `requires grading` rather than `complete` — which left it with no status test at all,
+  and Phase 134's safety-net sweep made that systematic. Phase 138 excludes one row:
+  `createSurveyAdoptionSubmission`'s marker (`status: ''`), which is local bookkeeping that a
+  team took a copy of a shared survey rather than a learner's answers, and which no Kotlin
+  config selects. Withholding it is only safe because the same phase publishes the adopted
+  clone itself, carrying `teamId` and `sourceSurveyId` — the route Kotlin has always used to
+  tell a second handset about an adoption.
+
+  Phase 134 named a second row, the **`createDraft` free-form submission** (`status:
+  'pending'`, a port-only shape with no Kotlin writer), and that half is **wrong**:
+  `submissions_screen.dart:172-194` runs `queuePending` *and* `drain` immediately after the
+  New-submission dialog's Save, so the row is a deliberate submission. Excluding it would
+  have made that button write to the device and nothing else, silently. The port still sends
+  it, which remains a divergence from Kotlin — Kotlin has no such button — and the
+  predicate is written as an exclusion rather than an allow-list so that an unanticipated
+  status is an extra document rather than data stranded on the handset. A **null** status is
+  deliberately not treated as a blank one, which is the inverse of the reading
+  `SurveysRepositoryImpl.kt:206` needs for the adoption *guard*; the detail is at the
+  predicate.
+
+- **A half-finished exam attempt is not uploaded; Kotlin's is.** `UploadConfigs.ExamResults`
+  -> `SubmissionDao.getPendingExamResults` (`:40`) has no status and no `isUpdated` test, so
+  every Kotlin sweep POSTs an attempt the learner abandoned two questions in and it appears
+  in Planet's course report. The port sets `isUpdated: false` at `_openExamSession` and flips
+  it only at `requires grading`, so an attempt becomes uploadable exactly when it is
+  submitted. Kept because a partial attempt is not a result, and Kotlin then POSTs a *second*
+  document for the retake (`deleteExamSubmissions` clears the local row, not the remote one).
+
+- **A retried upload cannot produce a duplicate document.**
+  `RetryQueueWorker.processOperationInternal` re-POSTs a queued payload and on success calls
+  only `retryQueue.markCompleted(operation.id)` (`RetryQueueWorker:231`,
+  `RetryQueue:64-67`) — the `submissions` row still has `_id = NULL` and `isUpdated = 1`, so
+  the next Kotlin sweep POSTs it again. Concrete: a survey POST that gets a 502, a successful
+  retry drain, then any sync — two CouchDB documents. `SubmissionsUploader.handler` calls
+  `markUploaded` on every successful send, retried ones included.
+
 - **A step's Take Test button opens the row its own label interrogated.** Kotlin's does not
   necessarily. `hideTestIfNoQuestion` decides the label from `stepExams[0]`, selected by
   `stepId = ? AND type = 'courses'`, but the button routes through `BaseExamFragment.initExam`

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -886,18 +886,51 @@ Deliberate *deviations*, all flagged in code:
   while the only two type literals the tree does write are the singular `"exam"` and `"survey"`
   fallbacks, which no Kotlin query ever selects on.
 
-- **An adopted team survey's upload records the CouchDB rev; Kotlin's records nothing.**
-  `UploadConfigs.AdoptedSurveys` (`UploadConfigs.kt:186-195`) declares no
-  `responseHandler` and no `markUploaded` — unlike `Meetups` five lines above it, which has
-  both — so the local row keeps `_rev = NULL`, stays in
-  `ExamDao.getPendingAdoptedSurveys()` for the life of the install, and is re-POSTed on
-  every sweep; `serializeExam` always writes `_id` (`StepExam.kt:73`), so CouchDB answers
-  the second POST with a 409 and every one after it, silently.
-  `AdoptedSurveysUploader.handler` calls `SurveyDao.markUploaded` instead. The rev is also
-  what scopes the port's prune exemption: Kotlin never deletes from `exams` at all
-  (`bulkInsertExamsFromSync` upserts, and `ExamDao.deleteById` has zero production callers),
-  while the port's `SurveyDao.deleteNotIn` has to spare an unpublished clone explicitly —
-  and only an unpublished one, so a document the server has stopped naming is still pruned.
+- **An adopted team survey is published, and an unpublished one is spared from the prune
+  by a local-authorship flag rather than by `_rev IS NULL`.** Kotlin's sweep is
+  `ExamDao.getPendingAdoptedSurveys()` — `sourceSurveyId IS NOT NULL AND _rev IS NULL`
+  (`ExamDao.kt:21`) — and that names exactly one writer, because `JsonUtils.getString`
+  returns `""` for a missing key (`JsonUtils.kt:64-68`) and both sync writers assign
+  `_rev` unconditionally (`StepExam.kt:47`, `CoursesRepositoryImpl.kt:736`), so a synced
+  Kotlin row's `_rev` is `""` and never NULL. Only `createMappedSurvey`'s explicit
+  `_rev = null` satisfies it.
+
+  **The port cannot ask that question.** Its mappers use `getStringOrNull`, so an absent
+  `_rev` becomes the same NULL an unpublished clone has — true of every course-embedded
+  survey (a sub-object carries no `_rev`) and every public-API one — and
+  `sourceSurveyId` is no help, since the courses walk reads it straight off the server.
+  A first cut of this predicate swept another team's private copy and POSTed it to `exams`
+  under the signed-in user's credentials. `Surveys.needsSync` (schema v47) is set only by
+  `adoptSurvey` and cleared by `SurveyDao.markUploaded`, which makes both the sweep and the
+  prune exemption exact.
+
+  The port also prunes this table, where Kotlin never deletes from `exams` at all
+  (`bulkInsertExamsFromSync` upserts, and `ExamDao.deleteById` has zero production callers).
+  So `markUploaded` serves two purposes here against Kotlin's one: it records the rev, as
+  Kotlin does — via `UploadConfig`'s **default** `persistUploaded`
+  (`UploadConfig.kt:46-56`, `StepExam::class -> UploadUpdateType.Exams`) reaching
+  `exam._rev = result.remoteRev` (`UploadRepositoryImpl.kt:76`), not via the
+  `markUploaded` lambda the config declaration omits — and it clears the flag that keeps a
+  clone out of the prune.
+
+  `UploadCoordinator`'s 409 arm (`UploadCoordinator.kt:169-204`) is ported alongside it,
+  and the port needs it *more* than Kotlin does: Kotlin mints the clone id with
+  `UUID.randomUUID()` so two leaders adopting the same survey write two documents, while
+  the port's deterministic `'<surveyId>_<teamId>'` converges on one — better, but it makes
+  a conflict ordinary. Without recovery the loser is stuck for good, because a re-pull does
+  **not** clear the flag: a mapper's companion omits the column and Drift's
+  `insertOnConflictUpdate` writes only the columns present, so the row gains a `rev` and
+  stays swept, re-POSTing and abandoning one outbox row every sync.
+
+- **The uploaded clone carries `courseId`, which neither app's serializer emits.** A clone
+  copies the source survey's `courseId` and the member sheets Send writes are keyed
+  `"<cloneId>@<courseId>"`. Without the key on the wire only the authoring handset keeps
+  the value (`SurveyMapper.fromDoc` writes `courseId` absent when the document omits it);
+  a second handset in the team gets NULL and keys the same survey's sheets bare, so one
+  member gets two pending sheets and the column oscillates between the repair sweep and
+  the next pull. Kotlin is *consistent* rather than correct — its re-pull wipes the column
+  on the authoring handset too, which is why `getSurveyInfos.resolveParentId` accepts both
+  key shapes (`SurveysRepositoryImpl.kt:304-307`). The port has no such tolerant reader.
 
 - **`hasUnfinishedSurveys` skips an adopted team clone; Kotlin's gate has no such rule
   because it cannot see one.** `getSurveysByCourseId` filters

--- a/flutter/PHASE_138_NOTES.md
+++ b/flutter/PHASE_138_NOTES.md
@@ -30,38 +30,101 @@ a member's answer sheet    ->  parentId resolves to no survey at all
 
 Three pieces:
 
-1. `SurveyDao.pendingAdoptedSurveys()` — the port of `ExamDao.kt:21`, **both
-   clauses**. `sourceSurveyId` alone is not a local-authorship marker: the
-   courses walk reads it straight off a server-embedded survey
-   (`survey_mapper.dart:163-167`), so an adopted copy Planet itself published
-   carries it, and sweeping on one clause would re-POST somebody else's
-   document. Same conjunction Phase 136 had to restore in
-   `hasUnfinishedSurveys` after shipping half of it.
-2. `SurveyDao.markUploaded(id, rev)`, and `deleteNotIn` spares
-   `sourceSurveyId IS NOT NULL AND rev IS NULL` — an **unpublished** clone
+1. `Surveys.needsSync` (**schema v47**), a local-authorship flag written only by
+   `adoptSurvey` — see *The port cannot ask Kotlin's question* below for why the
+   literal port of `ExamDao.kt:21` was a data leak.
+2. `SurveyDao.pendingAdoptedSurveys()` sweeps on that flag;
+   `SurveyDao.markUploaded(id, rev)` records the rev and clears it; and
+   `deleteNotIn` spares a row that still carries it — an **unpublished** clone
    only, so the exemption lapses on publication rather than making a clone
    immortal. A document the server has stopped naming is still a deletion this
    prune should honour.
 3. `AdoptedSurveysUploader` on the outbox, shaped like `EventsUploader`, with
-   the sweep wired into both submissions-sweep sites.
+   the sweep wired into both submissions-sweep sites, each in its own `try`.
 
-### Kotlin records nothing, and that is a defect rather than a behaviour to port
+### The port cannot ask Kotlin's question, and the literal port leaked data
 
-`UploadConfigs.AdoptedSurveys` declares **no `responseHandler` and no
-`markUploaded`** — contrast `Meetups` five lines above it (`:172-184`), which
-has both. So the Kotlin row keeps `_rev = NULL`, stays in
-`getPendingAdoptedSurveys()` for the life of the install, and is re-POSTed on
-every sweep; `serializeExam` always writes `_id` (`StepExam.kt:73`), so CouchDB
-answers the second POST with a 409 and every one after it, silently. Recording
-the rev is also what lets the prune exemption be *scoped* — without it the only
-available predicate is "spare every clone forever".
+**The most serious thing the implementation audit found, and the fix is a new
+column rather than a better predicate.**
 
-Note what this corrects in Phase 136's write-up: the clone does not survive in
-Kotlin because it "joins every later walk's keep set". **There is no keep
-set.** It survives because Kotlin never deletes. The upload's purpose there is
-publication; in the port the upload alone would not have sufficed, because the
-port's keep set is built only from `SurveyMapper.fromDoc`-mappable documents —
-which is what the next finding turns on.
+`ExamDao.getPendingAdoptedSurveys()` is `sourceSurveyId IS NOT NULL AND
+_rev IS NULL`, and in Kotlin that names **exactly one writer**:
+`JsonUtils.getString` returns `""` for a missing key (`JsonUtils.kt:64-68`) and
+both sync writers assign `_rev = JsonUtils.getString("_rev", …)`
+unconditionally (`StepExam.kt:47`, `CoursesRepositoryImpl.kt:736`), so a synced
+Kotlin row's `_rev` is `""` and never NULL. Only `createMappedSurvey`'s
+explicit `_rev = null` (`SurveysRepositoryImpl.kt:172`) satisfies it — which
+makes the `sourceSurveyId` clause nearly vacuous there.
+
+**The port's mappers use `getStringOrNull`, so absent becomes NULL and that
+distinction is gone.** `rev IS NULL` is true for every survey whose document
+omitted `_rev` — which is *every* course-embedded survey, because a sub-object
+carries no `_rev` of its own, and every public-API one. With `sourceSurveyId`
+as the only other clause, and the courses walk reading that straight off the
+server, the sweep selected **another team's private copy** and POSTed it to
+`exams` under the signed-in user's credentials, and the prune spared it forever.
+Reproduced on the tree's own embedded-survey fixture shape:
+
+```
+SWEPT: [survey-embedded]   teamId: someone-elses-team
+```
+
+Every embedded-survey fixture in the tree omits `_rev`; the only one that adds
+it is the counter-example test I wrote in the first round, which is precisely
+why my own test file was blind to the shape it should have caught.
+
+A flag with one writer has no such ambiguity. It also frees both predicates
+from depending on `surveys.rev`, a column **two sync walks disagree about the
+ownership of**: `SurveyMapper._build` writes `rev: Value(...)` unconditionally,
+so a courses walk clobbers the exams walk's authoritative rev with NULL, where
+`ExamMapper.fromDoc` uses `_presentOrAbsent` for exactly this reason. That is
+`survey_mapper.dart`, outside this lane's set — reported below, and no longer
+load-bearing for anything here.
+
+### Kotlin *does* record the rev, and claiming otherwise was my own misreading
+
+**The clearest instance in this project's history of "a Kotlin citation is not a
+Kotlin reading", and it is worse than the usual shape: the ground-truth audit
+told me correctly and I wrote the opposite anyway.**
+
+I read the config declaration — `UploadConfigs.AdoptedSurveys` really does
+declare no `markUploaded` and no `responseHandler`, unlike `Meetups` five lines
+above it — and concluded Kotlin records nothing. But `UploadConfig` carries a
+**default** `persistUploaded` keyed on the model class (`UploadConfig.kt:46-56`,
+`StepExam::class -> UploadUpdateType.Exams`), which
+`UploadRepositoryImpl.markExamsUploaded` resolves to
+`exam._rev = result.remoteRev` (`UploadRepositoryImpl.kt:76`), and
+`runPipeline` calls it on every successful batch (`UploadCoordinator.kt:63-68`).
+Kotlin records the rev, its row leaves `getPendingAdoptedSurveys()`, and there
+is no second POST. The `Meetups` contrast was wrong twice over: `Meetups` is a
+`RoomUploadConfig`, whose `persistUploaded` *is* only that lambda
+(`RoomUploadConfig.kt:42-45`) so it has no default to fall back on, and its
+`ResponseHandler.Custom("id", "rev")` is byte-identical to the `Standard`
+default (`UploadConfig.kt:24`).
+
+The first audit pass reported this correctly — it named
+`UploadConfig.persistUploaded`, the `StepExam::class` branch, and
+`markExamsUploaded`, and said "the lane's `markUploaded(id, rev)` matches this".
+I latched onto the sentence before it ("declares no `responseHandler` and no
+`markUploaded`") and wrote a wrong claim into four places: the DAO's doc
+comment, the commit message, a test's `reason:` string, and a
+*Deliberate deviations* entry — which is a **contract for later rounds**, so it
+would have told the next reader that Kotlin's adopted-survey upload is broken.
+All four are corrected. **Read the whole finding, not its first sentence**, and
+when an audit and your own summary disagree, the audit is not the thing to
+trust less.
+
+What *is* port-specific: the port also prunes this table, where Kotlin never
+deletes from `exams` at all. So `markUploaded` here serves two purposes against
+Kotlin's one — record the rev, and clear the flag that keeps a clone out of the
+prune.
+
+Note also what this corrects in Phase 136's write-up: the clone does not survive
+in Kotlin because it "joins every later walk's keep set". **There is no keep
+set.** It survives because Kotlin never deletes. In the port the upload alone
+would not have sufficed, because the port's keep set is built only from
+`SurveyMapper.fromDoc`-mappable documents — which is what the type finding
+below turns on.
 
 ### The payload has to carry `type`, and the brief's version would have undone the fix
 
@@ -188,6 +251,83 @@ so a server-authored status can never reach the predicate — but they fail
 differently: an unanticipated status under an allow-list is silently stranded,
 under the exclusion it is one extra document.
 
+### Three more the implementation audit found in this phase's green code
+
+**The wiring was pinned by nothing.** All fifteen first-round tests built
+`AdoptedSurveysUploader` directly and called `uploader.handler(...)` by hand, so
+deleting the sweep from both sync paths — or deleting the handler's
+registration in `outboxDrainerProvider` — left the whole suite green while the
+clone was destroyed again. The registration mattered most and least visibly:
+without it `OutboxDrainer._send` falls through to its generic replay branch,
+which POSTs the stored payload, gets a 201 and calls `markCompleted`
+**without ever calling `SurveyDao.markUploaded`** — the document exists, the
+local row is still `needsSync`, and the clone is re-POSTed every sweep. **This
+is the Phase 113 shape exactly: the writer exists, the reader exists, and
+nothing proves anything calls them.** `test/providers/adopted_survey_sweep_test.dart`
+now drives a real `ProviderContainer` from both paths and asserts the end state
+on the row, which is reachable only if the sweep ran *and* the drain dispatched
+to this uploader's own handler.
+
+**The published clone reached a second handset with `courseId = null`, so the
+two handsets keyed member sheets differently** — the Phase 120/125
+writer-reader key class, across devices this time, and newly reachable *because*
+this phase publishes the clone at all. `courseId` survives on the authoring
+handset only because `_presentOrAbsent` leaves an existing value alone; device
+B has never seen the row, so absent means NULL, and its Send keys the same
+survey's sheets bare where A keys them compound. One member, two pending
+sheets, and a column that oscillates between `repairCourseSurveyParentIds` and
+the next pull. `documentFor` now emits `courseId`, which neither app's
+serializer does — Kotlin is *consistent* rather than correct here, wiping the
+column on the authoring handset too, which is why
+`getSurveyInfos.resolveParentId` accepts both key shapes; the port has no such
+tolerant reader. **This qualifies a claim in the first round of these notes**
+("`courseId` survives the round trip, and not by luck"): it survived on the
+device that wrote it and never arrived anywhere else.
+
+**Both sweeps shared one `try`, contradicting the method's own doc comment.**
+`queuePendingSubmissions`' doc says, forty lines above the code, "**Its own
+`try`, not a shared one** … that is a Kotlin weakness rather than a behaviour to
+reproduce; `UserDataWorker`'s per-step `runCatching` is the shape to follow, and
+it is this one." It no longer was. And `SubmissionsUploader.kt:80-88`'s shared
+`try` is not a counter-example, because `uploadAdoptedSurveys()` **cannot
+throw** — `UploadCoordinator.runPipeline` catches `Exception` internally
+(`UploadCoordinator.kt:87-92`) — while `queuePending` can, since it reads device
+identity and `PlatformDeviceIdentitySource.read` rethrows on an engine with no
+channel and no primed cache, which is what a headless WorkManager engine is.
+One adopted clone on such a handset skipped the submissions safety net Phase 134
+added *and*, in the foreground, the whole outbox drain. Each arm now has its own
+`try`, pinned by a test whose identity source fails its **first** read only —
+without that the two shapes are indistinguishable, since both arms read
+identity.
+
+### And one the audit's own boundedness claim turned into a fix
+
+The audit reported the 409/deterministic-id gap as *bounded* and therefore
+reportable, and my first write-up said the same. Probing it — rather than
+reasoning about Drift's upsert semantics — showed it is **unbounded**: a
+mapper's companion omits `needsSync` and `insertOnConflictUpdate` writes only
+the columns present, so the losing device's re-pull gives its row the winner's
+`rev` and leaves the flag set, and it re-POSTs and abandons one outbox row every
+sync for the life of the install. Reachable by two leaders adopting the same
+survey before either syncs, which the port's *deterministic* clone id makes
+ordinary where Kotlin's `UUID.randomUUID()` makes it impossible.
+
+So the 409 arm is ported rather than reported: `UploadCoordinator.kt:169-204`
+GETs the document that already exists, takes its `_rev`, and reports success.
+The port now does the same, with the drain's credential (the endpoint is stored
+credential-free, so an unauthenticated CouchDB read is a 401 and the recovery
+would never fire — pinned, after the first version of that test used
+`any(named: 'authHeader')` and passed with the header removed). A GET that
+fails returns the original 409 rather than inventing success: clearing the flag
+with no rev in hand would drop the clone out of the prune exemption while it is
+still, as far as this device knows, unpublished.
+
+**Worth noting as a method point.** Two claims in this phase were wrong in the
+same way — "Kotlin records nothing" and "the 409 case is bounded" — and both
+were *reasoned* from a plausible reading rather than executed. The first cost a
+false contract in the deviations list; the second would have shipped an
+unbounded write loop. Neither survived a probe.
+
 ## Method notes
 
 **Two mutation checks silently did not apply, and both looked like a passing
@@ -198,11 +338,14 @@ result was implausible. Every mutation script here now asserts
 `s.count(old) == 1` before writing. Phase 122's rule generalises further than
 it was written: **mutation-test the test, and assert that the mutation landed.**
 
-Nine mutations were run and every one was caught by the intended test: the
-prune exemption, the payload's `type`, `markUploaded`, the exemption's scope,
-`pendingAdoptedSurveys`' second clause, the status exclusion, the F1 guard
-reverted to `rev`, the F1 guard's second clause dropped, and the null-status
-coalesce.
+**Twenty-one mutations** were run across both rounds and every one is caught by
+the intended test — and **four of the twenty-one silently did not apply on the
+first attempt**, all for the same reason. Every mutation script now asserts
+`s.count(old) == 1` before writing; two of the four were caught only because
+their green result was implausible, and one (`M21`, the 409 GET's credential)
+turned out to be a real gap in the *test* rather than a failed mutation: it
+passed with the header removed because the mock matched
+`any(named: 'authHeader')`.
 
 **Two files outside the lane's listed set were touched**, deliberately and
 flagged for the integrator: `lib/providers/dashboard_sync_provider.dart` and
@@ -213,9 +356,19 @@ Phase 134 established these same two files as the sweep sites for the sibling
 uploader, and the addition is a literal port of
 `SubmissionsUploader.kt:83-84`'s two adjacent calls.
 
-**No Drift `schemaVersion` bump.** A prune exemption, a new query and a rev
-write change no DDL; `rev` and `sourceSurveyId` already exist on `Surveys`.
-**47 is unspent** — the next round can take it.
+**Drift `schemaVersion` 47 is spent** — `Surveys.needsSync`. The next round must
+take 48. The first round of this phase needed no bump and said so; the audit's
+data-leak finding is what made a column the right answer rather than a better
+predicate. No `_addColumnIfMissing` step: `surveys` is not in
+`localAuthorityTables`, so it is dropped and recreated with the column. The
+`if (from < 47)` branch is present and deliberately empty, so the next reader
+sees the version was considered rather than forgotten.
+
+**Nine existing `SurveyRow(...)` fixtures in seven test files gained
+`needsSync: false`** — a non-nullable Drift column is a required argument on the
+row class. Three are under `test/ui/`, which is the nearest this lane came to
+another lane's territory; each edit is one line beside `teamShareAllowed: false`
+and carries no behaviour.
 
 ## Files
 
@@ -226,14 +379,18 @@ write change no DDL; `rev` and `sourceSurveyId` already exist on `Surveys`.
 * `lib/repository/submissions_repository.dart` — the `hasUnfinishedSurveys`
   guard.
 * `lib/providers/app_providers.dart` — provider + drainer handler.
+* `lib/data/local/tables.dart` — `Surveys.needsSync`.
 * `lib/providers/dashboard_sync_provider.dart`, `lib/background_entrypoint.dart`
-  — the sweep, ahead of the submissions sweep and ahead of the surveys pull.
+  — the sweep, ahead of the submissions sweep and ahead of the surveys pull,
+  each in its own `try`.
+* `test/providers/adopted_survey_sweep_test.dart` (3) — the wiring.
+* Nine `SurveyRow(...)` fixtures in seven existing test files.
 * `docs/kotlin-to-flutter-migration.md` — five deviations entries, including the
   four Phase 134 asked for and could not reach.
 * `test/repository/adopted_survey_survives_sync_test.dart` (11),
   `test/repository/pending_uploads_status_test.dart` (4).
 
-Gate green: `dart format` clean, `flutter analyze` clean, **2472 tests pass**
+Gate green: `dart format` clean, `flutter analyze` clean, **2479 tests pass**
 (2457 before).
 
 ## Reported, not fixed
@@ -265,38 +422,45 @@ hypothetical tax. It wants its own diff, with both tables' columns audited
 against the upgrade path. Whoever takes it should read the
 *preserved-table test* section of `docs/kotlin-to-flutter-migration.md` first.
 
-### A 409 has no recovery, and the port's deterministic clone id makes one reachable
-
-Kotlin mints the clone id with `UUID.randomUUID()`
-(`SurveysRepositoryImpl.kt:86`); the port uses `'${surveyId}_$teamId'`
-(`surveys_repository.dart:105`). The port's is better — two handsets adopting
-the same survey for the same team converge on **one** document where Kotlin
-writes two — but it makes a conflict ordinary rather than freakish: two leaders
-in one team both adopt before either syncs, and the second POST is a 409.
-
-Kotlin recovers: `UploadCoordinator.kt:169-204` GETs `$baseUrl/exams/<localId>`
-on a conflict and reads `_id`/`_rev` back. The port has nothing —
-`OutboxDrainer` classifies any `code < 500` as permanent
-(`outbox_drainer.dart:160-172`) — so the row is abandoned with the local rev
-unrecorded. It is **bounded**, which is why it is reported rather than fixed:
-the losing device's next `exams` walk pulls the winner's document, upserts a rev
-onto its own row, and the clone leaves `pendingAdoptedSurveys()`, so the
-accretion is one dead outbox row per conflict rather than one per sync. The
-handler's comment says this in place.
-
-The fix is a conflict arm — GET the document, read the rev, `markUploaded`, and
-report success — and it belongs at the drainer or in `PlanetApi`'s vocabulary
-rather than in one uploader, since it is the same shape for every
-client-supplied-`_id` POST in the tree. Bundling it here would fix one of
-twenty.
-
 ### The abandoned-row accretion Phase 134 reported now has a twentieth instance
 
-Unchanged and still a cross-uploader policy call: `OutboxDao.findOpen` ignores
-an `abandoned` row so a fresh enqueue is never blocked by one, `clearAbandoned`
-has one caller in the tree and `cleanup()` has none, and `outbox` is preserved
-across schema bumps. `AdoptedSurveysUploader` inherits the shape. The 409 above
-is its most likely trigger here, and it is bounded for the reason given.
+Unchanged and still a cross-uploader policy call, but the audit sharpened what
+is bounded and what is not — and my first write-up of this had it backwards.
+`OutboxDao.findOpen` ignores an `abandoned` row so a fresh enqueue is never
+blocked by one, `clearAbandoned` has one caller in the tree and `cleanup()` has
+none, and `outbox` is preserved across schema bumps. So **any permanent refusal
+that does not resolve the local row's state inserts one dead row and makes one
+doomed POST per sync, unbounded** — a 400/401/403, or the handler's own "no
+id/rev" error (`code == null`, so `(code ?? 0) < 500` is permanent on the first
+attempt). The auditor demonstrated three passes, three rows, three POSTs.
+
+I originally reported the 409 case as the bounded example, reasoning that a
+later walk would supply the rev and drop the clone out of the sweep. **Probed,
+and false**: a mapper's companion omits `needsSync` and Drift's
+`insertOnConflictUpdate` writes only the columns present, so the re-pull hands
+the row a `rev` and leaves the flag set — `needsSync=true rev=1-winner`, still
+swept. That is why the 409 arm is *fixed* in this phase rather than reported
+(see above) instead of being left as an example of a benign case. The general
+policy item stands for every other refusal and for all twenty uploaders: bound
+`cleanup()` and give it a caller, or clear an item's abandoned rows on
+re-enqueue and lose the diagnostic.
+
+### `surveys.rev` has two writers that disagree about who owns it
+
+`SurveyMapper._build` (the courses walk) writes `rev: Value(...)`
+unconditionally, so a course document's embedded copy of a survey clobbers the
+`exams` walk's authoritative `_rev` with NULL. `ExamMapper.fromDoc` documents
+precisely this hazard for `stepId`/`courseId` and uses `_presentOrAbsent` —
+"whichever of the two walks lands last decides…" — and `rev` wants the same
+treatment. It did not matter while nothing read `surveys.rev`; the first round
+of this phase made it decide an upload *and* a prune, which is why the fix moved
+to a dedicated flag instead. A full foreground pass repairs it (courses is area
+2, surveys area 5), but `retry(DashboardSyncArea.courses)`, a courses-only
+refresh, or a failed surveys walk leaves it NULL.
+
+`survey_mapper.dart` is outside this lane's set, and nothing here depends on the
+column any more — recorded so the next round does not build on `surveys.rev`
+without settling it first.
 
 ### `releaseStepJoinsForCourse` would strip a clone that ever carries a `stepId`
 
@@ -311,6 +475,17 @@ selection. Doing only the first silently reverts Phase 136; doing only the
 second silently reverts this phase. `app_database.dart` is this lane's file, but
 the change is not: nothing today writes that `stepId`, so a guard for it would
 be unreachable code guarding an unreachable state.
+
+### The outbox freezes `endpoint` at enqueue while the walk reads the live config
+
+Narrow, inherited from the outbox design rather than added here, and worth
+recording because this phase makes a *prune* depend on an upload. Both
+`credentialFreeDbUrl` and `dbUrl` switch on `config.isAlternativeUrl`
+(`url_utils.dart:45-51`). If the app moves to the clone URL between enqueue and
+drain while the primary is still reachable, the clone is published on one host
+and pruned by the other host's walk — and the `needsSync` exemption cannot save
+it, because publication is exactly what cleared the flag. Kotlin cannot reach
+this: it reads the live table at send time and never prunes `exams`.
 
 ### `progress_repository.dart:92-95` still reads as a contradiction
 

--- a/flutter/PHASE_138_NOTES.md
+++ b/flutter/PHASE_138_NOTES.md
@@ -404,6 +404,13 @@ schema bump on a handset that has adopted but not yet drained drops the clone
 and its questions and *keeps* the members' answer sheets — the same orphaning
 this phase removed from the sync path, reachable by an upgrade instead.
 
+**And it is not hypothetical for this release: the v47 bump above is such a
+bump.** Any handset carrying an adopted clone that has not yet reached the
+server loses it on upgrade to this build, and keeps the answer sheets. The
+window is narrow — an adoption is published on the next sync, and the outbox
+drains on app resume — but it is real, and it is the price of fixing the leak
+with a column. Worth stating plainly rather than leaving in the general case.
+
 By this project's own stated test — *can a sync restore this?*, not *is it
 local?* — the answer is mixed and the tables qualify: a **published** clone
 comes back on the next `exams` walk, an **unpublished** one exists nowhere else.

--- a/flutter/PHASE_138_NOTES.md
+++ b/flutter/PHASE_138_NOTES.md
@@ -1,14 +1,331 @@
-# Phase 138 — the adopted survey clone's lifecycle, and `pendingUploads`' missing status test
+# Phase 138 — the adopted survey clone's lifecycle, and `pendingUploads`' status test
 
 Lane A of a four-lane round. Two jobs, both handed over precisely by earlier
-rounds' *Reported, not fixed* lists:
+rounds' *Reported, not fixed* lists, and the round's own lesson is that **the
+handover was right about the defect and wrong about half of the fix** — twice.
 
-1. **An adopted team survey clone is destroyed on the next sync** (Phase 136's
-   top item). Kotlin uploads the clone so it gains a `_rev` and joins every
-   later walk's keep set; the port has neither the uploader nor a prune
-   exemption, so `SurveyDao.deleteNotIn` deletes it and orphans its answer
-   sheets.
-2. **`SubmissionDao.pendingUploads` has no status test where Kotlin's sweep
-   does** (Phase 134's top item). A behaviour decision, not an obvious repair.
+## Job 1 — an adopted team survey clone was destroyed on the next sync
 
-Work in progress; this file is written as the phase runs.
+Phase 136 found the clone had a lifetime of minutes. This is Phase 116's class
+at its worst: ported, tested, green, and *destroyed*.
+
+`SurveysRepository.adoptSurvey` mints a team's private copy of a shared survey
+locally. Kotlin then uploads it — `ExamDao.getPendingAdoptedSurveys()`
+(`ExamDao.kt:21`, `sourceSurveyId IS NOT NULL AND _rev IS NULL`) feeds
+`UploadConfigs.AdoptedSurveys` (`UploadConfigs.kt:186-195`) to the `exams`
+endpoint — and Kotlin's `exams` walk is insert-only, with no
+delete-except-ids on that table anywhere in the tree (`bulkInsertExamsFromSync`
+upserts; `ExamDao.deleteById` has zero production callers). The port had
+neither half: no adopted-survey uploader anywhere in `lib/`, and
+`SurveyDao.deleteNotIn` pruning every row without a `stepId` that the server
+did not name.
+
+Demonstrated failing before anything was written, on the production
+`adoptSurvey` over a course document shaped like the server's:
+
+```
+deleteNotIn(['survey-1'])  ->  clone row null, question rows gone
+a member's answer sheet    ->  parentId resolves to no survey at all
+```
+
+Three pieces:
+
+1. `SurveyDao.pendingAdoptedSurveys()` — the port of `ExamDao.kt:21`, **both
+   clauses**. `sourceSurveyId` alone is not a local-authorship marker: the
+   courses walk reads it straight off a server-embedded survey
+   (`survey_mapper.dart:163-167`), so an adopted copy Planet itself published
+   carries it, and sweeping on one clause would re-POST somebody else's
+   document. Same conjunction Phase 136 had to restore in
+   `hasUnfinishedSurveys` after shipping half of it.
+2. `SurveyDao.markUploaded(id, rev)`, and `deleteNotIn` spares
+   `sourceSurveyId IS NOT NULL AND rev IS NULL` — an **unpublished** clone
+   only, so the exemption lapses on publication rather than making a clone
+   immortal. A document the server has stopped naming is still a deletion this
+   prune should honour.
+3. `AdoptedSurveysUploader` on the outbox, shaped like `EventsUploader`, with
+   the sweep wired into both submissions-sweep sites.
+
+### Kotlin records nothing, and that is a defect rather than a behaviour to port
+
+`UploadConfigs.AdoptedSurveys` declares **no `responseHandler` and no
+`markUploaded`** — contrast `Meetups` five lines above it (`:172-184`), which
+has both. So the Kotlin row keeps `_rev = NULL`, stays in
+`getPendingAdoptedSurveys()` for the life of the install, and is re-POSTed on
+every sweep; `serializeExam` always writes `_id` (`StepExam.kt:73`), so CouchDB
+answers the second POST with a 409 and every one after it, silently. Recording
+the rev is also what lets the prune exemption be *scoped* — without it the only
+available predicate is "spare every clone forever".
+
+Note what this corrects in Phase 136's write-up: the clone does not survive in
+Kotlin because it "joins every later walk's keep set". **There is no keep
+set.** It survives because Kotlin never deletes. The upload's purpose there is
+publication; in the port the upload alone would not have sufficed, because the
+port's keep set is built only from `SurveyMapper.fromDoc`-mappable documents —
+which is what the next finding turns on.
+
+### The payload has to carry `type`, and the brief's version would have undone the fix
+
+The brief said to POST `SubmissionsRepository.surveyParentDocument`. Doing
+exactly that would have destroyed the clone by a longer route.
+
+`surveyParentDocument` deliberately omits `type`: for a submission's embedded
+`parent` object the value is not recoverable, because the port splits Kotlin's
+one `exams` table on `type` and then discards it. But `SurveyMapper.fromDoc`
+accepts a document only when `type == 'surveys'` (`survey_mapper.dart:66-69`)
+and `ExamMapper.fromDoc` accepts **everything that is not**
+(`exam_mapper.dart:30-35`), with `JsonUtils.getString` yielding `''` for a
+missing key. So a typeless upload would come back as a **graded course test**
+in the `exams` table, its id would go into `examIds` and never into the surveys
+walk's `ids`, and `deleteNotIn` would delete the surveys row anyway.
+
+For this upload the type *is* known: `createMappedSurvey` copies it from the
+source (`SurveysRepositoryImpl.kt:180`) and every list `adoptSurvey` is
+reachable from queries `type = "surveys"` (`ExamDao.kt:29-31`), so source and
+clone are always plural. `serializeExam` emits it unconditionally
+(`StepExam.kt:80`). `AdoptedSurveysUploader.documentFor` adds it, pinned by a
+test that runs the payload back through both mappers.
+
+**`courseId` survives the round trip**, and not by luck: `fromDoc` writes
+`courseId`/`stepId` as `Value.absent()` when the document omits the key
+(`_presentOrAbsent`), so the join `adoptSurvey` authored is preserved. Kotlin
+would lose it — `bulkInsertExamsFromSync` calls
+`insertCourseStepsExams("", "", jsonDoc, "")`, `checkIdsAndInsert` skips blank
+ids, and Room's `@Upsert` is a whole-row replace, which is why Kotlin's
+`getSurveyInfos` has to accept `pId == surveyId` **or**
+`pId.startsWith("$surveyId@")` (`SurveysRepositoryImpl.kt:304-307`).
+
+### Publishing the clone broke the mandatory-survey gate
+
+**The most valuable thing this phase found, and it was a defect this phase
+introduced.** Found by the ground-truth audit pass, on already-green code.
+
+Phase 136 keyed `hasUnfinishedSurveys`' clone skip on
+`sourceSurveyId != null && rev == null`, citing `ExamDao.kt:21`. That was exact
+only for as long as nothing ever published a clone. Job 1 publishes it, and
+the moment the rev is recorded the guard stops firing: the clone still carries
+the source's `courseId`, so `getByCourseId` hands it to **every** learner on the
+course, and nobody outside the adopting team has — or can have — a sheet keyed
+`"<cloneId>@<courseId>"`. On `MANDATORY_SURVEY_COURSE_ID` that is Phase 125's
+outcome reached by a new route: the course becomes uncompletable for everyone
+outside whichever team adopted its survey.
+
+Demonstrated: `hasUnfinishedSurveys('course-1','outsider')` is `false` before
+the drain and `true` after it, permanently.
+
+The guard is now `sourceSurveyId != null && stepId == null` — *does the courses
+walk own this row's course join?* A server-authored course-step survey always
+gets a `stepId` from `SurveyMapper._build` (positional, never blank); a clone
+never has one, deliberately; and `releaseStepJoinsForCourse` can only null it
+**together with** `courseId`, which drops the row out of this query altogether.
+Publication-independent, and Phase 136's own counter-example — a server-authored
+adopted step survey, which must still gate — passes unchanged and fails on the
+one-clause version.
+
+**And Kotlin has no such guard, which is why borrowing its predicate was the
+mistake.** `getSurveysByCourseId` filters
+`getByCourseIdAndType(courseId, "survey")` — *singular*
+(`SubmissionsRepositoryImpl.kt:367-379`) — so a Kotlin clone, being `"surveys"`,
+is never in that result set at all, rev or no rev. This is a port-invented
+guard on port-invented breadth. `ExamDao.kt:21` is an **upload sweep**;
+`rev` is a correct discriminator for a prune and was never one for a gate.
+
+## Job 2 — `pendingUploads` had no status test, and one of the two named rows should keep going
+
+Phase 134's sweep made an existing divergence systematic: `pendingUploads` runs
+on every sync for every row on the handset, with `isUpdated = true` as its only
+gate, where Kotlin's sweeps are `status = 'complete' AND …` (`SubmissionDao:41`)
+and `type = 'exam' AND … AND (_id IS NULL OR _id = '')` (`:40`). It named two
+rows the port sends and Kotlin never does. **Decided: only one of them stops.**
+
+**The team-adoption marker stops.** `createSurveyAdoptionSubmission` writes
+`status: ''` with `isUpdated: true`; no Kotlin config selects it. It is local
+bookkeeping that a team took a copy of a shared survey — no learner authored it
+and it carries no answers — and uploading it put an answerless `submissions`
+document into Planet's response set for every adoption.
+
+**Job 1 is what makes that safe, which is why the brief said to do Job 1
+first.** Before this phase the marker was the port's *only* server-side trace
+of an adoption, so withholding it would have lost the adoption off-device
+entirely. With the clone published — carrying `teamId` and `sourceSurveyId` —
+a second handset in the team learns of the adoption from the survey document,
+which is the route Kotlin has always used.
+
+**The `createDraft` free-form draft does not stop, and Phase 134's note that it
+should is wrong.** `createDraft` is the submissions screen's New-submission
+button, and `submissions_screen.dart:172-194` runs `queuePending` **and**
+`drain` on the very next lines: the learner typed a title and an answer and
+pressed Save. Having no Kotlin writer makes the *document shape* port-only; it
+does not make the user's intent absent. Excluding it would have made that button
+write to the device and nothing else — silently, since the sweep would return
+zero and the drain would find nothing to send. "Planet may refuse this shape" is
+a reason to fix the shape, not to strand the data. Kept, with a guard test
+carrying the reasoning so the claim is not re-seeded.
+
+### A null status is not a blank one
+
+The first cut was `coalesce(status,'') IN ('', 'pending')`, and the coalesce was
+wrong in the direction that loses data. Two of this table's *existing* tests
+build a row with no status at all to probe the guest-exam test, and the sync-in
+stores null for a document that omits the key — so coalescing null to `''`
+silently stranded every status-less row. Caught by the full suite, not by my
+own tests.
+
+The predicate is `status IS NOT NULL AND status = ''`. It is safe to be strict
+because a marker is only ever in this set as it was written, with the literal
+empty string: the re-pull that turns `''` into null also writes
+`isUpdated: false`. This is the **inverse** of the asymmetry Phase 136
+celebrated catching in the adoption *guard*, where `it.status.orEmpty().isEmpty()`
+(`SurveysRepositoryImpl.kt:206`) does mean null-or-blank. Same two values, two
+readers, opposite correct answers — worth knowing before anyone "makes them
+consistent". `FALSE AND NULL` is `FALSE` in SQL, so a null status fails the
+conjunction rather than poisoning it to NULL and dropping the row.
+
+Written as an **exclusion** rather than an allow-list of
+`complete`/`requires grading`/`pending`. The two forms select identically today
+— every local writer that sets `isUpdated: true` sets one of those four
+statuses, and `upsertDocuments` writes `isUpdated: false` on every pulled row,
+so a server-authored status can never reach the predicate — but they fail
+differently: an unanticipated status under an allow-list is silently stranded,
+under the exclusion it is one extra document.
+
+## Method notes
+
+**Two mutation checks silently did not apply, and both looked like a passing
+suite.** `dart format` had reflowed the exact lines the mutation strings
+matched, so `str.replace` was a no-op and the suite went green — which reads as
+"nothing pins this fix". Both were caught only because the *first* one's green
+result was implausible. Every mutation script here now asserts
+`s.count(old) == 1` before writing. Phase 122's rule generalises further than
+it was written: **mutation-test the test, and assert that the mutation landed.**
+
+Nine mutations were run and every one was caught by the intended test: the
+prune exemption, the payload's `type`, `markUploaded`, the exemption's scope,
+`pendingAdoptedSurveys`' second clause, the status exclusion, the F1 guard
+reverted to `rev`, the F1 guard's second clause dropped, and the null-status
+coalesce.
+
+**Two files outside the lane's listed set were touched**, deliberately and
+flagged for the integrator: `lib/providers/dashboard_sync_provider.dart` and
+`lib/background_entrypoint.dart`, two lines each. They are in **no other lane's**
+set this round. The alternative was shipping an uploader with no caller —
+ported, tested, green, and dead, which is the exact failure this phase is about.
+Phase 134 established these same two files as the sweep sites for the sibling
+uploader, and the addition is a literal port of
+`SubmissionsUploader.kt:83-84`'s two adjacent calls.
+
+**No Drift `schemaVersion` bump.** A prune exemption, a new query and a rev
+write change no DDL; `rev` and `sourceSurveyId` already exist on `Surveys`.
+**47 is unspent** — the next round can take it.
+
+## Files
+
+* `lib/data/local/app_database.dart` — `SurveyDao.pendingAdoptedSurveys`,
+  `SurveyDao.markUploaded`, the `deleteNotIn` exemption,
+  `SubmissionDao.pendingUploads`' status exclusion.
+* `lib/repository/adopted_surveys_uploader.dart` — new.
+* `lib/repository/submissions_repository.dart` — the `hasUnfinishedSurveys`
+  guard.
+* `lib/providers/app_providers.dart` — provider + drainer handler.
+* `lib/providers/dashboard_sync_provider.dart`, `lib/background_entrypoint.dart`
+  — the sweep, ahead of the submissions sweep and ahead of the surveys pull.
+* `docs/kotlin-to-flutter-migration.md` — five deviations entries, including the
+  four Phase 134 asked for and could not reach.
+* `test/repository/adopted_survey_survives_sync_test.dart` (11),
+  `test/repository/pending_uploads_status_test.dart` (4).
+
+Gate green: `dart format` clean, `flutter analyze` clean, **2472 tests pass**
+(2457 before).
+
+## Reported, not fixed
+
+### A schema bump still destroys an unpublished clone, and `submissions` outlives it
+
+**The one this phase creates the expectation for and does not close.** `surveys`
+and `survey_questions` are **not** in `localAuthorityTables`, while
+`submissions`, `submission_answers` and `submission_questions` all are. So a
+schema bump on a handset that has adopted but not yet drained drops the clone
+and its questions and *keeps* the members' answer sheets — the same orphaning
+this phase removed from the sync path, reachable by an upgrade instead.
+
+By this project's own stated test — *can a sync restore this?*, not *is it
+local?* — the answer is mixed and the tables qualify: a **published** clone
+comes back on the next `exams` walk, an **unpublished** one exists nowhere else.
+That is the `feedback` argument verbatim ("a feedback sync exists now, but it
+only refills what already reached the server — which is precisely not these
+rows"), and the mechanism is the `teams` precedent: preserve the whole table and
+let the next `deleteNotIn` evict the stale cache half.
+
+**Not done here, deliberately, because the cost lands on future rounds rather
+than this one.** `createAll` does not *alter* a preserved table, so every
+future column on `Surveys` or `SurveyQuestions` would need a hand-written
+`_addColumnIfMissing` step — and forgetting one does not fail loudly, it leaves
+the column absent on every existing install and breaks every query that names
+it. `Surveys` gained `courseId`/`stepId` as recently as v35, so this is not a
+hypothetical tax. It wants its own diff, with both tables' columns audited
+against the upgrade path. Whoever takes it should read the
+*preserved-table test* section of `docs/kotlin-to-flutter-migration.md` first.
+
+### A 409 has no recovery, and the port's deterministic clone id makes one reachable
+
+Kotlin mints the clone id with `UUID.randomUUID()`
+(`SurveysRepositoryImpl.kt:86`); the port uses `'${surveyId}_$teamId'`
+(`surveys_repository.dart:105`). The port's is better — two handsets adopting
+the same survey for the same team converge on **one** document where Kotlin
+writes two — but it makes a conflict ordinary rather than freakish: two leaders
+in one team both adopt before either syncs, and the second POST is a 409.
+
+Kotlin recovers: `UploadCoordinator.kt:169-204` GETs `$baseUrl/exams/<localId>`
+on a conflict and reads `_id`/`_rev` back. The port has nothing —
+`OutboxDrainer` classifies any `code < 500` as permanent
+(`outbox_drainer.dart:160-172`) — so the row is abandoned with the local rev
+unrecorded. It is **bounded**, which is why it is reported rather than fixed:
+the losing device's next `exams` walk pulls the winner's document, upserts a rev
+onto its own row, and the clone leaves `pendingAdoptedSurveys()`, so the
+accretion is one dead outbox row per conflict rather than one per sync. The
+handler's comment says this in place.
+
+The fix is a conflict arm — GET the document, read the rev, `markUploaded`, and
+report success — and it belongs at the drainer or in `PlanetApi`'s vocabulary
+rather than in one uploader, since it is the same shape for every
+client-supplied-`_id` POST in the tree. Bundling it here would fix one of
+twenty.
+
+### The abandoned-row accretion Phase 134 reported now has a twentieth instance
+
+Unchanged and still a cross-uploader policy call: `OutboxDao.findOpen` ignores
+an `abandoned` row so a fresh enqueue is never blocked by one, `clearAbandoned`
+has one caller in the tree and `cleanup()` has none, and `outbox` is preserved
+across schema bumps. `AdoptedSurveysUploader` inherits the shape. The 409 above
+is its most likely trigger here, and it is bounded for the reason given.
+
+### `releaseStepJoinsForCourse` would strip a clone that ever carries a `stepId`
+
+Phase 136 reported this as a hazard for a future round; it is now **twice**
+load-bearing, because `hasUnfinishedSurveys`' guard reads `stepId == null` as
+"this is a locally minted clone". If a later round decides the clone should
+carry a `stepId` — to match Kotlin's step button — it must fix three things
+together: spare `sourceSurveyId IS NOT NULL` in
+`SurveyDao.releaseStepJoinsForCourse`, re-key the `hasUnfinishedSurveys` guard
+on something else, and re-read `SurveyDao.deleteNotIn`'s `stepId IS NULL`
+selection. Doing only the first silently reverts Phase 136; doing only the
+second silently reverts this phase. `app_database.dart` is this lane's file, but
+the change is not: nothing today writes that `stepId`, so a guard for it would
+be unreachable code guarding an unreachable state.
+
+### `progress_repository.dart:92-95` still reads as a contradiction
+
+Phase 136's report, unchanged, and still outside this lane's set. Its comment
+justifies a `groupBy` with "`adoptSurvey` copies `stepId` onto a new row, so a
+step can legitimately carry more than one" — a statement about *Kotlin*, which
+now contradicts two files rather than one. The `groupBy` is correct and should
+stay; it wants one clarifying clause.
+
+### Adopt is still gated on team leadership; Kotlin gates on guest
+
+Phase 132's and Phase 136's report, unchanged. `team_surveys_screen.dart:32` has
+`canAdopt = membership?.isLeader == true` where Kotlin has no role gate at all
+(`SurveysAdapter:83-90`, whose only visibility rule hides the start affordance
+for a `guest` user). Still an authorization change wanting its own diff, and
+still not in this lane's set. Worth noting that this phase raises the stakes
+mildly: adoption now publishes a document, so widening who may adopt widens who
+may write to the `exams` database.

--- a/flutter/PHASE_138_NOTES.md
+++ b/flutter/PHASE_138_NOTES.md
@@ -1,0 +1,14 @@
+# Phase 138 — the adopted survey clone's lifecycle, and `pendingUploads`' missing status test
+
+Lane A of a four-lane round. Two jobs, both handed over precisely by earlier
+rounds' *Reported, not fixed* lists:
+
+1. **An adopted team survey clone is destroyed on the next sync** (Phase 136's
+   top item). Kotlin uploads the clone so it gains a `_rev` and joins every
+   later walk's keep set; the port has neither the uploader nor a prune
+   exemption, so `SurveyDao.deleteNotIn` deletes it and orphans its answer
+   sheets.
+2. **`SubmissionDao.pendingUploads` has no status test where Kotlin's sweep
+   does** (Phase 134's top item). A behaviour decision, not an obvious repair.
+
+Work in progress; this file is written as the phase runs.

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -300,6 +300,18 @@ Future<void> sweepPendingSubmissions(
   required String? userId,
 }) async {
   try {
+    // Immediately ahead of the submissions sweep, which is exactly where
+    // Kotlin has it: `SubmissionsUploader.uploadSubmissionsWithTiming` calls
+    // `uploadAdoptedSurveys()` then `uploadSubmissions(...)`
+    // (`SubmissionsUploader.kt:83-84`), and `UserDataWorker:47-48` runs the
+    // same pair in the same order. The order is load-bearing for the port in a
+    // way it is not for Kotlin: the drain that follows records each clone's
+    // rev before the surveys pull's `deleteNotIn` runs, so the clone is either
+    // named by the walk or still `rev IS NULL` and spared. Either way it
+    // survives — see [SurveyDao.deleteNotIn].
+    await container
+        .read(adoptedSurveysUploaderProvider)
+        .queuePending(config: config, userId: userId);
     await container
         .read(submissionsUploaderProvider)
         .queuePending(config: config, userId: userId);

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -309,9 +309,19 @@ Future<void> sweepPendingSubmissions(
     // rev before the surveys pull's `deleteNotIn` runs, so the clone is either
     // named by the walk or still `rev IS NULL` and spared. Either way it
     // survives — see [SurveyDao.deleteNotIn].
-    await container
-        .read(adoptedSurveysUploaderProvider)
-        .queuePending(config: config, userId: userId);
+    // In its own `try`: `UserDataWorker:47-48` wraps each arm in its own
+    // `runCatching`, and this arm can throw where the Kotlin's cannot —
+    // `queuePending` reads device identity, which rethrows on an engine with
+    // no channel and no primed cache, and a headless engine is exactly that
+    // case. Sharing the `try` let one adopted clone skip the submissions
+    // safety net entirely.
+    try {
+      await container
+          .read(adoptedSurveysUploaderProvider)
+          .queuePending(config: config, userId: userId);
+    } catch (_) {
+      // Deliberately ignored — see above.
+    }
     await container
         .read(submissionsUploaderProvider)
         .queuePending(config: config, userId: userId);

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -2469,15 +2469,76 @@ class SubmissionDao extends DatabaseAccessor<AppDatabase>
   /// that member answering it while signed in. On the answering turn scoped and
   /// unscoped agree.
   ///
-  /// `isUpdated` stays the status gate rather than Kotlin's
+  /// `isUpdated` stays the *primary* gate rather than Kotlin's
   /// `status = 'complete'`, because the port merges the two configs into one
   /// uploader: an exam is never `complete` (it finishes at
-  /// `requires grading`), so filtering on that would strand every exam
+  /// `requires grading`), so filtering on that alone would strand every exam
   /// attempt. The exam arm it stands in for is `ExamResults`, whose guest
   /// filter is ported alongside it — a guest's attempt is answer-sheet
   /// practice, and Kotlin does not send it. Both operands are coalesced so a
   /// null `type` or `userId` cannot turn the test into SQL NULL and drop a row
   /// that is nobody's guest exam.
+  ///
+  /// **On top of it there is now one status exclusion, and it is a behaviour
+  /// decision rather than a repair.** Having no status test at all was a
+  /// defensible trade while this ran from four deliberate write-time sites;
+  /// Phase 134 gave it a sweep on every sync, for every row on the handset,
+  /// and named two rows Kotlin's sweeps never send that therefore went up
+  /// systematically. **Only one of the two should stop.**
+  ///
+  /// The **team-adoption marker** does. `createSurveyAdoptionSubmission` writes
+  /// `status: ''` with `isUpdated: true`; Kotlin's `getPendingSubmissions`
+  /// wants `complete` and its `getPendingExamResults` wants `type = 'exam'`, so
+  /// neither selects it. It is local bookkeeping that a team has taken a copy
+  /// of a shared survey — no learner authored it and it carries no answers —
+  /// and uploading it put an answerless `submissions` document into Planet's
+  /// response set for every adoption.
+  ///
+  /// What makes withholding it *safe* rather than a data-sharing regression is
+  /// the other half of Phase 138: with [SurveyDao.pendingAdoptedSurveys] and
+  /// `AdoptedSurveysUploader` the clone itself now reaches the server carrying
+  /// `teamId` and `sourceSurveyId`, so a second handset in the team learns of
+  /// the adoption from the survey document — the route Kotlin has always used.
+  /// Before that the marker was the port's only server-side trace of an
+  /// adoption, and dropping it would have lost the team's adoption off-device.
+  ///
+  /// The **`pending` free-form draft does not**, and Phase 134's note that it
+  /// should was checked and is wrong. `createDraft` is the submissions screen's
+  /// New-submission button, and `submissions_screen.dart:172-194` runs
+  /// `queuePending` *and* `drain` on the very next lines: the learner filled in
+  /// a title and an answer and pressed Save, so the row is a deliberate
+  /// submission, not a bookkeeping artefact. Excluding it would have made that
+  /// button write to the device and nothing else — silently, since the sweep
+  /// would return zero and the drain would find nothing to send. That it has no
+  /// Kotlin writer makes the *document shape* port-only; it does not make the
+  /// user's intent absent, and "Planet may refuse this shape" is a reason to
+  /// fix the shape, not to strand the data. The divergence is recorded in
+  /// `docs/kotlin-to-flutter-migration.md`. (Its `status: 'pending'` is
+  /// arguably the wrong value for something the user just submitted, but that
+  /// string also drives the screen's own Pending/finished split, so it is a UI
+  /// change and not this predicate's to make.)
+  ///
+  /// The exclusion is written as an **exclusion** rather than an allow-list of
+  /// `complete`/`requires grading`/`pending`. The two forms select identically
+  /// today — every local writer that sets `isUpdated: true` sets one of those
+  /// four statuses, and `upsertDocuments` writes `isUpdated: false` on every
+  /// pulled row, so a server-authored status can never reach this predicate —
+  /// but they fail differently. An unanticipated status under an allow-list is
+  /// silently stranded on the handset, which is the failure this project keeps
+  /// paying for; under the exclusion it is an extra document. `coalesce`
+  /// because a null status is the empty one (`SurveysRepositoryImpl.kt:206`
+  /// reads `it.status.orEmpty().isEmpty()`, and `json_utils.dart:19-22` turns
+  /// the empty string back into null on a re-pull) — which is exactly the
+  /// state a marker that has round-tripped is in.
+  ///
+  /// Two things it deliberately does **not** change. A `pending` exam attempt
+  /// still does not upload, because `saveExamAnswer` only sets `isUpdated` at
+  /// `requires grading` — Kotlin's `ExamResults` config has no status test and
+  /// does send a half-finished attempt, a divergence recorded in
+  /// `docs/kotlin-to-flutter-migration.md` rather than closed here. And a bulk
+  /// `pending` sheet from `createBulkSurveySubmissions` was never selected
+  /// either way (`getOrCreateSurveySubmission` writes `isUpdated: false`),
+  /// which matches Kotlin, whose sweep wants `complete`.
   ///
   /// The one exclusion with no Kotlin counterpart is the **anonymous
   /// public-survey answer sheet**. `public_survey_screen` mints a
@@ -2499,9 +2560,28 @@ class SubmissionDao extends DatabaseAccessor<AppDatabase>
     Expression<bool> isGuestExamAttempt($SubmissionsTable row) =>
         coalesce([row.type, const Constant('')]).equals('exam') &
         owner(row).like('guest%');
+    // `status IS NOT NULL AND status = ''`, and the first clause is
+    // load-bearing in the direction opposite to `isGuestExamAttempt`'s
+    // `coalesce`. A **null** status is not a marker: `pendingUploads` was
+    // status-blind until Phase 138, so two of this table's own tests build a
+    // row with no status at all to probe the guest test, and the sync-in
+    // stores null for a document that omits the key. Coalescing null to `''`
+    // here — the reading `SurveysRepositoryImpl.kt:206` uses for the *adoption
+    // guard*, where a round-tripped marker really has read back as null —
+    // would silently strand every such row instead, which is the failure this
+    // predicate's shape is chosen to avoid. It is safe to be strict because a
+    // marker is only ever in this set as `createSurveyAdoptionSubmission`
+    // wrote it, with the literal empty string: the re-pull that turns `''`
+    // into null also writes `isUpdated: false`.
+    //
+    // `FALSE AND NULL` is `FALSE` in SQL, so a null status fails the
+    // conjunction rather than poisoning it to NULL and dropping the row.
+    Expression<bool> isATeamAdoptionMarker($SubmissionsTable row) =>
+        row.status.isNotNull() & row.status.equals('');
     return (select(submissions)..where(
           (row) =>
               row.isUpdated.equals(true) &
+              isATeamAdoptionMarker(row).not() &
               isGuestExamAttempt(row).not() &
               // The `_` is LIKE's single-character wildcard, not an escaped
               // literal, and nothing turns on that: the two patterns differ
@@ -2754,16 +2834,73 @@ class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
     }
   });
 
+  /// Every locally minted team-adoption clone that has not reached the server.
+  ///
+  /// Port of `ExamDao.getPendingAdoptedSurveys()` (`ExamDao.kt:21`),
+  /// `sourceSurveyId IS NOT NULL AND _rev IS NULL`, which feeds
+  /// `UploadConfigs.AdoptedSurveys` (`UploadConfigs.kt:186-195`) to the `exams`
+  /// endpoint. Kotlin carries no `type` clause because it has one `exams`
+  /// table; the port's split puts the whole query here, and the `exams` table
+  /// needs no counterpart because `adoptSurvey` writes only to [Surveys].
+  ///
+  /// **Both clauses matter, and the second is the load-bearing one.**
+  /// `sourceSurveyId` is not a local-authorship marker: the courses walk reads
+  /// it straight off a server-embedded survey (`survey_mapper.dart:163-167`),
+  /// so an adopted copy that Planet itself published carries it too. Only
+  /// `rev IS NULL` separates "this device minted it and nobody else has it"
+  /// from "the server sent it" — the same conjunction Phase 136 had to restore
+  /// in `hasUnfinishedSurveys` after shipping half of it.
+  Future<List<SurveyRow>> pendingAdoptedSurveys() => (select(
+    surveys,
+  )..where((row) => row.sourceSurveyId.isNotNull() & row.rev.isNull())).get();
+
+  /// Records that an adopted clone became a real CouchDB document.
+  ///
+  /// **Kotlin does not do this**, and the omission is a defect rather than a
+  /// behaviour to port: `UploadConfigs.AdoptedSurveys` declares no
+  /// `responseHandler` and no `markUploaded` (contrast `Meetups`, five lines
+  /// above it, which has both), so the row keeps `_rev = NULL`, stays in
+  /// `getPendingAdoptedSurveys()` for the life of the install, and is re-POSTed
+  /// on every sweep — `serializeExam` always writes `_id`
+  /// (`StepExam.kt:73`), so CouchDB answers the second POST with a 409 and
+  /// every one after it, silently.
+  ///
+  /// Recording the rev also gives [deleteNotIn] a precise exemption. Without it
+  /// the only predicate available would be "spare every clone forever", which
+  /// would keep a clone whose server document has since been deleted.
+  Future<int> markUploaded(String id, String rev) =>
+      (update(surveys)..where((row) => row.id.equals(id))).write(
+        SurveysCompanion(rev: Value(rev)),
+      );
+
   /// See [MeetupDao.deleteNotIn] for why the difference is taken in Dart and
   /// the deletes are chunked. Rows with a `stepId` are spared for the reason
   /// [ExamDao.deleteNotIn] gives: since Phase 113 a course step's survey is
   /// written by the *courses* walk and cannot be in this walk's keep set.
+  ///
+  /// **An unpublished team-adoption clone is spared too.** It is minted on this
+  /// handset by [SurveysRepository.adoptSurvey], carries no `stepId`
+  /// (deliberately — see that method) and is in no document the server can
+  /// name, so before this exemption the very next surveys sync deleted it and
+  /// its question rows and orphaned every answer sheet its members had filled
+  /// in. Kotlin cannot reach that outcome from either side: it uploads the
+  /// clone (`UploadConfigs.AdoptedSurveys`) and its `exams` walk is
+  /// insert-only — `bulkInsertExamsFromSync` upserts and nothing in the tree
+  /// ever deletes from that table.
+  ///
+  /// The exemption is scoped to `rev IS NULL` rather than to every clone, so it
+  /// lapses the moment [markUploaded] runs: once the document exists, the walk
+  /// that names it keeps it and a walk that stops naming it is reporting a
+  /// deletion this prune should honour.
   Future<int> deleteNotIn(List<String> ids) => transaction(() async {
     final keep = ids.toSet();
     final all =
         await (selectOnly(surveys)
               ..addColumns([surveys.id])
-              ..where(surveys.stepId.isNull()))
+              ..where(
+                surveys.stepId.isNull() &
+                    (surveys.sourceSurveyId.isNull() | surveys.rev.isNotNull()),
+              ))
             .map((row) => row.read(surveys.id)!)
             .get();
     final stale = all.where((id) => !keep.contains(id)).toList(growable: false);

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -109,7 +109,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 46;
+  int get schemaVersion => 47;
 
   /// Tables holding local intent the server cannot give back.
   ///
@@ -405,6 +405,21 @@ class AppDatabase extends _$AppDatabase {
       if (from < 46) {
         await _addColumnIfMissing(m, teamTasks, teamTasks.sync);
         await _addColumnIfMissing(m, teamTasks, teamTasks.link);
+      }
+
+      // v47 adds `Surveys.needsSync`, the local-authorship flag an adopted
+      // team clone is published on. No hand-written step: `surveys` is not in
+      // [_localAuthorityTables], so it is dropped above and `createAll`
+      // recreates it with the column. Which also means the bump itself
+      // destroys an unpublished clone — pre-existing for this table and
+      // recorded in the phase notes, not something this column changes.
+      //
+      // The default is `false`, which is correct for every row a re-sync
+      // refills: a survey the server sent is not this device's to publish.
+      if (from < 47) {
+        // Deliberately empty. Kept as an explicit branch so the next reader
+        // sees that v47 was considered here and needs nothing, rather than
+        // wondering whether a step was forgotten.
       }
     },
   );
@@ -2850,27 +2865,37 @@ class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
   /// `rev IS NULL` separates "this device minted it and nobody else has it"
   /// from "the server sent it" — the same conjunction Phase 136 had to restore
   /// in `hasUnfinishedSurveys` after shipping half of it.
-  Future<List<SurveyRow>> pendingAdoptedSurveys() => (select(
-    surveys,
-  )..where((row) => row.sourceSurveyId.isNotNull() & row.rev.isNull())).get();
+  Future<List<SurveyRow>> pendingAdoptedSurveys() =>
+      (select(surveys)..where((row) => row.needsSync.equals(true))).get();
 
   /// Records that an adopted clone became a real CouchDB document.
   ///
-  /// **Kotlin does not do this**, and the omission is a defect rather than a
-  /// behaviour to port: `UploadConfigs.AdoptedSurveys` declares no
-  /// `responseHandler` and no `markUploaded` (contrast `Meetups`, five lines
-  /// above it, which has both), so the row keeps `_rev = NULL`, stays in
-  /// `getPendingAdoptedSurveys()` for the life of the install, and is re-POSTed
-  /// on every sweep — `serializeExam` always writes `_id`
-  /// (`StepExam.kt:73`), so CouchDB answers the second POST with a 409 and
-  /// every one after it, silently.
+  /// **This is at parity with Kotlin, and an earlier revision of this comment
+  /// said the opposite.** `UploadConfigs.AdoptedSurveys` declares no
+  /// `markUploaded` and no `responseHandler`, which is what the declaration
+  /// looks like — but `UploadConfig` carries a **default** `persistUploaded`
+  /// keyed on the model class (`UploadConfig.kt:46-56`,
+  /// `StepExam::class -> UploadUpdateType.Exams`), which
+  /// `UploadRepositoryImpl.markExamsUploaded` resolves to
+  /// `exam._rev = result.remoteRev` (`UploadRepositoryImpl.kt:76`), and
+  /// `runPipeline` calls it on every successful batch
+  /// (`UploadCoordinator.kt:63-68`). So Kotlin records the rev, its row leaves
+  /// `getPendingAdoptedSurveys()`, and there is no second POST. The `Meetups`
+  /// contrast was wrong twice over: `Meetups` is a `RoomUploadConfig`, whose
+  /// `persistUploaded` *is* only that lambda (`RoomUploadConfig.kt:42-45`) so
+  /// it has no default to fall back on, and its
+  /// `ResponseHandler.Custom("id", "rev")` is byte-identical to the `Standard`
+  /// default (`UploadConfig.kt:24`).
   ///
-  /// Recording the rev also gives [deleteNotIn] a precise exemption. Without it
-  /// the only predicate available would be "spare every clone forever", which
-  /// would keep a clone whose server document has since been deleted.
+  /// Recorded here because the port needs it for the same reason Kotlin does,
+  /// plus one Kotlin does not have: [deleteNotIn] prunes this table where
+  /// Kotlin never deletes from `exams` at all, so clearing
+  /// [Surveys.needsSync] is what hands a published clone back to the walk that
+  /// now names it. Kotlin's `_rev` write and this one are the same statement
+  /// serving two purposes.
   Future<int> markUploaded(String id, String rev) =>
       (update(surveys)..where((row) => row.id.equals(id))).write(
-        SurveysCompanion(rev: Value(rev)),
+        SurveysCompanion(rev: Value(rev), needsSync: const Value(false)),
       );
 
   /// See [MeetupDao.deleteNotIn] for why the difference is taken in Dart and
@@ -2898,8 +2923,7 @@ class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
         await (selectOnly(surveys)
               ..addColumns([surveys.id])
               ..where(
-                surveys.stepId.isNull() &
-                    (surveys.sourceSurveyId.isNull() | surveys.rev.isNotNull()),
+                surveys.stepId.isNull() & surveys.needsSync.equals(false),
               ))
             .map((row) => row.read(surveys.id)!)
             .get();

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -541,6 +541,34 @@ class Surveys extends Table {
   TextColumn get courseId => text().nullable()();
   TextColumn get stepId => text().nullable()();
 
+  /// This device authored this row and the server has never seen it — set only
+  /// by `SurveysRepository.adoptSurvey`, cleared by [SurveyDao.markUploaded].
+  ///
+  /// **It exists because the port cannot ask `_rev IS NULL` the way Kotlin
+  /// can.** `ExamDao.getPendingAdoptedSurveys()` is
+  /// `sourceSurveyId IS NOT NULL AND _rev IS NULL` (`ExamDao.kt:21`), and in
+  /// Kotlin that names exactly one writer: `JsonUtils.getString` returns `""`
+  /// for a missing key (`JsonUtils.kt:64-68`) and both sync writers assign
+  /// `_rev = JsonUtils.getString("_rev", …)` unconditionally
+  /// (`StepExam.kt:47`, `CoursesRepositoryImpl.kt:736`), so a synced row's
+  /// `_rev` is `""` and never NULL. Only `createMappedSurvey`'s explicit
+  /// `_rev = null` (`SurveysRepositoryImpl.kt:172`) makes the predicate true.
+  ///
+  /// The port's mappers use `getStringOrNull`, so **absent becomes NULL** and
+  /// that distinction is gone: `rev IS NULL` is true for every survey whose
+  /// document omitted `_rev`, which is every course-embedded survey (a
+  /// sub-object carries no `_rev` of its own) and every public-API one. With
+  /// `sourceSurveyId` as the only other clause — and the courses walk reads
+  /// that straight off the server (`survey_mapper.dart:163-165`) — the sweep
+  /// selected another team's private copy and POSTed it to `exams` under this
+  /// user's credentials, and the prune spared it forever.
+  ///
+  /// A flag written by one caller has no such ambiguity, and it also frees
+  /// `SurveyDao.deleteNotIn` and `pendingAdoptedSurveys` from depending on a
+  /// `rev` column two sync walks disagree about the ownership of (see the
+  /// phase notes).
+  BoolColumn get needsSync => boolean().withDefault(const Constant(false))();
+
   @override
   Set<Column> get primaryKey => {id};
 }

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -16,6 +16,7 @@ import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 import '../repository/achievements_repository.dart';
 import '../repository/achievements_uploader.dart';
+import '../repository/adopted_surveys_uploader.dart';
 import '../repository/activities_repository.dart';
 import '../repository/activities_uploader.dart';
 import '../repository/chat_repository.dart';
@@ -230,6 +231,20 @@ final eventsRepositoryProvider = Provider<EventsRepository>(
   (ref) => EventsRepository(
     ref.watch(planetApiProvider),
     ref.watch(meetupDaoProvider),
+  ),
+);
+
+/// The missing half of the team-survey adoption path — see
+/// [AdoptedSurveysUploader]. Its sweep runs from
+/// `DashboardSyncNotifier.queuePendingSubmissions` and the headless
+/// `sweepPendingSubmissions`, immediately ahead of the submissions sweep, which
+/// is where Kotlin has it (`SubmissionsUploader.kt:83-84`).
+final adoptedSurveysUploaderProvider = Provider<AdoptedSurveysUploader>(
+  (ref) => AdoptedSurveysUploader(
+    ref.watch(planetApiProvider),
+    ref.watch(surveyDaoProvider),
+    ref.watch(outboxRepositoryProvider),
+    ref.watch(deviceIdentitySourceProvider),
   ),
 );
 
@@ -637,6 +652,9 @@ final outboxDrainerProvider = Provider<OutboxDrainer>((ref) {
           .watch(submitPhotosUploaderProvider)
           .handler,
       EventsUploader.type: ref.watch(eventsUploaderProvider).handler,
+      AdoptedSurveysUploader.type: ref
+          .watch(adoptedSurveysUploaderProvider)
+          .handler,
       VoicesUploader.type: ref.watch(voicesUploaderProvider).handler,
       TeamTasksUploader.type: ref.watch(teamTasksUploaderProvider).handler,
       TeamLogUploader.type: ref.watch(teamLogUploaderProvider).handler,

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -319,12 +319,27 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
       // Ahead of the submissions sweep, as `SubmissionsUploader.kt:83-84` has
       // it — and, unlike in Kotlin, ahead of the surveys pull below, which is
       // what keeps `SurveyDao.deleteNotIn` from destroying a team's adopted
-      // clone: the drain two lines down records the clone's rev, so by the
-      // time the prune runs the walk names it. A drain that fails leaves
-      // `rev IS NULL`, which that prune spares.
-      await ref
-          .read(adoptedSurveysUploaderProvider)
-          .queuePending(config: config, userId: user?.id);
+      // clone: the drain below records the clone's rev, so by the time the
+      // prune runs the walk names it. A drain that fails leaves the row
+      // `needsSync`, which that prune spares.
+      //
+      // **In its own `try`, for the reason this method's own doc gives for
+      // not sharing one.** `UserDataWorker:47-48` wraps each arm in its own
+      // `runCatching`, and `SubmissionsUploader.kt:80-88`'s shared `try` is
+      // not a counter-example because `uploadAdoptedSurveys()` cannot throw —
+      // `UploadCoordinator.runPipeline` catches `Exception` internally
+      // (`UploadCoordinator.kt:87-92`). This one can: `queuePending` reads
+      // device identity, and `PlatformDeviceIdentitySource.read` rethrows on
+      // an engine with no channel and no primed cache. Sharing the `try` let
+      // one adopted clone on such a handset skip the submissions safety net
+      // Phase 134 added *and* the whole outbox drain.
+      try {
+        await ref
+            .read(adoptedSurveysUploaderProvider)
+            .queuePending(config: config, userId: user?.id);
+      } catch (_) {
+        // Deliberately ignored — see above.
+      }
       await ref
           .read(submissionsUploaderProvider)
           .queuePending(config: config, userId: user?.id);

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -316,6 +316,15 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
       // reached here first. The `await` is inside the `try` because the future
       // can reject where `valueOrNull` could not.
       final user = await ref.read(sessionProvider.future);
+      // Ahead of the submissions sweep, as `SubmissionsUploader.kt:83-84` has
+      // it — and, unlike in Kotlin, ahead of the surveys pull below, which is
+      // what keeps `SurveyDao.deleteNotIn` from destroying a team's adopted
+      // clone: the drain two lines down records the clone's rev, so by the
+      // time the prune runs the walk names it. A drain that fails leaves
+      // `rev IS NULL`, which that prune spares.
+      await ref
+          .read(adoptedSurveysUploaderProvider)
+          .queuePending(config: config, userId: user?.id);
       await ref
           .read(submissionsUploaderProvider)
           .queuePending(config: config, userId: user?.id);

--- a/flutter/lib/repository/adopted_surveys_uploader.dart
+++ b/flutter/lib/repository/adopted_surveys_uploader.dart
@@ -1,0 +1,155 @@
+import '../core/config/server_config.dart';
+import '../core/network/network_result.dart';
+import '../core/system/device_identity.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
+import '../data/local/app_database.dart';
+import 'outbox_drainer.dart';
+import 'outbox_repository.dart';
+import 'submissions_repository.dart';
+
+/// Durable port of `UploadConfigs.AdoptedSurveys` (`UploadConfigs.kt:186-195`),
+/// which `UploadManager.uploadAdoptedSurveys` POSTs to the `exams` endpoint.
+///
+/// **This is the missing half of the port's adoption path, and its absence was
+/// destructive rather than merely incomplete.** `SurveysRepository.adoptSurvey`
+/// mints a team's private copy of a shared survey locally; Kotlin then uploads
+/// it, so it becomes a document every satellite can replicate, every later
+/// `exams` walk names it, and — Kotlin having no delete-except-ids on that
+/// table at all — nothing prunes it either way. The port had neither the upload
+/// nor a prune exemption, so `SurveyDao.deleteNotIn` destroyed the clone and
+/// its question rows on the next surveys sync and left its members' answer
+/// sheets pointing at nothing. A team's adopted survey had a lifetime of
+/// minutes.
+///
+/// Ported at the shape of [EventsUploader]: an unscoped sweep that enqueues,
+/// and a handler that POSTs and records the CouchDB identity.
+class AdoptedSurveysUploader {
+  AdoptedSurveysUploader(
+    this._api,
+    this._surveyDao,
+    this._outbox,
+    this._identity,
+  );
+
+  static const type = 'adopted_surveys';
+
+  final PlanetApi _api;
+  final SurveyDao _surveyDao;
+  final OutboxRepository _outbox;
+  final DeviceIdentitySource _identity;
+
+  /// Credential-free: this string is persisted in `outbox.endpoint`, a table
+  /// that deliberately survives schema upgrades. The PIN travels as the
+  /// `Authorization` header at send time instead.
+  static String endpointFor(ServerConfig config) =>
+      '${UrlUtils.credentialFreeDbUrl(config)}/exams';
+
+  /// The document `StepExam.serializeExam` (`StepExam.kt:71-95`) builds, which
+  /// is the serializer this upload config uses.
+  ///
+  /// [SubmissionsRepository.surveyParentDocument] is that serializer's port and
+  /// carries every other field, but it deliberately omits `type` — for a
+  /// submission's embedded `parent` object the value is not recoverable, since
+  /// the port splits Kotlin's one `exams` table on it and then discards it.
+  ///
+  /// **Here it is recoverable, and omitting it would have been the whole fix
+  /// undone.** `SurveyMapper.fromDoc` accepts a document only when
+  /// `type == 'surveys'` and `ExamMapper.fromDoc` accepts anything that is
+  /// *not*, so a re-pull of a typeless upload would have filed the team's
+  /// survey into the `exams` table as a graded course test, left the surveys
+  /// walk's keep set without its id, and had `deleteNotIn` delete the row this
+  /// class exists to save — the clone destroyed by a longer route. A clone's
+  /// type is known for certain: Kotlin's `createMappedSurvey` copies it from
+  /// the source (`type = exam.type`, `SurveysRepositoryImpl.kt:180`) and every
+  /// list `adoptSurvey` is reachable from queries `type = "surveys"`
+  /// (`ExamDao.kt:29-31`), so the source, and therefore the clone, is always
+  /// plural.
+  static Map<String, dynamic> documentFor(
+    SurveyRow survey,
+    List<SurveyQuestionRow> questions,
+  ) => {
+    ...SubmissionsRepository.surveyParentDocument(survey, questions),
+    'type': 'surveys',
+  };
+
+  /// Queues every adopted clone that has not reached the server.
+  ///
+  /// Unscoped, like the Kotlin sweep it ports: `getPendingAdoptedSurveys()`
+  /// carries no `userId` predicate and `uploadAdoptedSurveys()` takes no user,
+  /// so a clone adopted by whoever was signed in last still goes up. [userId]
+  /// only tags the outbox row.
+  ///
+  /// The identity read is guarded on an empty list so a pass with nothing to
+  /// send makes no platform-channel call — `PlatformDeviceIdentitySource.read`
+  /// rethrows on an engine with no channel and no primed cache.
+  Future<int> queuePending({
+    required ServerConfig config,
+    String? userId,
+  }) async {
+    final rows = await _surveyDao.pendingAdoptedSurveys();
+    final identity = rows.isEmpty ? null : await _identity.read();
+    var queued = 0;
+    for (final row in rows) {
+      // A send already on the wire is left alone, for the reason
+      // `SubmissionsUploader.queuePending` gives: `enqueue` would reset an
+      // `in_progress` row to `pending` to preserve a mid-flight payload edit,
+      // and the send that succeeds moments later then deletes nothing. This
+      // POST carries `_id`, so a replay is a 409 rather than a duplicate
+      // document — but a 409 is classified permanent and abandons a row whose
+      // document actually exists, leaving the local rev unrecorded and the
+      // clone permanently exempt from the prune.
+      if (await _outbox.isInFlight(type, row.id)) continue;
+      queued++;
+      await _outbox.enqueue(
+        uploadType: type,
+        itemId: row.id,
+        endpoint: endpointFor(config),
+        payload: {
+          ...documentFor(row, await _surveyDao.questionsFor(row.id)),
+          // `serializeExam`'s closing `addDocumentOrigin()` (`StepExam.kt:94`)
+          // — `androidId` and `app`, with no device names, so
+          // [DeviceIdentity.originFields] rather than `documentFields`.
+          ...identity!.originFields,
+        },
+        userId: userId,
+      );
+    }
+    return queued;
+  }
+
+  OutboxHandler get handler => (row, payload, authHeader) async {
+    final result = await _api.postJsonObject(
+      row.endpoint,
+      payload,
+      authHeader: authHeader,
+    );
+    if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
+      final couchId = data['id'];
+      final rev = data['rev'];
+      if (couchId is! String || rev is! String) {
+        // Reporting success would drop the outbox row while the clone keeps
+        // `rev == null`, so it would stay in `pendingAdoptedSurveys()` and be
+        // POSTed again on the next sweep.
+        return const NetworkError<Map<String, dynamic>>(
+          null,
+          'Upload response carried no id/rev',
+        );
+      }
+      if (couchId != row.itemId) {
+        // The payload names its own `_id`, so CouchDB is expected to honour it
+        // and the two are the same string. If a server ever answers with a
+        // different id, the document is unreachable from every local key that
+        // embeds this row's id — a member's answer sheet keys on
+        // `"<surveyId>@<courseId>"` — and recording a rev against the local id
+        // would claim a round trip that did not happen.
+        return NetworkError<Map<String, dynamic>>(
+          null,
+          'Adopted survey stored under $couchId, not ${row.itemId}',
+        );
+      }
+      await _surveyDao.markUploaded(row.itemId, rev);
+    }
+    return result;
+  };
+}

--- a/flutter/lib/repository/adopted_surveys_uploader.dart
+++ b/flutter/lib/repository/adopted_surveys_uploader.dart
@@ -65,12 +65,44 @@ class AdoptedSurveysUploader {
   /// list `adoptSurvey` is reachable from queries `type = "surveys"`
   /// (`ExamDao.kt:29-31`), so the source, and therefore the clone, is always
   /// plural.
+  /// **`courseId` is emitted, which neither app's serializer does**, and it is
+  /// the one deliberate addition to the wire format here.
+  ///
+  /// A clone copies the source survey's `courseId` (`adoptSurvey`, ported from
+  /// `createMappedSurvey`, `SurveysRepositoryImpl.kt:181`) and the member
+  /// sheets Send writes are keyed `"<cloneId>@<courseId>"`. Without the key on
+  /// the wire the *authoring* handset keeps its value only because
+  /// `SurveyMapper.fromDoc` writes `courseId` `Value.absent()` when the
+  /// document omits it — but a **second** handset in the team, which has never
+  /// seen the row, gets NULL, so its Send keys the same survey's sheets bare
+  /// and `latestPendingByUserAndParent` cannot see the other device's sheet.
+  /// One member ends up with two pending sheets for one survey, and
+  /// `repairCourseSurveyParentIds` and the next pull rewrite the column past
+  /// each other. That is the Phase 120/125 writer-reader key class, across
+  /// devices rather than across layers, and it becomes reachable only because
+  /// this class publishes the clone at all.
+  ///
+  /// Kotlin is *consistent* here rather than correct: `serializeExam` emits no
+  /// `courseId` either, and its own re-pull wipes the column on the authoring
+  /// handset too (`bulkInsertExamsFromSync` passes `("", "", doc, "")` and
+  /// Room's `@Upsert` is a whole-row replace), which is why
+  /// `getSurveyInfos.resolveParentId` has to accept both key shapes
+  /// (`SurveysRepositoryImpl.kt:304-307`). The port has no such tolerant
+  /// reader, so it needs the value instead.
+  ///
+  /// Safe to add: nothing contends for the column on a clone. The courses walk
+  /// owns `courseId`/`stepId` and retires them together
+  /// (`SurveyDao.releaseStepJoinsForCourse`), but a clone is in no course
+  /// document and carries no `stepId`, so that update cannot select it. And a
+  /// clone arriving with a `courseId` is still skipped by
+  /// `hasUnfinishedSurveys`, whose guard is `stepId == null`.
   static Map<String, dynamic> documentFor(
     SurveyRow survey,
     List<SurveyQuestionRow> questions,
   ) => {
     ...SubmissionsRepository.surveyParentDocument(survey, questions),
     'type': 'surveys',
+    if (survey.courseId != null) 'courseId': survey.courseId,
   };
 
   /// Queues every adopted clone that has not reached the server.
@@ -128,8 +160,8 @@ class AdoptedSurveysUploader {
       final couchId = data['id'];
       final rev = data['rev'];
       if (couchId is! String || rev is! String) {
-        // Reporting success would drop the outbox row while the clone keeps
-        // `rev == null`, so it would stay in `pendingAdoptedSurveys()` and be
+        // Reporting success would drop the outbox row while the clone stays
+        // `needsSync`, so it would stay in `pendingAdoptedSurveys()` and be
         // POSTed again on the next sweep.
         return const NetworkError<Map<String, dynamic>>(
           null,
@@ -141,8 +173,8 @@ class AdoptedSurveysUploader {
         // and the two are the same string. If a server ever answers with a
         // different id, the document is unreachable from every local key that
         // embeds this row's id — a member's answer sheet keys on
-        // `"<surveyId>@<courseId>"` — and recording a rev against the local id
-        // would claim a round trip that did not happen.
+        // `"<surveyId>@<courseId>"` — and clearing `needsSync` against the
+        // local id would claim a round trip that did not happen.
         return NetworkError<Map<String, dynamic>>(
           null,
           'Adopted survey stored under $couchId, not ${row.itemId}',
@@ -150,6 +182,62 @@ class AdoptedSurveysUploader {
       }
       await _surveyDao.markUploaded(row.itemId, rev);
     }
+    if (result case NetworkError<Map<String, dynamic>>(
+      :final code,
+    ) when code == 409) {
+      return _adoptExistingDocument(row, authHeader, result);
+    }
     return result;
   };
+
+  /// Port of `UploadCoordinator`'s 409 arm (`UploadCoordinator.kt:169-204`):
+  /// GET the document that already exists, take its `_rev`, and report the
+  /// upload as the success it effectively was.
+  ///
+  /// **The port needs this more than Kotlin does, because its clone id is
+  /// deterministic.** Kotlin mints one with `UUID.randomUUID()`
+  /// (`SurveysRepositoryImpl.kt:86`), so two leaders adopting the same survey
+  /// for the same team write two documents; the port's
+  /// `'${surveyId}_$teamId'` (`surveys_repository.dart:105`) converges on one,
+  /// which is better — but it makes a conflict ordinary rather than freakish,
+  /// since neither leader has synced yet and `adoptedTeamSurvey` can only
+  /// dedupe locally.
+  ///
+  /// Without this the loser is permanently stuck: `OutboxDrainer` classifies
+  /// any `code < 500` as permanent (`outbox_drainer.dart:160-172`) so the row
+  /// is abandoned, and **a later walk does not rescue it** — a mapper's
+  /// companion leaves `needsSync` absent, and Drift's `insertOnConflictUpdate`
+  /// writes only the columns present, so the re-pull hands the row a `rev` and
+  /// leaves the flag set. Probed: `needsSync=true rev=1-winner`, still swept.
+  /// `OutboxDao.findOpen` ignores an `abandoned` row, so every sweep
+  /// thereafter inserts a fresh one and makes a fresh doomed POST, for the
+  /// life of the install, in a table schema bumps preserve.
+  ///
+  /// A GET that fails returns the original 409 rather than inventing success:
+  /// clearing the flag without a rev would drop the clone out of the prune
+  /// exemption while it is still, as far as this device knows, unpublished.
+  Future<NetworkResult<Map<String, dynamic>>> _adoptExistingDocument(
+    OutboxRow row,
+    String? authHeader,
+    NetworkResult<Map<String, dynamic>> conflict,
+  ) async {
+    final existing = await _api.getJsonObject(
+      '${row.endpoint}/${row.itemId}',
+      // The drain's credential, not none: `outbox.endpoint` is stored
+      // credential-free on purpose, so an unauthenticated read of a CouchDB
+      // document is a 401 and this recovery would never fire.
+      authHeader: authHeader,
+    );
+    if (existing case NetworkSuccess<Map<String, dynamic>>(:final data)) {
+      final rev = data['_rev'];
+      if (rev is String && rev.isNotEmpty) {
+        await _surveyDao.markUploaded(row.itemId, rev);
+        return NetworkSuccess<Map<String, dynamic>>({
+          'id': row.itemId,
+          'rev': rev,
+        });
+      }
+    }
+    return conflict;
+  }
 }

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -1070,12 +1070,41 @@ class SubmissionsRepository {
       // survey that is itself an adopted copy arrives with `courseId`,
       // `stepId` and `sourceSurveyId` — it has a Take Survey button and a
       // working retake label, and skipping it let a learner finish
-      // `MANDATORY_SURVEY_COURSE_ID` having answered nothing. Kotlin's own
-      // test for a locally minted clone is the conjunction
-      // `sourceSurveyId IS NOT NULL AND _rev IS NULL` (`ExamDao.kt:21`, the
-      // upload sweep), and `adoptSurvey` writing `rev: Value(null)`
-      // explicitly is what makes the second half exact here.
-      if (survey.sourceSurveyId != null && survey.rev == null) continue;
+      // `MANDATORY_SURVEY_COURSE_ID` having answered nothing.
+      //
+      // **The second half is `stepId`, not `rev`, and the difference is a
+      // user-blocking bug.** Phase 136 wrote `rev == null` from `ExamDao.kt:21`
+      // — Kotlin's *upload sweep* — and it was exact only for as long as
+      // nothing ever published a clone. Phase 138 publishes it, and the moment
+      // `AdoptedSurveysUploader` records the rev this guard stops firing: the
+      // clone still carries the source's `courseId`, so `getByCourseId` hands
+      // it to every learner on the course, and nobody outside the adopting
+      // team has — or can have — a sheet keyed `"<cloneId>@<courseId>"`. On
+      // `MANDATORY_SURVEY_COURSE_ID` that is Phase 125's outcome reached by a
+      // new route: the course becomes uncompletable for everyone outside
+      // whichever team adopted its survey.
+      //
+      // `stepId` asks the question the guard actually means — *does the
+      // courses walk own this row's course join?* A server-authored
+      // course-step survey always gets one from `SurveyMapper._build`
+      // (positional, never blank); a clone never has one, deliberately, and
+      // `releaseStepJoinsForCourse` can only null it *together with*
+      // `courseId`, which drops the row out of this query altogether. So the
+      // conjunction keeps both properties without depending on publication
+      // state, and it is a **prune**-time discriminator that `rev` remains
+      // correct for (`SurveyDao.deleteNotIn`) but a **gate**-time one it never
+      // was.
+      //
+      // Kotlin needs no such guard and cannot be read for one:
+      // `getSurveysByCourseId` filters `getByCourseIdAndType(courseId,
+      // "survey")` — **singular** (`SubmissionsRepositoryImpl.kt:367-379`) —
+      // while a clone copies the source's `type`
+      // (`SurveysRepositoryImpl.kt:180`) and every list adoption is reachable
+      // from queries `type = "surveys"` (`ExamDao.kt:29-31`). A Kotlin clone is
+      // never in that result set at all. This is a port-invented guard on
+      // port-invented breadth, which is exactly why it must not borrow its
+      // predicate from a Kotlin query written for another purpose.
+      if (survey.sourceSurveyId != null && survey.stepId == null) continue;
       // Routed through the writers' own derivation so the two cannot drift
       // apart again. `courseId` is non-empty by the guard above and equal to
       // `survey.courseId` by the query that produced the row, so this is

--- a/flutter/lib/repository/surveys_repository.dart
+++ b/flutter/lib/repository/surveys_repository.dart
@@ -160,6 +160,14 @@ class SurveysRepository {
               teamShareAllowed: const Value(false),
               sourceSurveyId: Value(surveyId),
               courseId: Value(survey.courseId),
+              // The local-authorship flag `AdoptedSurveysUploader` sweeps on
+              // and `SurveyDao.deleteNotIn` spares. It stands in for Kotlin's
+              // `_rev IS NULL`, which the port cannot ask: `getStringOrNull`
+              // turns an absent `_rev` into the same NULL an unpublished clone
+              // has, so that predicate also matched every course-embedded and
+              // public-API survey — and the sweep POSTed another team's
+              // private copy under this user's credentials. See the column.
+              needsSync: const Value(true),
             ),
           ],
           {

--- a/flutter/test/providers/adopted_survey_sweep_test.dart
+++ b/flutter/test/providers/adopted_survey_sweep_test.dart
@@ -1,0 +1,299 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/background_entrypoint.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/system/device_identity.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/dashboard_sync_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/adopted_surveys_uploader.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/submissions_uploader.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// **The wiring, not the pieces.** Phase 138's implementation audit found that
+/// every test for the adopted-survey upload built `AdoptedSurveysUploader`
+/// directly and called `uploader.handler(...)` by hand — so deleting the sweep
+/// from both sync paths, or deleting the handler's registration in
+/// `outboxDrainerProvider`, left the whole suite green while the clone was
+/// destroyed again. That is the Phase 113 shape exactly: the writer exists, the
+/// reader exists, and nothing proves anything calls them.
+///
+/// These drive a real `ProviderContainer` from both sync paths and assert the
+/// end state on the row — a rev recorded and the local-authorship flag cleared
+/// — which is reachable only if the sweep ran *and* the drain dispatched to
+/// this uploader's own handler rather than the drainer's generic replay branch.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  const courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'Clean water',
+    'steps': [
+      {
+        'stepTitle': 'First',
+        'survey': {
+          '_id': 'survey-1',
+          'type': 'surveys',
+          'name': 'Water needs',
+          'teamShareAllowed': true,
+          'questions': [
+            {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+          ],
+        },
+      },
+    ],
+  };
+  const cloneId = 'survey-1_team-1';
+
+  late AppDatabase db;
+  late MockPlanetApi api;
+
+  setUpAll(() {
+    registerFallbackValue(config);
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+  });
+  tearDown(() => db.close());
+
+  /// A team's adopted clone, minted by the production `adoptSurvey` over a
+  /// course document shaped like the server's.
+  Future<void> seedAdoptedClone() async {
+    final submissions = SubmissionsRepository(
+      api,
+      db.submissionDao,
+      db.submitPhotosDao,
+      db.surveyDao,
+      db.examDao,
+      teamDao: db.teamDao,
+    );
+    final parsed = CourseMapper.fromDoc(courseDoc)!;
+    await db.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      courseDoc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await db.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+    await SurveysRepository(
+      api,
+      db.surveyDao,
+      db.examDao,
+      submissions,
+    ).adoptSurvey(
+      surveyId: 'survey-1',
+      userId: 'org.couchdb.user:ada',
+      userName: 'Ada',
+      teamId: 'team-1',
+      isTeam: true,
+      teamName: 'Team One',
+    );
+  }
+
+  /// See `pending_submissions_sweep_test.dart`: `outboxDrainerProvider` builds
+  /// every registered handler and several reach `planetPrefsProvider`, which is
+  /// `UnimplementedError` by default — the Phase 75 harness trap.
+  Future<ProviderContainer> containerFor() async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
+        serverConfigProvider.overrideWith(
+          () => _TestServerConfigNotifier(config),
+        ),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(buildUserRow(id: 'org.couchdb.user:ada')),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  void acceptPosts() {
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'id': cloneId,
+        'rev': '1-published',
+      }),
+    );
+  }
+
+  test('syncAll publishes an adopted clone', () async {
+    await seedAdoptedClone();
+    final container = await containerFor();
+    acceptPosts();
+
+    expect(
+      await db.outboxDao.forItem(AdoptedSurveysUploader.type, cloneId),
+      isEmpty,
+      reason: 'nothing has queued it — the state the gap leaves behind',
+    );
+
+    await container.read(dashboardSyncProvider.notifier).syncAll();
+
+    final clone = (await db.surveyDao.getById(cloneId))!;
+    expect(clone.rev, '1-published');
+    expect(
+      clone.needsSync,
+      isFalse,
+      reason:
+          'only this uploader\'s own handler clears the flag — the '
+          'drainer\'s generic replay branch would POST and report success '
+          'without ever calling SurveyDao.markUploaded',
+    );
+    expect(await db.surveyDao.pendingAdoptedSurveys(), isEmpty);
+  });
+
+  test('the headless sweep publishes it too', () async {
+    await seedAdoptedClone();
+    final container = await containerFor();
+    acceptPosts();
+
+    await sweepPendingSubmissions(
+      container,
+      config: config,
+      userId: 'org.couchdb.user:ada',
+    );
+
+    expect(
+      await db.outboxDao.forItem(AdoptedSurveysUploader.type, cloneId),
+      hasLength(1),
+      reason: 'the headless sweep queues; `drainOutbox` sends',
+    );
+  });
+
+  test('a throwing adopted sweep does not skip the submissions sweep', () async {
+    // The audit's finding: both sweeps shared one `try`, so this arm throwing
+    // — `PlatformDeviceIdentitySource.read` rethrows on an engine with no
+    // channel and no primed cache, and a headless engine is exactly that case
+    // — skipped the submissions safety net Phase 134 added. Kotlin wraps each
+    // arm in its own `runCatching` (`UserDataWorker:47-48`).
+    //
+    // The identity source fails its **first** read only, which is what makes
+    // this test able to distinguish the two shapes: under one shared `try` the
+    // adopted arm's throw skips the submissions arm and nothing is queued;
+    // under separate `try`s the submissions arm runs, gets a working identity,
+    // and queues the stranded sheet.
+    await seedAdoptedClone();
+    final submissions = SubmissionsRepository(
+      api,
+      db.submissionDao,
+      db.submitPhotosDao,
+      db.surveyDao,
+      db.examDao,
+      teamDao: db.teamDao,
+    );
+    final sheetId = await submissions.createDraft(
+      userId: 'org.couchdb.user:ada',
+      type: 'survey',
+      title: 'Water access',
+      answers: const [],
+    );
+    await submissions.markSubmissionComplete(sheetId, {
+      '_id': 'org.couchdb.user:ada',
+      'name': 'ada',
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        deviceIdentitySourceProvider.overrideWithValue(_FailsFirstRead()),
+        serverConfigProvider.overrideWith(
+          () => _TestServerConfigNotifier(config),
+        ),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(buildUserRow(id: 'org.couchdb.user:ada')),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await sweepPendingSubmissions(
+      container,
+      config: config,
+      userId: 'org.couchdb.user:ada',
+    );
+
+    expect(
+      await db.outboxDao.forItem(SubmissionsUploader.type, sheetId),
+      hasLength(1),
+      reason:
+          'the submissions sweep must be reached even when the adopted '
+          'sweep throws',
+    );
+    expect(
+      await db.outboxDao.forItem(AdoptedSurveysUploader.type, cloneId),
+      isEmpty,
+      reason: 'the arm that threw queued nothing, as intended',
+    );
+  });
+}
+
+/// Throws on its first read and works afterwards — see the test that uses it.
+class _FailsFirstRead implements DeviceIdentitySource {
+  var _reads = 0;
+
+  @override
+  Future<DeviceIdentity> read() async {
+    if (_reads++ == 0) throw StateError('no platform channel');
+    return testDeviceIdentity.read();
+  }
+}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  _TestServerConfigNotifier(this._config);
+
+  final ServerConfig? _config;
+
+  @override
+  ServerConfig? build() => _config;
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this._user);
+
+  final UserRow? _user;
+
+  @override
+  Future<UserRow?> build() async => _user;
+}

--- a/flutter/test/repository/adopted_survey_survives_sync_test.dart
+++ b/flutter/test/repository/adopted_survey_survives_sync_test.dart
@@ -1,0 +1,438 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/repository/adopted_surveys_uploader.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+
+import 'device_identity_fixture.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// **Ported, tested, green, and destroyed** — the reachability class at its
+/// worst, reported by Phase 136 and closed here.
+///
+/// `SurveysRepository.adoptSurvey` mints a team's private copy of a shared
+/// survey. Kotlin uploads it (`ExamDao.getPendingAdoptedSurveys()` ->
+/// `UploadConfigs.AdoptedSurveys`, endpoint `exams`) and never prunes that
+/// table at all; the port had neither half, so `SurveyDao.deleteNotIn` deleted
+/// the clone and its questions on the next surveys sync and orphaned every
+/// answer sheet its members had filled in.
+///
+/// Nothing here fabricates a join. The source survey comes out of
+/// `SurveyMapper.fromCourseDoc` reading a course document shaped like the
+/// server's, the clone is produced by the production `adoptSurvey`, and the
+/// re-pull feeds the uploader's own payload back through the production
+/// mappers.
+
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository submissions;
+  late SurveysRepository surveys;
+  late OutboxRepository outbox;
+  late AdoptedSurveysUploader uploader;
+  late MockPlanetApi api;
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+
+  const courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'Clean water',
+    'steps': [
+      {
+        'stepTitle': 'First',
+        'survey': {
+          '_id': 'survey-1',
+          'type': 'surveys',
+          'name': 'Water needs',
+          'teamShareAllowed': true,
+          'sourcePlanet': 'nation',
+          'questions': [
+            {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+          ],
+        },
+      },
+    ],
+  };
+
+  const cloneId = 'survey-1_team-1';
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    api = MockPlanetApi();
+    submissions = SubmissionsRepository(
+      api,
+      database.submissionDao,
+      database.submitPhotosDao,
+      database.surveyDao,
+      database.examDao,
+      teamDao: database.teamDao,
+    );
+    surveys = SurveysRepository(
+      api,
+      database.surveyDao,
+      database.examDao,
+      submissions,
+    );
+    outbox = OutboxRepository(database.outboxDao);
+    uploader = AdoptedSurveysUploader(
+      api,
+      database.surveyDao,
+      outbox,
+      testDeviceIdentity,
+    );
+
+    final parsed = CourseMapper.fromDoc(courseDoc)!;
+    await database.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      courseDoc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+    await surveys.adoptSurvey(
+      surveyId: 'survey-1',
+      userId: 'user-1',
+      userName: 'Ada',
+      teamId: 'team-1',
+      isTeam: true,
+      teamName: 'Team One',
+    );
+  });
+  tearDown(() => database.close());
+
+  test('a clone survives the surveys walk that has never seen it', () async {
+    expect(await database.surveyDao.getById(cloneId), isNotNull);
+
+    // The keep set a real `exams` walk produces before the clone has ever been
+    // uploaded: the server knows the source survey and nothing else.
+    await database.surveyDao.deleteNotIn(['survey-1']);
+
+    expect(
+      await database.surveyDao.getById(cloneId),
+      isNotNull,
+      reason: 'the clone is locally authored and in no walk keep set',
+    );
+    expect(await database.surveyDao.questionsFor(cloneId), isNotEmpty);
+  });
+
+  test(
+    "a member's answer sheet still resolves its survey after a sync",
+    () async {
+      await submissions.createBulkSurveySubmissions(cloneId, const [
+        'member-1',
+      ]);
+      final sheet = await database.submissionDao.latestPendingByUserAndParent(
+        'member-1',
+        '$cloneId@course-1',
+      );
+      expect(sheet, isNotNull, reason: 'Send writes the sheet under the clone');
+
+      await database.surveyDao.deleteNotIn(['survey-1']);
+
+      final parentSurveyId = sheet!.parentId!.split('@').first;
+      expect(
+        await database.surveyDao.getById(parentSurveyId),
+        isNotNull,
+        reason: 'an answer sheet whose survey is gone cannot be reviewed',
+      );
+    },
+  );
+
+  /// Sends the queued clone, as a drain would.
+  Map<String, dynamic> decoded(OutboxRow row) =>
+      jsonDecode(row.payload) as Map<String, dynamic>;
+
+  Future<void> drain() async {
+    final operation = (await outbox.due()).single;
+    when(
+      () => api.postJsonObject(
+        operation.endpoint,
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'id': operation.itemId,
+        'rev': '1-abc',
+      }),
+    );
+    final result = await uploader.handler(operation, decoded(operation), null);
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+  }
+
+  test('the clone is swept for upload and the source survey is not', () async {
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+    final operation = (await outbox.due()).single;
+    expect(operation.itemId, cloneId);
+    expect(operation.endpoint, endsWith('/exams'));
+    final payload = decoded(operation);
+    expect(payload['_id'], cloneId);
+    expect(payload.containsKey('_rev'), isFalse);
+    expect(payload['sourceSurveyId'], 'survey-1');
+    expect(payload['teamId'], 'team-1');
+    expect((payload['questions'] as List), hasLength(1));
+    // `serializeExam`'s closing `addDocumentOrigin()`.
+    expect(payload['app'], isNotNull);
+    expect(payload['androidId'], isNotNull);
+  });
+
+  test(
+    'the uploaded document is typed, so a re-pull files it as a survey',
+    () async {
+      await uploader.queuePending(config: config, userId: 'user-1');
+      final payload = decoded((await outbox.due()).single);
+
+      // `StepExam.serializeExam` writes `type` (`StepExam.kt:81`); the port's
+      // `surveyParentDocument` omits it, which is right for a submission's
+      // embedded parent and wrong on the wire. Without it `SurveyMapper` refuses
+      // the document, `ExamMapper` accepts it, and the clone comes back as a
+      // graded course test while the surveys walk's keep set never learns its id.
+      expect(payload['type'], 'surveys');
+      expect(SurveyMapper.fromDoc(payload), isNotNull);
+      expect(
+        ExamMapper.fromDoc(payload),
+        isNull,
+        reason: 'a survey must not be re-pulled into the exams table',
+      );
+    },
+  );
+
+  test(
+    'after the upload the clone is named by the walk and keeps its course',
+    () async {
+      await submissions.createBulkSurveySubmissions(cloneId, const [
+        'member-1',
+      ]);
+      await uploader.queuePending(config: config, userId: 'user-1');
+      final payload = decoded((await outbox.due()).single);
+      await drain();
+
+      expect(
+        (await database.surveyDao.getById(cloneId))!.rev,
+        '1-abc',
+        reason: 'Kotlin never records this, and re-POSTs the clone forever',
+      );
+      expect(
+        await database.surveyDao.pendingAdoptedSurveys(),
+        isEmpty,
+        reason: 'a published clone is out of the sweep',
+      );
+
+      // The next surveys walk: the server now has the document, so the page
+      // carries it and the keep set names it. Fed back through the production
+      // mapper rather than hand-written.
+      final mapped = SurveyMapper.fromDoc({...payload, '_rev': '1-abc'})!;
+      await database.surveyDao.upsertAll(
+        [mapped.survey],
+        {mapped.survey.id.value: mapped.questions},
+      );
+      await database.surveyDao.deleteNotIn(['survey-1', cloneId]);
+
+      final clone = (await database.surveyDao.getById(cloneId))!;
+      expect(clone.teamId, 'team-1');
+      expect(clone.sourceSurveyId, 'survey-1');
+      expect(
+        clone.courseId,
+        'course-1',
+        reason:
+            'the wire format carries no courseId, so the re-pull must not '
+            'overwrite the join `adoptSurvey` authored',
+      );
+      expect(await database.surveyDao.questionsFor(cloneId), hasLength(1));
+
+      final sheet = await database.submissionDao.latestPendingByUserAndParent(
+        'member-1',
+        '$cloneId@course-1',
+      );
+      expect(
+        await database.surveyDao.getById(sheet!.parentId!.split('@').first),
+        isNotNull,
+      );
+    },
+  );
+
+  test('a published clone the server stops naming is pruned', () async {
+    await uploader.queuePending(config: config, userId: 'user-1');
+    await drain();
+
+    // The exemption is scoped to `rev IS NULL`, so it lapses on publication —
+    // a walk that no longer names a document it once did is reporting a
+    // deletion, and Kotlin's insert-only walk is the reason to spare an
+    // *unpublished* clone, not every clone forever.
+    await database.surveyDao.deleteNotIn(['survey-1']);
+    expect(await database.surveyDao.getById(cloneId), isNull);
+  });
+
+  test('a server-authored adopted survey is not swept for upload', () async {
+    // `sourceSurveyId` is not a local-authorship marker: the courses walk reads
+    // it off a server-embedded survey, so an adopted copy Planet published
+    // carries it *and* a rev. Sweeping on the first clause alone would re-POST
+    // somebody else's document.
+    final mapped = SurveyMapper.fromDoc(const {
+      '_id': 'survey-9',
+      '_rev': '4-server',
+      'type': 'surveys',
+      'name': 'Adopted elsewhere',
+      'sourceSurveyId': 'survey-1',
+      'teamId': 'team-9',
+      'questions': <Map<String, dynamic>>[],
+    })!;
+    await database.surveyDao.upsertAll(
+      [mapped.survey],
+      {mapped.survey.id.value: mapped.questions},
+    );
+
+    final pending = await database.surveyDao.pendingAdoptedSurveys();
+    expect(pending.map((row) => row.id), [cloneId]);
+  });
+
+  test(
+    'publishing a clone does not block an outsider from finishing the course',
+    () async {
+      // The learner outside the adopting team has answered the *course's* survey.
+      await submissions.createSurveyDraft(
+        survey: (await database.surveyDao.getById('survey-1'))!,
+        questions: await database.surveyDao.questionsFor('survey-1'),
+        userId: 'outsider',
+      );
+      expect(
+        await submissions.hasUnfinishedSurveys('course-1', 'outsider'),
+        isFalse,
+      );
+
+      // Phase 136 keyed the clone skip on `rev == null`, which was exact while
+      // nothing ever published a clone. Publishing it is what this phase adds,
+      // and `rev` stops discriminating the moment it does: the clone carries the
+      // source's `courseId`, so `getByCourseId` returns it to every learner on
+      // the course, and nobody outside `team-1` has — or can have — a sheet
+      // keyed `"$cloneId@course-1"`.
+      //
+      // Kotlin cannot reach this: `getSurveysByCourseId` filters
+      // `getByCourseIdAndType(courseId, "survey")` — **singular**
+      // (`SubmissionsRepositoryImpl.kt:367-379`) — while a clone copies the
+      // source's `type` and every list adoption is reachable from is
+      // `"surveys"` (`ExamDao.kt:29-31`), so a Kotlin clone is never in that
+      // result set at all, rev or no rev.
+      await uploader.queuePending(config: config, userId: 'user-1');
+      await drain();
+
+      expect(
+        await submissions.hasUnfinishedSurveys('course-1', 'outsider'),
+        isFalse,
+        reason:
+            'a team\'s private copy is never the course\'s to demand, '
+            'published or not',
+      );
+    },
+  );
+
+  test(
+    'a server-authored adopted step survey still gates after this change',
+    () async {
+      // The counter-example Phase 136 was pinning: an adopted copy that Planet
+      // itself published into a course step. It carries `sourceSurveyId` *and* a
+      // `stepId`, it has a Take Survey button, and it must still be demanded.
+      const adoptedStepCourse = {
+        '_id': 'course-2',
+        'courseTitle': 'Adopted elsewhere',
+        'steps': [
+          {
+            'stepTitle': 'Only',
+            'survey': {
+              '_id': 'survey-2',
+              '_rev': '3-server',
+              'type': 'surveys',
+              'name': 'Published adopted survey',
+              'sourceSurveyId': 'survey-1',
+              'questions': [
+                {'id': 's2', 'title': 'Well?', 'type': 'input'},
+              ],
+            },
+          },
+        ],
+      };
+      final parsed = CourseMapper.fromDoc(adoptedStepCourse)!;
+      await database.courseDao.upsertAll([parsed.course], parsed.steps);
+      for (final mapping in SurveyMapper.fromCourseDoc(
+        adoptedStepCourse,
+        stepIdFor: CourseMapper.stepIdFor,
+      )) {
+        await database.surveyDao.upsertAll(
+          [mapping.survey],
+          {mapping.survey.id.value: mapping.questions},
+        );
+      }
+
+      expect(
+        await submissions.hasUnfinishedSurveys('course-2', 'outsider'),
+        isTrue,
+      );
+    },
+  );
+
+  test('a send already on the wire is not re-enqueued', () async {
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+    final operation = (await outbox.due()).single;
+    // What a drain does before it sends (`OutboxDrainer._send`).
+    expect(await outbox.markInProgress(operation.id), isTrue);
+
+    // Re-enqueueing over an in-flight row would reset it to `pending`, so the
+    // send that succeeds moments later deletes nothing (`markCompleted` is
+    // `deleteIfInProgress`) and the next drain POSTs the same `_id` again — a
+    // 409, which the drainer classifies permanent, abandoning a row whose
+    // document does exist and leaving the local rev unrecorded.
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 0);
+    expect(
+      await outbox.isInFlight(AdoptedSurveysUploader.type, operation.itemId),
+      isTrue,
+      reason: 'the claimed row is still the one on the wire',
+    );
+  });
+
+  test(
+    'a response naming a different document is not recorded as a round trip',
+    () async {
+      await uploader.queuePending(config: config, userId: 'user-1');
+      final operation = (await outbox.due()).single;
+      when(
+        () => api.postJsonObject(
+          operation.endpoint,
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          'id': 'some-other-doc',
+          'rev': '1-abc',
+        }),
+      );
+
+      // The payload names its own `_id`, so the two are the same string in every
+      // real exchange. If they ever differ, the document is unreachable from
+      // every local key that embeds this row's id, and recording a rev against
+      // the local id would claim a round trip that did not happen — and would
+      // drop the clone out of the prune exemption at the same time.
+      expect(
+        await uploader.handler(operation, decoded(operation), null),
+        isA<NetworkError<Map<String, dynamic>>>(),
+      );
+      expect((await database.surveyDao.getById(cloneId))!.rev, isNull);
+    },
+  );
+}

--- a/flutter/test/repository/adopted_survey_survives_sync_test.dart
+++ b/flutter/test/repository/adopted_survey_survives_sync_test.dart
@@ -226,7 +226,7 @@ void main() {
       expect(
         (await database.surveyDao.getById(cloneId))!.rev,
         '1-abc',
-        reason: 'Kotlin never records this, and re-POSTs the clone forever',
+        reason: 'the published clone is handed back to the walk that names it',
       );
       expect(
         await database.surveyDao.pendingAdoptedSurveys(),
@@ -279,28 +279,139 @@ void main() {
     expect(await database.surveyDao.getById(cloneId), isNull);
   });
 
-  test('a server-authored adopted survey is not swept for upload', () async {
-    // `sourceSurveyId` is not a local-authorship marker: the courses walk reads
-    // it off a server-embedded survey, so an adopted copy Planet published
-    // carries it *and* a rev. Sweeping on the first clause alone would re-POST
-    // somebody else's document.
+  /// **The shape that made `rev IS NULL` the wrong predicate.** Kotlin can ask
+  /// `_rev IS NULL` because `JsonUtils.getString` returns `''` for a missing
+  /// key, so only `createMappedSurvey`'s explicit null satisfies it. The port's
+  /// mappers use `getStringOrNull`, and a course document's embedded survey
+  /// carries no `_rev` of its own — every embedded-survey fixture in this tree
+  /// omits it — so `rev IS NULL` was true for another team's private copy and
+  /// the sweep POSTed it to `exams` under this user's credentials.
+  test(
+    "another team's course-embedded copy is neither swept nor spared",
+    () async {
+      const otherCourse = {
+        '_id': 'course-9',
+        'courseTitle': "Another planet's course",
+        'steps': [
+          {
+            'stepTitle': 'One',
+            'survey': {
+              '_id': 'survey-embedded',
+              'type': 'surveys',
+              'name': "Another team's copy",
+              'sourceSurveyId': 'survey-1',
+              'teamId': 'someone-elses-team',
+              'questions': <Map<String, dynamic>>[],
+            },
+          },
+        ],
+      };
+      final parsed = CourseMapper.fromDoc(otherCourse)!;
+      await database.courseDao.upsertAll([parsed.course], parsed.steps);
+      for (final mapping in SurveyMapper.fromCourseDoc(
+        otherCourse,
+        stepIdFor: CourseMapper.stepIdFor,
+      )) {
+        await database.surveyDao.upsertAll(
+          [mapping.survey],
+          {mapping.survey.id.value: mapping.questions},
+        );
+      }
+      final embedded = (await database.surveyDao.getById('survey-embedded'))!;
+      expect(embedded.rev, isNull, reason: 'the fixture shape this is about');
+      expect(embedded.sourceSurveyId, 'survey-1');
+
+      expect(
+        (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+        [cloneId],
+        reason: 'the port must not publish a document it did not author',
+      );
+
+      // And the prune exemption must not spare it either: once the courses walk
+      // stops naming that step, `releaseStepJoinsForCourse` nulls its `stepId`
+      // and `courseId` and it is an ordinary cache row again.
+      await database.surveyDao.releaseStepJoinsForCourse('course-9', const {});
+      await database.surveyDao.deleteNotIn(['survey-1']);
+      expect(await database.surveyDao.getById('survey-embedded'), isNull);
+      expect(await database.surveyDao.getById(cloneId), isNotNull);
+    },
+  );
+
+  /// A public-API survey lands through `SurveyMapper.fromDoc` too, and the
+  /// port's own public-survey fixtures carry no `_rev` either.
+  test('a rev-less cache row is not swept for upload', () async {
     final mapped = SurveyMapper.fromDoc(const {
-      '_id': 'survey-9',
-      '_rev': '4-server',
+      '_id': 'survey-public',
       'type': 'surveys',
-      'name': 'Adopted elsewhere',
+      'name': 'From the public API',
       'sourceSurveyId': 'survey-1',
-      'teamId': 'team-9',
       'questions': <Map<String, dynamic>>[],
     })!;
     await database.surveyDao.upsertAll(
       [mapped.survey],
       {mapped.survey.id.value: mapped.questions},
     );
-
-    final pending = await database.surveyDao.pendingAdoptedSurveys();
-    expect(pending.map((row) => row.id), [cloneId]);
+    expect(
+      (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+      [cloneId],
+    );
   });
+
+  test(
+    'a second handset in the team keys member sheets the same way',
+    () async {
+      await uploader.queuePending(config: config, userId: 'user-1');
+      final payload = decoded((await outbox.due()).single);
+      await drain();
+      await submissions.createBulkSurveySubmissions(cloneId, const [
+        'member-1',
+      ]);
+
+      // Device B has never seen this row, so `_presentOrAbsent` cannot preserve
+      // anything: whatever the wire carries is all it gets.
+      final b = AppDatabase.memory();
+      addTearDown(b.close);
+      final bSubmissions = SubmissionsRepository(
+        api,
+        b.submissionDao,
+        b.submitPhotosDao,
+        b.surveyDao,
+        b.examDao,
+        teamDao: b.teamDao,
+      );
+      final mapped = SurveyMapper.fromDoc({...payload, '_rev': '1-abc'})!;
+      await b.surveyDao.upsertAll(
+        [mapped.survey],
+        {mapped.survey.id.value: mapped.questions},
+      );
+      final onB = (await b.surveyDao.getById(cloneId))!;
+      expect(
+        onB.courseId,
+        'course-1',
+        reason:
+            'without this B keys the same survey bare and A keys it '
+            'compound — one member, two pending sheets',
+      );
+      expect(
+        onB.needsSync,
+        isFalse,
+        reason: "a row B pulled is not B's to publish",
+      );
+
+      await bSubmissions.createBulkSurveySubmissions(cloneId, const [
+        'member-2',
+      ]);
+      final aKey = (await database.submissionDao.latestPendingByUserAndParent(
+        'member-1',
+        '$cloneId@course-1',
+      ))!.parentId;
+      final bKey = (await b.submissionDao.latestPendingByUserAndParent(
+        'member-2',
+        '$cloneId@course-1',
+      ))!.parentId;
+      expect(aKey, bKey);
+    },
+  );
 
   test(
     'publishing a clone does not block an outsider from finishing the course',
@@ -435,4 +546,85 @@ void main() {
       expect((await database.surveyDao.getById(cloneId))!.rev, isNull);
     },
   );
+
+  /// **The two-leader race, and why a later walk does not rescue it.** The
+  /// port's clone id is deterministic (`'<surveyId>_<teamId>'`) where Kotlin's
+  /// is a UUID, so two leaders adopting the same survey for the same team
+  /// before either syncs converge on one document — better than Kotlin's two,
+  /// but it makes a 409 ordinary. `OutboxDrainer` treats any `code < 500` as
+  /// permanent, and a re-pull leaves `needsSync` set (a mapper's companion
+  /// omits the column and Drift writes only the columns present), so without
+  /// recovery the loser re-POSTs and abandons one outbox row every sync, for
+  /// the life of the install.
+  test(
+    'a 409 adopts the winning document instead of abandoning the row',
+    () async {
+      await uploader.queuePending(config: config, userId: 'user-1');
+      final operation = (await outbox.due()).single;
+      when(
+        () => api.postJsonObject(
+          operation.endpoint,
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const NetworkError<Map<String, dynamic>>(409, 'Document conflict'),
+      );
+      // The header is asserted, not `any`: `outbox.endpoint` is stored
+      // credential-free on purpose, so an unauthenticated read of a CouchDB
+      // document is a 401 and this recovery would never fire.
+      when(
+        () => api.getJsonObject(
+          '${operation.endpoint}/$cloneId',
+          authHeader: 'Basic x',
+        ),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': cloneId,
+          '_rev': '1-winner',
+        }),
+      );
+
+      expect(
+        await uploader.handler(operation, decoded(operation), 'Basic x'),
+        isA<NetworkSuccess<Map<String, dynamic>>>(),
+      );
+      final clone = (await database.surveyDao.getById(cloneId))!;
+      expect(clone.rev, '1-winner');
+      expect(clone.needsSync, isFalse);
+      expect(await database.surveyDao.pendingAdoptedSurveys(), isEmpty);
+    },
+  );
+
+  test('a 409 whose document cannot be read stays a failure', () async {
+    await uploader.queuePending(config: config, userId: 'user-1');
+    final operation = (await outbox.due()).single;
+    when(
+      () => api.postJsonObject(
+        operation.endpoint,
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          const NetworkError<Map<String, dynamic>>(409, 'Document conflict'),
+    );
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => const NetworkError<Map<String, dynamic>>(503, 'Unavailable'),
+    );
+
+    // Clearing the flag with no rev in hand would drop the clone out of the
+    // prune exemption while it is still, as far as this device knows,
+    // unpublished — the destruction this whole file is about.
+    expect(
+      await uploader.handler(operation, decoded(operation), 'Basic x'),
+      isA<NetworkError<Map<String, dynamic>>>(),
+    );
+    final clone = (await database.surveyDao.getById(cloneId))!;
+    expect(clone.needsSync, isTrue);
+    expect(clone.rev, isNull);
+  });
 }

--- a/flutter/test/repository/pending_uploads_status_test.dart
+++ b/flutter/test/repository/pending_uploads_status_test.dart
@@ -1,0 +1,137 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository submissions;
+  late SurveysRepository surveys;
+
+  const courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'Clean water',
+    'steps': [
+      {
+        'stepTitle': 'First',
+        'survey': {
+          '_id': 'survey-1',
+          'type': 'surveys',
+          'name': 'Water needs',
+          'teamShareAllowed': true,
+          'questions': [
+            {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+          ],
+        },
+      },
+    ],
+  };
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    final api = MockPlanetApi();
+    submissions = SubmissionsRepository(
+      api,
+      database.submissionDao,
+      database.submitPhotosDao,
+      database.surveyDao,
+      database.examDao,
+      teamDao: database.teamDao,
+    );
+    surveys = SurveysRepository(
+      api,
+      database.surveyDao,
+      database.examDao,
+      submissions,
+    );
+    final parsed = CourseMapper.fromDoc(courseDoc)!;
+    await database.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      courseDoc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+  });
+  tearDown(() => database.close());
+
+  test('the team-adoption marker is not swept for upload', () async {
+    await surveys.adoptSurvey(
+      surveyId: 'survey-1',
+      userId: 'user-1',
+      userName: 'Ada',
+      teamId: 'team-1',
+      isTeam: true,
+      teamName: 'Team One',
+    );
+    final marker = (await database.submissionDao.byTeam('team-1')).single;
+    expect(
+      marker.status,
+      '',
+      reason: 'the marker as `createMappedSubmission` writes it',
+    );
+    expect(marker.isUpdated, isTrue);
+
+    expect(
+      await submissions.pendingUploads(),
+      isEmpty,
+      reason:
+          "Kotlin's sweep is `status = 'complete'` — it has no config that "
+          'selects a bookkeeping row whose status is blank',
+    );
+  });
+
+  /// Phase 134 named this row alongside the marker as one the port should stop
+  /// sending. **Checked, and it is wrong** — kept as a guard so the claim is
+  /// not re-seeded. `createDraft` is the submissions screen's New-submission
+  /// button and `submissions_screen.dart:172-194` runs `queuePending` *and*
+  /// `drain` on the next lines: the learner typed a title and an answer and
+  /// pressed Save. Having no Kotlin writer makes the document shape port-only,
+  /// not the intent absent, and excluding it would have made that button write
+  /// to the device and nothing else, silently.
+  test('a deliberate free-form submission is still swept for upload', () async {
+    await submissions.createDraft(
+      userId: 'user-1',
+      type: 'submission',
+      title: 'My note',
+      answers: const [SubmissionDraftAnswer(value: 'something')],
+    );
+    expect(await submissions.pendingUploads(), hasLength(1));
+  });
+
+  /// A null status is not a blank one here, and the asymmetry is deliberate —
+  /// see the predicate. The sync-in stores null for a document that omits
+  /// `status`, and `pendingUploads` was status-blind before Phase 138, so a
+  /// row like this is what the port has always carried.
+  test('a row with no status at all is still swept for upload', () async {
+    await database.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 'bare',
+        userId: const Value('user-1'),
+        isUpdated: const Value(true),
+      ),
+    ]);
+    expect((await submissions.pendingUploads()).single.id, 'bare');
+  });
+
+  test('a finished survey sheet is still swept for upload', () async {
+    final survey = (await database.surveyDao.getById('survey-1'))!;
+    await submissions.createSurveyDraft(
+      survey: survey,
+      questions: await database.surveyDao.questionsFor('survey-1'),
+      userId: 'user-1',
+      answers: const {},
+    );
+    expect(await submissions.pendingUploads(), hasLength(1));
+  });
+}

--- a/flutter/test/repository/search_surveys_test.dart
+++ b/flutter/test/repository/search_surveys_test.dart
@@ -13,6 +13,7 @@ SurveyRow _native(String id, String? name, {int createdDate = 0}) => SurveyRow(
   totalMarks: 0,
   isFromNation: false,
   teamShareAllowed: false,
+  needsSync: false,
 );
 
 /// An adopted survey — copied from a source, so it carries a `sourceSurveyId`
@@ -33,6 +34,7 @@ SurveyRow _adopted(
   totalMarks: 0,
   isFromNation: false,
   teamShareAllowed: false,
+  needsSync: false,
 );
 
 void main() {

--- a/flutter/test/repository/submissions_repository_test.dart
+++ b/flutter/test/repository/submissions_repository_test.dart
@@ -254,6 +254,7 @@ void main() {
           totalMarks: 0,
           isFromNation: false,
           teamShareAllowed: false,
+          needsSync: false,
         ),
         questions: const [],
         userId: 'user-2',

--- a/flutter/test/repository/submissions_sync_round_trip_test.dart
+++ b/flutter/test/repository/submissions_sync_round_trip_test.dart
@@ -571,6 +571,7 @@ void main() {
           totalMarks: 0,
           isFromNation: false,
           teamShareAllowed: false,
+          needsSync: false,
         ),
         const [],
       );
@@ -600,6 +601,7 @@ void main() {
           isFromNation: false,
           teamId: 'team-9',
           teamShareAllowed: false,
+          needsSync: false,
           sourceSurveyId: 'survey-0',
           courseId: 'course-1',
         ),
@@ -662,6 +664,7 @@ void main() {
           totalMarks: 0,
           isFromNation: false,
           teamShareAllowed: false,
+          needsSync: false,
         ),
         const [],
       );

--- a/flutter/test/ui/surveys/survey_team_context_test.dart
+++ b/flutter/test/ui/surveys/survey_team_context_test.dart
@@ -79,6 +79,7 @@ void main() {
         totalMarks: 0,
         isFromNation: false,
         teamShareAllowed: false,
+        needsSync: false,
       );
 
   Future<void> seedSurvey({String id = 's1', bool fromNation = false}) async {

--- a/flutter/test/ui/surveys_screen_test.dart
+++ b/flutter/test/ui/surveys_screen_test.dart
@@ -17,6 +17,7 @@ void main() {
       totalMarks: 0,
       isFromNation: false,
       teamShareAllowed: false,
+      needsSync: false,
     );
     await tester.pumpWidget(
       wrapScreen(

--- a/flutter/test/ui/team_surveys_screen_test.dart
+++ b/flutter/test/ui/team_surveys_screen_test.dart
@@ -37,6 +37,7 @@ SurveyRow _survey({
   totalMarks: 0,
   isFromNation: false,
   teamShareAllowed: false,
+  needsSync: false,
 );
 
 UserRow _user() => UserRow(


### PR DESCRIPTION
Lane A of a four-lane Phase 138 round. Draft; opened as the first action so the integrator has an inbound channel (`subscribe_pr_activity` is called on it).

## Job 1 — an adopted team survey clone is destroyed on the next sync

Phase 136's top *Reported, not fixed* item. Kotlin uploads the clone (`ExamDao.getPendingAdoptedSurveys()` → `UploadConfigs.kt:186-195`, endpoint `exams`) so it gains a `_rev` and joins every later walk's keep set, and Kotlin has no delete-except-ids on that table at all. The port has neither half: no adopted-survey uploader, and `SurveyDao.deleteNotIn` prunes every row without a `stepId` that the server did not name. The clone and its question rows are gone after one surveys sync, and its answer sheets are orphaned.

Three pieces: a pending-adopted query plus a `deleteNotIn` exemption, an `AdoptedSurveysUploader` on the outbox, and the `adoptSurvey` enqueue.

## Job 2 — `pendingUploads` has no status test where Kotlin's sweep does

Phase 134's top item, made systematic by that phase's safety-net sweep. A behaviour decision: either a status predicate, or a recorded deviation in `docs/kotlin-to-flutter-migration.md`.

## Files this lane owns

`flutter/lib/data/local/app_database.dart`, `flutter/lib/repository/{surveys,submissions,outbox}_repository.dart`, `submissions_uploader.dart`, `outbox_drainer.dart`, a new `adopted_surveys_uploader.dart`, `providers/app_providers.dart` (registration only), `docs/kotlin-to-flutter-migration.md`, `flutter/PHASE_138_NOTES.md`, and tests for the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCCysiGYa9bmY1GFQo1drT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCCysiGYa9bmY1GFQo1drT)_