### PR TITLE
Phase 141 (Lane D): recover the remaining human translations from the Kotlin strings.xml

### DIFF
--- a/flutter/PHASE_141_NOTES.md
+++ b/flutter/PHASE_141_NOTES.md
@@ -7,7 +7,7 @@ and say precisely what is left and why. **No machine translation was generated.*
 ## The headline
 
 **The recoverable pool is essentially exhausted, and the reason is a floor rather
-than a backlog.** 16 values were recovered (below). The next 38 values a looser
+than a backlog.** 16 values were recovered (below). The next 42 values a looser
 matcher would reach are not a missed opportunity — they are a trap that would have
 replaced real translations with English tokens, and the largest single remaining
 block is blocked by a defect in `app_en.arb`, which this lane does not own.
@@ -59,8 +59,14 @@ All by re-running the existing tool; no new matching rule was needed.
   re-ran the tool after the keys landed. *(This is the recurring one — Phase 130
   found the same shape with `playbackSpeed`. Re-running the tool after any template
   key is added costs nothing and is not automated.)*
-- **`fr/storagePdfs`**: the `.arb` carried the English "PDFs"; `values-fr` says
-  "PDF".
+- **`fr/storagePdfs`**: the `.arb` carried the English "PDFs", and French supplies
+  "PDF". Note the provenance, because my first write-up got it wrong:
+  `values-fr/storage_pdfs` is *itself* untranslated ("PDFs"); the value comes from
+  the sibling `filter_pdfs`, a different Kotlin key with the same English, whose
+  French is "PDF". The untranslated namesake is dropped by the
+  `proposal == templateValue` rule, leaving `filter_pdfs` as the unanimous
+  candidate. The recovery is sound — a French human wrote "PDF" for that exact
+  English — but it is not the namesake key.
 
 Plus one marking-only fix and one deletion, neither of which changes a rendered
 string:
@@ -102,12 +108,21 @@ pins it directly as a unit test — which is the correct place for it.
 
 11 template keys match the Kotlin XML *only* under internal-whitespace
 normalisation — one notch below the `casing` tier. Adding that tier would adopt
-**38 values across the five locales**. I measured what those 38 are before writing
-any code, and **almost all of them are degradations**:
+**42 values across the five locales** (ar 5, es 6, fr 9, ne 11, so 11). My first
+count said 38; it missed `usernameOnlyLettersNumbers` in ar/fr/ne/so, which does
+match (an internal space before a comma) and does substitute one valid translation
+for another. The error under-counted the damage, so it argued the point weakly
+rather than wrongly. I measured them before writing any code, and **almost all are
+degradations**:
 
-- `mySurveys` → the literal token **`mySurveys`** in all five locales, replacing
-  Arabic `استطلاعاتي` and French `Mes enquêtes`. Kotlin's `my_survey` is untranslated
-  everywhere; `my_library` is `"mylibrary"` everywhere.
+- `mySurveys` → the literal token **`mySurveys`** in ar/fr/ne/so, replacing Arabic
+  `استطلاعاتي` and French `Mes enquêtes`. **Spanish is the exception** and translates
+  both `my_survey` (`misEncuestas`) and `my_library` (`miBiblioteca`) — an earlier
+  draft of this file said "all five", which is wrong and understates how the guard
+  has to work: it must pass Spanish while refusing the other four. In ne/so there is
+  no existing value at all, so the tier would *add* an English token rather than
+  overwrite a translation. And the tool writes the case-aligned form (`MySurveys`),
+  not the bare token.
 - `addedToMyLibrary` (ar) → `تمت الإضافة إلى myLibrary`, an English token spliced
   into an Arabic sentence.
 - `myPersonals` (so) → `Dhamaan xogtaaga caafimaadka` — "all your health
@@ -115,8 +130,9 @@ any code, and **almost all of them are degradations**:
 - `logOut` (fr) → `Se déconnecter` replaced by `Déconnexion`: substituting one valid
   translation for another, which the rules forbid outright.
 
-**47 of the Kotlin app's 1055 strings are byte-identical to their English in at
-least four of the five locales.** The `my*` compound family is the worst of them,
+**47 of the Kotlin app's 1055 translatable strings are byte-identical to their
+English in at least four of the five locales** (1055 excludes the one
+`translatable="false"` entry; the raw element count is 1056). The `my*` compound family is the worst of them,
 and it is exactly what a looser tier reaches — because the port deliberately
 re-spaced Kotlin's `myLibrary`/`mySurveys` into "My Library"/"My surveys". The port's
 English is a *correction* of Kotlin's, and Kotlin's translations inherit the original
@@ -126,28 +142,48 @@ So the ladder's floor is not an oversight. **It is the line past which the Kotli
 data stops being trustworthy**, and the honest report is that these 11 keys are
 unrecoverable rather than pending.
 
-Two guards now hold that line, both mutation-tested (each was confirmed to fail when
-the code it pins is reverted):
+Two guards hold that line. **Both were wrong in their first cut, and an audit pass
+against my own finished work is what found it** — the unit test pinning them passed
+because its fixture fabricated an input the pipeline cannot produce, which is the
+exact "a fixture that fabricates a join is not evidence" shape this project keeps
+relearning.
 
-- `isUntranslatedSource` in `tool/arb_from_strings_xml.dart` — rejects a proposal
-  equal to the Kotlin string's **own** English where that differs from the template's.
-  The existing guard compared against the *template's* English, which is only sound
-  while every tier matches English byte-identical to it. It is a no-op today by
-  design; it is what keeps the floor safe by construction rather than by luck.
-  Pinned in `format_derivation_test.dart`.
-- `no locale value is an untranslated Kotlin source string` in
-  `placeholder_integrity_test.dart` — the same invariant asserted over the shipped
-  `.arb` files, so *any* route into the state fails, not only the one I anticipated.
-  **This test found `aiChat` on its first run**, which is the only reason that fix
-  is in this phase.
+- **`isUntranslatedSource` in `tool/arb_from_strings_xml.dart` — the guard that
+  matters.** It refuses a Kotlin string whose locale value is still its own English,
+  where that English differs from the template's. The first cut judged
+  `_proposal`'s *output*, and `_proposal` runs `_alignInitialCase` for every
+  non-`exact` tier — so `values-ar`'s `mySurveys` arrived as `MySurveys` and no
+  longer equalled the `mySurveys` it is a copy of. **It returned false on both
+  examples its own comment named**, and simulating the whitespace tier with the
+  guard on and off gave 42 adoptions either way: it blocked nothing. It now judges
+  the raw `values-<locale>` string, which is where the question is actually
+  answerable — "did this translator leave the source in place" is a fact about the
+  XML, not about our rendering of it. Verified firing on `mySurveys`/`mylibrary`,
+  correctly passing Spanish's `misEncuestas` and the invariant `HTML`, and pinned
+  against the real XML rather than hand-made inputs.
+- **`no locale value is an untranslated Kotlin source string` in
+  `placeholder_integrity_test.dart` — the backstop.** It found `aiChat` on its first
+  run, but that was also *the only thing it could ever have found*: it keyed on
+  `_camelCase`, which maps `my_survey` to `mySurvey` (not a template key), and read
+  the XML with a regex that left Android's quoting on, so `my_library` came back as
+  `"mylibrary"` with quotes and could never match. It now parses the XML properly
+  (which also fixes three silent misparses — a self-closing `<string/>` was
+  swallowing the next element entirely, so `message_placeholder` appeared nowhere in
+  the map) and matches loosely enough to reach the `my*` family.
+  **Its limit, stated rather than papered over:** the comparison is byte-exact, so it
+  catches a value that *is* the source but not the case-aligned form the tool would
+  write. It cannot: at the ARB level "the untranslated source" and "the port's own
+  English" are the same string modulo case and spacing for exactly this class,
+  because the port's English *is* a re-spacing of Kotlin's. Loosening it to reach
+  `Mylibrary` also flags `appTitle`. Only the tool sees what a proposal would
+  *overwrite*, which is where the damage is.
 
 ## Reported, not fixed
 
