### PR TITLE
Phase 139 (Lane B): course-step assessment gates, survey return, explicit stepNum

### DIFF
--- a/flutter/PHASE_139_NOTES.md
+++ b/flutter/PHASE_139_NOTES.md
@@ -24,8 +24,13 @@ the highest-yield source of work:
    material items I had not asked about. All of them are recorded below rather
    than quietly folded in.
 3. Implement, with each defect demonstrated failing first.
-4. **Sixteen mutations**, each replayed against the suite to confirm the
+4. **Eighteen mutations**, each replayed against the suite to confirm the
    intended test reds.
+5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
+   already-green code. It found one test that could not fail, three recorded
+   rationales that were wrong, and four divergences worth naming — every one of
+   them is folded in below rather than left in the transcript. **That is five
+   consecutive rounds in which the second pass found something on green code.**
 
 ## What the ground-truth audit corrected
 
@@ -274,9 +279,24 @@ to `course_progress` is the one the learner saw, and it cannot disagree with
 `take_course_screen._recordProgress`'s `stepNum: index + 1`.
 
 The derivation stays as the fallback, because the route's query parameters are
-optional and a location without a `stepNum` must still work. A non-positive
+optional and a location without a `stepNum` must still work — though with both
+pushers sending it, that branch now has no production caller. A non-positive
 value is treated as absent: `0` is Kotlin's missing-argument default and
 `WHERE stepNum = 0` is precisely the value its own update matches nothing with.
+
+**The argument for passing it is one materialisation versus two queries, and
+my first version of that argument was unsound.** I wrote that the derivation
+rests on `stepIndex`, whose column default of `0` makes ties legal. It does
+not: `CourseMapper._parseSteps` is the only writer of `course_steps` and always
+sets `stepIndex: Value(i)`, so no tie is reachable — and if one were,
+`watchSteps` and `getSteps` are byte-identical queries, so it would corrupt the
+*passed* number just as badly, because that ordering is where the tile's number
+comes from. The sound argument is the other one: the tile's rendered number,
+`_recordProgress`'s `index + 1` and the pushed `stepNum` all index the same
+`widget.steps` list, while the derivation issues a fresh query and re-finds the
+step by id. Corrected at the code too. Relatedly, my claim that the old comment
+"used the *same* ordering as Kotlin" misread it — it was a port-to-port claim
+about `getSteps` versus `_recordProgress`, and a true one.
 
 **What passing it explicitly buys, concretely:** the derivation had to resolve
 the *step id* in a re-query first, so a step id the course does not list — a
@@ -306,7 +326,7 @@ ids, which is a mapper and migration question.
 | `lib/ui/router.dart` | parses `stepNum` |
 | `lib/ui/exam/take_exam_screen.dart` | **outside the brief's file set — see below** |
 | `lib/l10n/app_en.arb` | `pleaseCompleteTest`, additions only |
-| `test/ui/courses/step_next_lock_test.dart` | new, 14 tests |
+| `test/ui/courses/step_next_lock_test.dart` | new, 15 tests |
 | `test/ui/courses/step_num_argument_test.dart` | new, 6 tests |
 | `test/ui/surveys/take_survey_screen_test.dart` | +4 tests, and the harness fix above |
 | `test/ui/courses/take_course_screen_test.dart` | +1 round-trip test |
@@ -343,8 +363,9 @@ hand-off; this is one key rather than five.
 
 ## Mutation testing
 
-Sixteen reverts, each replayed against the suite. Every one reds its intended
-test, and eight red exactly one.
+Eighteen reverts, each replayed against the suite. Every one reds its intended
+test, and nine red exactly one. The last two close the gap the second audit
+pass found.
 
 | # | mutation | reds |
 |---|---|---|
@@ -364,18 +385,39 @@ test, and eight red exactly one.
 | 14 | drop `&stepNum=` from the detail tile | *"the second tile sends 2"* |
 | 15 | router stops parsing `stepNum` | the router pair test |
 | 16 | `_resolveStepNum` ignores the passed value | 2 tests |
+| 17 | the lock reads `steps[0]` rather than the displayed step | *"the lock reads the displayed step"* |
+| 18 | the lock reads `steps[currentStep + 1]` | 4 tests |
 
-Two tests of my own needed fixing because they could not fail for the reason
-they named, both the same trap: **`find.text` searches the element tree and
-`PageView.builder` leaves an off-screen page in it.** Every step tile renders
-the identical label (`take test [N]`'s count is that step's `exams.length`, so
-it reads `[1]` on any step with one), so the first cut of the second-step
-`stepNum` test matched the page the learner had *left* and reported
-`stepNum=1` for step 2. The fixtures now put exactly one exam tile in the
-course, and the lock tests assert on `_ProgressSection`'s counter rather than a
-step title. This is also what makes the *page* assertions meaningful: a title
-that is present but off-screen would have hidden the `PageController` defect
-for a second round.
+**Three tests of mine could not fail for the reason their names gave.** Two I
+found; the third the implementation audit found, and it was the most important
+of the three.
+
+*The audit's:* nothing pinned which step the lock reads.
+`_nextStepLock` takes `steps[currentStep]`, Kotlin takes
+`steps.getOrNull(position - 1)` — and replacing it with `steps[0]` left the
+**entire suite green**. Every fixture here put the assessment on step 1 of a
+two-step course, and the lock is only ever *consulted* at index 0: at index 1
+`onNext` is null and `_NavigationBar` renders Finish, so the value computed for
+the last step is discarded. Nothing distinguished `currentStep` from `0`,
+`currentStep + 1` or `currentStep - 1`. Closed by a three-step course with the
+exam on the **middle** step, where the two readings disagree in both directions
+— reading `steps[0]` lets the learner off the locked step *and* blocks them on
+the unlocked one. `steps[0]` now reds exactly that test; `steps[currentStep+1]`
+reds four.
+
+*Mine, and the reason I recorded for them was wrong.* The first cut of the
+second-step `stepNum` test tapped a tile belonging to step 1 and reported
+`stepNum=1` for step 2, and I attributed it to `find.text` reaching an
+off-screen `PageView` page. **It does not reach one:** `PageView`'s
+`cacheExtent` is `allowImplicitScrolling ? 1.0 : 0.0` and that flag defaults
+false, so a settled `PageView` has only the visible page in the element tree —
+which is what the `findsNothing` assertion in *Next moves the page* depends on.
+The real cause was the `PageController` defect this phase then fixed: the page
+never moved, so step 1's tile was the only one built. The wrong reason was
+recorded in three places and is corrected in all three, because it would have
+told the next lane that page assertions are unreliable when they are the
+strongest assertions in the file — and a title assertion is exactly what would
+have caught the controller defect a round earlier.
 
 One harness note worth carrying forward: **`pumpAndSettle` does not clear a
 `SnackBar`.** It returns as soon as no frame is scheduled, and the four-second
@@ -397,19 +439,34 @@ released". `letSnackBarExpire` exists for that and says so.
    ```dart
    Future<int> countCompletedByUserAndExamId(String? userId, String examId)
    ```