-1. **`app_en.arb`'s three printf keys are a live user-visible bug, not just a
-   derivation blocker.** `communityEarnings` and `yourEarnings` declare
-   `{amount: int}` while their English is `'Community total earnings: **$%1$d** / 500'`.
-   ICU never interpolates `%1$d`, so the generated getter takes the argument and
-   drops it:
+1. **`app_en.arb`'s three printf keys render their own format specifier.**
+   `communityEarnings` and `yourEarnings` declare `{amount: int}` while their
+   English is `'Community total earnings: **$%1$d** / 500'`. ICU never interpolates
+   `%1$d`, so the generated getter takes the argument and drops it:
 
    ```dart
    String communityEarnings(int amount) {
@@ -155,23 +191,38 @@ the code it pins is reverted):
    }
    ```
 
-   `lib/ui/components/challenge_dialog.dart:145,146,149,150` calls both. **The
-   challenge dialog renders the literal `%1$d` to users in every language, English
-   included.** `app_en.arb` is not this lane's file, so this is a report.
+   Kotlin renders these correctly (`ChallengePrompter.kt:41,55` passes the argument
+   through `getString`), so it is a genuine parity defect, in every language
+   including English.
 
-   The fix is `%1$d` → `{amount}` and `%1$s` → `{status}`. Note what it does and does
-   not unlock: **`perSurvey` then derives in all five locales** (Kotlin's
-   `%1$s per survey` matches the template literal exactly). `communityEarnings` and
-   `yourEarnings` do **not** — Kotlin writes `/$500`, the template writes `/ 500`, so
-   the literals differ and the exact-literal rule correctly refuses. So: 3 rendering
-   bugs fixed, 5 human translations unlocked.
+   **It is not, however, "live", and an earlier draft of this file said it was.**
+   The only caller is `lib/ui/components/challenge_dialog.dart:145,146,149,150`, and
+   `lib/providers/challenge_provider.dart:30-31,55-60` gates that dialog on
+   `promptStart = 2024-11-30` / `promptEnd = 2025-01-16` plus one of six hardcoded
+   server URLs. **That window closed 20 months ago**, so no user sees this today.
+   The accurate statement is *a latent rendering defect on a currently unreachable
+   screen* — and calling it live was the reachability over-read this project has now
+   been caught by three times, in the same direction each time. `app_en.arb` is not
+   this lane's file either way.
+
+   The fix is `%1$d` → `{amount}` and `%1$s` → `{status}`. What it unlocks is
+   smaller than I first wrote: **`perSurvey` would derive in all five locales**
+   (Kotlin's `%1$s per survey` matches the template literal exactly), but
+   `perSurvey` **has zero callers in `lib/`**, so those five values would render
+   nowhere. `communityEarnings`/`yourEarnings` do **not** derive at all — Kotlin
+   writes `/$500`, the template `/ 500`, so the literals differ and the
+   exact-literal rule correctly refuses. So: 3 rendering defects corrected, 0
+   translations reaching a screen.
 
 2. **Four `x-mt` flags sit on values that are byte-identical to a Kotlin human
    translation, and I deliberately left them.** `ar/profitLoss`, `es/height`,
    `es/weight`, `es/bloodPressure`. Unlike `ar/progressFilterCompleted` (fixed above,
-   where the Kotlin English is byte-identical to the template's), these matched at the
+   where the Kotlin English is byte-identical to the template's), three of these matched at the
    *name-only* tier where the English differs materially — Kotlin's `height` is
-   "Height (cm)", the template's is "Height". Byte-identity to a translation of
+   "Height (cm)", the template's is "Height". (`ar/profitLoss` is not one of them:
+   `Profit/Loss` against `Profit / loss` differs only in spacing and case, so it is
+   one of the 11 below-floor keys of §4. The conservative decision stands; the
+   rationale I gave fits the other three.) Byte-identity to a translation of
    *different* English is weak evidence: "Altura" is simply the obvious translation
    of "Height", so the machine and the human agreeing proves the string is *right*,
    not that it was *reviewed*. A flag wrongly cleared hides a string from review
@@ -202,6 +253,24 @@ the code it pins is reverted):
    the tool. Phase 130 hit the identical shape. A CI step, or a test asserting the
    tool produces no diff, would close it permanently — but it belongs to whoever owns
    `flutter.yml`, not to this lane.
+
+## What the audit changed
+
+A `parity-auditor` pass at `effort: max` was run against this phase's own finished,
+already-green work, as the round requires. It found that **both guards were inert**
+— each failing on the exact example its own doc comment named — plus five
+measurement overstatements (§2 `storagePdfs` provenance, §4 "all five locales" and
+"38 values", the 1055/1056 denominator, and the "live bug" over-read above). None of
+it was a defect in the shipped translation data, which the audit reproduced
+byte-identically from the pre-141 state; all of it was in the guards and the claims.
+
+That is the second time in this phase the same mistake shape appeared: **a green
+test whose fixture fabricated the input.** The unit test pinning
+`isUntranslatedSource` passed `proposal: 'mySurveys'`, a value `_proposal` cannot
+emit, so it certified a guard that never fired. The tests now drive the real
+`values-*/strings.xml`. Worth stating plainly because I had already written the
+"fixtures that fabricate a join are not evidence" rule into this very file's
+reasoning before walking into it.
 
 ## The gate
 

--- a/flutter/PHASE_141_NOTES.md
+++ b/flutter/PHASE_141_NOTES.md
@@ -1,17 +1,217 @@
 # Phase 141 — l10n recovery (Lane D)
 
-Status: in progress.
+The brief: measure what is still recoverable from the Kotlin `values-*/strings.xml`,
+verify the Phase 121 placeholder fix is complete, recover what recovery can reach,
+and say precisely what is left and why. **No machine translation was generated.**
 
-## Baseline (measured on `3025d04`)
+## The headline
 
-| Locale | ARB keys | of which `"x-mt": true` |
-|---|---:|---:|
-| en (template) | 906 | — |
-| ar | 851 | 433 |
-| es | 886 | 416 |
-| fr | 886 | 469 |
-| ne | 444 | 25 |
-| so | 444 | 25 |
+**The recoverable pool is essentially exhausted, and the reason is a floor rather
+than a backlog.** 16 values were recovered (below). The next 38 values a looser
+matcher would reach are not a missed opportunity — they are a trap that would have
+replaced real translations with English tokens, and the largest single remaining
+block is blocked by a defect in `app_en.arb`, which this lane does not own.
 
-Goal: measure the pool still recoverable from the Kotlin `values-*/strings.xml`,
-recover it, and report precisely what is left and why.
+## 1. The measurement
+
+Template `app_en.arb` is **906** keys; the Kotlin `values/strings.xml` is **1055**
+strings. Final state of the five locale files:
+
+| Locale | ARB keys | `x-mt` | human | absent | value == English |
+|---|---:|---:|---:|---:|---:|
+| ar | 853 | 432 | 421 | 53 | 36 |
+| es | 889 | 416 | 473 | 17 | 48 |
+| fr | 888 | 469 | 419 | 18 | 71 |
+| ne | 446 | 25 | 421 | 460 | 35 |
+| so | 446 | 25 | 421 | 460 | 43 |
+
+**Do not read the last column as a defect count.** For French and Spanish most of
+it is correct — "Description", "Date", "Documents", "Format" *are* the French
+words. For Arabic and Nepali, 30 of the ~35 are the ICU plural keys plus
+`disclaimerContent`, and the rest are endonyms (`spanish` → `español`) or invariant
+tokens (`HTML`, `N/A`, `myPlanet`). This column was my own first cut at "the
+recoverable pool" and it was wrong by about an order of magnitude; the number that
+matters is what a *safe match against the Kotlin XML* can produce, which is the
+next section.
+
+### The pool, decomposed by why a key cannot be recovered
+
+Of the keys with no human value in a given locale, matched against the Kotlin XML:
+
+| Bucket | ar | es | fr | ne | so | Recoverable? |
+|---|---:|---:|---:|---:|---:|---|
+| No Kotlin counterpart at all (port-minted UI text) | 433 | 389 | 434 | 433 | 433 | **No** — nothing to derive from |
+| Kotlin name matches, English differs (`report` tier) | 53 | 47 | 53 | 53 | 53 | **No** — needs an `app_en.arb` judgement |
+| Exact/punctuation English match | 12 | 21 | 30 | 11 | 19 | mostly already correct; 16 taken |
+
+The first row is the real answer to "how much is left to recover": **~390–434 keys
+per locale have no Kotlin string to recover from.** They are the port's own screens
+— `videoFileNotFound`, `exportCancelled`, the resource-viewer error states. Only a
+translator can fill them.
+
+## 2. What was recovered — 16 values
+
+All by re-running the existing tool; no new matching rule was needed.
+
+- **`takeTestCount`, `retakeTestCount`, `redoSurvey` × 5 locales = 15.** Template
+  keys added after Phase 121's derivation run; Kotlin's `take_test`, `retake_test`
+  and `redo_survey` ship human translations in all five `values-*` files. Nobody
+  re-ran the tool after the keys landed. *(This is the recurring one — Phase 130
+  found the same shape with `playbackSpeed`. Re-running the tool after any template
+  key is added costs nothing and is not automated.)*
+- **`fr/storagePdfs`**: the `.arb` carried the English "PDFs"; `values-fr` says
+  "PDF".
+
+Plus one marking-only fix and one deletion, neither of which changes a rendered
+string:
+
+- **`ar/progressFilterCompleted`** lost a stale `x-mt` flag. It already held
+  `status_completed`'s Arabic (`مكتمل`) word for word, but the recovery pass tested
+  unanimity *before* it tested whether the value was already one of the candidates,
+  and Kotlin's `completed`/`status_completed` disagree in Arabic — so the key was
+  ruled `no-unanimous` and never reached flag reconciliation. Fixed by ordering the
+  verdict cascade correctly.
+- **`aiChat` dropped from ar/fr/ne/so.** All four held the English "AI Chat" as an
+  unflagged *human* translation, because `values-ar/-fr/-ne/-so` leave Kotlin's
+  `ai_chat` untranslated. Spanish is the only locale that rendered it ("Chat IA"),
+  which is what makes the other four a gap rather than a deliberate invariant. Now
+  falls back to the template; on screen that is one capital letter, and the key
+  rejoins the review queue instead of inflating the human-reviewed count.
+
+## 3. Question 2 — is anything still being skipped structurally?
+
+Phase 121's placeholder fix is **complete and correct**. The format layer derives
+22–27 human translations per locale that no plain-text rule could reach. Four
+structural exclusions remain, three of them legitimate:
+
+| Skipped | Count | Verdict |
+|---|---:|---|
+| ICU plural/select template keys | 23 | **Legitimate.** Android `<plurals>` do exist (4 names) but none matches a template key by English — Kotlin's `minutes` is "%d minutes", the template's `relativeMinutesAgo` is "{count} minutes ago". Filling `other` and leaving `=0`/`=1` in English is worse than the fallback. |
+| Literal with no word (`ratingCompact`, `percentageValue`, `userNameWithLogins`) | 3 | **Legitimate.** `%1$s (%2$s)` is punctuation; it matches any key of that shape. |
+| `<plurals>` elements never read by `_readStringsXml` | 4 names | **Legitimate**, per the row above — and reading them would be *actively unsafe*: `values-ne`'s `minutes`/`hours`/`days` contain **Somali** (`%d daqiiqad`) and `values-so`'s contain **Nepali** (`%d मिनेट`). The two files are swapped upstream. |
+| **printf in the template** (`communityEarnings`, `yourEarnings`, `perSurvey`) | 3 | **A defect — see below.** |
+
+Phase 121's headline reordering case is worth a correction: the four Kotlin strings
+whose translations reorder arguments (`ne/download_progress`,
+`ne/download_progress_with_errors`, `ne/steps_done_of_total`, `ar/member_description`)
+have **no matching template key**, so the reordering machinery is currently
+unexercised by shipped data. It is still right, and `format_derivation_test.dart`
+pins it directly as a unit test — which is the correct place for it.
+
+## 4. The trap: why the tier ladder stops where it does
+
+11 template keys match the Kotlin XML *only* under internal-whitespace
+normalisation — one notch below the `casing` tier. Adding that tier would adopt
+**38 values across the five locales**. I measured what those 38 are before writing
+any code, and **almost all of them are degradations**:
+
+- `mySurveys` → the literal token **`mySurveys`** in all five locales, replacing
+  Arabic `استطلاعاتي` and French `Mes enquêtes`. Kotlin's `my_survey` is untranslated
+  everywhere; `my_library` is `"mylibrary"` everywhere.
+- `addedToMyLibrary` (ar) → `تمت الإضافة إلى myLibrary`, an English token spliced
+  into an Arabic sentence.
+- `myPersonals` (so) → `Dhamaan xogtaaga caafimaadka` — "all your health
+  information", a copy-paste error in `values-so`, not a translation of "My personals".
+- `logOut` (fr) → `Se déconnecter` replaced by `Déconnexion`: substituting one valid
+  translation for another, which the rules forbid outright.
+
+**47 of the Kotlin app's 1055 strings are byte-identical to their English in at
+least four of the five locales.** The `my*` compound family is the worst of them,
+and it is exactly what a looser tier reaches — because the port deliberately
+re-spaced Kotlin's `myLibrary`/`mySurveys` into "My Library"/"My surveys". The port's
+English is a *correction* of Kotlin's, and Kotlin's translations inherit the original
+defect.
+
+So the ladder's floor is not an oversight. **It is the line past which the Kotlin
+data stops being trustworthy**, and the honest report is that these 11 keys are
+unrecoverable rather than pending.
+
+Two guards now hold that line, both mutation-tested (each was confirmed to fail when
+the code it pins is reverted):
+
+- `isUntranslatedSource` in `tool/arb_from_strings_xml.dart` — rejects a proposal
+  equal to the Kotlin string's **own** English where that differs from the template's.
+  The existing guard compared against the *template's* English, which is only sound
+  while every tier matches English byte-identical to it. It is a no-op today by
+  design; it is what keeps the floor safe by construction rather than by luck.
+  Pinned in `format_derivation_test.dart`.
+- `no locale value is an untranslated Kotlin source string` in
+  `placeholder_integrity_test.dart` — the same invariant asserted over the shipped
+  `.arb` files, so *any* route into the state fails, not only the one I anticipated.
+  **This test found `aiChat` on its first run**, which is the only reason that fix
+  is in this phase.
+
+## Reported, not fixed
+
+1. **`app_en.arb`'s three printf keys are a live user-visible bug, not just a
+   derivation blocker.** `communityEarnings` and `yourEarnings` declare
+   `{amount: int}` while their English is `'Community total earnings: **$%1$d** / 500'`.
+   ICU never interpolates `%1$d`, so the generated getter takes the argument and
+   drops it:
+
+   ```dart
+   String communityEarnings(int amount) {
+     return 'Community total earnings: **\$%1\$d** / 500';   // app_localizations_en.dart:2474
+   }
+   ```
+
+   `lib/ui/components/challenge_dialog.dart:145,146,149,150` calls both. **The
+   challenge dialog renders the literal `%1$d` to users in every language, English
+   included.** `app_en.arb` is not this lane's file, so this is a report.
+
+   The fix is `%1$d` → `{amount}` and `%1$s` → `{status}`. Note what it does and does
+   not unlock: **`perSurvey` then derives in all five locales** (Kotlin's
+   `%1$s per survey` matches the template literal exactly). `communityEarnings` and
+   `yourEarnings` do **not** — Kotlin writes `/$500`, the template writes `/ 500`, so
+   the literals differ and the exact-literal rule correctly refuses. So: 3 rendering
+   bugs fixed, 5 human translations unlocked.
+
+2. **Four `x-mt` flags sit on values that are byte-identical to a Kotlin human
+   translation, and I deliberately left them.** `ar/profitLoss`, `es/height`,
+   `es/weight`, `es/bloodPressure`. Unlike `ar/progressFilterCompleted` (fixed above,
+   where the Kotlin English is byte-identical to the template's), these matched at the
+   *name-only* tier where the English differs materially — Kotlin's `height` is
+   "Height (cm)", the template's is "Height". Byte-identity to a translation of
+   *different* English is weak evidence: "Altura" is simply the obvious translation
+   of "Height", so the machine and the human agreeing proves the string is *right*,
+   not that it was *reviewed*. A flag wrongly cleared hides a string from review
+   permanently; a flag left on a correct string costs a reviewer seconds. I took the
+   asymmetric side. A human reviewer can clear all four in a minute.
+
+3. **`values-ne` and `values-so` have their `minutes`/`hours`/`days` `<plurals>`
+   swapped** — Nepali contains Somali and vice versa. This is a bug in the Kotlin
+   app (`app/`), outside both this lane and the port. It costs the port nothing today
+   because those plurals are unreachable (§3), but it will mislead anyone who tries to
+   derive from them later.
+
+4. **English is stored *as a value* for ~30 keys each in ar and ne** — mostly the ICU
+   plural family (`itemsSynced`, `relativeMinutesAgo`, `syncedResources`, …) plus
+   `noFileSelected`, `surveySentToUsers`, `fileSelected`, `feedbackTypeRequired`,
+   `receiptSelected`, `storageDeleteSelectedConfirm`. They render identically to a
+   fallback, so there is no user-visible defect — but `gen-l10n`'s untranslated count
+   (ar 53, ne 460) **understates** the real gap by roughly 26 per locale, and each key
+   is counted as human-reviewed. Deleting them is the Phase 118 move and would be
+   correct; I did not, because separating them from the legitimately invariant values
+   (endonyms, `HTML`, `disclaimerContent`) is a per-key judgement rather than a
+   derivation, and that judgement is precisely the human pass the l10n row needs. The
+   list is one `json.load` away — see the query in §1.
+
+5. **Nothing automatically re-runs the derivation when a template key is added.**
+   15 of this phase's 16 recovered values existed in the Kotlin XML the whole time
+   and were missed only because Phases 122–140 added template keys without re-running
+   the tool. Phase 130 hit the identical shape. A CI step, or a test asserting the
+   tool produces no diff, would close it permanently — but it belongs to whoever owns
+   `flutter.yml`, not to this lane.
+
+## The gate
+
+```
+flutter gen-l10n                                        ✅  ar 53 / es 17 / fr 18 / ne 460 / so 460 untranslated
+dart format --output=none --set-exit-if-changed lib test tool   ✅  468 files, 0 changed
+flutter analyze                                         ✅  No issues found
+flutter test                                            ✅  2462 passed (was 2457; +5 new l10n guards)
+```
+
+`dart tool/arb_from_strings_xml.dart` then `--adopt` then the plain run again
+produces **no further change** — idempotence verified by checksum across three runs,
+including after the `aiChat` deletion, which the tool correctly does not re-add.

--- a/flutter/PHASE_141_NOTES.md
+++ b/flutter/PHASE_141_NOTES.md
@@ -1,0 +1,17 @@
+# Phase 141 — l10n recovery (Lane D)
+
+Status: in progress.
+
+## Baseline (measured on `3025d04`)
+
+| Locale | ARB keys | of which `"x-mt": true` |
+|---|---:|---:|
+| en (template) | 906 | — |
+| ar | 851 | 433 |
+| es | 886 | 416 |
+| fr | 886 | 469 |
+| ne | 444 | 25 |
+| so | 444 | 25 |
+
+Goal: measure the pool still recoverable from the Kotlin `values-*/strings.xml`,
+recover it, and report precisely what is left and why.

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -138,7 +138,6 @@
     "x-mt": true
   },
   "appTheme": "سمة التطبيق",