-   with `userId` matched null-safely (Kotlin's `IS`), `parentId.like('%$examId%')`
-   escaped against the stored form, and `status.equals('pending').not()` — noting
-   that a NULL status must **not** count, which is what SQL gives for free and
+   with `userId` matched null-safely (Kotlin's `IS`),
+   `parentId.like('%$examId%')`, `status.equals('pending').not()`, and **no
+   `type` predicate** — Kotlin's count has none, where `_isStepCompleted` picks
+   its table by type, so adopting this closes a divergence rather than
+   preserving one. A NULL status must not count, which SQL gives for free and
    Dart does not.
+   **Do not escape the `LIKE` pattern**, which an earlier draft of this item
+   advised: Kotlin interpolates the raw exam id and escaping would make the
+   port *stricter* than Kotlin, the opposite of the looseness the `contains`
+   was chosen to preserve. Two axes the `contains` gets wrong in the other
+   direction, and which the DAO version would fix for free: SQLite's `LIKE` is
+   case-insensitive for ASCII, and it treats `%`/`_` in the pattern as
+   wildcards. All three are unreachable while `parentId` is minted from the
+   same `exam.id` through `examParentId`.
 2. **`_NavigationBar` shows Next and Previous to a non-member**, where
-   `updateNavigationVisibility:256-270` hides both — so a Kotlin non-member
-   cannot page through a course at all (its pager is also
-   `isUserInputEnabled = false`, and `navigateToStep` *is* membership-gated at
-   `:290`). Porting that would remove this phase's need for a membership gate on
-   the lock, and it is a one-line change to `_NavigationBar`. Left alone because
-   it takes a capability away from a browsing learner and is a behavioural call
-   beyond this brief. Note Kotlin's else-branch does not touch `finishStep`, so
-   a faithful port has to decide what a non-member sees on the last step.
+   `updateNavigationVisibility:267-270` hides both. Porting that would remove
+   this phase's need for a membership gate on the lock, and it is a one-line
+   change to `_NavigationBar`. Left alone because it takes a capability away
+   from a browsing learner and is a behavioural call beyond this brief.
+   **Do not port it as "a non-member cannot page through a course at all"** —
+   an earlier draft of this item said exactly that, contradicting this file's
+   own §*One claim was simply wrong* two screens up, which is the half that is
+   right: `onResume:146-162` puts Next back with no membership test, and
+   `steps` is a fragment field that survives view destruction, so a non-member
+   who leaves and returns *does* get Next. Kotlin's rule is stricter on the
+   first open than on any later one. Note also that the else branch does not
+   touch `finishStep`, so a faithful port has to decide what a non-member sees
+   on the last step.
 3. **`_ProgressSection` labels step 1 "Course Details".** It renders
    `currentStep == 0 ? l10n.courseDetails : l10n.stepNumber(currentStep + 1)`,
    a fossil of Kotlin's pager where position 0 *is* the course cover. The port's
@@ -420,8 +477,8 @@ released". `letSnackBarExpire` exists for that and says so.
 4. **The resources tile still has a chevron that does nothing** — Phase 128's
    item 1, unchanged, in both `take_course_screen` and `course_detail_screen`.
 5. **`getExamQuestionCount` shares `isStepCompleted`'s untyped first-row pick.**
-   `CoursesStepsAdapter.kt:51-55` renders `R.string.test_size,
-   step.questionCount`, which is `examDao.getFirstByStepId(stepId)?.noOfQuestions`
+   `CoursesStepsAdapter.kt:52-56` renders `R.string.test_size`
+   (`:54`) with `step.questionCount`, which is `examDao.getFirstByStepId(stepId)?.noOfQuestions`
    (`SubmissionsRepositoryImpl.kt:162-164`) — so Kotlin's step tile can show a
    *survey's* question count under a "Test:" label. The port's course-detail
    tile shows `resourcesInStep` instead and has no analogue, so there is nothing
@@ -445,7 +502,40 @@ released". `letSnackBarExpire` exists for that and says so.
    this phase edited. It stayed out because the values come from the session
    user and threading them through is a change to the screen's provider reads
    rather than to any of these three jobs.
-9. **The port's `Exams` table has no `type` column**, which is what makes the
+9. **The port does not resume a course at the learner's saved step.**
+   `_TakeCourseScreenState._currentStep` starts at 0 and nothing reads the
+   saved progress, where Kotlin opens at
+   `position = if (lastPositionBeforeExam > 0) … else if (currentStep > 0)
+   currentStep else 0` from `progressMap[courseId]?.current`
+   (`TakeCourseFragment.kt:104`, `:116`). Surfaced by the audit while checking
+   this phase's `PageController`, whose `initialPage` is therefore always 0.
+   Worth knowing that it also narrows the membership-gate rationale above: the
+   Kotlin path on which a returning non-member meets the lock depends on that
+   restored position, which the port has no equivalent of.
+10. **`TakeCourseScreen.build`'s clamp moves the index without driving the
+    controller.** When the step list shrinks it assigns `_currentStep` during
+    `build` and never calls `animateToPage` — the same shape this phase just
+    fixed 250 lines below. The scroll position self-corrects at layout, so the
+    page lands right; it is one line and it is pre-existing.
+11. **`_resolveStepNum`'s derivation branch is now test-only.** Both builders
+    of `/courses/exam/` send `stepNum`, so nothing in `lib/` reaches the
+    fallback. Kept deliberately as a defensive path for a location typed
+    without the parameter; named so nobody reads its coverage as proof it is
+    live.
+12. **The `isFromNation` team arm now ends in the thank-you dialog and a pop,
+    where Kotlin toasts and replaces with the survey list**
+    (`BaseExamFragment.kt:156-163`). That branch is dead in Kotlin — its only
+    writer derives `isFromNation` from a `parentId` both callers pass as `""` —
+    but it is **live in the port**, because `SurveyMapper` reads the field
+    straight off the server document, so "dead code" is not a reason to ignore
+    it here. I gave the path the same exit as every other non-team survey
+    rather than reproducing an unexercised Kotlin branch; the other view is
+    defensible and this is where to argue it.
+13. **`barrierDismissible: false` is not `setCancelable(false)`.** Kotlin's
+    thank-you dialog also swallows the back button. No behavioural difference
+    today, since either exit reaches the same pop, and `PopScope` is the
+    literal port if the pop ever becomes conditional on how the dialog closed.
+14. **The port's `Exams` table has no `type` column**, which is what makes the
    superset described above unavoidable. Adding one would let the port
    distinguish Kotlin's `"courses"` from its `"exam"` fallback and reproduce
    both the missing button and the wedged step — neither of which is desirable,

--- a/flutter/PHASE_139_NOTES.md
+++ b/flutter/PHASE_139_NOTES.md
@@ -1,14 +1,453 @@
 # Phase 139 — the per-step assessment lock, the survey's return, and an explicit `stepNum`
 
 Lane B of a four-lane round. Three jobs, all from previous rounds'
-*Reported, not fixed* lists:
+*Reported, not fixed* lists — the sixth consecutive round where that list was
+the highest-yield source of work:
 
-1. `TakeCourseFragment.changeNextButtonState` is unported — the per-step
-   next-button lock for `MANDATORY_SURVEY_COURSE_ID` (Phase 128 item 4).
+1. `TakeCourseFragment.changeNextButtonState` was unported — the per-step Next
+   lock for `MANDATORY_SURVEY_COURSE_ID` (Phase 128 item 4).
 2. A course-step survey `go`es to the submissions screen instead of returning
-   to the step, so half of Phase 128's tile-refresh fix is unreachable
-   (Phase 128 item 6).
-3. A course step's number is derived from `stepIndex` where `?stepNum=` is the
+   to the step, making half of Phase 128's tile refresh unreachable (Phase 128
+   item 6).
+3. A course step's number was derived from `stepIndex` where `?stepNum=` is the
    closer port (Phase 135 item 4).
 
-*In progress — this file is written as the work lands.*
+## Method
+
+1. Read the Kotlin by hand: `TakeCourseFragment`, `CourseStepFragment`,
+   `CoursesPagerAdapter`, `TakeCourseViewModel`, `CoursesRepositoryImpl
+   .getCourseStepData`, `SubmissionsRepositoryImpl.isStepCompleted`,
+   `BaseExamFragment.continueExam`/`showUserInfoDialog`, `SubmissionsAdapter
+   .openSurvey` and all five of its call sites.
+2. A `parity-auditor` pass at `effort: max` on **24 numbered claims** about that
+   reading, before any Dart. It confirmed most, corrected four, and added six
+   material items I had not asked about. All of them are recorded below rather
+   than quietly folded in.
+3. Implement, with each defect demonstrated failing first.
+4. **Sixteen mutations**, each replayed against the suite to confirm the
+   intended test reds.
+
+## What the ground-truth audit corrected
+
+### One claim was simply wrong: a non-member *can* meet Kotlin's lock
+
+I claimed `changeNextButtonState` has no membership test but
+`updateNavigationVisibility` (`:256-270`) hides Next for a non-member, so a
+non-member can never reach the lock. **The second half is false**, and the
+audit found the line: `onResume:154-160` makes Next visible again with **no**
+membership test, `setNavigationButtons`/`onClickNext`/`onClickPrevious` are
+equally ungated, and `next_step` carries no `android:visibility` in the layout
+(visible by default — only `finish_step` is `gone`). Since `position` is
+restored from the learner's saved progress (`:116`), somebody who joined, made
+progress, left the course and came back opens at `position > 0` with a visible
+Next and meets the lock.
+
+So gating the port's lock on membership is a **deviation, not fidelity**, and it
+is now documented as one at `_nextStepLock`. It is still the right call: the
+port's `_NavigationBar` has no membership gate at all, so gating the lock
+reproduces Kotlin's *intended* rule (`updateNavigationVisibility`) and diverges
+only from its `onResume` slip — and it keeps the lock consistent with the step
+tile, which `_StepContent` hides for a non-member. Being blocked by an
+assessment the screen is not offering you is worse than not being blocked.
+
+### `stepExams` is `type`-filtered where `getFirstByStepId` is not, and the port cannot reproduce the split
+
+The most important omission. Kotlin's `type` column holds **the server
+document's own `type`**, with the singular `examKey` only as a fallback:
+
+```kotlin
+// CoursesRepositoryImpl.kt:746
+type = if (examJson.has("type")) JsonUtils.getString("type", examJson) else examKey,
+```
+
+`examKey` is `"exam"`/`"survey"` — values no Kotlin query ever selects. So a
+`steps[i].exam` object carrying **no `type` field** is stored as `"exam"` and
+`getByStepIdAndType(stepId, "courses")` returns nothing: no Take Test button,
+and **no lock**. Kotlin's lock only ever fires for documents that declare
+`"type": "courses"` or `"type": "surveys"`.
+
+The port has no `type` column on `Exams`: `ExamMapper` routes on
+`type == 'surveys'` and files everything else as an exam, so its tables are a
+**strict superset** of Kotlin's. A step carrying a type-less exam and a
+type-less survey is unlocked in Kotlin and locked in the port. That is Phase
+113's documented deviation, extended from the buttons to the lock — the
+rationale now lives at `_isStepCompleted` rather than only at the mappers.
+
+Two more consequences, both in the port's favour:
+
+* **Kotlin can wedge a step permanently and the port cannot.** `stepExams` is
+  `type`-filtered while `getFirstByStepId` is not, so a step whose exam object
+  is type-less and whose survey says `"type": "surveys"` locks with the *survey*
+  message while the unlock condition interrogates the *exam* row. Answering the
+  survey never opens it.
+* **Kotlin's row pick is not deterministic even in Kotlin.** `exams` has an
+  index on `stepId`, so the order is rowid-within-stepId, and a course-document
+  edit mints a new Base64 step id whose row lands later — flipping the order.
+  The port's positional step ids make the pick deterministic.
+
+### `isStepCompleted` differs from `hasSubmission` in four ways, not one
+
+I had named the `status != 'pending'` test. The audit's table:
+
+| | `isStepCompleted` (`:359-365`) | `hasSubmission` (`:176-192`) |
+|---|---|---|
+| parentId | `LIKE '%' \|\| examId \|\| '%'` | exact `"$examId@$courseId"` |
+| status | `!= 'pending'` | none |
+| type | none | `type = :type` |
+| questions | none | `countByExamId == 0 → false` |
+| missing input | `stepId == null → true`; no row → **true** | blank id/course/user → **false** |
+
+**The row that mattered most was the first, not the one I had spotted.** Given
+Phase 125, a Dart `isStepCompleted` written as `parentId == examId` finds
+nothing (every writer stores the compound key), and one written as
+`parentId == '$examId@$courseId'` diverges the other way — Kotlin's `LIKE`
+matches a bare-id row, a compound row, and anything else carrying the id as a
+substring. `_isStepCompleted` uses a `contains` and says at the code that it is
+deliberately loose. Mutating it to `==` reds three tests.
+
+Also from the audit, and reproduced: a NULL `status` does **not** count
+(`status != 'pending'` is NULL in SQL, hence false), while the team-adoption
+marker `status: ''` **does**.
+
+### `CourseDao.getSteps` does not exist in Kotlin, and "the same ordering" was wrong
+
+`take_exam_screen`'s doc comment claimed the derivation used "the *same*
+ordering" as Kotlin. There is no such ordering: the query is
+`CourseStepDao.getByCourseId`, `SELECT * FROM course_steps WHERE courseId = ?`
+with **no `ORDER BY`**, and `CourseStep`'s PK is `Base64(stepJson)` with no
+position column — so Kotlin's step order is first-sync document order and is
+*not* stable under an edit. The port's `stepIndex` ordering is deterministic
+where Kotlin's is not. The comment is corrected.
+
+## Job 1 — the per-step Next lock
+
+`stepNextLockProvider` (`courses_providers.dart`) plus `_nextStepLock` on
+`_CourseContentState`. The lock reads **presence**, not submission-existence,
+and that distinction is the feature: `changeNextButtonState:320-321` locally
+shadows the names `hasExam`/`hasSurvey` with `stepExams.isNotEmpty()` /
+`stepSurvey.isNotEmpty()`, where the identically-named `CourseStepData` fields
+are `hasSubmission(...)`. Building the lock on those inverts it — only a learner
+who had already answered would be blocked. **Confirmed material by the audit**,
+and mutating presence → `assessment.hasExam` reds five tests.
+
+The lists come off `stepAssessmentProvider` rather than a fresh query, so the
+lock and the tile cannot disagree about what the step carries **and** the tile's
+post-return `invalidate` refreshes both. That is not an optimisation. The audit
+flagged it independently: Kotlin re-evaluates the lock only on a page-selection
+event (`onPageSelected:309`; `onResume` does *not* call
+`changeNextButtonState`) and stays correct anyway because `openCallFragment`'s
+`replace()` destroys the fragment's view, so returning from the exam
+re-dispatches `onPageSelected`. A `context.push` leaves the screen mounted, so
+an unshared read would hold a step the learner had just finished. Giving the
+lock its own step read reds exactly the return-trip test.
+
+Faithful quirks kept deliberately:
+
+* **The button stays enabled** and shows a `Snackbar`; `isNextStepLocked` is
+  read in `onClick` (`:367-370`), which returns before advancing. Kotlin never
+  touches `isEnabled`.
+* **A loading or rejected read is unlocked.** `getCourseStepData` throws on a
+  missing step row and `changeNextButtonState`'s `lifecycleScope.launch` has no
+  `try`, so Kotlin's flag keeps the `false` that `onPageSelected:306` had just
+  assigned. Reading `.valueOrNull` gives Kotlin's outcome without Kotlin's
+  crash, and the same mapping reproduces Kotlin's own race (`:306` clears the
+  flag synchronously, `:318` sets it from a coroutine, so a fast tap escapes).
+* **`please_complete_survey`'s wording is written for the finish gate**
+  ("…to finish the course") because Kotlin shares one string between the two
+  sites. Pinned so nobody mints a second key.
+
+`viewPager2.isUserInputEnabled = false` (`:137`) is ported alongside, and it is
+load-bearing rather than cosmetic: a swipe reaches `onPageChanged` directly, so
+while the `PageView` scrolled the lock could be dragged past. The audit
+confirmed there is no *other* bypass — the SeekBar that looks like one sits
+inside `ll_progress`, which is `gone` in the layout and never made visible by
+any code, so its `onProgressChanged` jump is dead UI.
+
+## The defect this lane did not go looking for
+
+**Previous and Next moved the step counter and left the page where it was.**
+
+The `PageController` was built inline in `build` as
+`PageController(initialPage: currentStep)`. `Scrollable` hands a replacement
+controller the existing `ScrollPosition`'s pixels
+(`createScrollPosition(..., oldPosition: _position)`), so `initialPage` is read
+once at first attach and ignored on every rebuild after it. Tapping Next
+advanced `_currentStep` — so `_ProgressSection` read `2 / 2` and the button set
+switched to Finish — while the pager still showed step 1.
+
+**Why nothing caught it:** every navigation assertion in the suite read the
+counter, which is driven by the same `currentStep` the controller was being
+handed. The two agreed about the *number* while disagreeing about what was on
+screen. It surfaced only because a `stepNum` test tapped the *second* step's
+assessment tile and could not find it; a probe of the rendered `Text` widgets
+showed `[Step 2, 2 / 2, 1, First, …]` — the counter on step 2, the content on
+step 1.
+
+It had to be fixed here rather than reported, because Job 1 makes it worse:
+with `isUserInputEnabled = false` ported, the buttons are the *only* way through
+a course, so a lock guarding a button that does not navigate would have been the
+only working half of the pair — and a learner would have had no way to advance
+at all. The controller now lives in the state, `goToStep` drives it with
+`animateToPage` (matching `viewPager2.currentItem += 1`, whose ViewPager2
+default is a smooth scroll), and `onPageChanged` only reports the landing rather
+than re-driving the controller from inside its own completion.
+
+Two tests assert on the *page* rather than the counter; reverting the fix reds
+both, plus the second-step `stepNum` test.
+
+## Job 2 — where a finished survey leaves the learner
+
+`TakeSurveyScreen._submit` ended with `context.go('${Routes.submissions}/$id')`.
+**That is a port invention with no Kotlin counterpart on any entry point** — no
+Kotlin path shows the learner their own submission after finishing one; the only
+openers of `SubmissionDetailFragment` are list-row taps.
+
+`BaseExamFragment.continueExam:132-148` ends a non-team survey with a thank-you
+dialog whose Finish calls `FragmentNavigator.popBackStack`. All five
+`openSurvey` call sites reach it, four hardcoding `isTeam = false`
+(`SubmissionsAdapter:98`, `CourseStepFragment:289`, `BellDashboardFragment:256`,
+`DashboardActivity:220`) and the fifth (`SurveysAdapter:88`) passing a variable.
+So the individual list, the my-surveys row, the dashboard prompt, a deep link
+and a course step all pop.
+
+**A pop is what makes one exit right for all of them**: each was reached by a
+`context.push`, so each lands back on its own caller. The brief expected these
+entry points to want different destinations; they do not — they want the same
+*rule*, which resolves to a different screen per caller by construction.
+
+The course step is the entry that was actually broken: `go` unmounted
+`TakeCourseScreen` outright, so the tile's `await context.push(…)` never
+resumed and Phase 128's *redo survey* relabel — whose only trigger is a
+submission made on this screen — was unreachable on the one path that produces
+it. The round trip is now tested with the **real** `TakeSurveyScreen` as the
+push target: the existing test that looks like it covers this path stubs the
+route with a `Text` widget, so the real screen's exit had never been exercised
+by anything.
+
+Three corrections the audit made to my plan, all applied:
+
+* **The thank-you string is composed**, not a single key:
+  `"${thank_you_for_taking_this}$type! ${we_wish_you_all_the_best}"` (`:135`) →
+  *"Thank you for taking this survey! We wish you all the best."* No single
+  Kotlin string matches that, so a new ARB key for it could derive nothing from
+  `values-*/strings.xml` and would render English in all five locales.
+  `thankYouForTakingSurvey` is one sentence shorter and has a **reviewed human
+  translation in every locale**. Five translations beat four extra words;
+  recorded as a deviation.
+* **`popBackStack` is a no-op on an empty back stack** (`FragmentNavigator
+  .kt:55`), so with nothing to pop the new exit does nothing rather than
+  inventing a destination.
+* **The team branch's existing `go(Routes.surveys)` fallback cites dead code.**
+  It claimed to mirror `navigateToSurveyList`, which is unreachable:
+  `isFromNation` has no Kotlin writer that can make it true
+  (`insertCourseStepsExams` sets it from a `parentId` its only caller passes as
+  `""`). Behaviour left alone; the comment now says what it is.
+
+One existing test changed: `survey_team_context_test.dart`'s *"a personal survey
+goes straight to the submission"*. Its point was that a personal sheet must not
+acquire the profile step, and the `SUBMISSION_PAGE` assertion was incidental to
+that; it now asserts the thank-you dialog instead.
+
+**And a finding about the existing tests in `take_survey_screen_test.dart`:**
+every submit in that file was landing in `_submit`'s **failure** branch. The
+real `serverConfigProvider` reaches `planetPrefs`, which is `UnimplementedError`
+in the harness, and `_submit` reads it *inside* its own `try` — so the screen
+wrote the row and then showed "Could not save your answers". The tests assert
+only on the stored row, so they never saw it, which is how the screen's whole
+exit path stayed untested through four phases. `survey_team_context_test.dart`
+had already found and documented this for its own harness; the note had not
+travelled. Both harnesses in the file now override it.
+
+## Job 3 — the explicit step number
+
+Kotlin never derives the number: `CoursesPagerAdapter.kt:49` stamps the pager
+position on the step fragment as `"stepNumber"`, `CourseStepFragment.kt:280`
+forwards it to the exam as `"stepNum"` (**the key is renamed across the
+boundary**, which is why no other entry point carries one), and
+`BaseExamFragment.kt:75` reads it back with a default of 0.
+
+Both port pushers now send it — `take_course_screen`'s step tile from the
+`stepNumber` it already drew in the step header, and `course_detail_screen`'s
+tile from its own `number` — the router parses it with `int.tryParse`, and
+`TakeExamScreen.stepNum` prefers it over the derivation. So the number written
+to `course_progress` is the one the learner saw, and it cannot disagree with
+`take_course_screen._recordProgress`'s `stepNum: index + 1`.
+
+The derivation stays as the fallback, because the route's query parameters are
+optional and a location without a `stepNum` must still work. A non-positive
+value is treated as absent: `0` is Kotlin's missing-argument default and
+`WHERE stepNum = 0` is precisely the value its own update matches nothing with.
+
+**What passing it explicitly buys, concretely:** the derivation had to resolve
+the *step id* in a re-query first, so a step id the course does not list — a
+step row that has not synced, or one re-bound by a reorder — skipped the write
+entirely. Kotlin never consults the step table here at all. Tested.
+
+**What it does not buy, stated because my `stepNum` work sits on top of it.**
+Phase 135 item 5: a course-step reorder re-binds the port's step ids to
+different content, because the port mints `<courseId>:<index>` while Kotlin's id
+is content-derived (`Base64(stepElement.toString())`, `CoursesRepositoryImpl
+.kt:681`). Passing `stepNum` explicitly does **not** fix that and is not offered
+as a fix — the number is still the position the learner navigated from, so after
+a reorder it names the new content at that position while older progress rows
+name the old. What it removes is only the extra hop: a reorder can no longer
+make the write miss the row entirely rather than merely describe the wrong step.
+Fixing the underlying divergence means changing how `CourseMapper` mints step
+ids, which is a mapper and migration question.
+
+## Files touched
+
+| file | change |
+|---|---|
+| `lib/providers/courses_providers.dart` | `StepNextLock`, `stepNextLockProvider`, `_isStepCompleted` |
+| `lib/ui/courses/take_course_screen.dart` | the lock wiring, the owned `PageController`, `NeverScrollableScrollPhysics`, `&stepNum=` |
+| `lib/ui/courses/course_detail_screen.dart` | `&stepNum=` |
+| `lib/ui/surveys/take_survey_screen.dart` | `_thankAndLeave` replaces the `go` |
+| `lib/ui/router.dart` | parses `stepNum` |
+| `lib/ui/exam/take_exam_screen.dart` | **outside the brief's file set — see below** |
+| `lib/l10n/app_en.arb` | `pleaseCompleteTest`, additions only |
+| `test/ui/courses/step_next_lock_test.dart` | new, 14 tests |
+| `test/ui/courses/step_num_argument_test.dart` | new, 6 tests |
+| `test/ui/surveys/take_survey_screen_test.dart` | +4 tests, and the harness fix above |
+| `test/ui/courses/take_course_screen_test.dart` | +1 round-trip test |
+| `test/ui/exam/take_exam_screen_test.dart` | +3 tests, `pumpExam` gains `stepNum` |
+| `test/ui/surveys/survey_team_context_test.dart` | one existing test's destination assertion |
+
+**`lib/ui/exam/take_exam_screen.dart` is outside the file set the brief listed**,
+and it is named here rather than left to be noticed in the diff. Job 3 cannot
+land without it: the router has nowhere to put the parsed `stepNum` unless
+`TakeExamScreen` accepts one, so passing the number explicitly would have been a
+push nothing read — the writer/reader shape this project has paid for four
+times. No other lane owns the file (Lane A has the repositories and
+`app_providers`, Lane C the chat and voices, Lane D the locale files). The
+change is three things: the constructor parameter, `_resolveStepNum` preferring
+it, and two stale doc claims corrected.
+
+## Integrator: one command, and a count
+
+`lib/l10n/app_en.arb` gains **one** key, `pleaseCompleteTest`, worded as the
+exact literal from `values/strings.xml` — *"please complete the test to
+proceed"* — so `tool/arb_from_strings_xml.dart` can derive it. **All five
+`values-*/strings.xml` carry `please_complete_test` as a human translation
+already shipping in the Android app**, so:
+
+**Run `dart run tool/arb_from_strings_xml.dart` (Lane D's file) and bump
+`humanReviewed` in `test/l10n/placeholder_integrity_test.dart` by +1 per
+locale: ar 418→419, es 470→471, fr 417→418, ne 419→420, so 419→420.**
+
+Until that runs, an Arabic, Spanish, French, Nepali or Somali learner sees
+`please complete the test to proceed` in English on a screen where the Android
+app has always shown their own language. I did not run it myself because Lane D
+owns those five files and the tool this round. Phase 128 left the identical
+hand-off; this is one key rather than five.
+
+## Mutation testing
+
+Sixteen reverts, each replayed against the suite. Every one reds its intended
+test, and eight red exactly one.
+
+| # | mutation | reds |
+|---|---|---|
+| 1 | the lock never fires | 6 tests |
+| 2 | presence → `hasSubmission` (the inversion) | 5 tests |
+| 3 | drop `status != 'pending'` | *"a half-answered attempt still blocks"* |
+| 4 | drop the user scoping | *"another learner's finished attempt…"* |
+| 5 | drop the course-id gate | *"any other course is never locked"* |
+| 6 | drop `NeverScrollableScrollPhysics` | *"the lock cannot be swiped past"* |
+| 7 | `blockedByTest` always false | 5 tests |
+| 8 | drop the membership gate | *"a learner who has not joined is not locked"* |
+| 9 | give the lock its own step read | *"the lock releases on returning from the exam"* |
+| 10 | `contains` → `==` on `parentId` | 3 tests |
+| 11 | restore `go('${Routes.submissions}/$id')` | 6 tests, across three files |
+| 12 | restore the inline `PageController` | 3 tests |
+| 13 | drop `&stepNum=` from the step tile | 2 tests |
+| 14 | drop `&stepNum=` from the detail tile | *"the second tile sends 2"* |
+| 15 | router stops parsing `stepNum` | the router pair test |
+| 16 | `_resolveStepNum` ignores the passed value | 2 tests |
+
+Two tests of my own needed fixing because they could not fail for the reason
+they named, both the same trap: **`find.text` searches the element tree and
+`PageView.builder` leaves an off-screen page in it.** Every step tile renders
+the identical label (`take test [N]`'s count is that step's `exams.length`, so
+it reads `[1]` on any step with one), so the first cut of the second-step
+`stepNum` test matched the page the learner had *left* and reported
+`stepNum=1` for step 2. The fixtures now put exactly one exam tile in the
+course, and the lock tests assert on `_ProgressSection`'s counter rather than a
+step title. This is also what makes the *page* assertions meaningful: a title
+that is present but off-screen would have hidden the `PageController` defect
+for a second round.
+
+One harness note worth carrying forward: **`pumpAndSettle` does not clear a
+`SnackBar`.** It returns as soon as no frame is scheduled, and the four-second
+dismiss timer needs wall-clock time pumped — so a second tap on a bottom
+navigation button lands on the SnackBar, is silently swallowed (only a
+`warnIfMissed` line in the log), and the test reads as "the lock never
+released". `letSnackBarExpire` exists for that and says so.
+
+## Reported, not fixed
+
+1. **`SubmissionDao` wants `countCompletedByUserAndExamId`.** `_isStepCompleted`
+   reads one user's submissions of one type and filters in Dart, where Kotlin
+   issues `SELECT COUNT(*) FROM submissions WHERE userId IS :userId AND parentId
+   LIKE '%' || :examId || '%' AND status != 'pending'` (`SubmissionDao.kt:24`).
+   The set is bounded, so this is not a performance defect — it is a layering
+   one: every other query in the port lives in a DAO, and adding this one means
+   editing `app_database.dart`, which Lane A owns this round. **The method to
+   add**, for whoever takes it:
+   ```dart
+   Future<int> countCompletedByUserAndExamId(String? userId, String examId)
+   ```
+   with `userId` matched null-safely (Kotlin's `IS`), `parentId.like('%$examId%')`
+   escaped against the stored form, and `status.equals('pending').not()` — noting
+   that a NULL status must **not** count, which is what SQL gives for free and
+   Dart does not.
+2. **`_NavigationBar` shows Next and Previous to a non-member**, where
+   `updateNavigationVisibility:256-270` hides both — so a Kotlin non-member
+   cannot page through a course at all (its pager is also
+   `isUserInputEnabled = false`, and `navigateToStep` *is* membership-gated at
+   `:290`). Porting that would remove this phase's need for a membership gate on
+   the lock, and it is a one-line change to `_NavigationBar`. Left alone because
+   it takes a capability away from a browsing learner and is a behavioural call
+   beyond this brief. Note Kotlin's else-branch does not touch `finishStep`, so
+   a faithful port has to decide what a non-member sees on the last step.
+3. **`_ProgressSection` labels step 1 "Course Details".** It renders
+   `currentStep == 0 ? l10n.courseDetails : l10n.stepNumber(currentStep + 1)`,
+   a fossil of Kotlin's pager where position 0 *is* the course cover. The port's
+   `PageView` has no cover page, so index 0 is a real step and is mislabelled —
+   and the label is off by one against `stepNumber` for every other step. Not
+   touched because it is display-only and outside all three jobs, but it is in
+   the file this phase edited most.
+4. **The resources tile still has a chevron that does nothing** — Phase 128's
+   item 1, unchanged, in both `take_course_screen` and `course_detail_screen`.
+5. **`getExamQuestionCount` shares `isStepCompleted`'s untyped first-row pick.**
+   `CoursesStepsAdapter.kt:51-55` renders `R.string.test_size,
+   step.questionCount`, which is `examDao.getFirstByStepId(stepId)?.noOfQuestions`
+   (`SubmissionsRepositoryImpl.kt:162-164`) — so Kotlin's step tile can show a
+   *survey's* question count under a "Test:" label. The port's course-detail
+   tile shows `resourcesInStep` instead and has no analogue, so there is nothing
+   to fix today; recorded because anyone porting that count will meet the same
+   row-pick question this phase answered for the lock.
+6. **`computeParentId()` is wrong on the step-exam path in Kotlin and inert.**
+   `ExamTakingFragment.kt:90-96` yields `"@<courseId>"` there, because
+   `checkId()` leaves `id = ""` whenever `stepId` is non-empty. Never used on
+   that path — the pending lookup is gated on `type != "exam"` and
+   `createExamSubmission` recomputes `parentId` from the exam itself. It becomes
+   live for any port that derives its parent id at the call site instead of in
+   the writer; the port derives it in the writer, so this is a "do not change
+   that" note.
+7. **`isValidClickRight` is off by one** (`TakeCourseFragment.kt:487`):
+   `currentItem < itemCount` should be `< itemCount - 1`. Unreachable today
+   because Next is hidden on the last page. Named because this phase ported the
+   surrounding click handler and deliberately did not carry the bug.
+8. **Phase 135 items 5, 7, 9, 10 and 11 are all still open**, and item 9 —
+   `_recordProgress` writing neither `planetCode` nor `parentCode`, so every
+   locally-authored progress row reaches CouchDB with both null — is in the file
+   this phase edited. It stayed out because the values come from the session
+   user and threading them through is a change to the screen's provider reads
+   rather than to any of these three jobs.
+9. **The port's `Exams` table has no `type` column**, which is what makes the
+   superset described above unavoidable. Adding one would let the port
+   distinguish Kotlin's `"courses"` from its `"exam"` fallback and reproduce
+   both the missing button and the wedged step — neither of which is desirable,
+   so this is recorded as a reason the deviation is permanent rather than as
+   work.

--- a/flutter/PHASE_139_NOTES.md
+++ b/flutter/PHASE_139_NOTES.md
@@ -1,0 +1,14 @@
+# Phase 139 — the per-step assessment lock, the survey's return, and an explicit `stepNum`
+
+Lane B of a four-lane round. Three jobs, all from previous rounds'
+*Reported, not fixed* lists:
+
+1. `TakeCourseFragment.changeNextButtonState` is unported — the per-step
+   next-button lock for `MANDATORY_SURVEY_COURSE_ID` (Phase 128 item 4).
+2. A course-step survey `go`es to the submissions screen instead of returning
+   to the step, so half of Phase 128's tile-refresh fix is unreachable
+   (Phase 128 item 6).
+3. A course step's number is derived from `stepIndex` where `?stepNum=` is the
+   closer port (Phase 135 item 4).
+
+*In progress — this file is written as the work lands.*

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -1316,6 +1316,7 @@
   "addedToCourse": "Added to your courses",
   "removedFromCourse": "Removed from your courses",
   "pleaseCompleteSurvey": "please complete the survey to finish the course",
+  "pleaseCompleteTest": "please complete the test to proceed",
   "takeCourse": "Take Course",
   "teamCalendar": "Team Calendar",
   "noMeetupsOnDate": "No meetups on this date",

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -486,8 +486,12 @@ typedef StepNextLock = ({bool locked, bool blockedByTest});
 /// so a tap in between is not blocked there either.
 final stepNextLockProvider = FutureProvider.autoDispose
     .family<StepNextLock, StepAssessmentKey>((ref, key) async {
-      final assessment = await ref.watch(stepAssessmentProvider(key).future);
+      // Watched before the await rather than after it: a `ref.watch` on the
+      // far side of an `await` runs against an element that may already be
+      // disposed. Harmless for this provider, which never changes, but the
+      // shape is not worth keeping.
       final db = ref.watch(appDatabaseProvider);
+      final assessment = await ref.watch(stepAssessmentProvider(key).future);
       // Kotlin's order (`:323-333`) is completion first, presence second. The
       // two agree either way — `isStepCompleted` answers true when the step
       // carries no assessment — and this keeps the cheap test first.
@@ -529,7 +533,10 @@ final stepNextLockProvider = FutureProvider.autoDispose
 ///    `getFirstByStepId` is not, so a step whose exam object carries no `type`
 ///    and whose survey object says `"type": "surveys"` locks with the *survey*
 ///    message while the unlock condition interrogates the *exam* row —
-///    answering the survey never opens it.
+///    answering the survey never opens it. The type filter is not the only
+///    route to that disagreement: `getFirstByStepId` has no `ORDER BY` either,
+///    so a step that gains an exam *after* its first sync leaves the survey
+///    holding the lower rowid and Kotlin picks the survey.
 ///  * **The lock fires on documents Kotlin's does not.** Kotlin's `type`
 ///    column holds the server document's own `type`, falling back to the
 ///    singular `"exam"`/`"survey"` that no Kotlin query selects
@@ -542,10 +549,20 @@ final stepNextLockProvider = FutureProvider.autoDispose
 ///    buttons to the lock.
 ///
 /// The submission read picks its table from the row's own, the way
-/// [SubmissionsRepository.hasSubmission] picks its question table — Kotlin has
-/// one `submissions` query with no `type` filter, and the only input that
-/// would tell the two apart is an exam and a survey sharing an `_id`, which is
-/// also the case where Kotlin's own row pick is undefined.
+/// [SubmissionsRepository.hasSubmission] picks its question table. **Kotlin's
+/// count has no `type` predicate at all** (`SubmissionDao.kt:24`), so this is
+/// a divergence rather than a translation: a submission whose `type` is null or
+/// unexpected, but whose `parentId` carries the assessment id, releases
+/// Kotlin's lock and not this one. Unreachable today — every port writer sets
+/// `'exam'` or `'survey'` and the sync-in copies Planet's own value — and the
+/// DAO method named in `PHASE_139_NOTES.md` would drop the filter and close it.
+///
+/// Two more axes on which `contains` is not `LIKE`, both unreachable for the
+/// same reason (`parentId` is always minted from the same `exam.id` through
+/// `examParentId`) and both worth knowing before anyone rewrites this as SQL:
+/// SQLite's `LIKE` is **case-insensitive** for ASCII where `contains` is not,
+/// and it treats `%`/`_` in the pattern as wildcards, which Kotlin does not
+/// escape.
 ///
 /// **This reads a list where Kotlin reads a `COUNT(*)`.** The faithful query
 /// is `SubmissionDao.countCompletedByUserAndExamId`, which the port does not
@@ -565,6 +582,11 @@ Future<bool> _isStepCompleted({
       : (surveys.isEmpty ? null : surveys.first.id);
   // `examDao.getFirstByStepId(stepId) ?: return true` — a step with no
   // assessment row is complete, which is what unlocks an ordinary step.
+  //
+  // Unreachable from the one caller, which short-circuits on both lists being
+  // empty before it gets here. Kept because it is Kotlin's own `?:` and this
+  // function reads as a port of `isStepCompleted` rather than as a helper for
+  // one call site; its lack of coverage is deliberate, not a gap.
   if (assessmentId == null) return true;
   final rows = fromExam
       ? await db.submissionDao.getExamSubmissionsByUser(userId)

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -416,6 +416,167 @@ final stepAssessmentProvider = FutureProvider.autoDispose
       );
     });
 
+/// Kotlin's `isNextStepLocked` / `lockedStepMessage` pair for one step
+/// ([locked] and, when locked, which of the two messages to show).
+///
+/// [blockedByTest] picks the message the way `changeNextButtonState:327-330`
+/// does — `please_complete_test` when the step carries an exam, otherwise
+/// `please_complete_survey` — so it is only meaningful while [locked].
+typedef StepNextLock = ({bool locked, bool blockedByTest});
+
+/// Port of `TakeCourseFragment.changeNextButtonState`
+/// (`TakeCourseFragment.kt:315-338`) — the per-step refusal to advance that
+/// the MyPlanet Onboarding course puts in front of an unanswered step
+/// assessment. **This is not the finish-time gate**, which is
+/// `onFinishStep`'s `hasUnfinishedSurveys` and lives in
+/// `take_course_screen._onFinish`; the two are independent, and Kotlin's
+/// per-step lock never applies to the last step because Next is replaced by
+/// Finish there.
+///
+/// The course-id gate (`:316`) is deliberately **not** here: it reads the
+/// screen's own course, so the caller decides whether to watch this at all,
+/// exactly as `changeNextButtonState`'s `if` wraps its whole body and its
+/// `else` is a bare `isNextStepLocked = false` (`:336`).
+///
+/// **Presence, not submission — and that distinction is the whole point.**
+/// `changeNextButtonState` reads `stepData.stepExams.isNotEmpty()` /
+/// `stepData.stepSurvey.isNotEmpty()` (`:320-321`), i.e. *does the step carry
+/// an assessment at all*. It locally shadows the names `hasExam`/`hasSurvey`,
+/// which on `CourseStepData` mean something else entirely —
+/// `hasSubmission(...)`, *has the learner already answered*
+/// (`CoursesRepositoryImpl.kt:534-542`). Building the lock on those would
+/// invert it: only a learner who had already answered would be blocked. The
+/// lists are read off [stepAssessmentProvider] rather than re-queried so the
+/// lock and the step tile cannot disagree about what the step carries, and so
+/// that the tile's post-return `invalidate` refreshes both — see below.
+///
+/// **The completion half is [SubmissionsRepository]-adjacent but is not
+/// `hasSubmission`.** Kotlin's is `isStepCompleted`
+/// (`SubmissionsRepositoryImpl.kt:359-365`), and it differs from
+/// `hasSubmission` in four ways, of which two decide this feature:
+///
+///  * `status != 'pending'`. `hasSubmission` is status-blind, so a learner who
+///    has merely *started* the exam satisfies it; this needs them to have
+///    finished. `saveExamAnswer` writes `complete` for a survey's last answer
+///    and `requires grading` for an exam's, both of which pass; a half-answered
+///    attempt is `pending` and does not. In SQL `status != 'pending'` is NULL —
+///    so false — for a NULL status, which [_isStepCompleted] reproduces
+///    explicitly; the team-adoption marker (`status: ''`) does pass, as it does
+///    in Kotlin.
+///  * `parentId LIKE '%' || :examId || '%'` (`SubmissionDao.kt:24`), against
+///    `hasSubmission`'s exact `"$examId@$courseId"`. The `LIKE` is
+///    deliberately loose and [_isStepCompleted] keeps it as a `contains`: it
+///    matches the compound key every current writer stores (Phase 125), a bare
+///    id an older build wrote, and — as Kotlin does — any other `parentId`
+///    carrying the id as a substring.
+///
+/// It also takes no `courseId` and no `type`, and answers **true** for a step
+/// with no assessment row at all (`?: return true`) — which is why a step
+/// carrying neither an exam nor a survey is unlocked.
+///
+/// **A rejected read is unlocked, and that is a decision rather than a
+/// default.** `getCourseStepData` throws `IllegalStateException` on a missing
+/// step row (`CoursesRepositoryImpl.kt:527-528`) and
+/// `changeNextButtonState`'s `lifecycleScope.launch` (`:318`) has no `try`, so
+/// Kotlin's `isNextStepLocked` keeps the `false` that `onPageSelected:306` had
+/// just assigned. A caller reading `.valueOrNull` gets null here and treats it
+/// as unlocked, which is Kotlin's outcome without Kotlin's crash. The same
+/// mapping covers the still-loading case, which reproduces Kotlin's own race:
+/// `:306` clears the flag synchronously and `:318` sets it from a coroutine,
+/// so a tap in between is not blocked there either.
+final stepNextLockProvider = FutureProvider.autoDispose
+    .family<StepNextLock, StepAssessmentKey>((ref, key) async {
+      final assessment = await ref.watch(stepAssessmentProvider(key).future);
+      final db = ref.watch(appDatabaseProvider);
+      // Kotlin's order (`:323-333`) is completion first, presence second. The
+      // two agree either way — `isStepCompleted` answers true when the step
+      // carries no assessment — and this keeps the cheap test first.
+      final hasExam = assessment.exams.isNotEmpty;
+      final hasSurvey = assessment.surveys.isNotEmpty;
+      if (!hasExam && !hasSurvey) {
+        return (locked: false, blockedByTest: false);
+      }
+      final completed = await _isStepCompleted(
+        db: db,
+        exams: assessment.exams,
+        surveys: assessment.surveys,
+        userId: key.userId,
+      );
+      return (locked: !completed, blockedByTest: hasExam);
+    });
+
+/// Port of `SubmissionsRepositoryImpl.isStepCompleted` (`:359-365`).
+///
+/// **Which row is interrogated is a judgement call the split tables force.**
+/// Kotlin keeps every exam and survey in one `exams` table and picks the row
+/// with `ExamDao.getFirstByStepId`, which is `WHERE stepId = ? LIMIT 1` with
+/// **no type filter and no `ORDER BY`** (`ExamDao.kt:13`) — so on a step
+/// carrying both, the row is whichever SQLite returns first. In practice that
+/// is the exam: `buildCoursePayload` collects `steps[i].exam` before
+/// `steps[i].survey` into one list (`CoursesRepositoryImpl.kt:698-699`) and
+/// `@Upsert` inserts in list order, giving the exam the lower rowid. This
+/// takes the step's first exam and falls back to its first survey, which
+/// matches that and has a property worth keeping deliberately: the message
+/// [stepNextLockProvider] chooses is the *test* one whenever an exam is
+/// present (`changeNextButtonState:328`), so message and remedy name the same
+/// assessment. An `OR` across both tables would let the two disagree.
+///
+/// Two consequences of the split, both in the port's favour and both
+/// deviations rather than fidelity:
+///
+///  * **Kotlin can wedge a step permanently and the port cannot.** Its
+///    `stepExams`/`stepSurvey` are filtered on `type` while
+///    `getFirstByStepId` is not, so a step whose exam object carries no `type`
+///    and whose survey object says `"type": "surveys"` locks with the *survey*
+///    message while the unlock condition interrogates the *exam* row —
+///    answering the survey never opens it.
+///  * **The lock fires on documents Kotlin's does not.** Kotlin's `type`
+///    column holds the server document's own `type`, falling back to the
+///    singular `"exam"`/`"survey"` that no Kotlin query selects
+///    (`CoursesRepositoryImpl.kt:746`), so `getByStepIdAndType(…, "courses"
+///    / "surveys")` misses a type-less step assessment — no button *and* no
+///    lock. `ExamMapper` routes on `type == 'surveys'` and files everything
+///    else as an exam, so the port's tables are a superset and a type-less
+///    assessment both shows a tile and holds the step. That is Phase 113's
+///    documented deviation; this is the reader that extends it from the
+///    buttons to the lock.
+///
+/// The submission read picks its table from the row's own, the way
+/// [SubmissionsRepository.hasSubmission] picks its question table — Kotlin has
+/// one `submissions` query with no `type` filter, and the only input that
+/// would tell the two apart is an exam and a survey sharing an `_id`, which is
+/// also the case where Kotlin's own row pick is undefined.
+///
+/// **This reads a list where Kotlin reads a `COUNT(*)`.** The faithful query
+/// is `SubmissionDao.countCompletedByUserAndExamId`, which the port does not
+/// have; adding it means editing `app_database.dart`, which another lane owns
+/// this round. The set is one user's submissions of one type, so the read is
+/// bounded — but it is a workaround, and `PHASE_139_NOTES.md` names the method
+/// that should replace it.
+Future<bool> _isStepCompleted({
+  required AppDatabase db,
+  required List<ExamRow> exams,
+  required List<SurveyRow> surveys,
+  required String? userId,
+}) async {
+  final fromExam = exams.isNotEmpty;
+  final assessmentId = fromExam
+      ? exams.first.id
+      : (surveys.isEmpty ? null : surveys.first.id);
+  // `examDao.getFirstByStepId(stepId) ?: return true` — a step with no
+  // assessment row is complete, which is what unlocks an ordinary step.
+  if (assessmentId == null) return true;
+  final rows = fromExam
+      ? await db.submissionDao.getExamSubmissionsByUser(userId)
+      : await db.submissionDao.getSurveySubmissionsByUser(userId ?? '');
+  return rows.any((row) {
+    final status = row.status;
+    return (row.parentId ?? '').contains(assessmentId) &&
+        status != null &&
+        status != 'pending';
+  });
+}
+
 /// Distinct grade levels present locally, for the filter spinner.
 ///
 /// Deliberately *not* derived from [coursesStreamProvider]: that watches

--- a/flutter/lib/ui/courses/course_detail_screen.dart
+++ b/flutter/lib/ui/courses/course_detail_screen.dart
@@ -217,9 +217,18 @@ class _StepTile extends ConsumerWidget {
                 child: FilledButton.tonalIcon(
                   icon: const Icon(Icons.assignment_turned_in_outlined),
                   label: Text(l10n.takeExam),
+                  // `stepNum` is the tile's own 1-based position, passed
+                  // explicitly rather than derived from the step's place in a
+                  // re-query. There is no Kotlin `stepNum` to copy on this
+                  // path — the button itself is a port addition — but the
+                  // number is the same one `take_course_screen` sends, and
+                  // both come from the ordering `courseStepsProvider` renders,
+                  // so the two entries into the same step exam cannot key
+                  // `course_progress` differently.
                   onPressed: () => context.push(
                     '/courses/exam/${exam.value!.id}'
-                    '?stepId=${step.id}&courseId=${step.courseId ?? ''}',
+                    '?stepId=${step.id}&courseId=${step.courseId ?? ''}'
+                    '&stepNum=$number',
                   ),
                 ),
               ),

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -133,6 +133,33 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
   /// this mount, so a rebuild is not a re-visit.
   int? _recordedStep;
 
+  /// **Owned by the state, and that is a fix rather than a tidy-up.** The
+  /// controller used to be built inline in `build` as
+  /// `PageController(initialPage: currentStep)`, which meant Previous and Next
+  /// moved the step *counter* and left the page where it was: `Scrollable`
+  /// hands a replacement controller the existing `ScrollPosition`'s pixels
+  /// (`createScrollPosition(..., oldPosition: _position)`), so `initialPage` is
+  /// read once at first attach and ignored on every rebuild after it.
+  ///
+  /// Nothing caught it because nothing asserted on the page. The tests here
+  /// checked the counter, which is driven by the same `currentStep` the
+  /// controller was being handed — so the two agreed about the number while
+  /// disagreeing about what was on screen. Found by a `stepNum` test that
+  /// tapped the second step's assessment tile and could not find it.
+  ///
+  /// Kotlin drives the pager explicitly for the same reason: `onClick` does
+  /// `binding.viewPager2.currentItem += 1` (`TakeCourseFragment.kt:372`) and
+  /// `navigateToStep` calls `setCurrentItem(index + 1, true)` (`:293`).
+  late final PageController _pageController = PageController(
+    initialPage: widget.currentStep,
+  );
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
   /// **Stateful for one reason: the step the learner *lands on* has to be
   /// recorded, and a page-change callback never fires for it.**
   ///
@@ -212,8 +239,20 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
 
     // The recording moved to [_recordCurrentStep], which covers this and the
     // step the screen opens on alike.
+    //
+    // Moves the pager as well as the index, because with the controller held
+    // in state nothing else does — see [_pageController]. `animateToPage`
+    // rather than `jumpToPage` to match `viewPager2.currentItem += 1`, whose
+    // ViewPager2 default is a smooth scroll.
     void goToStep(int index) {
       onStepChanged(index);
+      if (_pageController.hasClients) {
+        _pageController.animateToPage(
+          index,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeInOut,
+        );
+      }
     }
 
     /// `onClick`'s `R.id.next_step` arm (`TakeCourseFragment.kt:366-376`): a
@@ -244,8 +283,12 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
         Expanded(
           child: PageView.builder(
             itemCount: steps.length,
-            controller: PageController(initialPage: currentStep),
-            onPageChanged: goToStep,
+            controller: _pageController,
+            // Reports the landing rather than re-driving the controller: a
+            // programmatic `animateToPage` fires this too, and routing it back
+            // through `goToStep` would call `animateToPage` from inside its own
+            // completion.
+            onPageChanged: onStepChanged,
             // `binding.viewPager2.isUserInputEnabled = false`
             // (`TakeCourseFragment.kt:137`). Kotlin advances the course by its
             // two buttons and nothing else — the SeekBar that looks like a

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -204,14 +204,36 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final currentStep = widget.currentStep;
     final onStepChanged = widget.onStepChanged;
     final isMyCourse = _isMyCourse;
+    final lock = _nextStepLock(currentStep, isMyCourse);
 
     // The recording moved to [_recordCurrentStep], which covers this and the
     // step the screen opens on alike.
     void goToStep(int index) {
       onStepChanged(index);
+    }
+
+    /// `onClick`'s `R.id.next_step` arm (`TakeCourseFragment.kt:366-376`): a
+    /// locked step shows the message and returns **before** advancing. The
+    /// button stays enabled — Kotlin never touches `isEnabled`, and a disabled
+    /// button would say "you cannot go on" without saying why.
+    void onNext() {
+      if (lock?.locked ?? false) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              lock!.blockedByTest
+                  ? l10n.pleaseCompleteTest
+                  : l10n.pleaseCompleteSurvey,
+            ),
+          ),
+        );
+        return;
+      }
+      goToStep(currentStep + 1);
     }
 
     return Column(
@@ -224,6 +246,18 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
             itemCount: steps.length,
             controller: PageController(initialPage: currentStep),
             onPageChanged: goToStep,
+            // `binding.viewPager2.isUserInputEnabled = false`
+            // (`TakeCourseFragment.kt:137`). Kotlin advances the course by its
+            // two buttons and nothing else — the SeekBar that looks like a
+            // third way is inside `ll_progress`, which is `gone` in the layout
+            // and never made visible by any code, so its `onProgressChanged`
+            // jump is dead UI.
+            //
+            // Load-bearing for the lock above rather than cosmetic: a swipe
+            // goes straight to `onPageChanged`, so while this `PageView`
+            // scrolled, the refusal to advance an unanswered step could be
+            // got past by dragging the page.
+            physics: const NeverScrollableScrollPhysics(),
             itemBuilder: (context, index) => _StepContent(
               step: steps[index],
               stepNumber: index + 1,
@@ -239,14 +273,68 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
           totalSteps: steps.length,
           isMyCourse: isMyCourse,
           onPrevious: currentStep > 0 ? () => goToStep(currentStep - 1) : null,
-          onNext: currentStep < steps.length - 1
-              ? () => goToStep(currentStep + 1)
-              : null,
+          onNext: currentStep < steps.length - 1 ? onNext : null,
           onFinish: () => _onFinish(context, ref),
           onToggleMembership: () => _toggleMembership(context, ref, isMyCourse),
         ),
       ],
     );