-  "aiChat": "AI Chat",
   "syncNow": "مزامنة الآن",
   "syncCenter": "مركز المزامنة",
   "@syncCenter": {
@@ -1875,9 +1874,6 @@
   "progressFilterNotStarted": "لم يبدأ",
   "progressFilterInProgress": "قيد التنفيذ",
   "progressFilterCompleted": "مكتمل",
-  "@progressFilterCompleted": {
-    "x-mt": true
-  },
   "stepProgress": "{current} من {max} الخطوات",
   "@stepProgress": {
     "x-mt": true
@@ -2156,5 +2152,8 @@
   "filterAudio": "صوتيات",
   "mediumTextHtml": "نص / HTML",
   "mediumHtml": "HTML",
-  "filterOther": "أخرى"
+  "filterOther": "أخرى",
+  "takeTestCount": "إجراء الاختبار [{count}]",
+  "retakeTestCount": "إعادة الاختبار [{count}]",
+  "redoSurvey": "أعد إجراء الاستبيان"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -2157,5 +2157,8 @@
   "filterAudio": "Audio",
   "mediumTextHtml": "Texto / HTML",
   "mediumHtml": "HTML",
-  "filterOther": "Otro"
+  "filterOther": "Otro",
+  "takeTestCount": "Realizar examen [{count}]",
+  "retakeTestCount": "Volver a tomar el test [{count}]",
+  "redoSurvey": "volver a hacer la encuesta"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -146,7 +146,6 @@
     "x-mt": true
   },
   "appTheme": "Thème de l'application",
-  "aiChat": "AI Chat",
   "syncNow": "Synchroniser maintenant",
   "syncCenter": "Centre de synchronisation",
   "@syncCenter": {
@@ -1840,7 +1839,7 @@
   "storageTotalDownloaded": "Total téléchargé",
   "storageVideos": "Vidéos",
   "storageAudio": "Audio",
-  "storagePdfs": "PDFs",
+  "storagePdfs": "PDF",
   "storageImages": "Images",
   "storageOther": "Autre",
   "fileCountOne": "1 fichier",
@@ -2299,5 +2298,8 @@
   "filterAudio": "Audio",
   "mediumTextHtml": "Texte / HTML",
   "mediumHtml": "HTML",
-  "filterOther": "Autre"
+  "filterOther": "Autre",
+  "takeTestCount": "Passer le test [{count}]",
+  "retakeTestCount": "Repasser le test [{count}]",
+  "redoSurvey": "refaire le sondage"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -18,7 +18,6 @@
   "ok": "ठिक छ",
   "home": "होम",
   "appTheme": "एप थिम",
-  "aiChat": "AI Chat",
   "syncNow": "अहिले सिङ्क गर्नुहोस्",
   "syncing": "सिङ्क हुँदैछ…",
   "surveys": "सर्वेक्षणहरू",
@@ -525,5 +524,8 @@
   "filterAudio": "अडियो",
   "mediumTextHtml": "पाठ / HTML",
   "mediumHtml": "HTML",
-  "filterOther": "अन्य"
+  "filterOther": "अन्य",
+  "takeTestCount": "परीक्षा दिनुहोस् [{count}]",
+  "retakeTestCount": "पुन: टेस्ट दिनुहोस् [{count}]",
+  "redoSurvey": "सर्वे पुनः गर्नुहोस्"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -18,7 +18,6 @@
   "ok": "Sax",
   "home": "Guriga",
   "appTheme": "Mawduuca app-ka",
-  "aiChat": "AI Chat",
   "syncNow": "Isku-dar hadda",
   "syncing": "La waafajinayaa…",
   "surveys": "Sahaminta",
@@ -525,5 +524,8 @@
   "filterAudio": "Codad",
   "mediumTextHtml": "Qoraal / HTML",
   "mediumHtml": "HTML",
-  "filterOther": "Kale"
+  "filterOther": "Kale",
+  "takeTestCount": "Barto Imtixaan [{count}]",
+  "retakeTestCount": "Dib u habayn Imtixaanka [{count}]",
+  "redoSurvey": "Dib u samee sahanka"
 }

--- a/flutter/test/l10n/format_derivation_test.dart
+++ b/flutter/test/l10n/format_derivation_test.dart
@@ -186,34 +186,56 @@ void main() {
     // that would match only one notch below it — `logOut`/`Logout`,
     // `myLibrary`/`myLibrary`, `profitLoss`/`Profit/Loss`, the rest of the
     // `my*` compound family — are not an oversight waiting to be swept up.
-    // That is where the Kotlin data stops being trustworthy: 47 of its 1056
-    // strings are byte-identical to their English in at least four of the five
-    // locales, and the `my*` family is the worst of them. A tier reaching those
-    // keys would have written the token `mySurveys` over the real `استطلاعاتي`
-    // and `Mes enquêtes`, in all five locales, and called it a recovery.
+    // That is where the Kotlin data stops being trustworthy: 47 of its 1055
+    // translatable strings are byte-identical to their English in at least four
+    // of the five locales, and the `my*` family is the worst of them. A tier
+    // reaching those keys would have written the token `mySurveys` over the real
+    // `استطلاعاتي` and `Mes enquêtes`, and called it a recovered translation.
+    //
+    // These read the real `values-*/strings.xml` rather than hand-made inputs.
+    // The first cut of this group did hand-make them, and that is exactly why
+    // it certified a guard that never fired: it passed `proposal: 'mySurveys'`,
+    // a string the pipeline cannot produce, because `_proposal` case-aligns
+    // every non-`exact` tier and hands the guard `MySurveys`.
 
     test('an untranslated source string is not a candidate translation', () {
-      // `my_survey` is `mySurveys` in `values/strings.xml` and `mySurveys` in
-      // every `values-<locale>` file. Whatever tier proposes it, it is English.
-      expect(
-        isUntranslatedSource(
-          proposal: 'mySurveys',
-          kotlinEnglish: 'mySurveys',
-          templateEnglish: 'My surveys',
-        ),
-        isTrue,
-      );
+      // `my_survey` is `mySurveys` in `values/strings.xml` and left at
+      // `mySurveys` in Arabic, French, Nepali and Somali.
+      for (final code in ['ar', 'fr', 'ne', 'so']) {
+        for (final name in ['my_survey', 'my_library']) {
+          expect(
+            isUntranslatedSource(
+              localeValue: _kotlin(code, name),
+              kotlinEnglish: _kotlin('en', name),
+              templateEnglish: name == 'my_survey'
+                  ? 'My surveys'
+                  : 'My Library',
+            ),
+            isTrue,
+            reason:
+                '$code/$name is "${_kotlin(code, name)}" against the English '
+                '"${_kotlin('en', name)}" and must be refused',
+          );
+        }
+      }
     });
 
-    test('a real translation of the same key is still a candidate', () {
-      expect(
-        isUntranslatedSource(
-          proposal: 'استطلاعاتي',
-          kotlinEnglish: 'mySurveys',
-          templateEnglish: 'My surveys',
-        ),
-        isFalse,
-      );
+    test('the one locale that did translate them is still a candidate', () {
+      // Spanish is why the headline figure is "four of five" and not "all
+      // five": it renders both, so both are real candidates there.
+      expect(_kotlin('es', 'my_survey'), 'misEncuestas');
+      expect(_kotlin('es', 'my_library'), ' miBiblioteca');
+      for (final name in ['my_survey', 'my_library']) {
+        expect(
+          isUntranslatedSource(
+            localeValue: _kotlin('es', name),
+            kotlinEnglish: _kotlin('en', name),
+            templateEnglish: name == 'my_survey' ? 'My surveys' : 'My Library',
+          ),
+          isFalse,
+          reason: 'es/$name is a real translation',
+        );
+      }
     });
 
     test('a legitimately invariant value is not mistaken for English', () {
@@ -222,19 +244,12 @@ void main() {
       // that are correctly identical to their source. `medium_html` is "HTML"
       // in `values/strings.xml` and "HTML" in `values-fr` — that is the French
       // translation, not a missing one, and `app_fr.arb` ships it.
+      expect(_kotlin('fr', 'medium_html'), _kotlin('en', 'medium_html'));
       expect(
         isUntranslatedSource(
-          proposal: 'HTML',
-          kotlinEnglish: 'HTML',
+          localeValue: _kotlin('fr', 'medium_html'),
+          kotlinEnglish: _kotlin('en', 'medium_html'),
           templateEnglish: 'HTML',
-        ),
-        isFalse,
-      );
-      expect(
-        isUntranslatedSource(
-          proposal: 'PDF',
-          kotlinEnglish: 'PDFs',
-          templateEnglish: 'PDFs',
         ),
         isFalse,
       );
@@ -243,7 +258,7 @@ void main() {
     test('an absent source string proposes nothing either way', () {
       expect(
         isUntranslatedSource(
-          proposal: 'anything',
+          localeValue: 'anything',
           kotlinEnglish: '',
           templateEnglish: 'Something',
         ),

--- a/flutter/test/l10n/format_derivation_test.dart
+++ b/flutter/test/l10n/format_derivation_test.dart
@@ -181,6 +181,77 @@ void main() {
     });
   });
 
+  group('the trust floor', () {
+    // Phase 141. The tier ladder stops at `casing`, and the 11 template keys
+    // that would match only one notch below it — `logOut`/`Logout`,
+    // `myLibrary`/`myLibrary`, `profitLoss`/`Profit/Loss`, the rest of the
+    // `my*` compound family — are not an oversight waiting to be swept up.
+    // That is where the Kotlin data stops being trustworthy: 47 of its 1056
+    // strings are byte-identical to their English in at least four of the five
+    // locales, and the `my*` family is the worst of them. A tier reaching those
+    // keys would have written the token `mySurveys` over the real `استطلاعاتي`
+    // and `Mes enquêtes`, in all five locales, and called it a recovery.
+
+    test('an untranslated source string is not a candidate translation', () {
+      // `my_survey` is `mySurveys` in `values/strings.xml` and `mySurveys` in
+      // every `values-<locale>` file. Whatever tier proposes it, it is English.
+      expect(
+        isUntranslatedSource(
+          proposal: 'mySurveys',
+          kotlinEnglish: 'mySurveys',
+          templateEnglish: 'My surveys',
+        ),
+        isTrue,
+      );
+    });
+
+    test('a real translation of the same key is still a candidate', () {
+      expect(
+        isUntranslatedSource(
+          proposal: 'استطلاعاتي',
+          kotlinEnglish: 'mySurveys',
+          templateEnglish: 'My surveys',
+        ),
+        isFalse,
+      );
+    });
+
+    test('a legitimately invariant value is not mistaken for English', () {
+      // The guard must compare against the Kotlin string's own English *and*
+      // require it to differ from the template's, or it would reject the values
+      // that are correctly identical to their source. `medium_html` is "HTML"
+      // in `values/strings.xml` and "HTML" in `values-fr` — that is the French
+      // translation, not a missing one, and `app_fr.arb` ships it.
+      expect(
+        isUntranslatedSource(
+          proposal: 'HTML',
+          kotlinEnglish: 'HTML',
+          templateEnglish: 'HTML',
+        ),
+        isFalse,
+      );
+      expect(
+        isUntranslatedSource(
+          proposal: 'PDF',
+          kotlinEnglish: 'PDFs',
+          templateEnglish: 'PDFs',
+        ),
+        isFalse,
+      );
+    });
+
+    test('an absent source string proposes nothing either way', () {
+      expect(
+        isUntranslatedSource(
+          proposal: 'anything',
+          kotlinEnglish: '',
+          templateEnglish: 'Something',
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('plain text', () {
     // Not a placeholder concern, but the same file: this is where the tool's
     // derivation rules are tested, and the plain-text rules turned out to

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:xml/xml.dart';
 import 'package:myplanet/providers/settings_provider.dart';
 
 /// Guards the *values* in the locale files, which nothing checked before.
@@ -254,49 +255,90 @@ void main() {
 
   test('no locale value is an untranslated Kotlin source string', () {
     // Phase 141, and the other end of `format_derivation_test`'s trust-floor
-    // guard: that one pins the predicate, this one pins the shipped files, so
-    // *any* route into the bad state fails rather than only the one anticipated.
+    // guard: that one pins the predicate against the real XML, this one pins the
+    // shipped files, so a bad value fails however it got there.
     //
-    // 47 of the Kotlin app's 1056 strings are byte-identical to their English
-    // in at least four of the five locales. The `my*` compound family is the
-    // worst of them — `my_survey` is the literal token `mySurveys` everywhere,
-    // `my_library` is `"mylibrary"` everywhere — and it is also exactly what a
-    // tier looser than `casing` would reach, because the port re-spaced Kotlin's
-    // `myLibrary`/`mySurveys` into "My Library"/"My surveys". Adopting one of
-    // those would replace `استطلاعاتي` and `Mes enquêtes` with English and
-    // report it as a recovered human translation.
+    // 47 of the Kotlin app's 1055 translatable strings are byte-identical to
+    // their English in at least four of the five locales. The `my*` compound
+    // family is the worst — `my_survey` is the token `mySurveys` in ar/fr/ne/so
+    // and `my_library` is `mylibrary` in the same four (Spanish translates
+    // both) — and it is also exactly what a tier looser than `casing` reaches,
+    // because the port re-spaced Kotlin's `myLibrary`/`mySurveys` into
+    // "My Library"/"My surveys". Adopting one would replace `استطلاعاتي` and
+    // `Mes enquêtes` with English and report it as a recovered translation.
     //
-    // The Kotlin XML is read rather than the tokens listed here: a hardcoded
-    // list would go stale the moment upstream translates one of them.
+    // **The match has to be looser than the tool's**, or this guard cannot see
+    // the keys it exists for. Its first cut keyed on `_camelCase` alone, which
+    // maps `my_survey` to `mySurvey` — not a template key — and read the XML
+    // with a regex that left Android's quoting on, so `my_library` came back as
+    // `"mylibrary"` with the quotes. Between them, `ai_chat` was the only thing
+    // the test could ever have found. Matching loosely here is safe: it only
+    // selects which pairs to *check*, and the policy of refusing to adopt at
+    // that looseness lives in the tool.
+    //
+    // **What this cannot see, and why the tool holds the real line.** The
+    // comparison below is byte-exact, so it catches a value that *is* the source
+    // string. It does not catch the case-aligned form the tool would actually
+    // write (`Mylibrary`, `MySurveys`), and it cannot: at the ARB level "the
+    // untranslated Kotlin source" and "the port's own English" are the same
+    // string modulo case and spacing for precisely this class — the port's
+    // English *is* a re-spacing of Kotlin's. Loosening the comparison to reach
+    // `Mylibrary` also reaches `appTitle` ("myPlanet" against `app_name`'s
+    // "My Planet"), which is correct as it stands. Only the tool sees what a
+    // proposal would *overwrite*, which is where the damage is, so
+    // `isUntranslatedSource` is the guard that matters and this one is the
+    // backstop for the verbatim case.
+    final english = _kotlinStrings('values');
+    final byTight = <String, List<String>>{};
+    for (final name in english.keys) {
+      byTight.putIfAbsent(_tight(name), () => []).add(name);
+      byTight.putIfAbsent(_tight(english[name]!), () => []).add(name);
+    }
+
+    final defects = <String>[];
     for (final code in locales) {
-      final english = _kotlinStrings('values');
       final localised = _kotlinStrings('values-$code');
       final arb = _readArb(code);
-      for (final entry in english.entries) {
-        final source = entry.value.trim();
-        final key = _camelCase(entry.key);
-        final value = arb[key];
-        if (value is! String) continue;
-        // Only a *source* string sitting untranslated is evidence. A locale
-        // value equal to its English where the template says the same thing is
-        // an invariant translation ("HTML", "N/A"), not a missing one.
-        if (source.isEmpty || localised[entry.key]?.trim() != source) continue;
+      for (final key in _messageKeys(arb)) {
+        final value = (arb[key] as String).trim();
         final templateValue = template[key];
-        if (templateValue is! String || templateValue.trim() == source) {
-          continue;
+        if (templateValue is! String) continue;
+        final names =
+            {
+              ...?byTight[_tight(key)],
+              ...?byTight[_tight(templateValue)],
+              if (english.containsKey(key)) key,
+            }..removeWhere(
+              (n) =>
+                  _camelCase(n) != key &&
+                  _tight(n) != _tight(key) &&
+                  _tight(english[n]!) != _tight(templateValue),
+            );
+        for (final name in names) {
+          final source = english[name]!.trim();
+          // Only a *source* string left in place is evidence. A locale value
+          // equal to its English where the template says the same thing is an
+          // invariant translation ("HTML", "N/A"), not a missing one.
+          if (source.isEmpty || localised[name]?.trim() != source) continue;
+          if (templateValue.trim() == source) continue;
+          if (value != source) continue;
+          defects.add(
+            '$code:$key is the untranslated Kotlin source "$name" ("$source"), '
+            'not a translation of the template\'s "$templateValue"',
+          );
         }
-        expect(
-          value.trim(),
-          isNot(source),
-          reason:
-              'app_$code.arb "$key" is the untranslated Kotlin source string '
-              '"${entry.key}" ("$source"), not a translation of the template\'s '
-              '"$templateValue". Adopting one of these replaces a real '
-              'translation with English — see the trust floor in '
-              'tool/arb_from_strings_xml.dart.',
-        );
       }
     }
+
+    expect(
+      defects,
+      isEmpty,
+      reason:
+          '${defects.length} locale value(s) are untranslated Kotlin source '
+          'strings:\n${defects.join("\n")}\n'
+          'Adopting one of these replaces a real translation with English — see '
+          'the trust floor in tool/arb_from_strings_xml.dart.',
+    );
   });
 
   test('the template declares no review state of its own', () {
@@ -486,17 +528,31 @@ bool _usesPlaceholder(String value, String name) =>
 /// A regex rather than an XML parser: the test needs one string, `strings.xml`
 /// writes it on one line, and pulling a parser into the test tree to read it
 /// would be the larger dependency.
-/// Every `<string name=…>` in a `values*` directory, flattened to its text.
+/// Every translatable `<string>` in a `values*` directory, read exactly as
+/// `tool/arb_from_strings_xml.dart` reads it: inline markup flattened, Android's
+/// whitespace quoting undone, `translatable="false"` skipped.
+///
+/// The first cut of this was a regex, and it misread the real file four ways.
+/// `<string name="empty_text" />` is self-closing, so the opener matched and
+/// `(.*?)` ran on to the *next* `</string>` — swallowing `message_placeholder`,
+/// which then existed nowhere in the map. CDATA came back wrapped in its own
+/// `<![CDATA[…]]>`, entities came back unresolved, and the quoting this
+/// function now undoes made `my_library` read as `"mylibrary"` *with* the
+/// quotes, so it could never equal an ARB value — which is what blinded the
+/// guard below to the very key its comment names.
 Map<String, String> _kotlinStrings(String valuesDir) {
-  final xml = File(
-    '../app/src/main/res/$valuesDir/strings.xml',
-  ).readAsStringSync();
+  final document = XmlDocument.parse(
+    File('../app/src/main/res/$valuesDir/strings.xml').readAsStringSync(),
+  );
   final result = <String, String>{};
-  for (final match in RegExp(
-    r'<string name="([^"]+)"[^>]*>(.*?)</string>',
-    dotAll: true,
-  ).allMatches(xml)) {
-    result[match.group(1)!] = match.group(2)!;
+  for (final element in document.findAllElements('string')) {
+    final name = element.getAttribute('name');
+    if (name == null) continue;
+    if (element.getAttribute('translatable') == 'false') continue;
+    final raw = element.innerText;
+    result[name] = raw.length > 1 && raw.startsWith('"') && raw.endsWith('"')
+        ? raw.substring(1, raw.length - 1)
+        : raw;
   }
   return result;
 }
@@ -511,6 +567,15 @@ String _camelCase(String snakeCase) {
           .join();
 }
 
+/// A key reduced to letters and digits only, lower-cased — the loosest match
+/// anybody could reasonably propose. Used here to *find* keys worth checking,
+/// never to adopt one: `my_survey`'s English is `mySurveys` and the template's
+/// is `My surveys`, so neither the name nor the text links them, which is
+/// precisely why the guard could not see the case it was written for.
+String _tight(String value) =>
+    value.replaceAll(RegExp(r'[^\p{L}\p{N}]', unicode: true), '').toLowerCase();
+
+/// The `incorrect_ans` string alone, for the retry-hint test above.
 String _kotlinString(String valuesDir) {
   final xml = File(
     '../app/src/main/res/$valuesDir/strings.xml',

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -252,6 +252,53 @@ void main() {
     );
   });
 
+  test('no locale value is an untranslated Kotlin source string', () {
+    // Phase 141, and the other end of `format_derivation_test`'s trust-floor
+    // guard: that one pins the predicate, this one pins the shipped files, so
+    // *any* route into the bad state fails rather than only the one anticipated.
+    //
+    // 47 of the Kotlin app's 1056 strings are byte-identical to their English
+    // in at least four of the five locales. The `my*` compound family is the
+    // worst of them — `my_survey` is the literal token `mySurveys` everywhere,
+    // `my_library` is `"mylibrary"` everywhere — and it is also exactly what a
+    // tier looser than `casing` would reach, because the port re-spaced Kotlin's
+    // `myLibrary`/`mySurveys` into "My Library"/"My surveys". Adopting one of
+    // those would replace `استطلاعاتي` and `Mes enquêtes` with English and
+    // report it as a recovered human translation.
+    //
+    // The Kotlin XML is read rather than the tokens listed here: a hardcoded
+    // list would go stale the moment upstream translates one of them.
+    for (final code in locales) {
+      final english = _kotlinStrings('values');
+      final localised = _kotlinStrings('values-$code');
+      final arb = _readArb(code);
+      for (final entry in english.entries) {
+        final source = entry.value.trim();
+        final key = _camelCase(entry.key);
+        final value = arb[key];
+        if (value is! String) continue;
+        // Only a *source* string sitting untranslated is evidence. A locale
+        // value equal to its English where the template says the same thing is
+        // an invariant translation ("HTML", "N/A"), not a missing one.
+        if (source.isEmpty || localised[entry.key]?.trim() != source) continue;
+        final templateValue = template[key];
+        if (templateValue is! String || templateValue.trim() == source) {
+          continue;
+        }
+        expect(
+          value.trim(),
+          isNot(source),
+          reason:
+              'app_$code.arb "$key" is the untranslated Kotlin source string '
+              '"${entry.key}" ("$source"), not a translation of the template\'s '
+              '"$templateValue". Adopting one of these replaces a real '
+              'translation with English — see the trust floor in '
+              'tool/arb_from_strings_xml.dart.',
+        );
+      }
+    }
+  });
+
   test('the template declares no review state of its own', () {
     // `app_en.arb` is the source text, not a translation of anything. An
     // `x-mt` flag there would mean the English itself is machine output.
@@ -336,12 +383,24 @@ void main() {
     // which carries the Kotlin `other` for the filter's own chip rather than
     // borrowing `storageOther` — that key is the port of `storage_other`
     // ("Other Files") and its value is wrong, so the chip must not ride on it.
+    //
+    // Phase 141 adds 3 per locale and one more for Arabic. The three are
+    // `takeTestCount`, `retakeTestCount` and `redoSurvey` — template keys added
+    // after Phase 121's derivation run, whose Kotlin `take_test`/`retake_test`/
+    // `redo_survey` ship human translations in all five locales; they needed no
+    // new rule, only a re-run. French gains a fourth, `storagePdfs`, where the
+    // `.arb` carried the English "PDFs" and `values-fr` says "PDF". Arabic's
+    // extra is not a value at all: `progressFilterCompleted` already held
+    // `status_completed`'s Arabic word for word while flagged unreviewed
+    // machine output, because the recovery pass tested unanimity before it
+    // tested whether the value was already one of the candidates, and Kotlin's
+    // `completed` and `status_completed` disagree in Arabic. Marking only.
     const humanReviewed = {
-      'ar': 418,
-      'es': 470,
-      'fr': 417,
-      'ne': 419,
-      'so': 419,
+      'ar': 421,
+      'es': 473,
+      'fr': 419,
+      'ne': 421,
+      'so': 421,
     };
 
     for (final code in locales) {
@@ -427,6 +486,31 @@ bool _usesPlaceholder(String value, String name) =>
 /// A regex rather than an XML parser: the test needs one string, `strings.xml`
 /// writes it on one line, and pulling a parser into the test tree to read it
 /// would be the larger dependency.
+/// Every `<string name=…>` in a `values*` directory, flattened to its text.
+Map<String, String> _kotlinStrings(String valuesDir) {
+  final xml = File(
+    '../app/src/main/res/$valuesDir/strings.xml',
+  ).readAsStringSync();
+  final result = <String, String>{};
+  for (final match in RegExp(
+    r'<string name="([^"]+)"[^>]*>(.*?)</string>',
+    dotAll: true,
+  ).allMatches(xml)) {
+    result[match.group(1)!] = match.group(2)!;
+  }
+  return result;
+}
+
+/// `snake_case` → `camelCase`, the ARB key naming the derivation tool uses.
+String _camelCase(String snakeCase) {
+  final parts = snakeCase.split('_');
+  return parts.first +
+      parts
+          .skip(1)
+          .map((p) => p.isEmpty ? '' : p[0].toUpperCase() + p.substring(1))
+          .join();
+}
+
 String _kotlinString(String valuesDir) {
   final xml = File(
     '../app/src/main/res/$valuesDir/strings.xml',

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -524,7 +524,7 @@ void _recover(List<String> args, {required bool apply}) {
           continue;
         }
         if (isUntranslatedSource(
-          proposal: proposal,
+          localeValue: value,
           kotlinEnglish: english[name] ?? '',
           templateEnglish: templateValue,
         )) {
@@ -778,7 +778,7 @@ String? derivePlainTextValue({
 String _mirrorTrailingSpace(String value, String templateEnglish) =>
     templateEnglish.endsWith(' ') && !value.endsWith(' ') ? '$value ' : value;
 
-/// Whether a candidate translation is really the Kotlin *source* string sitting
+/// Whether [localeValue] is really the Kotlin *source* string sitting
 /// untranslated in a `values-<locale>` file, and must therefore not be adopted.
 ///
 /// 47 of the Kotlin app's 1056 strings are byte-identical to their English in at
@@ -803,18 +803,31 @@ String _mirrorTrailingSpace(String value, String templateEnglish) =>
 /// otherwise this would reject the legitimately invariant values ("HTML",
 /// "PDF", "N/A"), which are translations that happen to equal their source.
 ///
+/// **Judge the raw `values-<locale>` string, never the proposal.** The first
+/// cut of this took `_proposal`'s output and was inert: `_proposal` runs
+/// `_alignInitialCase` for every non-`exact` tier, so `values-ar`'s `mySurveys`
+/// arrives as `MySurveys` and no longer equals the `mySurveys` it is a copy of.
+/// The guard returned false on both examples its own comment names, and the
+/// unit test pinning it passed only because the fixture handed it a `proposal`
+/// the pipeline cannot produce — a fabricated join, which is the shape this
+/// project has been caught by before. Comparing the untransformed locale value
+/// is what makes the question answerable at all: "did this translator leave the
+/// source string in place" is a fact about the XML, not about our rendering
+/// of it.
+///
 /// No tier reaches this today; it is the guard that keeps the floor safe by
 /// construction rather than by luck. `test/l10n/format_derivation_test.dart`
-/// pins it, and `test/l10n/placeholder_integrity_test.dart` pins the outcome
-/// from the other end, over the shipped `.arb` files.
+/// pins it against the real `values-*/strings.xml`, and
+/// `test/l10n/placeholder_integrity_test.dart` pins the outcome from the other
+/// end, over the shipped `.arb` files.
 bool isUntranslatedSource({
-  required String proposal,
+  required String localeValue,
   required String kotlinEnglish,
   required String templateEnglish,
 }) {
   final source = kotlinEnglish.trim();
   if (source.isEmpty || source == templateEnglish.trim()) return false;
-  return proposal.trim() == source;
+  return localeValue.trim() == source;
 }
 
 /// Whether [current] is something other than a human translation, and may

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -523,6 +523,13 @@ void _recover(List<String> args, {required bool apply}) {
             _printfSpecifier.hasMatch(proposal)) {
           continue;
         }
+        if (isUntranslatedSource(
+          proposal: proposal,
+          kotlinEnglish: english[name] ?? '',
+          templateEnglish: templateValue,
+        )) {
+          continue;
+        }
         byKotlinName[name] = proposal;
       }
       // A locale entry that is still the English is an untranslated string, not
@@ -564,10 +571,20 @@ void _recover(List<String> args, {required bool apply}) {
         // The Kotlin name exists but this locale never translated it. Nothing
         // to recover; not a disagreement either.
         verdict = 'no-translation';
+      } else if (current != null && proposals.contains(current)) {
+        // The value already *is* one of the Kotlin translations — which settles
+        // it whether or not the candidates agree with each other. This used to
+        // sit below the unanimity test, so a key whose two Kotlin names
+        // disagreed was called `no-unanimous` even when the `.arb` carried one
+        // of them verbatim, and `_adopt`'s flag reconciliation (which only ever
+        // looks at `apply` and `already`) never reached it. `progressFilterCompleted`
+        // is the live instance: Kotlin's `completed` and `status_completed` are
+        // different Arabic strings, `app_ar.arb` holds `status_completed`'s
+        // word for word, and it was still flagged unreviewed machine output.
+        // Nothing a user sees changes here — only the marking.
+        verdict = 'already';
       } else if (proposals.length != 1) {
         verdict = 'no-unanimous';
-      } else if (current == proposals.single) {
-        verdict = 'already';
       } else if (current != null &&
           _sameButForSpacing(current, proposals.single)) {
         // Identical words, different space character. `app_fr.arb` writes
@@ -760,6 +777,45 @@ String? derivePlainTextValue({
 /// does, this is the function to extend rather than a third one to add.
 String _mirrorTrailingSpace(String value, String templateEnglish) =>
     templateEnglish.endsWith(' ') && !value.endsWith(' ') ? '$value ' : value;
+
+/// Whether a candidate translation is really the Kotlin *source* string sitting
+/// untranslated in a `values-<locale>` file, and must therefore not be adopted.
+///
+/// 47 of the Kotlin app's 1056 strings are byte-identical to their English in at
+/// least four of the five locales — `my_survey` is the literal token
+/// `mySurveys` in all five, `my_library` is `"mylibrary"` in all five. They are
+/// not translations, and adopting one *replaces* a translation with English:
+/// `app_ar.arb` holds `استطلاعاتي` for `mySurveys` and `app_fr.arb` holds
+/// `Mes enquêtes`, both of which such an adoption would overwrite.
+///
+/// The caller already drops a proposal equal to the *template's* English, which
+/// is the same idea — but only sound while every tier matches English that is
+/// byte-identical to the template's. The three tiers today do: `_proposal`
+/// normalises a punctuation- or casing-tier value back toward the template, so
+/// an untranslated one collapses onto it and is caught. A tier matching on
+/// anything looser would not, and the `my*` compound family is exactly what
+/// such a tier reaches — the port re-spaced Kotlin's `myLibrary`/`mySurveys`
+/// into "My Library"/"My surveys", so those keys sit one notch below the
+/// ladder's floor with Kotlin translations that inherit the original defect.
+///
+/// So the comparison that actually means "untranslated" is against the Kotlin
+/// string's *own* English, and only where that differs from the template's —
+/// otherwise this would reject the legitimately invariant values ("HTML",
+/// "PDF", "N/A"), which are translations that happen to equal their source.
+///
+/// No tier reaches this today; it is the guard that keeps the floor safe by
+/// construction rather than by luck. `test/l10n/format_derivation_test.dart`
+/// pins it, and `test/l10n/placeholder_integrity_test.dart` pins the outcome
+/// from the other end, over the shipped `.arb` files.
+bool isUntranslatedSource({
+  required String proposal,
+  required String kotlinEnglish,
+  required String templateEnglish,
+}) {
+  final source = kotlinEnglish.trim();
+  if (source.isEmpty || source == templateEnglish.trim()) return false;
+  return proposal.trim() == source;
+}
 
 /// Whether [current] is something other than a human translation, and may
 /// therefore be replaced. See the header — this is the guard that keeps the


### PR DESCRIPTION
Lane D of the Phase 141 parallel round. Full detail in `flutter/PHASE_141_NOTES.md`.

**Owned files only:** `flutter/lib/l10n/app_{ar,es,fr,ne,so}.arb`, `flutter/tool/arb_from_strings_xml.dart`, `flutter/test/l10n/*`, `flutter/PHASE_141_NOTES.md`. `app_en.arb` untouched.

## Outcome

**The recoverable pool is essentially exhausted, and the reason is a floor rather than a backlog.** No machine translation was generated.

**Recovered — 16 values**, all by re-running the existing tool, no new matching rule:
- `takeTestCount`, `retakeTestCount`, `redoSurvey` × 5 locales — template keys added after Phase 121's derivation run whose Kotlin counterparts ship human translations. Nobody re-ran the tool. (Phase 130 hit the identical shape.)
- `fr/storagePdfs` — the ARB carried English "PDFs" and French supplies "PDF". Provenance is the *sibling* `filter_pdfs`, not the namesake `storage_pdfs`, which French itself leaves untranslated.

**Marking fixes, no rendered string changes:** `ar/progressFilterCompleted` lost a stale `x-mt` flag (the verdict cascade tested unanimity before membership); `aiChat` dropped from ar/fr/ne/so, which held English "AI Chat" as an *unflagged human* translation.

## The finding: why the tier ladder stops at `casing`

11 template keys match one notch below it. A tier reaching them would adopt **42 values — measured before writing any code, and almost all degradations**: `mySurveys` is the literal token `mySurveys` in **four of five** Kotlin locales (Spanish renders `misEncuestas`) and would overwrite Arabic `استطلاعاتي` and French `Mes enquêtes`. **47 of the Kotlin app's 1055 translatable strings are byte-identical to their English in ≥4 of 5 locales.** The port's English is a *correction* of Kotlin's — it re-spaced `myLibrary` into "My Library" — so Kotlin's translations there inherit the original defect. The floor is where the Kotlin data stops being trustworthy.

## What the audit changed (second commit)

A `parity-auditor` pass at `effort: max` against this phase's own finished, green work found **both guards inert**, each failing on the exact example its own doc comment named.

`isUntranslatedSource` judged `_proposal`'s *output*, and `_proposal` case-aligns every non-`exact` tier — so `mySurveys` arrived as `MySurveys`. Simulating the whitespace tier with the guard on and off gave **42 adoptions either way: it blocked nothing.** It now judges the raw locale XML value. The unit test passed only because its fixture handed it a `proposal` the pipeline cannot emit — a fabricated join; the tests now drive the real `values-*/strings.xml`.

The ARB-side backstop found `aiChat` on first run and **that was the only thing it could ever have found**: it keyed on `_camelCase` (`my_survey` → `mySurvey`, not the template's `mySurveys`) and its regex left Android's quoting on, so `my_library` read as `"mylibrary"` *with* quotes. Now parses XML properly — which also fixed three silent misparses, one a self-closing `<string/>` swallowing the next element so `message_placeholder` appeared nowhere in the map.

Its remaining limit is stated in the test rather than papered over: byte-exact comparison cannot separate "the untranslated source" from "the port's own English" at the ARB level, because the port's English *is* a re-spacing of Kotlin's. The tool holds the real line — only it sees what a proposal would *overwrite*.

**No `.arb` file changed in that commit.** The audit reproduced all five byte-identically from the pre-141 state; the defects were in guards and claims, not data.

## Reported, not fixed (for the integrator)

**`app_en.arb`'s three printf keys render their own format specifier.** `communityEarnings` declares `{amount: int}` while its English carries `%1$d`, which ICU never interpolates — the getter takes the argument and drops it. Kotlin renders these correctly, so it is a genuine parity defect.

**It is latent, not live**, and an earlier revision of this PR said otherwise. The only caller is `challenge_dialog.dart`, gated on a prompt window that closed **2025-01-16**; and `perSurvey` — the one key a template fix would unlock — has **zero callers**. So a fix corrects 3 rendering defects and puts 0 translations on a screen. Calling it live was the reachability over-read this project has been caught by three times in the same direction.

Also reported: 4 deliberately-uncleared `x-mt` flags; `values-ne`/`values-so` have their `minutes`/`hours`/`days` `<plurals>` **swapped upstream** (Nepali contains Somali); ~26 English-valued keys per locale inflating the coverage count; and nothing re-runs the derivation when a template key is added, which is why 15 of the 16 recoveries were sitting there.

## Gate

```
flutter gen-l10n  ✅   dart format ✅ (0 changed)
flutter analyze   ✅   No issues found
flutter test      ✅   2462 passed (was 2457)
```
Tool idempotent across derive → adopt → derive, verified by checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbKfoqK2QygFPKed6CE1f3