+  }
+
+  /// The lock on advancing past [currentStep], or null when nothing can lock
+  /// it. Port of the `if` that wraps `changeNextButtonState`'s whole body
+  /// (`TakeCourseFragment.kt:315-338`); [stepNextLockProvider] carries the
+  /// decision itself and documents it.
+  ///
+  /// Three reasons this returns null, in Kotlin's own terms:
+  ///
+  ///  * **Any other course.** `:316` compares against a hardcoded
+  ///    `"4e6b78800b6ad18b4e8b0e1e38a98cac"` — the same value as the
+  ///    `MANDATORY_SURVEY_COURSE_ID` companion constant, which only the finish
+  ///    gate reads — and `:336` is an unconditional `isNextStepLocked = false`
+  ///    for everything else. Kotlin compares the *navigation* argument
+  ///    (`arguments.getString("id")`, `:61`) rather than the loaded row;
+  ///    `course.id` is that same value, since the row is looked up by it.
+  ///  * **A step index out of range**, which is `steps.getOrNull(position - 1)`
+  ///    returning null and `isStepCompleted(null, …)` answering true (`:317`,
+  ///    `SubmissionsRepositoryImpl.kt:360`).
+  ///  * **A course the learner has not joined — and this one is a deviation,
+  ///    named rather than assumed.** `changeNextButtonState` has no membership
+  ///    test; Kotlin's is on the button, `updateNavigationVisibility:256-270`
+  ///    hiding Next and Previous outright for a non-member. But that is not
+  ///    Kotlin's last word: `onResume:154-160` makes Next visible again with
+  ///    no membership test, and `position` is restored from the learner's
+  ///    saved progress (`:116`), so somebody who joined, made progress, left
+  ///    the course and came back *can* meet the lock there. This port gates
+  ///    the lock instead of the button, because the port's `_NavigationBar`
+  ///    has no membership gate at all (see `PHASE_139_NOTES.md`) — so the
+  ///    effect matches Kotlin's intended rule and diverges from its `onResume`
+  ///    slip. It also keeps the lock consistent with the step tile, which
+  ///    `_StepContent` hides for a non-member: a learner cannot be blocked by
+  ///    an assessment the screen is not offering them.
+  StepNextLock? _nextStepLock(int currentStep, bool isMyCourse) {
+    if (course.id != _mandatorySurveyCourseId) return null;
+    if (!isMyCourse) return null;
+    if (currentStep < 0 || currentStep >= steps.length) return null;
+    final step = steps[currentStep];
+    // The same key `_StepContent` builds, so the tile's post-return
+    // `invalidate` of `stepAssessmentProvider` refreshes this too. That is not
+    // an optimisation: Kotlin re-evaluates the lock only on a page-selection
+    // event (`onPageSelected:309`, and `onResume` does *not* call it), and
+    // gets away with it because `openCallFragment`'s `replace()` destroys this
+    // screen's view so returning from the exam re-dispatches `onPageSelected`.
+    // A `context.push` leaves the screen mounted, so without sharing the
+    // refresh the lock would still be holding a step the learner had just
+    // finished.
+    return ref
+        .watch(
+          stepNextLockProvider((
+            stepId: step.id,
+            courseId: step.courseId,
+            userId: userId,
+          )),
+        )
+        .valueOrNull;
   }
 
   /// Port of `CourseStepFragment.launchSaveCourseProgress` — landing on a step
@@ -530,10 +618,22 @@ class _StepContent extends ConsumerWidget {
                 // dropped the learner on go_router's error page. The exam
                 // screen wants the step and course as query parameters, as
                 // `CourseStepFragment` passes `stepId`/`stepNum`.
+                // `stepNum` is Kotlin's own argument, not a derivation:
+                // `CoursesPagerAdapter.kt:49` puts the pager position on the
+                // step fragment as `"stepNumber"` and
+                // `CourseStepFragment.kt:280` forwards it to the exam as
+                // `"stepNum"`, which `BaseExamFragment.kt:75` reads. Passing
+                // it from here assumes nothing about ordering, where deriving
+                // it from the step's position in a re-query rests on
+                // `stepIndex`, whose column default of `0` makes ties legal.
+                // This widget already holds the number it drew in the step
+                // header, so the number written to `course_progress` is the
+                // one the learner saw.
                 onTap: () async {
                   await context.push(
                     '/courses/exam/${exams.first.id}'
-                    '?stepId=${step.id}&courseId=${step.courseId ?? ''}',
+                    '?stepId=${step.id}&courseId=${step.courseId ?? ''}'
+                    '&stepNum=$stepNumber',
                   );
                   refreshAssessment();
                 },
@@ -562,20 +662,18 @@ class _StepContent extends ConsumerWidget {
                 // being a pattern rather than a base, an unmatchable route: a
                 // course-step survey has no `teamId`, so the interpolation
                 // left an empty segment too.
-                // **The refresh here only fires on a back-out, and that is a
-                // gap rather than a design.** `TakeSurveyScreen`'s submit ends
-                // with `context.go('${Routes.submissions}/<id>')`, not a pop,
-                // so answering the survey unmounts this screen and the `await`
-                // never resolves into a live element — `refreshAssessment`
-                // short-circuits on `context.mounted`. Kotlin *does* return:
+                // **The refresh fires on a submit as well as a back-out since
+                // Phase 139.** It used to fire only on a back-out: the survey
+                // screen's submit ended with
+                // `context.go('${Routes.submissions}/<id>')`, which unmounted
+                // this screen, so the `await` never resolved into a live
+                // element and `refreshAssessment` short-circuited on
+                // `context.mounted` — the *redo survey* relabel was
+                // unreachable on the one path that produces the submission it
+                // reads. `TakeSurveyScreen` now ends where Kotlin does:
                 // `openSurvey` → `BaseExamFragment.continueExam` shows the
                 // thank-you dialog and its Finish calls
-                // `FragmentNavigator.popBackStack`, landing back on the step
-                // with the label now reading *redo survey*. Making the port
-                // match means changing that screen's exit, which four other
-                // entry points share — outside this phase's diff, recorded in
-                // PHASE_128_NOTES.md. The call stays because it is correct for
-                // the back-out case and a no-op otherwise.
+                // `FragmentNavigator.popBackStack`, landing back on the step.
                 onTap: () async {
                   await context.push('${Routes.surveys}/${surveys.first.id}');
                   refreshAssessment();

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -244,6 +244,13 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
     // in state nothing else does — see [_pageController]. `animateToPage`
     // rather than `jumpToPage` to match `viewPager2.currentItem += 1`, whose
     // ViewPager2 default is a smooth scroll.
+    // `hasClients` cannot be false at either call site — both are button
+    // `onPressed` callbacks, so the controller is attached — and if it ever
+    // were, this would perform half the operation: the index would move and
+    // the page would not, which is exactly the defect [_pageController]
+    // documents. Guarded rather than left to throw because a throw out of a
+    // tap handler is worse for the learner than a stuck page, and the state
+    // that would cause it is unreachable.
     void goToStep(int index) {
       onStepChanged(index);
       if (_pageController.hasClients) {

--- a/flutter/lib/ui/exam/take_exam_screen.dart
+++ b/flutter/lib/ui/exam/take_exam_screen.dart
@@ -35,12 +35,24 @@ class TakeExamScreen extends ConsumerStatefulWidget {
     required this.examId,
     this.stepId,
     this.courseId,
+    this.stepNum,
     super.key,
   });
 
   final String examId;
   final String? stepId;
   final String? courseId;
+
+  /// The step's 1-based position in its course — Kotlin's `"stepNum"`
+  /// argument, which `CourseStepFragment.kt:280` forwards from the pager
+  /// position `CoursesPagerAdapter.kt:49` stamped on the step fragment, and
+  /// `BaseExamFragment.kt:75` reads back.
+  ///
+  /// Null when the caller did not pass one, which is every entry that is not a
+  /// course step — Kotlin's equivalent is the `getInt` default of `0`, whose
+  /// `UPDATE … WHERE stepNum = 0` matches nothing a course step ever wrote.
+  /// [_resolveStepNum] falls back to deriving it in that case.
+  final int? stepNum;
 
   @override
   ConsumerState<TakeExamScreen> createState() => _TakeExamScreenState();
@@ -595,24 +607,25 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   /// nullable column, so `widget.courseId` can be the empty string — reading
   /// the exam avoids inheriting that.
   ///
-  /// `stepNum` is derived rather than passed. Kotlin threads it through the
-  /// fragment arguments (`CourseStepFragment.kt:280` forwards the
-  /// `stepNumber` that `CoursesPagerAdapter.kt:49` set to the pager position,
-  /// where page 0 is the course cover — so step *i* carries *i+1*). This route
-  /// carries `stepId` and not `stepNum`, and the same 1-based number falls out
-  /// of the step's position in `CourseDao.getSteps`, which is the *same*
-  /// ordering `take_course_screen._recordProgress` counts to write
-  /// `stepNum: index + 1`. Both halves of the pair therefore agree by
-  /// construction rather than by two independent conventions.
+  /// `stepNum` is **passed**, as Kotlin passes it: `CourseStepFragment.kt:280`
+  /// forwards the `stepNumber` that `CoursesPagerAdapter.kt:49` set to the
+  /// pager position, where page 0 is the course cover — so step *i* carries
+  /// *i+1* — and `BaseExamFragment.kt:75` reads it back. Both port pushers
+  /// send it on the query string; [_resolveStepNum] carries the fallback for a
+  /// location that does not, and why the fallback is the weaker rule.
   ///
-  /// An unresolvable step (no `stepId`, an empty `courseId`, or a `stepId` the
-  /// course does not list) skips the write rather than writing `stepNum: 0`.
-  /// Kotlin reaches the same outcome by a different route: `stepNumber`
-  /// defaults to 0 there, and `WHERE stepNum = 0` matches no row a course step
-  /// ever wrote.
+  /// An unresolvable step with no passed number (no `stepId`, an empty
+  /// `courseId`, or a `stepId` the course does not list) skips the write
+  /// rather than writing `stepNum: 0`. Kotlin reaches the same outcome by a
+  /// different route: `stepNumber` defaults to 0 there, and
+  /// `WHERE stepNum = 0` matches no row a course step ever wrote. (Not quite
+  /// *no* row: the sync-in reads `stepNum` with a 0 default too
+  /// (`ProgressRepositoryImpl.kt:259`), so a `courses_progress` document
+  /// missing the field would land on 0. Planet writes it; do not build an
+  /// invariant on the value being impossible.)
   ///
-  /// One asymmetry worth naming since a derivation now rests on it, and it
-  /// runs **against** the port rather than for it. Kotlin's step id is
+  /// One asymmetry worth naming, and it runs **against** the port rather than
+  /// for it. Kotlin's step id is
   /// content-derived — `Base64(stepElement.toString())`
   /// (`CoursesRepositoryImpl.kt:681`) — so reordering a course changes no
   /// step's id, `@Upsert` updates each row in place, and every existing
@@ -624,7 +637,15 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   /// existing progress rows keep their old `stepNum` — a step the learner
   /// passed can end up describing a different step. Pre-existing, not
   /// introduced here, and not fixable without changing how step ids are
-  /// minted; recorded because this derivation now rests on it.
+  /// minted.
+  ///
+  /// Passing `stepNum` explicitly does **not** fix it and is not offered as a
+  /// fix: the number is still the position the learner navigated from, so
+  /// after a reorder it names the new content at that position while the
+  /// learner's older rows name the old. What it does remove is the extra hop
+  /// — the derivation had to find the *step id* in a re-query first, so a
+  /// reorder could make the write miss the row entirely rather than merely
+  /// describe the wrong step.
   Future<void> _recordExamProgress(
     String submissionId,
     ExamRow exam,
@@ -684,7 +705,36 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     }
   }
 
+  /// [TakeExamScreen.stepNum] when the caller passed one, otherwise the step's
+  /// position in its course.
+  ///
+  /// **The passed value is the closer port and now the live path**: Kotlin
+  /// threads the number through the fragment arguments and never re-derives
+  /// it, and both port pushers — `take_course_screen`'s step tile and
+  /// `course_detail_screen`'s — send it, each from the 1-based number it had
+  /// already rendered. So the number written to `course_progress` is the one
+  /// the learner saw, and it cannot disagree with
+  /// `take_course_screen._recordProgress`'s `stepNum: index + 1`.
+  ///
+  /// The derivation stays as the fallback because the route's query
+  /// parameters are optional: it keeps a location typed without a `stepNum`
+  /// working. It is the weaker rule — `CourseDao.getSteps` orders by
+  /// `stepIndex`, whose column default of `0` makes ties legal, and a tie
+  /// makes `indexWhere`'s answer depend on which row SQLite returns first.
+  ///
+  /// A `stepNum` of 0 or less is treated as absent rather than written: that
+  /// is Kotlin's missing-argument default, and `WHERE stepNum = 0` is the
+  /// value its own update deliberately matches nothing with.
+  ///
+  /// An unresolvable step (no `stepId`, a `stepId` the course does not list)
+  /// still skips the write when no number was passed. Note the passed value
+  /// makes the write reachable where the derivation could not: a step whose
+  /// row is missing locally, or one re-bound by a course-step reorder, has no
+  /// resolvable position but does have the position the learner navigated
+  /// from.
   Future<int?> _resolveStepNum(String courseId) async {
+    final passed = widget.stepNum;
+    if (passed != null && passed > 0) return passed;
     final stepId = widget.stepId;
     if (stepId == null || stepId.isEmpty) return null;
     final steps = await ref.read(courseDaoProvider).getSteps(courseId);

--- a/flutter/lib/ui/exam/take_exam_screen.dart
+++ b/flutter/lib/ui/exam/take_exam_screen.dart
@@ -718,9 +718,25 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   ///
   /// The derivation stays as the fallback because the route's query
   /// parameters are optional: it keeps a location typed without a `stepNum`
-  /// working. It is the weaker rule — `CourseDao.getSteps` orders by
-  /// `stepIndex`, whose column default of `0` makes ties legal, and a tie
-  /// makes `indexWhere`'s answer depend on which row SQLite returns first.
+  /// working. Since both pushers send the value, that branch is reached by no
+  /// production caller today.
+  ///
+  /// **Why the passed value is the stronger rule: one materialisation instead
+  /// of two independent queries.** The step tile's rendered number,
+  /// `take_course_screen._recordProgress`'s `stepNum: index + 1` and the
+  /// pushed `stepNum` all index the *same* `widget.steps` list, so the number
+  /// the learner saw is the number written and the pair cannot disagree. The
+  /// derivation issues a fresh `CourseDao.getSteps` and finds the step by id in
+  /// its result.
+  ///
+  /// An earlier version of this comment argued instead that `stepIndex`'s
+  /// column default of `0` makes ties legal, so the ordering is unreliable.
+  /// **That argument is unsound** and is recorded here so it is not repeated:
+  /// `CourseMapper._parseSteps` is the only writer of `course_steps` and always
+  /// sets `stepIndex: Value(i)`, so no tie is reachable — and if one were,
+  /// `watchSteps` and `getSteps` are byte-identical queries, so it would
+  /// corrupt the *passed* number just as badly, since that ordering is where
+  /// the tile's number comes from.
   ///
   /// A `stepNum` of 0 or less is treated as absent rather than written: that
   /// is Kotlin's missing-argument default, and `WHERE stepNum = 0` is the

--- a/flutter/lib/ui/router.dart
+++ b/flutter/lib/ui/router.dart
@@ -306,10 +306,18 @@ final routerProvider = Provider<GoRouter>((ref) {
       ),
       GoRoute(
         path: Routes.exam,
+        // `stepNum` is Kotlin's `"stepNum"` fragment argument
+        // (`CourseStepFragment.kt:280` → `BaseExamFragment.kt:75`), the pager
+        // position `CoursesPagerAdapter` stamped on the step. `int.tryParse`
+        // rather than a cast, so a hand-typed or malformed value reads as
+        // absent and the screen falls back to deriving it — Kotlin's own
+        // default for a missing argument is `0`, which its `UPDATE` then
+        // matches nothing with.
         builder: (context, state) => TakeExamScreen(
           examId: state.pathParameters['examId']!,
           stepId: state.uri.queryParameters['stepId'],
           courseId: state.uri.queryParameters['courseId'],
+          stepNum: int.tryParse(state.uri.queryParameters['stepNum'] ?? ''),
         ),
       ),
       GoRoute(

--- a/flutter/lib/ui/surveys/take_survey_screen.dart
+++ b/flutter/lib/ui/surveys/take_survey_screen.dart
@@ -313,9 +313,17 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
       );
       if (!mounted) return;
       // `FragmentNavigator.popBackStack`. A team survey is always reached by
-      // a push from the team's surveys tab, so there is something to pop;
-      // the fallback covers a `go` — Kotlin's own dead `isFromNation` arm
-      // lands on the survey list too (`navigateToSurveyList`).
+      // a push from the team's surveys tab, so there is something to pop.
+      //
+      // The fallback is **not** a mirror of anything, and an earlier version
+      // of this comment claimed it was: it cited Kotlin's `isFromNation` arm
+      // landing on the survey list via `navigateToSurveyList`, which is dead
+      // code (`isFromNation` has no writer that can make it true in Kotlin —
+      // `insertCourseStepsExams` sets it from a `parentId` its only caller
+      // passes as `""`), and `FragmentNavigator.popBackStack` is simply a
+      // no-op on an empty back stack (`FragmentNavigator.kt:55`). Kept as a
+      // belt-and-braces destination for a `go`-entered survey rather than for
+      // fidelity.
       if (context.canPop()) {
         context.pop();
       } else {
@@ -323,7 +331,65 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
       }
       return;
     }
-    context.go('${Routes.submissions}/$id');
+    await _thankAndLeave();
+  }
+
+  /// Kotlin's terminal state for every non-team survey: the thank-you dialog,
+  /// and its Finish button pops the survey off the back stack
+  /// (`BaseExamFragment.continueExam:132-148`).
+  ///
+  /// **This replaced a `context.go('${Routes.submissions}/$id')`, which was a
+  /// port invention with no Kotlin counterpart on any entry point.** No Kotlin
+  /// path shows the learner their own submission after finishing one — the
+  /// only openers of `SubmissionDetailFragment` are list-row taps. All five
+  /// `openSurvey` call sites reach `continueExam`, four of them hardcoding
+  /// `isTeam = false` (`SubmissionsAdapter.kt:98`, `CourseStepFragment.kt:289`,
+  /// `BellDashboardFragment.kt:256`, `DashboardActivity.kt:220`) and the fifth
+  /// (`SurveysAdapter.kt:88`) passing a variable, so the individual list, the
+  /// my-surveys row, the dashboard's pending prompt, a deep link and a course
+  /// step all end here.
+  ///
+  /// A pop rather than a destination is what makes one exit right for all of
+  /// them: each was reached by a `context.push`, so each lands back where the
+  /// learner started. **The course step is the entry that was actually
+  /// broken**: `go` unmounted `TakeCourseScreen` outright, so the step tile's
+  /// `await context.push(…)` never resumed and Phase 128's *redo survey*
+  /// relabel — whose only trigger is a submission made on this screen — was
+  /// unreachable on the one path that produces it.
+  ///
+  /// One deviation, deliberate. Kotlin composes its dialog title from two
+  /// strings and the survey/exam word — *"Thank you for taking this survey!
+  /// We wish you all the best."* (`:135`) — and no single Kotlin string
+  /// matches that, so a new ARB key for it could not derive a translation from
+  /// `values-*/strings.xml` and would show English in all five locales.
+  /// [AppLocalizations.thankYouForTakingSurvey] is one sentence shorter and
+  /// has a reviewed human translation in every locale. Five translations beat
+  /// four extra words.
+  ///
+  /// `barrierDismissible: false` is `setCancelable(false)` (`:147`), so the
+  /// learner leaves through Finish rather than by tapping outside — which is
+  /// what makes the pop reliable enough for the step tile to refresh behind
+  /// it.
+  Future<void> _thankAndLeave() async {
+    final l10n = AppLocalizations.of(context);
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l10n.thankYouForTakingSurvey),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(l10n.finish),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    // `popBackStack` is a no-op on an empty back stack, so a survey that was
+    // somehow reached without a push stays put rather than being sent
+    // somewhere Kotlin would not send it.
+    if (context.canPop()) context.pop();
   }
 }
 

--- a/flutter/lib/ui/surveys/take_survey_screen.dart
+++ b/flutter/lib/ui/surveys/take_survey_screen.dart
@@ -366,10 +366,26 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
   /// has a reviewed human translation in every locale. Five translations beat
   /// four extra words.
   ///
-  /// `barrierDismissible: false` is `setCancelable(false)` (`:147`), so the
-  /// learner leaves through Finish rather than by tapping outside — which is
-  /// what makes the pop reliable enough for the step tile to refresh behind
-  /// it.
+  /// `barrierDismissible: false` stands in for `setCancelable(false)`
+  /// (`:147`) but is **not** its equal: Kotlin's also swallows the back
+  /// button, and this dialog can still be dismissed with back. The outcome is
+  /// identical today because either exit reaches the pop below, and it stops
+  /// being identical the moment the pop is made conditional on how the dialog
+  /// closed — `PopScope` is the literal port if that ever happens.
+  ///
+  /// **One arm reaches here that Kotlin sends elsewhere, and the divergence is
+  /// a choice.** `showUserInfoDialog`'s else branch — a team survey that is
+  /// `isFromNation` — marks the sheet complete, toasts and
+  /// `navigateToSurveyList`s (`:156-163`). That branch is dead in Kotlin
+  /// (`isFromNation`'s only writer derives it from a `parentId` both callers
+  /// pass as `""`), but it is **live here**, because `SurveyMapper` reads the
+  /// field straight off the server document. So its Kotlin behaviour is
+  /// unexercised, unreviewed code, and this port gives the path the same exit
+  /// as every other non-team survey rather than reproducing it. Recorded in
+  /// `PHASE_139_NOTES.md` so the next lane can take the other view.
+  ///
+  /// `_submit` awaits `queuePending` before reaching here, so the pop cannot
+  /// race the outbox row.
   Future<void> _thankAndLeave() async {
     final l10n = AppLocalizations.of(context);
     await showDialog<void>(

--- a/flutter/test/ui/courses/step_next_lock_test.dart
+++ b/flutter/test/ui/courses/step_next_lock_test.dart
@@ -286,6 +286,54 @@ void main() {
       );
     });
 
+    testWidgets('Next moves the page, not just the counter', (tester) async {
+      // **A pre-existing defect this lane's own `stepNum` test surfaced, and
+      // it made the lock meaningless.** The `PageController` was built inline
+      // in `build` as `PageController(initialPage: currentStep)`; `Scrollable`
+      // hands a replacement controller the previous `ScrollPosition`'s pixels,
+      // so `initialPage` applies once and Previous/Next moved the step counter
+      // while leaving the page where it was.
+      //
+      // Nothing here caught it because every navigation assertion read the
+      // counter, which is driven by the same `currentStep` the controller was
+      // being handed — the two agreed about the number and disagreed about
+      // what was on screen. So this asserts on the *page*: pre-fix the second
+      // step's content was never built at all.
+      //
+      // It matters for this file specifically: with `isUserInputEnabled =
+      // false` ported, the buttons are the only way through a course, so a
+      // lock guarding a button that does not navigate would have been the only
+      // working half of the pair.
+      await pumpCourse(
+        tester,
+        db: await seed(courseDoc(courseId: mandatoryCourseId)),
+      );
+
+      expect(find.text('First'), findsOneWidget);
+      expect(find.text('Second'), findsNothing);
+
+      await tapNext(tester);
+
+      expect(onStep(2, 2), findsOneWidget);
+      expect(find.text('Second'), findsOneWidget);
+    });
+
+    testWidgets('Previous moves the page back', (tester) async {
+      await pumpCourse(
+        tester,
+        db: await seed(courseDoc(courseId: mandatoryCourseId)),
+      );
+
+      await tapNext(tester);
+      expect(find.text('Second'), findsOneWidget);
+
+      await tester.tap(find.text('Previous'));
+      await tester.pumpAndSettle();
+
+      expect(onStep(1, 2), findsOneWidget);
+      expect(find.text('First'), findsOneWidget);
+    });
+
     testWidgets('a step with no assessment advances', (tester) async {
       // `isStepCompleted` answers **true** for a step with no exam row at all
       // (`?: return true`, `SubmissionsRepositoryImpl.kt:361`), which is what

--- a/flutter/test/ui/courses/step_next_lock_test.dart
+++ b/flutter/test/ui/courses/step_next_lock_test.dart
@@ -70,6 +70,24 @@ void main() {
     ],
   };
 
+  /// A three-step course whose assessment sits on the **middle** step.
+  ///
+  /// This is what distinguishes `steps[currentStep]` from `steps[0]`, and
+  /// nothing else in this file does: in a two-step course the lock is only
+  /// ever *consulted* at index 0, because at index 1 `onNext` is null and
+  /// `_NavigationBar` renders Finish, so whatever the lock returns for the
+  /// last step is computed and discarded. Kotlin reads the displayed step
+  /// (`steps.getOrNull(position - 1)`, `TakeCourseFragment.kt:317`).
+  Map<String, Object?> middleStepCourseDoc() => {
+    '_id': mandatoryCourseId,
+    'courseTitle': 'Onboarding',
+    'steps': [
+      {'stepTitle': 'First'},
+      {'stepTitle': 'Second', 'exam': examDoc()},
+      {'stepTitle': 'Third'},
+    ],
+  };
+
   Future<AppDatabase> seed(Map<String, Object?> doc) async {
     final db = AppDatabase.memory();
     final parsed = CourseMapper.fromDoc(doc)!;
@@ -188,13 +206,21 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  /// The step counter in `_ProgressSection`, which is the only widget that
-  /// reflects the current step and nothing else.
+  /// The step counter in `_ProgressSection`.
   ///
-  /// Deliberately not the step *title*: `PageView.builder` keeps an
-  /// off-screen page in the element tree, and `find.text` searches the element
-  /// tree, so "Second" can be found for a page the learner is not on. A test
-  /// that asserted the title would pass whether or not Next was blocked.
+  /// Paired with an assertion on the step *title* wherever the page itself
+  /// matters, because the two can disagree and did: the counter is driven by
+  /// `currentStep` and the title by what the `PageView` actually built, which
+  /// is how the `PageController` defect hid — see *Next moves the page*.
+  ///
+  /// An earlier version of this comment said the title was unreliable because
+  /// `PageView.builder` leaves an off-screen page in the element tree. **That
+  /// was a misdiagnosis.** `PageView`'s `cacheExtent` is
+  /// `allowImplicitScrolling ? 1.0 : 0.0`, and that flag defaults false, so
+  /// once a scroll settles only the visible page is in the tree — which the
+  /// `findsNothing` assertion in *Next moves the page* relies on. The first
+  /// cut of the second-step test failed because the page never moved, not
+  /// because a stale page lingered.
   Finder onStep(int number, int total) => find.text('$number / $total');
 
   Future<void> tapNext(WidgetTester tester) async {
@@ -332,6 +358,33 @@ void main() {
 
       expect(onStep(1, 2), findsOneWidget);
       expect(find.text('First'), findsOneWidget);
+    });
+
+    testWidgets('the lock reads the displayed step, not the first one', (
+      tester,
+    ) async {
+      // The assessment is on the **middle** step of three, so the two
+      // readings disagree in both directions: reading `steps[0]` would let
+      // the learner off the locked step and block them on the unlocked one.
+      //
+      // Every other test here puts the assessment on step 1 of two, where
+      // `steps[currentStep]`, `steps[0]` and "the only step the lock is
+      // consulted for" are the same thing — so the whole file was green
+      // against `steps[0]`. Found by the implementation audit.
+      await pumpCourse(tester, db: await seed(middleStepCourseDoc()));
+
+      // Step 1 carries nothing, so Next goes through.
+      expect(onStep(1, 3), findsOneWidget);
+      await tapNext(tester);
+      expect(onStep(2, 3), findsOneWidget);
+      expect(find.text('Second'), findsOneWidget);
+      expect(find.textContaining('please complete'), findsNothing);
+
+      // Step 2 carries the unanswered test, so Next is refused here.
+      await tapNext(tester);
+      expect(find.text('please complete the test to proceed'), findsOneWidget);
+      expect(onStep(2, 3), findsOneWidget);
+      expect(find.text('Third'), findsNothing);
     });
 
     testWidgets('a step with no assessment advances', (tester) async {

--- a/flutter/test/ui/courses/step_next_lock_test.dart
+++ b/flutter/test/ui/courses/step_next_lock_test.dart
@@ -1,0 +1,481 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/courses_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/ui/courses/take_course_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/mock_planet_api.dart';
+import '../../support/widget_harness.dart';
+
+/// `TakeCourseFragment.changeNextButtonState` (`TakeCourseFragment.kt:315-338`)
+/// — the per-step refusal to advance past an unanswered assessment on the
+/// MyPlanet Onboarding course. Unported until Phase 139; reported by Phase 128
+/// as its item 4.
+///
+/// **Distinct from the finish gate**, which is `onFinishStep`'s
+/// `hasUnfinishedSurveys` and has its own tests in
+/// `take_course_screen_test.dart`. That one fires on the *last* step, where
+/// Next has already been replaced by Finish; this one fires on every earlier
+/// step. Two independent reads, two independent messages.
+///
+/// Every course here is seeded from a real-shaped course document through the
+/// real mappers, so `exams.stepId == course_steps.id` is the join under test
+/// rather than a hand-written row — the Phase 113 lesson. Every submission is
+/// authored by `SubmissionsRepository`, never inserted, because the whole
+/// question is whether the lock reads what the writers write.
+void main() {
+  const mandatoryCourseId = '4e6b78800b6ad18b4e8b0e1e38a98cac';
+
+  /// A two-step course. The **first** step carries the assessment, so the step
+  /// on screen is one the lock can hold and there is a second step for Next to
+  /// advance to — Kotlin's lock is computed for the displayed step
+  /// (`steps.getOrNull(position - 1)`) and blocks moving away from it.
+  Map<String, Object?> courseDoc({
+    required String courseId,
+    Map<String, Object?>? exam,
+    Map<String, Object?>? survey,
+  }) => {
+    '_id': courseId,
+    'courseTitle': 'Onboarding',
+    'steps': [
+      {'stepTitle': 'First', 'exam': ?exam, 'survey': ?survey},
+      {'stepTitle': 'Second'},
+    ],
+  };
+
+  Map<String, Object?> examDoc() => {
+    '_id': 'exam-1',
+    'type': 'courses',
+    'name': 'Step test',
+    'questions': [
+      {'id': 'q1', 'title': 'One?', 'type': 'input'},
+    ],
+  };
+
+  Map<String, Object?> surveyDoc() => {
+    '_id': 'survey-1',
+    'type': 'surveys',
+    'name': 'Step survey',
+    'questions': [
+      {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+    ],
+  };
+
+  Future<AppDatabase> seed(Map<String, Object?> doc) async {
+    final db = AppDatabase.memory();
+    final parsed = CourseMapper.fromDoc(doc)!;
+    await db.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in ExamMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await db.examDao.upsertAll(
+        [mapping.exam],
+        {mapping.exam.id.value: mapping.questions},
+      );
+    }
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await db.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+    return db;
+  }
+
+  SubmissionsRepository repositoryFor(AppDatabase db) => SubmissionsRepository(
+    MockPlanetApi(),
+    db.submissionDao,
+    db.submitPhotosDao,
+    db.surveyDao,
+    db.examDao,
+    teamDao: db.teamDao,
+  );
+
+  /// Answers the step's exam through to `requires grading` — the status
+  /// `saveExamAnswer` writes for the last answer of an explicit submission,
+  /// and the one `isStepCompleted`'s `status != 'pending'` accepts.
+  ///
+  /// The question is an `input` with no answer key, which
+  /// `ExamGrading.isTextCorrect` treats as "any answer will do", so one
+  /// non-empty value finishes the attempt.
+  Future<void> finishExam(AppDatabase db, {String userId = 'user-1'}) async {
+    final submissions = repositoryFor(db);
+    final exam = (await db.examDao.getById('exam-1'))!;
+    final questions = await db.examDao.questionsFor('exam-1');
+    final id = await submissions.startExamSession(
+      exam: exam,
+      questions: questions,
+      userId: userId,
+      courseId: mandatoryCourseId,
+    );
+    await submissions.saveExamAnswer(
+      submissionId: id,
+      question: questions.single,
+      answer: const ExamDraftAnswer(value: 'because'),
+      isFinal: true,
+      isExplicitSubmission: true,
+    );
+  }
+
+  Future<void> pumpCourse(
+    WidgetTester tester, {
+    required AppDatabase db,
+    String courseId = mandatoryCourseId,
+    bool joined = true,
+  }) async {
+    addTearDown(db.close);
+    SharedPreferences.setMockInitialValues({});
+    final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    final steps = await db.courseDao.getSteps(courseId);
+
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') router.push('/take');
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (context) => TakeCourseScreen(courseId: courseId),
+          '/courses/exam/:examId': (context) =>
+              const Scaffold(body: Text('EXAM_ROUTE')),
+          '/life/surveys/:surveyId': (context) =>
+              const Scaffold(body: Text('SURVEY_ROUTE')),
+        },
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          appDatabaseProvider.overrideWithValue(db),
+          sessionProvider.overrideWith(
+            () => _Session(buildUserRow(id: 'user-1', name: 'ada')),
+          ),
+          courseProvider(courseId).overrideWith(
+            (ref) => Stream.value(
+              buildCourseRow(
+                id: courseId,
+                courseTitle: 'Onboarding',
+                userId: joined ? const ['user-1'] : const [],
+              ),
+            ),
+          ),
+          courseStepsProvider(
+            courseId,
+          ).overrideWith((ref) => Stream.value(steps)),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// The step counter in `_ProgressSection`, which is the only widget that
+  /// reflects the current step and nothing else.
+  ///
+  /// Deliberately not the step *title*: `PageView.builder` keeps an
+  /// off-screen page in the element tree, and `find.text` searches the element
+  /// tree, so "Second" can be found for a page the learner is not on. A test
+  /// that asserted the title would pass whether or not Next was blocked.
+  Finder onStep(int number, int total) => find.text('$number / $total');
+
+  Future<void> tapNext(WidgetTester tester) async {
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+  }
+
+  /// Runs the SnackBar's four-second timer out.
+  ///
+  /// Necessary rather than tidy, and it cost a debugging round: a SnackBar
+  /// sits over the navigation bar, and `pumpAndSettle` does **not** clear it —
+  /// it returns as soon as no frame is scheduled, and the dismiss timer needs
+  /// wall-clock time to be pumped. So a second `tap(find.text('Next'))` lands
+  /// on the SnackBar, the tap is silently swallowed (with only a `warnIfMissed`
+  /// notice in the log), and the test reads as "the lock never released".
+  Future<void> letSnackBarExpire(WidgetTester tester) async {
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+  }
+
+  group('the mandatory course refuses Next until the step is answered', () {
+    testWidgets('an unanswered step test blocks Next with the test message', (
+      tester,
+    ) async {
+      await pumpCourse(
+        tester,
+        db: await seed(courseDoc(courseId: mandatoryCourseId, exam: examDoc())),
+      );
+
+      expect(onStep(1, 2), findsOneWidget);
+      await tapNext(tester);
+
+      // `getString(R.string.please_complete_test)` (`:328`), which is
+      // "please complete the test to proceed" — a different string from the
+      // finish gate's, and one the port had no ARB key for at all.
+      expect(find.text('please complete the test to proceed'), findsOneWidget);
+      // And the learner did not advance: `onClick` returns before
+      // `viewPager2.currentItem += 1` (`:367-370`).
+      expect(onStep(1, 2), findsOneWidget);
+      expect(onStep(2, 2), findsNothing);
+    });
+
+    testWidgets('an unanswered step survey blocks Next with the survey '
+        'message', (tester) async {
+      await pumpCourse(
+        tester,
+        db: await seed(
+          courseDoc(courseId: mandatoryCourseId, survey: surveyDoc()),
+        ),
+      );
+
+      await tapNext(tester);
+
+      // `:329` falls through to `please_complete_survey`, whose wording is
+      // written for the *finish* gate — "…to finish the course" — because
+      // Kotlin shares one string between the two sites. Faithful, odd, and
+      // pinned so nobody "fixes" it into a second key.
+      expect(
+        find.text('please complete the survey to finish the course'),
+        findsOneWidget,
+      );
+      expect(onStep(1, 2), findsOneWidget);
+    });
+
+    testWidgets('a step carrying both names the test, not the survey', (
+      tester,
+    ) async {
+      // `:327-330` is `hasExam -> please_complete_test` with the survey as the
+      // else, and `isStepCompleted` interrogates the exam row on such a step
+      // (`getFirstByStepId` has no type filter and the exam is inserted
+      // first), so message and remedy name the same assessment.
+      await pumpCourse(
+        tester,
+        db: await seed(
+          courseDoc(
+            courseId: mandatoryCourseId,
+            exam: examDoc(),
+            survey: surveyDoc(),
+          ),
+        ),
+      );
+
+      await tapNext(tester);
+
+      expect(find.text('please complete the test to proceed'), findsOneWidget);
+      expect(
+        find.text('please complete the survey to finish the course'),
+        findsNothing,
+      );
+    });
+
+    testWidgets('a step with no assessment advances', (tester) async {
+      // `isStepCompleted` answers **true** for a step with no exam row at all
+      // (`?: return true`, `SubmissionsRepositoryImpl.kt:361`), which is what
+      // keeps every ordinary step of the onboarding course walkable.
+      await pumpCourse(
+        tester,
+        db: await seed(courseDoc(courseId: mandatoryCourseId)),
+      );
+
+      await tapNext(tester);
+
+      expect(onStep(2, 2), findsOneWidget);
+      expect(find.textContaining('please complete'), findsNothing);
+    });
+
+    testWidgets('a finished attempt releases the lock', (tester) async {
+      final db = await seed(
+        courseDoc(courseId: mandatoryCourseId, exam: examDoc()),
+      );
+      await finishExam(db);
+      await pumpCourse(tester, db: db);
+
+      await tapNext(tester);
+
+      expect(onStep(2, 2), findsOneWidget);
+      expect(find.textContaining('please complete'), findsNothing);
+    });
+
+    testWidgets('an answered step survey releases the lock', (tester) async {
+      final db = await seed(
+        courseDoc(courseId: mandatoryCourseId, survey: surveyDoc()),
+      );
+      final submissions = repositoryFor(db);
+      final survey = (await db.surveyDao.getByCourseId(
+        mandatoryCourseId,
+      )).single;
+      // `createSurveyDraft` writes `status: 'complete'`, which is what
+      // `saveExamAnswer` writes for a survey's last answer in Kotlin — and
+      // `'complete' != 'pending'`, so the step counts as done.
+      await submissions.createSurveyDraft(
+        survey: survey,
+        questions: await db.surveyDao.questionsFor('survey-1'),
+        userId: 'user-1',
+      );
+      await pumpCourse(tester, db: db);
+
+      await tapNext(tester);
+
+      expect(onStep(2, 2), findsOneWidget);
+    });
+
+    testWidgets('a half-answered attempt still blocks', (tester) async {
+      // **The difference between `isStepCompleted` and `hasSubmission`, at the
+      // screen.** `hasSubmission` is status-blind, so it is satisfied the
+      // moment `startExamSession` writes its `pending` row — which is what
+      // makes the step tile read *Retake Test*. The lock needs
+      // `status != 'pending'` (`SubmissionDao.kt:24`), so opening the exam and
+      // answering nothing must not buy the learner the next step.
+      final db = await seed(
+        courseDoc(courseId: mandatoryCourseId, exam: examDoc()),
+      );
+      final submissions = repositoryFor(db);
+      final exam = (await db.examDao.getById('exam-1'))!;
+      await submissions.startExamSession(
+        exam: exam,
+        questions: await db.examDao.questionsFor('exam-1'),
+        userId: 'user-1',
+        courseId: mandatoryCourseId,
+      );
+      await pumpCourse(tester, db: db);
+
+      await tapNext(tester);
+
+      expect(find.text('please complete the test to proceed'), findsOneWidget);
+      expect(onStep(1, 2), findsOneWidget);
+    });
+
+    testWidgets('another learner\'s finished attempt does not release it', (
+      tester,
+    ) async {
+      // `userId IS :userId` (`SubmissionDao.kt:24`). A shared handset must not
+      // let one learner through on somebody else's answers.
+      final db = await seed(
+        courseDoc(courseId: mandatoryCourseId, exam: examDoc()),
+      );
+      await finishExam(db, userId: 'someone-else');
+      await pumpCourse(tester, db: db);
+
+      await tapNext(tester);
+
+      expect(find.text('please complete the test to proceed'), findsOneWidget);
+      expect(onStep(1, 2), findsOneWidget);
+    });
+
+    testWidgets('any other course is never locked', (tester) async {
+      // `:316` gates the whole body on one hardcoded course id and `:336` is
+      // an unconditional `isNextStepLocked = false` for everything else. An
+      // ordinary course's unanswered step test does not hold the learner up.
+      await pumpCourse(
+        tester,
+        courseId: 'course-ordinary',
+        db: await seed(courseDoc(courseId: 'course-ordinary', exam: examDoc())),
+      );
+
+      await tapNext(tester);
+
+      expect(onStep(2, 2), findsOneWidget);
+      expect(find.textContaining('please complete'), findsNothing);
+    });
+
+    testWidgets('a learner who has not joined is not locked', (tester) async {
+      // A deviation, pinned so it is a decision rather than a drift.
+      // `changeNextButtonState` has no membership test — Kotlin's is on the
+      // button (`updateNavigationVisibility:256-270` hides Next for a
+      // non-member) — but `onResume:154-160` puts Next back with no such test,
+      // so a returning ex-member *can* meet Kotlin's lock. The port has no
+      // membership gate on Next at all, so the gate went on the lock: a
+      // learner cannot be blocked by an assessment `_StepContent` is not
+      // offering them.
+      await pumpCourse(
+        tester,
+        joined: false,
+        db: await seed(courseDoc(courseId: mandatoryCourseId, exam: examDoc())),
+      );
+
+      // The tile is hidden for a non-member, which is the reason.
+      expect(find.textContaining('take test'), findsNothing);
+      await tapNext(tester);
+
+      expect(onStep(2, 2), findsOneWidget);
+    });
+  });
+
+  testWidgets('the lock releases on returning from the exam, without leaving '
+      'the course', (tester) async {
+    // **The reachability half, and the one Kotlin gets for free.** Kotlin
+    // re-evaluates the lock only on a page-selection event
+    // (`onPageSelected:309`; `onResume` does *not* call
+    // `changeNextButtonState`), and stays correct anyway because
+    // `openCallFragment`'s `replace()` destroys `TakeCourseFragment`'s view —
+    // so returning from the exam rebuilds the pager and re-dispatches
+    // `onPageSelected`. A `context.push` leaves this screen mounted, so
+    // without sharing the step tile's post-return `invalidate` the lock would
+    // still be holding a step the learner had just finished, until they left
+    // the course entirely.
+    final db = await seed(
+      courseDoc(courseId: mandatoryCourseId, exam: examDoc()),
+    );
+    await pumpCourse(tester, db: db);
+
+    await tapNext(tester);
+    expect(find.text('please complete the test to proceed'), findsOneWidget);
+    await letSnackBarExpire(tester);
+
+    await tester.tap(find.textContaining('take test'));
+    await tester.pumpAndSettle();
+    expect(find.text('EXAM_ROUTE'), findsOneWidget);
+
+    // The learner sits the exam on the pushed screen…
+    await finishExam(db);
+
+    // …and comes back to the step.
+    GoRouter.of(tester.element(find.text('EXAM_ROUTE'))).pop();
+    await tester.pumpAndSettle();
+
+    await tapNext(tester);
+    expect(onStep(2, 2), findsOneWidget);
+  });
+
+  testWidgets('the lock cannot be swiped past', (tester) async {
+    // `binding.viewPager2.isUserInputEnabled = false`
+    // (`TakeCourseFragment.kt:137`). A swipe reaches `onPageChanged`
+    // directly, so while this `PageView` scrolled, the refusal to advance an
+    // unanswered step was a suggestion.
+    await pumpCourse(
+      tester,
+      db: await seed(courseDoc(courseId: mandatoryCourseId, exam: examDoc())),
+    );
+
+    await tester.drag(find.byType(PageView), const Offset(-600, 0));
+    await tester.pumpAndSettle();
+
+    expect(onStep(1, 2), findsOneWidget);
+    expect(onStep(2, 2), findsNothing);
+  });
+}
+
+class _Session extends SessionNotifier {
+  _Session(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}

--- a/flutter/test/ui/courses/step_num_argument_test.dart
+++ b/flutter/test/ui/courses/step_num_argument_test.dart
@@ -47,14 +47,20 @@ void main() {
 
   /// A two-step course carrying an exam on whichever steps are named.
   ///
-  /// **Exactly one exam tile per fixture, and that is not tidiness.** Every
-  /// step tile renders the identical label — the count in `take test [N]` is
-  /// `exams.length` for that step, so it reads `[1]` on every step that has
-  /// one — and `PageView.builder` leaves an off-screen page in the element
-  /// tree, which `find.text` searches. The first cut of the second-step test
-  /// put an exam on both steps, matched the page the learner had *left*, and
-  /// reported `stepNum=1` for step 2. A fixture with one tile cannot be tapped
-  /// on the wrong page.
+  /// One exam tile per fixture, which is now belt-and-braces rather than
+  /// necessary — and the reason it looked necessary is worth recording,
+  /// because it was a misdiagnosis. Every step tile renders the identical
+  /// label (`take test [N]`'s count is that step's own `exams.length`, so it
+  /// reads `[1]` wherever there is one), and the first cut of the second-step
+  /// test tapped a tile belonging to step 1 and reported `stepNum=1` for step
+  /// 2. I attributed that to `find.text` reaching an off-screen `PageView`
+  /// page. **It does not:** `cacheExtent` is
+  /// `allowImplicitScrolling ? 1.0 : 0.0` and that flag defaults false, so a
+  /// settled `PageView` has only the visible page in the tree. The real cause
+  /// was the `PageController` defect this phase then fixed — the page never
+  /// moved, so step 1's tile was the only one built. With that fixed, a
+  /// two-tile fixture would match only the built page; one tile per fixture
+  /// stays because it makes the assertion independent of that reasoning.
   Map<String, Object?> courseDoc({
     Map<String, Object?>? firstExam,
     Map<String, Object?>? secondExam,

--- a/flutter/test/ui/courses/step_num_argument_test.dart
+++ b/flutter/test/ui/courses/step_num_argument_test.dart
@@ -1,0 +1,385 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/courses_providers.dart';
+import 'package:myplanet/providers/ratings_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/ratings_repository.dart';
+import 'package:myplanet/ui/courses/course_detail_screen.dart';
+import 'package:myplanet/ui/courses/take_course_screen.dart';
+import 'package:myplanet/ui/exam/take_exam_screen.dart';
+import 'package:myplanet/ui/router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/widget_harness.dart';
+
+/// The step number a course step hands its exam — Kotlin's `"stepNum"`
+/// fragment argument, and Phase 135's item 4.
+///
+/// Kotlin never derives it. `CoursesPagerAdapter.kt:49` stamps the pager
+/// position on the step fragment as `"stepNumber"`,
+/// `CourseStepFragment.kt:280` forwards it to the exam as `"stepNum"`, and
+/// `BaseExamFragment.kt:75` reads it back. The port derived it instead, from
+/// the step's position in a re-query of `CourseDao.getSteps` — equivalent for
+/// every reachable case, but resting on `stepIndex`, whose column default of
+/// `0` makes ties legal.
+///
+/// **These are pair tests on purpose.** A push writing `stepNum` and a route
+/// reading `step_num` is the Phase 74/100 shape — each half passes its own
+/// test and only the pair is wrong — so the location under test is taken from
+/// the *screen* that builds it and fed to the *real* router, rather than
+/// written out here as a third copy of the key that agrees with neither.
+void main() {
+  Map<String, Object?> examOn(String id) => {
+    '_id': id,
+    'type': 'courses',
+    'name': '$id test',
+    'questions': [
+      {'id': 'q1', 'title': 'One?', 'type': 'input'},
+    ],
+  };
+
+  /// A two-step course carrying an exam on whichever steps are named.
+  ///
+  /// **Exactly one exam tile per fixture, and that is not tidiness.** Every
+  /// step tile renders the identical label — the count in `take test [N]` is
+  /// `exams.length` for that step, so it reads `[1]` on every step that has
+  /// one — and `PageView.builder` leaves an off-screen page in the element
+  /// tree, which `find.text` searches. The first cut of the second-step test
+  /// put an exam on both steps, matched the page the learner had *left*, and
+  /// reported `stepNum=1` for step 2. A fixture with one tile cannot be tapped
+  /// on the wrong page.
+  Map<String, Object?> courseDoc({
+    Map<String, Object?>? firstExam,
+    Map<String, Object?>? secondExam,
+  }) => {
+    '_id': 'course-1',
+    'courseTitle': 'Algebra',
+    'steps': [
+      {'stepTitle': 'First', 'exam': ?firstExam},
+      {'stepTitle': 'Second', 'exam': ?secondExam},
+    ],
+  };
+
+  Future<AppDatabase> seed(Map<String, Object?> doc) async {
+    final db = AppDatabase.memory();
+    final parsed = CourseMapper.fromDoc(doc)!;
+    await db.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in ExamMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await db.examDao.upsertAll(
+        [mapping.exam],
+        {mapping.exam.id.value: mapping.questions},
+      );
+    }
+    return db;
+  }
+
+  /// Records the location the screen pushes at the exam route.
+  late Uri? pushed;
+
+  Map<String, WidgetBuilder> examCapture() => {
+    '/courses/exam/:examId': (context) {
+      pushed = GoRouterState.of(context).uri;
+      return const Scaffold(body: Text('EXAM_ROUTE'));
+    },
+  };
+
+  setUp(() => pushed = null);
+
+  group('the take-course step tile passes the step number', () {
+    Future<void> pumpTakeCourse(WidgetTester tester, AppDatabase db) async {
+      addTearDown(db.close);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+      final steps = await db.courseDao.getSteps('course-1');
+
+      await tester.pumpWidget(
+        wrapScreen(
+          Builder(
+            builder: (context) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                final router = GoRouter.of(context);
+                final location = router
+                    .routerDelegate
+                    .currentConfiguration
+                    .last
+                    .matchedLocation;
+                if (location != '/take') router.push('/take');
+              });
+              return const Scaffold(body: Text('ROOT_PAGE'));
+            },
+          ),
+          pushTargets: {
+            '/take': (context) => const TakeCourseScreen(courseId: 'course-1'),
+            ...examCapture(),
+          },
+          overrides: [
+            planetPrefsProvider.overrideWithValue(prefs),
+            appDatabaseProvider.overrideWithValue(db),
+            sessionProvider.overrideWith(
+              () => _Session(buildUserRow(id: 'user-1', name: 'ada')),
+            ),
+            courseProvider('course-1').overrideWith(
+              (ref) => Stream.value(
+                buildCourseRow(
+                  id: 'course-1',
+                  courseTitle: 'Algebra',
+                  userId: const ['user-1'],
+                ),
+              ),
+            ),
+            courseStepsProvider(
+              'course-1',
+            ).overrideWith((ref) => Stream.value(steps)),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('the first step sends 1', (tester) async {
+      await pumpTakeCourse(
+        tester,
+        await seed(courseDoc(firstExam: examOn('exam-1'))),
+      );
+
+      await tester.tap(find.text('take test [1]'));
+      await tester.pumpAndSettle();
+
+      expect(pushed, isNotNull, reason: 'the exam route was not reached');
+      expect(pushed!.queryParameters['stepNum'], '1');
+      // The arguments that were already there must survive the addition.
+      expect(pushed!.queryParameters['stepId'], 'course-1:0');
+      expect(pushed!.queryParameters['courseId'], 'course-1');
+      expect(pushed!.path, '/courses/exam/exam-1');
+    });
+
+    testWidgets('the second step sends 2', (tester) async {
+      // The assertion a hardcoded number, or an off-by-one, fails. Kotlin's
+      // is the pager position with the course cover at 0, so step *i* carries
+      // *i+1* and the second step is 2 — not 1, and not 3.
+      await pumpTakeCourse(
+        tester,
+        await seed(courseDoc(secondExam: examOn('exam-2'))),
+      );
+
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('take test [1]'));
+      await tester.pumpAndSettle();
+
+      expect(pushed!.queryParameters['stepNum'], '2');
+      expect(pushed!.path, '/courses/exam/exam-2');
+    });
+  });
+
+  group('the course-detail step tile passes the step number', () {
+    Future<void> pumpDetail(WidgetTester tester, AppDatabase db) async {
+      addTearDown(db.close);
+      final steps = await db.courseDao.getSteps('course-1');
+
+      await tester.pumpWidget(
+        wrapScreen(
+          const CourseDetailScreen(courseId: 'course-1'),
+          pushTargets: examCapture(),
+          overrides: [
+            appDatabaseProvider.overrideWithValue(db),
+            sessionProvider.overrideWith(
+              () => _Session(buildUserRow(id: 'user-1', name: 'ada')),
+            ),
+            courseProvider('course-1').overrideWith(
+              (ref) => Stream.value(
+                buildCourseRow(id: 'course-1', courseTitle: 'Algebra'),
+              ),
+            ),
+            courseStepsProvider(
+              'course-1',
+            ).overrideWith((ref) => Stream.value(steps)),
+            ratingSummaryProvider((
+              type: 'course',
+              itemId: 'course-1',
+            )).overrideWith(
+              (ref) => Stream.value(
+                const RatingSummary(average: 0, total: 0, userRating: null),
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('the second tile sends 2', (tester) async {
+      // This screen's exam button is a port addition with no Kotlin
+      // counterpart — `CourseDetailFragment` shows a count, not a button — so
+      // there is no Kotlin `stepNum` to copy. The number is the tile's own
+      // 1-based position, which is the same one `take_course_screen` sends,
+      // so the two entries into one step exam cannot key `course_progress`
+      // differently.
+      await pumpDetail(
+        tester,
+        await seed(
+          courseDoc(firstExam: examOn('exam-1'), secondExam: examOn('exam-2')),
+        ),
+      );
+
+      await tester.tap(find.text('Second'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Take exam'));
+      await tester.pumpAndSettle();
+
+      expect(pushed!.queryParameters['stepNum'], '2');
+      expect(pushed!.path, '/courses/exam/exam-2');
+    });
+  });
+
+  group('the exam route reads the step number the pushers write', () {
+    testWidgets('the location the step tile builds reaches the screen', (
+      tester,
+    ) async {
+      // The pair, end to end: the location comes from the take-course tile
+      // above and is resolved by the real router rather than a harness stub.
+      final db = await seed(courseDoc(secondExam: examOn('exam-2')));
+      addTearDown(db.close);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+      final container = ProviderContainer(
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          appDatabaseProvider.overrideWithValue(db),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final built =
+          await _buildFromRouter(
+                tester,
+                container.read(routerProvider),
+                '/courses/exam/exam-2?stepId=course-1:1&courseId=course-1'
+                '&stepNum=2',
+              )
+              as TakeExamScreen;
+
+      expect(built.stepNum, 2);
+      expect(built.examId, 'exam-2');
+      expect(built.stepId, 'course-1:1');
+      expect(built.courseId, 'course-1');
+    });
+
+    testWidgets('a location with no step number leaves it null', (
+      tester,
+    ) async {
+      // Every entry that is not a course step, which is Kotlin's `getInt`
+      // default of 0 — and the screen then derives the number instead.
+      final db = await seed(courseDoc(secondExam: examOn('exam-2')));
+      addTearDown(db.close);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+      final container = ProviderContainer(
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          appDatabaseProvider.overrideWithValue(db),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final built =
+          await _buildFromRouter(
+                tester,
+                container.read(routerProvider),
+                '/courses/exam/exam-2?stepId=course-1:1',
+              )
+              as TakeExamScreen;
+
+      expect(built.stepNum, isNull);
+    });
+
+    testWidgets('a malformed step number reads as absent, not as zero', (
+      tester,
+    ) async {
+      // `int.tryParse` rather than a cast: a hand-typed location must fall
+      // back to the derivation rather than crash the route or write
+      // `stepNum: 0`.
+      final db = await seed(courseDoc(secondExam: examOn('exam-2')));
+      addTearDown(db.close);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+      final container = ProviderContainer(
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          appDatabaseProvider.overrideWithValue(db),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final built =
+          await _buildFromRouter(
+                tester,
+                container.read(routerProvider),
+                '/courses/exam/exam-2?stepNum=second',
+              )
+              as TakeExamScreen;
+
+      expect(built.stepNum, isNull);
+    });
+  });
+}
+
+/// Builds the widget the router's own route builder produces for [location].
+///
+/// Mirrors the helper `survey_team_context_test.dart` uses for the same reason:
+/// it exercises `router.dart`'s builder rather than a copy of it.
+Future<Widget> _buildFromRouter(
+  WidgetTester tester,
+  GoRouter router,
+  String location,
+) async {
+  final uri = Uri.parse(location);
+  final matchList = router.configuration.findMatch(uri);
+  expect(matchList.isError, isFalse, reason: 'no route matches $location');
+  final leaf = _leafMatch(matchList.matches.last);
+  final route = leaf.route;
+
+  late Widget built;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) {
+          built = route.builder!(
+            context,
+            GoRouterState(
+              router.configuration,
+              uri: uri,
+              matchedLocation: leaf.matchedLocation,
+              fullPath: matchList.fullPath,
+              pathParameters: matchList.pathParameters,
+              pageKey: const ValueKey('phase-139'),
+            ),
+          );
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  );
+  return built;
+}
+
+RouteMatch _leafMatch(RouteMatchBase match) => match is ShellRouteMatch
+    ? _leafMatch(match.matches.last)
+    : match as RouteMatch;
+
+class _Session extends SessionNotifier {
+  _Session(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -16,7 +16,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:myplanet/repository/ratings_repository.dart';
 import 'package:myplanet/repository/submissions_repository.dart';
 import 'package:myplanet/repository/surveys_repository.dart';
+import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/ui/courses/take_course_screen.dart';
+import 'package:myplanet/ui/surveys/take_survey_screen.dart';
 
 import '../../support/widget_harness.dart';
 import '../../support/mock_planet_api.dart';
@@ -24,6 +26,13 @@ import '../../support/mock_planet_api.dart';
 /// Mirrors the test-session notifier in `session_provider_test.dart`: returns a
 /// fixed user (or none) without touching the database or prefs, so the
 /// take-course screen has a `userId` for the rating check.
+class _TestServerConfig extends ServerConfigNotifier {
+  _TestServerConfig(this.config);
+  final ServerConfig? config;
+  @override
+  ServerConfig? build() => config;
+}
+
 class _TestSessionNotifier extends SessionNotifier {
   _TestSessionNotifier(this.user);
   final UserRow? user;
@@ -696,6 +705,100 @@ void main() {
 
     expect(find.text('Retake Test [1]'), findsOneWidget);
     expect(find.text('take test [1]'), findsNothing);
+  });
+
+  testWidgets('answering a step survey returns to the step and relabels the '
+      'tile', (tester) async {
+    // **Phase 128 built this refresh and Phase 128's own item 6 recorded that
+    // half of it was unreachable.** `TakeSurveyScreen._submit` ended with
+    // `context.go('${Routes.submissions}/<id>')` — `go`, not a pop — so
+    // answering a course-step survey unmounted `TakeCourseScreen` outright,
+    // the tile's `await context.push(…)` never resumed, and
+    // `refreshAssessment` short-circuited on `context.mounted`. The *redo
+    // survey* relabel was therefore unreachable on the one path that produces
+    // the submission it reads: the learner had to leave the course and come
+    // back to see it.
+    //
+    // The survey target here is the **real** `TakeSurveyScreen`, not a
+    // sentinel. That is the whole point — the existing test that looks like it
+    // covers this path stubs the route with a `Text` widget, so the real
+    // screen's exit was never exercised by anything. A fixture that fakes the
+    // return proves nothing about whether the return happens.
+    tester.view.physicalSize = const Size(1000, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final db = await seedStepAssessments();
+    addTearDown(db.close);
+    final steps = await db.courseDao.getSteps('course-1');
+
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') router.push('/take');
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (context) => const TakeCourseScreen(courseId: 'course-1'),
+          '/life/surveys/:surveyId': (context) => TakeSurveyScreen(
+            surveyId: GoRouterState.of(context).pathParameters['surveyId']!,
+          ),
+        },
+        overrides: [
+          await _prefsOverride(),
+          appDatabaseProvider.overrideWithValue(db),
+          sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
+          serverConfigProvider.overrideWith(() => _TestServerConfig(null)),
+          courseProvider('course-1').overrideWith(
+            (ref) => Stream.value(
+              buildCourseRow(
+                id: 'course-1',
+                courseTitle: 'Algebra',
+                userId: const ['user-1'],
+              ),
+            ),
+          ),
+          courseStepsProvider(
+            'course-1',
+          ).overrideWith((ref) => Stream.value(steps)),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Record survey'), findsOneWidget);
+    await tester.tap(find.text('Record survey'));
+    await tester.pumpAndSettle();
+
+    // The real survey screen, answered and submitted.
+    expect(find.byType(TakeSurveyScreen), findsOneWidget);
+    await tester.enterText(find.byType(TextField), 'it was fine');
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Submit survey'));
+    // Never pumpAndSettle straight after Submit: while `submitting` is true
+    // the button holds an indefinite CircularProgressIndicator.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Finish'));
+    await tester.pumpAndSettle();
+
+    // Back on the step — and the tile now reads *redo survey*, which is only
+    // observable because the pop let the `await` resume.
+    expect(find.byType(TakeSurveyScreen), findsNothing);
+    expect(find.text('redo survey'), findsOneWidget);
+    expect(find.text('Record survey'), findsNothing);
   });
 
   testWidgets('an attempt by another learner does not swap the label', (

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -284,6 +284,7 @@ void main() {
     String examId = 'exam-1',
     String? courseId,
     String? stepId,
+    int? stepNum,
     UserRow? session,
     ServerConfig? config = server,
     List<Override> overrides = const [],
@@ -309,6 +310,7 @@ void main() {
             examId: examId,
             courseId: courseId,
             stepId: stepId,
+            stepNum: stepNum,
           ),
         },
         overrides: [
@@ -1008,6 +1010,92 @@ void main() {
       expect(step1?.passed, isFalse);
       // And the step-2 rows, which a wrong number would have hit.
       expect(await passedFor('user-1'), isTrue);
+      expect(await passedFor('other-user'), isTrue);
+    });
+
+    testWidgets('the passed step number is used in preference to the '
+        'derivation', (tester) async {
+      // Kotlin never derives the number: `CourseStepFragment.kt:280` forwards
+      // the pager position and `BaseExamFragment.kt:75` reads it back. Both
+      // port pushers now send it, so this is the live path.
+      //
+      // The `stepId` here resolves to step **1** and the passed number is
+      // **2**, so the two disagree on purpose: whichever the screen uses is
+      // the row that moves.
+      await seedTwoQuestionExam(courseId: 'course-1');
+      await seedCourseWithGradedPeer();
+      await db.courseProgressDao.upsert(
+        CourseProgressCompanion.insert(
+          id: 'progress-user-1-step-1',
+          courseId: const Value('course-1'),
+          userId: const Value('user-1'),
+          stepNum: const Value(1),
+          passed: const Value(true),
+        ),
+      );
+      await pumpExam(
+        tester,
+        courseId: 'course-1',
+        stepId: 'course-1:0',
+        stepNum: 2,
+      );
+
+      await finishExam(tester);
+
+      // The passed number won: step 2's row was cleared…
+      expect(await passedFor('user-1'), isFalse);
+      // …and step 1's, which the derivation would have hit, was not.
+      final step1 = await db.courseProgressDao.findByCourseUserAndStep(
+        'course-1',
+        'user-1',
+        1,
+      );
+      expect(step1?.passed, isTrue);
+      // A peer's step-2 row is still `ed5609f`-safe.
+      expect(await passedFor('other-user'), isTrue);
+    });
+
+    testWidgets('a passed step number writes progress the derivation could '
+        'not resolve', (tester) async {
+      // What passing it explicitly buys, concretely. The derivation has to
+      // find the *step id* in a re-query of `CourseDao.getSteps` first, so a
+      // step id the course does not list — a step row that has not synced, or
+      // one re-bound by a course-step reorder — skipped the write entirely.
+      // Kotlin never consults the step table here at all.
+      await seedTwoQuestionExam(courseId: 'course-1');
+      await seedCourseWithGradedPeer();
+      await pumpExam(
+        tester,
+        courseId: 'course-1',
+        stepId: 'course-9:7',
+        stepNum: 2,
+      );
+
+      await finishExam(tester);
+
+      expect(await passedFor('user-1'), isFalse);
+      expect(await passedFor('other-user'), isTrue);
+    });
+
+    testWidgets('a non-positive step number falls back to the derivation', (
+      tester,
+    ) async {
+      // `0` is Kotlin's missing-argument default (`getInt("stepNum")`), and
+      // `WHERE stepNum = 0` is the value its own update deliberately matches
+      // nothing with — so a `0` must not be written as if it named a step.
+      // The derivation resolves `course-1:1` to 2 instead.
+      await seedTwoQuestionExam(courseId: 'course-1');
+      await seedCourseWithGradedPeer();
+      await pumpExam(
+        tester,
+        courseId: 'course-1',
+        stepId: 'course-1:1',
+        stepNum: 0,
+      );
+
+      await finishExam(tester);
+
+      expect(await passedFor('user-1'), isFalse);
       expect(await passedFor('other-user'), isTrue);
     });
 

--- a/flutter/test/ui/surveys/survey_team_context_test.dart
+++ b/flutter/test/ui/surveys/survey_team_context_test.dart
@@ -428,18 +428,24 @@ void main() {
       expect(profile.submissionId, (await submissions()).single.id);
     });
 
-    testWidgets('a personal survey goes straight to the submission', (
-      tester,
-    ) async {
+    testWidgets('a personal survey goes to the thank-you dialog, not the '
+        'profile step', (tester) async {
       // The other side of the same gate: Kotlin reaches `showUserInfoDialog`
       // only under `isTeam`, so a personal sheet must not acquire a profile
-      // step it never had.
+      // step it never had. It gets `continueExam`'s thank-you dialog instead
+      // (`BaseExamFragment.kt:132-148`).
+      //
+      // This used to assert `SUBMISSION_PAGE`, because the screen ended with
+      // `context.go('/life/submissions/<id>')` — a port invention with no
+      // Kotlin counterpart on any entry point, and the reason a course-step
+      // survey never returned the learner to the step. Phase 139.
       await seedSurvey();
       await pumpTakeSurvey(tester);
       await tester.pumpAndSettle();
 
       expect(find.byType(UserInformationScreen), findsNothing);
-      expect(find.text('SUBMISSION_PAGE'), findsOneWidget);
+      expect(find.text('Thank you for taking this survey'), findsOneWidget);
+      expect(find.text('SUBMISSION_PAGE'), findsNothing);
     });
 
     testWidgets('a nation survey skips the profile step', (tester) async {

--- a/flutter/test/ui/surveys/take_survey_screen_test.dart
+++ b/flutter/test/ui/surveys/take_survey_screen_test.dart
@@ -2,7 +2,9 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/data/local/converters.dart';
@@ -79,6 +81,11 @@ void main() {
           sessionProvider.overrideWith(
             () => _StubSession(buildUserRow(id: 'user-a', name: 'jane')),
           ),
+          // See the note in `pumpPushed`: without this every submit in this
+          // file lands in `_submit`'s failure branch. The tests that assert
+          // only on the stored row never noticed, which is how the screen's
+          // whole exit path stayed untested.
+          serverConfigProvider.overrideWith(() => _StubServerConfig(null)),
         ],
       ),
     );
@@ -196,6 +203,146 @@ void main() {
     expect(questions.single.choices, ['Water', 'Power']);
   });
 
+  group('where a finished survey leaves the learner', () {
+    /// Pushes the survey screen from a root page, so `context.pop()` has
+    /// somewhere to return to — which is the state every real entry point is
+    /// in, since all five push.
+    Future<void> pumpPushed(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1000, 3000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        wrapScreen(
+          Builder(
+            builder: (context) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                final router = GoRouter.of(context);
+                final location = router
+                    .routerDelegate
+                    .currentConfiguration
+                    .last
+                    .matchedLocation;
+                if (location != '/survey') router.push('/survey');
+              });
+              return const Scaffold(body: Text('WHERE_I_CAME_FROM'));
+            },
+          ),
+          pushTargets: {
+            '/survey': (_) => const TakeSurveyScreen(surveyId: 'survey-1'),
+            '/life/submissions/:id': (_) =>
+                const Scaffold(body: Text('SUBMISSION_PAGE')),
+            '/life/surveys': (_) => const Scaffold(body: Text('SURVEY_LIST')),
+          },
+          overrides: [
+            appDatabaseProvider.overrideWith((ref) {
+              ref.onDispose(db.close);
+              return db;
+            }),
+            planetApiProvider.overrideWithValue(MockPlanetApi()),
+            sessionProvider.overrideWith(
+              () => _StubSession(buildUserRow(id: 'user-a', name: 'jane')),
+            ),
+            // **Not optional, and its absence is silent.** `_submit` reads
+            // `serverConfigProvider` *inside* its own `try`, and the real
+            // notifier reaches `planetPrefs`, which is `UnimplementedError`
+            // in this harness — so without this the screen writes the row and
+            // then takes the `surveySubmitFailed` branch, which returns before
+            // the exit path this group exists to test. A null config is what
+            // an offline handset has, and it skips the queue step.
+            serverConfigProvider.overrideWith(() => _StubServerConfig(null)),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('submitting shows the thank-you dialog', (tester) async {
+      // `BaseExamFragment.continueExam:132-148` — the non-team terminal state
+      // is a thank-you dialog whose one button is Finish, and
+      // `setCancelable(false)` means the learner leaves through it.
+      await seedSurvey(type: 'select');
+      await pumpPushed(tester);
+
+      await tester.tap(find.text('Water'));
+      await tester.pumpAndSettle();
+      await tapSubmit(tester);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Thank you for taking this survey'), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Finish'), findsOneWidget);
+      // Not the submission detail: `context.go('/life/submissions/<id>')` was
+      // a port invention with no Kotlin counterpart on any entry point.
+      expect(find.text('SUBMISSION_PAGE'), findsNothing);
+    });
+
+    testWidgets('Finish returns the learner where they came from', (
+      tester,
+    ) async {
+      // `FragmentNavigator.popBackStack(parentFragmentManager)` (`:146`). The
+      // pop is what makes one exit right for all five entry points: each was
+      // reached by a push, so each lands back on its own caller.
+      await seedSurvey(type: 'select');
+      await pumpPushed(tester);
+
+      await tester.tap(find.text('Water'));
+      await tester.pumpAndSettle();
+      await tapSubmit(tester);
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Finish'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('WHERE_I_CAME_FROM'), findsOneWidget);
+      expect(find.byType(TakeSurveyScreen), findsNothing);
+      expect(find.text('SUBMISSION_PAGE'), findsNothing);
+      // And it did not invent a destination either: Kotlin's `popBackStack`
+      // goes back, it does not navigate to the survey list.
+      expect(find.text('SURVEY_LIST'), findsNothing);
+    });
+
+    testWidgets('the answers are still stored', (tester) async {
+      // The exit changed; what it exits *from* must not have. A pop that
+      // happened before the write would lose the sheet.
+      await seedSurvey(type: 'select');
+      await pumpPushed(tester);
+
+      await tester.tap(find.text('Water'));
+      await tester.pumpAndSettle();
+      await tapSubmit(tester);
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Finish'));
+      await tester.pumpAndSettle();
+
+      final stored = await answers();
+      expect(stored, hasLength(1));
+      expect(stored.single.valueChoices, [
+        jsonEncode({'id': 'water', 'text': 'Water'}),
+      ]);
+    });
+
+    testWidgets('nothing to pop leaves the learner on the screen', (
+      tester,
+    ) async {
+      // `FragmentNavigator.popBackStack` is a no-op on an empty back stack
+      // (`FragmentNavigator.kt:55`), so a survey reached without a push stays
+      // put rather than being sent somewhere Kotlin would not send it. This
+      // is the harness's own shape — `wrapScreen` puts the screen at `/` — so
+      // it is also what every other test in this file exercises.
+      await seedSurvey(type: 'select');
+      await pumpScreen(tester);
+
+      await tester.tap(find.text('Water'));
+      await tester.pumpAndSettle();
+      await tapSubmit(tester);
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Finish'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TakeSurveyScreen), findsOneWidget);
+      expect(find.text('SUBMISSION_PAGE'), findsNothing);
+    });
+  });
+
   testWidgets('a survey with no questions offers no submit button', (
     tester,
   ) async {
@@ -213,6 +360,13 @@ void main() {
     expect(find.text('This survey has no questions'), findsOneWidget);
     expect(find.widgetWithText(FilledButton, 'Submit survey'), findsNothing);
   });
+}
+
+class _StubServerConfig extends ServerConfigNotifier {
+  _StubServerConfig(this.config);
+  final ServerConfig? config;
+  @override
+  ServerConfig? build() => config;
 }
 
 class _StubSession extends SessionNotifier {


### PR DESCRIPTION
Lane B of a four-lane round. Draft — opened first so the integrator has an inbound channel.

Three jobs, all from previous rounds' *Reported, not fixed* lists:

1. **Job 1** — `TakeCourseFragment.changeNextButtonState` is unported: the per-step Next lock for `MANDATORY_SURVEY_COURSE_ID` (Phase 128 item 4).
2. **Job 2** — a course-step survey `go`es to the submissions screen rather than returning to the step, making half of Phase 128's tile-refresh fix unreachable (Phase 128 item 6).
3. **Job 3** — pass a course step's number explicitly rather than deriving it from `stepIndex` (Phase 135 item 4).

Files owned by this lane: `flutter/lib/ui/courses/take_course_screen.dart`, `flutter/lib/ui/courses/course_detail_screen.dart`, `flutter/lib/ui/surveys/take_survey_screen.dart`, `flutter/lib/ui/router.dart`, the course/step providers, their tests, and `flutter/PHASE_139_NOTES.md`.

Progress and findings land in `flutter/PHASE_139_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQpsNcQ2rVioXBreg7MDcj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQpsNcQ2rVioXBreg7MDcj)_