### PR TITLE
Phase 140 (Lane C): port the chat share to the Flutter port

### DIFF
--- a/flutter/PHASE_140_NOTES.md
+++ b/flutter/PHASE_140_NOTES.md
@@ -39,9 +39,15 @@ was missing was a writer, and everything upstream of it. No schema bump needed.
 | share affordance + three dialogs | `lib/ui/chat/chat_history_screen.dart` | `ChatHistoryAdapter.bindShareChat`, `showGrandChildRecyclerView`, `showEditTextAndShareButton` |
 | 7 English keys | `lib/l10n/app_en.arb` | `share_chat`, `share_with_team_enterprise`, `add_note`, `chat_already_shared_to_destination`, `join_team_first`, `join_enterprise_first`, plus a shared-confirmation string |
 
-48 new tests in four files. Every claim below was mutation-tested: each piece
-was reverted in turn and the expected test confirmed to fail (15 mutations, 15
-caught — the list is at the bottom).
+**60 new tests** in four files (11 + 20 + 15 + 14, counted from the runner, not
+remembered). Every claim below was mutation-tested: each piece was reverted in
+turn and the expected test confirmed to fail — 24 mutations, 24 caught. The
+list is at the bottom.
+
+Two `parity-auditor` passes at `effort: max` ran, one on the Kotlin ground truth
+before implementing and one on the finished green code. **Both found things**,
+and the second found two defects that green tests could not have caught, plus
+one wrong claim of mine. They are in *What the second audit changed* below.
 
 ## The three reachability questions
 
@@ -177,64 +183,143 @@ string is the bug, not the baseline.
   membership set short-circuits to an empty list** rather than falling through
   to the whole catalog.
 
+## What the second audit changed
+
+The pass on the finished code found nine things. Six were acted on; the rest are
+in *Reported, not fixed*.
+
+**Every chat share reached CouchDB with no author.** `serializeNews` writes no
+top-level `userId` or `userName` — the nested `user` object is the *only* author
+identity a news document carries, and `NewsMapper.fromDoc` reads both back out
+of it. So an author-less share showed no author on Planet **and** lost its
+author on this device at the next sync-in. Kotlin sets
+`news.user = gson.toJson(user.serialize())`. The port's `createPost` has never
+passed one, so this was pre-existing — but shipping a new writer with the same
+hole is not "pre-existing", it is a new instance. `VoicesRepository.authorJson`
+is `serialize()` minus the credential branch (`password` / `derived_key` /
+`salt` / `password_scheme`), the device trio, and the `_attachments` photo. A
+voices post is a public document; `UserMapper.toDoc` is the `_users` PUT body
+and must never be used here. The test asserts the fields that must be present
+*and* the four that must not.
+
+**The community branch could not be reached in the running app.** The provider
+read `PlanetPrefs.communityName`, and **nothing in `lib/` ever calls
+`setCommunityName`** — the pref's only writer was one of my own tests. So
+`community` was permanently null, the community row never rendered, and the
+whole branch was dead behind green tests, including the checkmark path and four
+widget assertions. Kotlin writes the configuration document's `code` into that
+pref; the port persists the same value as `ServerConfig.code`, which is now the
+fallback. **The tell was in the fixture**: the test hand-set a pref production
+never sets, with a comment explaining that the value is really the configuration
+code — true of the Kotlin, false of the port. That test now drives the config
+path, and a second one keeps the pref precedence.
+
+**A member registered offline was offered no teams at all.**
+`chatShareTargetsProvider` scoped memberships by `session.id` where Kotlin uses
+`currentUser?._id`. They coincide for a synced account, but a member registered
+on-device keeps a locally minted `'<millis>'` id while their membership document
+carries `org.couchdb.user:<name>` — and here it is a *hard* filter, so that user
+saw "Please join a Team to share this chat" while being a member. My first cut
+had logged this as a note-worthy inconsistency, which undersold it: in
+`teams_provider` the same divergence only affects sort order. Fixed to
+`couchId ?? id`, matching what the write path two methods away already did.
+
+**The "cannot share" snackbar said "Chats could not be loaded".** Two of the
+three routes to `ChatShareOutcome.unavailable` have nothing to do with loading,
+and the chat is visibly on screen. A new key, `chatCannotBeShared`.
+
+**The stale-destination window.** Only a local share refreshed the map, so a
+share pulled from another device left the destination tappable until the app
+restarted. `ChatShareActions.destinations()` now recomputes on every dialog
+open, which is what Kotlin does on every `refreshChatSignal`. Note the Riverpod
+detail: `invalidate` then `read` still resolves the *stale* future in the same
+microtask — it must be `refresh`. The first cut used `invalidate` and the test
+caught it.
+
+**One of my test comments stated a Kotlin behaviour that is false.** It said a
+null conversation list makes `createNews` dereference a null and throw an
+uncaught NPE. It does not: `gson.toJson(null)` yields `"null"`, `fromJson`
+raises `JsonSyntaxException`, and the inner `catch (e: JsonSyntaxException)`
+catches it, leaving the column null. The notes had this right and the test
+comment contradicted them in the same commit pair. Corrected. This is the second
+Kotlin claim of mine this phase that a `parity-auditor` pass overturned by
+*running* the code rather than reading it — the first being the `=` replace.
+
+**Three comment claims that nothing pinned** now have tests: the two
+`await …future`-inside-`try` guards (a rejecting `sessionProvider`, a rejecting
+`chatShareTargetsProvider`), and `String.toBoolean()`'s case-insensitivity. All
+three mutate-and-fail. A near-tautological test — `viewInSection` is carried
+verbatim, which would pass for any literals — gained a sibling that pins the
+three constants themselves, since those literals *are* the deviation.
+
 ## Reported, not fixed
 
-Four of these need a file another lane owns this round. Each names the file, the
-change, and why.
+Each names the file, the change, and why it was not made here.
 
 1. **`teams` has no `teamPlanetCode` column**, so `messagePlanetCode` is `""` on
-   every chat share the port sends. `MyTeam.teamPlanetCode` is read from the
-   team document (`MyTeam.kt:86`) and is the third of the three `TeamSummary`
-   fields the payload uses. Fix: a nullable `teamPlanetCode` text column on
-   `Teams` in `lib/data/local/tables.dart`, populated in
-   `lib/data/local/team_mapper.dart`, and a `schemaVersion` bump in
+   every chat share the port sends. Kotlin sends `team.teamPlanetCode`
+   (`ChatSharePayload.kt:29`, read at `MyTeam.kt:86`). Fix: a nullable
+   `teamPlanetCode` column on `Teams` in `lib/data/local/tables.dart`, populated
+   in `lib/data/local/team_mapper.dart`, and a `schemaVersion` bump in
    `lib/data/local/app_database.dart` (**Lane A's file**, and no number is
-   allocated to this lane). `ChatShareTarget.teamPlanetCode` already exists and
-   is already tested with a non-null value, so only `_targetOf` changes.
-   Severity: low — Kotlin sends `""` too for a team document that omits the
-   field, and nothing in either app reads it back.
+   allocated to this lane). `ChatShareTarget.teamPlanetCode` exists and is
+   tested with a non-null value, so only `_targetOf` changes. Severity: low —
+   Kotlin sends `""` too when the document omits the field, and nothing reads it
+   back. Worth pairing with a second observation: the port's `createTeamPost`
+   writes `messagePlanetCode: user.planetCode` for a team *voice* post, so the
+   port now has two writers addressing the same team with two different values
+   for one field, where Kotlin uses `team.teamPlanetCode` for both.
 2. **`NewsDao` has no `getByNewsId` or `getPlanetMessages`.** `isAlreadyShared`
-   and `planetNewsMessages` walk `getAll()` and filter in Dart instead. Same
-   result set, more rows read — the Kotlin filters in memory after
-   `getByNewsId` anyway. Fix: two queries on `NewsDao` in
-   `lib/data/local/app_database.dart` (**Lane A's file**):
-   `SELECT * FROM news WHERE newsId = ?` and
+   and `planetNewsMessages` walk `getAll()` and filter in Dart. Same result set,
+   more rows read — the Kotlin filters in memory after `getByNewsId` anyway.
+   Fix: two queries on `NewsDao` in `lib/data/local/app_database.dart`
+   (**Lane A's file**): `WHERE newsId = ?`, and
    `WHERE docType = 'message' COLLATE NOCASE AND createdOn = ? COLLATE NOCASE`.
-3. **The `viewInSection` deviation is not in the migration tracker.**
-   `docs/kotlin-to-flutter-migration.md` (**Lane A's file**) lists faithful
-   quirks and deliberate deviations, and this is in neither. Suggested line, for
-   the deviations list: *"`viewIn[].section` is written as the stable literal
+3. **Six deviations want recording in the migration tracker.**
+   `docs/kotlin-to-flutter-migration.md` (**Lane A's file**) has no chat-share
+   entry in either its faithful-quirks or its deliberate-deviations list. The
+   full set: the stable-literal `viewInSection`; `[]` rather than `"null"` for a
+   null conversation list; `ChatShareOutcome.unavailable` where Kotlin drops the
+   tap; not rendering a community row when the target is null; recomputing the
+   shared-destination map on dialog open; and the "Chat shared" confirmation
+   snackbar, which Kotlin has no counterpart for. Suggested line for the first:
+   *"`viewIn[].section` is written as the stable literal
    `community`/`teams`/`enterprises`. `ChatHistoryAdapter` passes the localised
    `strings.xml` value, so a community share from a non-English handset writes a
    translated section and is invisible to `isVisibleToUser`, which matches
    `"community"`."*
-4. **A locally authored `news` row carries no `user` object.**
-   `News.createNews` sets `news.user = gson.toJson(user.serialize())` and the
-   uploaded document carries the whole user object; the port's `createPost` has
-   never passed a `userJson`, so `serialize` writes `'user': null` for every
-   post the port authors, chat shares included. `createFromShareMap` accepts a
-   `userJson` parameter and is ready for it. **Do not wire `UserMapper.toDoc`
-   into it** — that is the `_users` PUT body and carries `derived_key`/`salt`;
-   Planet reads `user.name` and `user._id` off a news document, so this wants a
-   small display-only projection. Pre-existing and port-wide, not introduced
-   here; `lib/providers/voices_provider.dart` is the other caller.
-
-Two more, outside anyone's file set:
-
-5. **`chatShareTargetsProvider` scopes memberships by `session.id`** where the
-   Kotlin uses `currentUser?._id`. Identical for a synced account (both are the
-   CouchDB `_id`), different for one created offline, whose `id` is a random
-   UUID. The port's own teams catalog uses `session.id`, so this follows the
-   port's convention rather than the Kotlin's; worth one deliberate decision
-   somewhere rather than two conventions.
+4. **There is no periodic voices upload sweep, and the enqueue is conditional.**
+   Kotlin's `uploadNews()` is an unconditional full-table sweep from
+   `AutoSyncWorker` and `UserDataWorker`, so a share cannot be stranded. The
+   port enqueues at write time — which is better when it runs — but
+   `ChatShareActions.share` skips the enqueue when `serverConfigProvider` is
+   null (there is no endpoint to queue against) and still reports success, and
+   nothing else ever sweeps `VoicesRepository.pendingUploads`. Grepped:
+   `dashboard_sync_provider.dart`, `background_entrypoint.dart` and
+   `outbox_drain_scope.dart` mention no voices uploader. This is exactly the
+   Phase 134 shape — a safety net Kotlin has and the port does not — and it
+   covers *every* port-authored voice, not just chat shares, so it wants its own
+   slice rather than a corner of this one. **The earlier claim in these notes
+   that "a shared chat cannot sit undelivered on the device" was too strong and
+   is withdrawn.**
+5. **A locally authored `news` row still carries no author on the other two
+   write paths.** `VoicesRepository.authorJson` now exists and is used by the
+   chat share; `createPost`, `createTeamPost` and `postReply` — called from
+   `lib/providers/voices_provider.dart`, outside this lane's files — still pass
+   none, so every ordinary voice post and reply the port authors uploads with
+   `"user": null` and loses its author locally on the next sync-in. One
+   argument each: `userJson: VoicesRepository.authorJson(user)`.
 6. **The port's "root team" predicate is `docType IS NULL` where Kotlin's is
-   `teamId IS NULL OR TRIM(teamId) = ''`.** Pre-existing in `watchCatalog` and
-   shared with the whole teams catalog; noted because the share now depends on
-   it too.
+   `teamId IS NULL OR TRIM(teamId) = ''`,** and `watchCatalog` adds an
+   `ORDER BY name ASC` that `getRootTeamsByType` does not have. Both
+   pre-existing in the shared teams catalog; noted because the share now depends
+   on them.
 
 ## Mutations run
 
 Each was applied alone to green code and reverted; all 15 were caught.
+
+**Round one — the port itself.**
 
 | Mutation | Caught by |
 |---|---|
@@ -253,3 +338,17 @@ Each was applied alone to green code and reverted; all 15 were caught.
 | membership scoping removed | provider: 2 target tests |
 | unsynced-chat gate removed | provider: `unavailable` |
 | share affordance renamed | 4 widget tests |
+
+**Round two — the fixes the second audit prompted.**
+
+| Mutation | Caught by |
+|---|---|
+| author object not passed | provider: the uploaded document names its author |
+| author object carries `derived_key` | the same test's negative assertions |
+| `communityName` read from the pref only | provider: the community id comes from the configuration code |
+| memberships scoped by the row id | provider: a member registered offline is still offered their teams |
+| `destinations()` reads the cache instead of refreshing | provider: a share arriving from elsewhere |
+| `unavailable` reuses `chatsUnavailable` | widget: an unshareable chat says so |
+| the `sessionProvider` try/catch removed | provider: a rejecting session is reported, not thrown |
+| the chat flag parsed case-sensitively | round trip: the chat flag is read the way Kotlin reads it |
+| the screen's try/catch removed | widget: a rejecting targets provider |

--- a/flutter/PHASE_140_NOTES.md
+++ b/flutter/PHASE_140_NOTES.md
@@ -1,8 +1,255 @@
-# Phase 140 — chat share (Kotlin `ChatSharePayload` → Flutter)
+# Phase 140 — the chat share (Lane C)
 
-Lane C of a four-lane round. Status: in progress.
+Kotlin's chat history can **share a conversation into the voices feed** — to a
+team, an enterprise, or the planet community. The port had none of it. Phase 133
+checked upstream `7167684` ("smoother chat history model payload sharing"),
+found the port unaffected, and said why: not because the port matches, but
+because `ChatSharePayload.buildShareMap` has no counterpart at all.
 
-Gap, as logged by Phase 133: `ChatSharePayload.buildShareMap` has no counterpart
-in `flutter/lib` — the port has no chat share at all.
+## What the share actually is
 
-(Notes filled in as the phase proceeds.)
+Not a system share sheet, and not a chat-to-chat forward. A shared chat becomes
+a **`news` document** — the same table the voices feed reads — with `chat: true`
+and the whole conversation embedded under a nested `news` object:
+
+```
+ChatHistoryAdapter (share icon)
+  → target dialog → team/enterprise picker → note dialog
+  → ChatSharePayload.buildShareMap(chat, note, team, section, nowMillis)
+  → ChatViewModel.shareChatToVoices
+       ├ VoicesRepositoryImpl.isAlreadyShared(chatId, viewInId) → snackbar
+       └ VoicesRepositoryImpl.createNews → News.createNews → newsDao.upsert
+  → UploadManager.uploadNews (a full-table sweep, on the next sync)
+```
+
+So the repository is `VoicesRepository`, not `ChatRepository`, and the upload
+path is the voices one. Every column the payload fills — `newsId`, `newsRev`,
+`newsUser`, `aiProvider`, `newsTitle`, `conversations`, `newsCreatedDate`,
+`newsUpdatedDate`, `chat` — **already existed** on the port's `NewsEntries`
+table and was already written to the wire by `VoicesRepository.serialize`. What
+was missing was a writer, and everything upstream of it. No schema bump needed.
+
+## What landed
+
+| Piece | Where | Ports |
+|---|---|---|
+| `buildChatShareMap`, `ChatShareTarget`, `ChatShareSection` | `lib/repository/chat_repository.dart` | `model/ChatSharePayload.kt`, the three `TeamSummary` fields the share reads |
+| `createFromShareMap`, `isAlreadyShared`, `planetNewsMessages`, `extractSharedViewInIds` | `lib/repository/voices_repository.dart` | the `map["news"]` branch of `News.createNews`, `VoicesRepositoryImpl:77-81`, `NewsDao.getPlanetMessages`, `ChatRepositoryImpl:288-315` |
+| `chatShareTargetsProvider`, `sharedChatDestinationsProvider`, `ChatShareActions` | `lib/providers/chat_provider.dart` | `ChatViewModel.loadShareTargets` / `shareChatToVoices` / the fragment's gate |
+| share affordance + three dialogs | `lib/ui/chat/chat_history_screen.dart` | `ChatHistoryAdapter.bindShareChat`, `showGrandChildRecyclerView`, `showEditTextAndShareButton` |
+| 7 English keys | `lib/l10n/app_en.arb` | `share_chat`, `share_with_team_enterprise`, `add_note`, `chat_already_shared_to_destination`, `join_team_first`, `join_enterprise_first`, plus a shared-confirmation string |
+
+48 new tests in four files. Every claim below was mutation-tested: each piece
+was reverted in turn and the expected test confirmed to fail (15 mutations, 15
+caught — the list is at the bottom).
+
+## The three reachability questions
+
+**Who writes this table?** `createFromShareMap`, and nothing else. Before this
+phase the chat columns on `news` had a mapper that read them, a serializer that
+wrote them to the wire, and a viewer that could render them — and no writer at
+all, which is why the round trip was green and dead.
+
+**Can the writer produce values the reader's predicate matches?** This is where
+the trap was. The already-shared marker is computed by
+`extractSharedViewInIds(getPlanetNewsMessages(user.planetCode))`, and
+`getPlanetMessages` is `WHERE docType = 'message' AND createdOn = :planetCode`.
+So a share whose row omits `createdOn`, or writes any `docType` but `message`,
+uploads correctly and is invisible to every "already shared" checkmark. Both
+pairings have a test that drives the writer and then the reader —
+`a share is found by planetNewsMessages and mapped to its chat` — and both fail
+when the writer is mutated. Likewise `newsId` must be the *chat's* CouchDB id,
+because that is what `isAlreadyShared` looks a row up by; sourcing it from the
+outer map instead fails four tests across two files.
+
+**Does anything navigate here?** The share icon on each chat row is the only
+entrance, and `every chat row offers a share action` is the test that says so.
+Renaming its key turns four widget tests red.
+
+A fourth question this slice needed: **does anything deliver it?** Kotlin
+uploads news by sweeping the entire table on every sync
+(`getNewsForUpload` = `newsDao.getAll()` minus guests) — there is no queue, so
+a share cannot be stranded. The port has no such sweep, so `ChatShareActions`
+enqueues at write time, the shape `VoicesActions` already uses.
+`a share writes the voices row and queues it for upload` asserts the outbox row
+and its payload; deleting the enqueue turns it red.
+
+## Two Kotlin lines deliberately not carried across
+
+**`News.kt:187`'s `newsObj?.replace("=", ":")`.** A fossil from when the value
+was a `HashMap.toString()` (`{_id=abc}`) rather than JSON. It is a **no-op in
+Kotlin**, and not for any reason visible in the source: `JsonUtils.gson` is a
+bare `Gson()`, whose `htmlSafe` default escapes `=` to `=` inside every
+string, so the encoded payload contains no `=` to replace. Dart's `jsonEncode`
+emits `=` raw. Porting the line would rewrite every `=` in the user's own title
+and transcript — `2+2=4`, a URL query string, base64 padding — and CouchDB
+would keep the damage. Dropping it *preserves* behaviour rather than diverging
+from it. **My first draft of this note had the reasoning backwards** — it said
+the Kotlin corrupts the text and the port declines to. It does not; the
+ground-truth `parity-auditor` pass caught it by running Gson rather than reading
+it. The behaviour is the same either way, but the note would have seeded a false
+belief about the Kotlin, so it is corrected here and at the code.
+
+**The localised `viewInSection`.** `ChatHistoryAdapter` passes
+`context.getString(R.string.teams)` / `R.string.enterprises` /
+`R.string.community` straight into the payload, so the value that reaches
+CouchDB is whatever the handset's locale renders. Every reader on both sides
+compares against the literal `"community"` (`isVisibleToUser`,
+`calculateSortDate`, `deletePost`, and the port's ports of all three), so **a
+community share made on a Spanish or French handset is invisible in the
+community feed of both apps, permanently, in the stored document**. The port
+writes the stable literals `community` / `teams` / `enterprises`, which is what
+every other writer on both sides already does (`VoicesFragment` writes
+`"community"`, `TeamsVoicesFragment` writes `"teams"`, the port's
+`createTeamPost` writes `"teams"`). In English the only observable difference is
+that `R.string.enterprises` is `"Enterprises"` with a capital E, and nothing
+reads that value. This is the `9c037f2` lesson — routing on a localised display
+string is the bug, not the baseline.
+
+## Smaller divergences, each deliberate
+
+- **A null-titled chat.** Upstream `7167684` changed `"${chatHistory.title}".trim()`
+  to `(chat.title ?: "").trim()`; a Kotlin template of null renders the four
+  characters `null`, so an untitled chat used to be shared under the title
+  `"null"`. The **current** behaviour is ported and pinned, and reinstating the
+  template turns two payload tests red.
+- **A chat with no conversations.** Kotlin's `gson.toJson(null)` writes the
+  string `"null"`, which `createNews` hands to `fromJson(..., JsonArray)`; that
+  throws `JsonSyntaxException`, is caught, and leaves the column null. The port
+  writes `[]`, whose consumer also leaves the column null. Same end state, no
+  exception on the way.
+- **`viewIn`'s `name` key is absent, not null.** `getViewInJson` writes
+  `map["name"]`, which `buildShareMap` never sets; Gson's `serializeNulls` is
+  off, so the key is dropped. This is load-bearing rather than cosmetic:
+  `shareToCommunity` back-fills the first entry's name only when
+  `!containsKey('name')` (Kotlin's `!obj.has("name")`, false for an explicit
+  null), so writing `"name": null` would silently disable that back-fill for
+  every post sharing the helper. `_viewInJson` now omits it, and a test shares a
+  chat to a team and then to the community and asserts the name arrives.
+- **A community target that does not exist.** Kotlin still renders and enables
+  the community row when `shareTargets.community` is null (the row comes from a
+  static map), so the user picks it, types a note, taps *share chat* — and
+  nothing happens: no row, no upload, no snackbar, no log. The port does not
+  render the row at all in that case (`a planet with no community offers no
+  community entry`). Silence is not a behaviour worth porting.
+- **The shared-destination cache is refreshed after a successful share.**
+  Kotlin's `ChatHistoryFragment:225-235` appends the new `News` to its list but
+  passes the *unchanged* `sharedViewInIds`, so the checkmark does not appear
+  until a realtime sync signal rebuilds the screen — and a second share of the
+  same chat walks the whole dialog flow again before the snackbar tells the user
+  it was pointless. The port invalidates `sharedChatDestinationsProvider`. The
+  "already shared" path stays reachable (another device, another user on the
+  same planet, or a row whose `createdOn` differs from the viewer's planet code)
+  and has its own test.
+- **`ChatShareOutcome.unavailable` instead of a dropped tap.** The fragment's
+  `if (chatId.isNotEmpty() && viewInId.isNotEmpty())` gate is kept — a chat the
+  server has never seen cannot be shared, because the payload's `newsId` is what
+  every duplicate check keys on — but the port says so in a snackbar rather than
+  discarding the tap.
+
+## Faithful quirks worth naming, because they look like bugs
+
+- **The row's own `updatedDate` is `0`.** `createNews` reads `map["updatedDate"]`
+  from the **outer** map, which `buildShareMap` never writes — the millis only
+  go into the nested object. So `updatedDate` is 0 while `newsUpdatedDate`
+  carries the share time. My first cut of the round-trip test asserted the share
+  time here and failed; the *test* was wrong.
+- **Three different timestamps.** `time` is `Date().time` inside `createNews`,
+  `newsCreatedDate`/`newsUpdatedDate` are the dialog's `nowMillis` (one read,
+  since `7167684`), and `updatedDate` is 0. Not collapsed.
+- **Stringified millis.** Every value of the payload is a `String`, the nested
+  `createdDate`/`updatedDate` included; `JsonUtils.getLong`'s
+  `asString.toLongOrNull()` fallback is what turns them back into numbers, and
+  they are numbers on the wire. `_shareMillis` ports that fallback, and removing
+  it turns two tests red.
+- **The nested `conversations` is a JSON array encoded into a string**, which is
+  why `createNews` re-parses it out of a string primitive. A port that wrote a
+  real array would store **null** conversations with nothing erroring.
+- **`isAlreadyShared` and the checkmark cache disagree on purpose.**
+  `isAlreadyShared` is a case-*insensitive* raw substring match on `viewIn`
+  (`"_id":"<id>"`) with no planet scope; `extractSharedViewInIds` parses and
+  compares case-sensitively over rows scoped to the viewer's planet code. Both
+  are ported as they are, with a test on each axis. Unifying them would be a
+  behaviour change.
+- **`messageType` and `messagePlanetCode` are `""` for a community share**,
+  because the community `TeamSummary` is synthesized with both null.
+- **Team and enterprise eligibility is membership-scoped, and an empty
+  membership set short-circuits to an empty list** rather than falling through
+  to the whole catalog.
+
+## Reported, not fixed
+
+Four of these need a file another lane owns this round. Each names the file, the
+change, and why.
+
+1. **`teams` has no `teamPlanetCode` column**, so `messagePlanetCode` is `""` on
+   every chat share the port sends. `MyTeam.teamPlanetCode` is read from the
+   team document (`MyTeam.kt:86`) and is the third of the three `TeamSummary`
+   fields the payload uses. Fix: a nullable `teamPlanetCode` text column on
+   `Teams` in `lib/data/local/tables.dart`, populated in
+   `lib/data/local/team_mapper.dart`, and a `schemaVersion` bump in
+   `lib/data/local/app_database.dart` (**Lane A's file**, and no number is
+   allocated to this lane). `ChatShareTarget.teamPlanetCode` already exists and
+   is already tested with a non-null value, so only `_targetOf` changes.
+   Severity: low — Kotlin sends `""` too for a team document that omits the
+   field, and nothing in either app reads it back.
+2. **`NewsDao` has no `getByNewsId` or `getPlanetMessages`.** `isAlreadyShared`
+   and `planetNewsMessages` walk `getAll()` and filter in Dart instead. Same
+   result set, more rows read — the Kotlin filters in memory after
+   `getByNewsId` anyway. Fix: two queries on `NewsDao` in
+   `lib/data/local/app_database.dart` (**Lane A's file**):
+   `SELECT * FROM news WHERE newsId = ?` and
+   `WHERE docType = 'message' COLLATE NOCASE AND createdOn = ? COLLATE NOCASE`.
+3. **The `viewInSection` deviation is not in the migration tracker.**
+   `docs/kotlin-to-flutter-migration.md` (**Lane A's file**) lists faithful
+   quirks and deliberate deviations, and this is in neither. Suggested line, for
+   the deviations list: *"`viewIn[].section` is written as the stable literal
+   `community`/`teams`/`enterprises`. `ChatHistoryAdapter` passes the localised
+   `strings.xml` value, so a community share from a non-English handset writes a
+   translated section and is invisible to `isVisibleToUser`, which matches
+   `"community"`."*
+4. **A locally authored `news` row carries no `user` object.**
+   `News.createNews` sets `news.user = gson.toJson(user.serialize())` and the
+   uploaded document carries the whole user object; the port's `createPost` has
+   never passed a `userJson`, so `serialize` writes `'user': null` for every
+   post the port authors, chat shares included. `createFromShareMap` accepts a
+   `userJson` parameter and is ready for it. **Do not wire `UserMapper.toDoc`
+   into it** — that is the `_users` PUT body and carries `derived_key`/`salt`;
+   Planet reads `user.name` and `user._id` off a news document, so this wants a
+   small display-only projection. Pre-existing and port-wide, not introduced
+   here; `lib/providers/voices_provider.dart` is the other caller.
+
+Two more, outside anyone's file set:
+
+5. **`chatShareTargetsProvider` scopes memberships by `session.id`** where the
+   Kotlin uses `currentUser?._id`. Identical for a synced account (both are the
+   CouchDB `_id`), different for one created offline, whose `id` is a random
+   UUID. The port's own teams catalog uses `session.id`, so this follows the
+   port's convention rather than the Kotlin's; worth one deliberate decision
+   somewhere rather than two conventions.
+6. **The port's "root team" predicate is `docType IS NULL` where Kotlin's is
+   `teamId IS NULL OR TRIM(teamId) = ''`.** Pre-existing in `watchCatalog` and
+   shared with the whole teams catalog; noted because the share now depends on
+   it too.
+
+## Mutations run
+
+Each was applied alone to green code and reverted; all 15 were caught.
+
+| Mutation | Caught by |
+|---|---|
+| `title` back to the pre-`7167684` template | payload: untitled chat, trimmed title |
+| `chat` flag flipped | payload + round trip + wire doc |
+| nested `conversations` written as raw text, not JSON | 4 tests across two files |
+| empty conversation list stored as `[]` | round trip: column stays null |
+| `createdOn` not written | 4 tests: the planet-scoped readers |
+| `docType` not `message` | the same 4 |
+| `newsId` sourced from the outer map | 4 across two files |
+| `viewIn` writes an explicit `"name": null` | round trip incl. the back-fill pair |
+| `isAlreadyShared` made case-sensitive | round trip: case-insensitive match |
+| `_shareMillis` string branch removed | round trip + wire doc |
+| duplicate check removed | provider: second share refused |
+| enqueue removed | provider: outbox row |
+| membership scoping removed | provider: 2 target tests |
+| unsynced-chat gate removed | provider: `unavailable` |
+| share affordance renamed | 4 widget tests |

--- a/flutter/PHASE_140_NOTES.md
+++ b/flutter/PHASE_140_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 140 — chat share (Kotlin `ChatSharePayload` → Flutter)
+
+Lane C of a four-lane round. Status: in progress.
+
+Gap, as logged by Phase 133: `ChatSharePayload.buildShareMap` has no counterpart
+in `flutter/lib` — the port has no chat share at all.
+
+(Notes filled in as the phase proceeds.)

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -1589,5 +1589,33 @@
   "filterOther": "Other",
   "@filterOther": {
     "description": "Label for the `other` entry in the resources media-type filter. Recovered from the Kotlin `other`. Deliberately NOT `storageOther`: that key is the port of `storage_other` (\"Other Files\"), whose value is currently wrong, and this chip must not move when it is repaired."
+  },
+  "shareChat": "Share chat",
+  "@shareChat": {
+    "description": "Positive button of the note dialog that sends a chat conversation to a team, enterprise or the community. The Kotlin `share_chat` is lowercase (\"share chat\"); sentence case matches every other button label in the port."
+  },
+  "shareWithTeamEnterprise": "Share with team/enterprise",
+  "@shareWithTeamEnterprise": {
+    "description": "Group header in the chat share dialog, above the teams and enterprises entries. Port of `share_with_team_enterprise`."
+  },
+  "addNoteOptional": "Add a note (optional)",
+  "@addNoteOptional": {
+    "description": "Hint of the note field shown before a chat conversation is shared. Port of `add_note`."
+  },
+  "chatAlreadyShared": "This chat has already been shared to this destination",
+  "@chatAlreadyShared": {
+    "description": "Shown when the user shares a chat to a destination that already has it. Port of `chat_already_shared_to_destination`."
+  },
+  "chatShared": "Chat shared",
+  "@chatShared": {
+    "description": "Confirmation shown after a chat conversation is shared."
+  },
+  "joinTeamFirst": "Please join a Team to share this chat",
+  "@joinTeamFirst": {
+    "description": "Shown when the user belongs to no team to share a chat with. Port of `join_team_first`."
+  },
+  "joinEnterpriseFirst": "Please join an Enterprise to share this chat",
+  "@joinEnterpriseFirst": {
+    "description": "Shown when the user belongs to no enterprise to share a chat with. Port of `join_enterprise_first`."
   }
 }

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -1617,5 +1617,9 @@
   "joinEnterpriseFirst": "Please join an Enterprise to share this chat",
   "@joinEnterpriseFirst": {
     "description": "Shown when the user belongs to no enterprise to share a chat with. Port of `join_enterprise_first`."
+  },
+  "chatCannotBeShared": "This chat cannot be shared yet",
+  "@chatCannotBeShared": {
+    "description": "Shown when a share cannot be attempted \u2014 no signed-in user, no destination, or a chat the server has never seen. `ChatHistoryFragment` drops the tap silently instead."
   }
 }

--- a/flutter/lib/providers/chat_provider.dart
+++ b/flutter/lib/providers/chat_provider.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../data/local/app_database.dart';
 import '../data/local/chat_mapper.dart';
 import '../repository/chat_repository.dart';
+import '../repository/teams_repository.dart';
+import '../repository/voices_repository.dart';
 import '../core/config/server_config.dart';
 import '../core/sync/sync_result.dart';
 import 'app_providers.dart';
@@ -265,4 +267,179 @@ class ChatSyncNotifier extends SyncNotifier {
 
 final chatSyncProvider = NotifierProvider<ChatSyncNotifier, SyncUiState>(
   ChatSyncNotifier.new,
+);
+
+/// Port of `model/ChatShareTargets.kt` — the three destination groups the
+/// share dialog offers.
+class ChatShareTargets {
+  const ChatShareTargets({
+    this.community,
+    this.teams = const [],
+    this.enterprises = const [],
+  });
+
+  final ChatShareTarget? community;
+  final List<ChatShareTarget> teams;
+  final List<ChatShareTarget> enterprises;
+}
+
+/// Port of `ChatViewModel.loadShareTargets`.
+///
+/// Teams and enterprises are the *root*, non-archived documents of each type
+/// the signed-in user is a member of; a signed-out session sees the whole
+/// catalog, which is the Kotlin's `userId.isNullOrBlank()` branch. The
+/// community is a pseudo-team whose id is `"<communityName>@<parentCode>"`,
+/// taken from the cached team document when the planet has one and
+/// synthesized from the name when it does not — so the community entry is
+/// offered even on a device that has never synced a community team.
+///
+/// The session is awaited rather than read: this provider never watches
+/// `sessionProvider` for its value, and `valueOrNull` is null until something
+/// else resolves it.
+final chatShareTargetsProvider = FutureProvider<ChatShareTargets>((ref) async {
+  final session = await ref.watch(sessionProvider.future);
+  final repo = ref.watch(teamsRepositoryProvider);
+  final prefs = ref.watch(planetPrefsProvider);
+
+  final userId = session?.id;
+  final teams = await _shareableTargets(repo, 'team', userId);
+  final enterprises = await _shareableTargets(repo, 'enterprise', userId);
+
+  final communityName = prefs.communityName;
+  final parentCode = prefs.serverConfig?.parentCode ?? '';
+  ChatShareTarget? community;
+  if (communityName.trim().isNotEmpty && parentCode.trim().isNotEmpty) {
+    final id = '$communityName@$parentCode';
+    final row = await repo.getById(id);
+    community = row == null
+        ? ChatShareTarget(id: id, name: communityName)
+        : _targetOf(row);
+  }
+
+  return ChatShareTargets(
+    community: community,
+    teams: teams,
+    enterprises: enterprises,
+  );
+});
+
+/// Port of `getShareableTeams` / `getShareableEnterpriseSummaries`, which
+/// differ only in the `type` they query.
+///
+/// `watchCatalog` is `getRootTeamsByType`: real team documents of that type
+/// that are not archived. A blank user id skips the membership filter, and a
+/// user with no memberships gets an empty list rather than the catalog.
+Future<List<ChatShareTarget>> _shareableTargets(
+  TeamsRepository repo,
+  String type,
+  String? userId,
+) async {
+  final rows = await repo.watchCatalog(type: type).first;
+  if (userId == null || userId.trim().isEmpty) {
+    return rows.map(_targetOf).toList(growable: false);
+  }
+  final statuses = await repo.memberStatuses(userId, rows.map((r) => r.id));
+  return rows
+      .where((row) => statuses[row.id]?.isMember ?? false)
+      .map(_targetOf)
+      .toList(growable: false);
+}
+
+/// Port of `MyTeam.toSummary()`, narrowed to the fields the share reads.
+ChatShareTarget _targetOf(TeamRow row) =>
+    ChatShareTarget(id: row.id, name: row.name ?? '', teamType: row.teamType);
+
+/// The destinations each already-shared chat has reached, keyed by the chat's
+/// CouchDB `_id`.
+///
+/// Port of `ChatViewModel.loadChatHistoryScreenData`'s
+/// `chatRepository.extractSharedViewInIds(newsMessages)` over
+/// `voicesRepository.getPlanetNewsMessages(currentUser?.planetCode)`.
+final sharedChatDestinationsProvider = FutureProvider<Map<String, Set<String>>>(
+  (ref) async {
+    final session = await ref.watch(sessionProvider.future);
+    final rows = await ref
+        .watch(voicesRepositoryProvider)
+        .planetNewsMessages(session?.planetCode);
+    return VoicesRepository.extractSharedViewInIds(rows);
+  },
+);
+
+/// What a share attempt did, so the screen can tell the user.
+enum ChatShareOutcome {
+  shared,
+
+  /// `ShareChatResult.AlreadyShared` — the chat is already in this
+  /// destination's feed.
+  alreadyShared,
+
+  /// The share was not attempted: no signed-in user, no destination, or a
+  /// chat the server has never seen. `ChatHistoryFragment` gates on
+  /// `chatId.isNotEmpty() && viewInId.isNotEmpty()` and drops the tap
+  /// silently; the port says so instead.
+  unavailable,
+}
+
+/// The write path for a chat share, keeping "build the payload", "write the
+/// voices row" and "queue it for upload" together — the shape
+/// `VoicesActions` uses, and the reason a shared chat cannot sit undelivered
+/// on the device.
+class ChatShareActions {
+  ChatShareActions(this.ref);
+
+  final Ref ref;
+
+  Future<ChatShareOutcome> share({
+    required ChatRow chat,
+    required ChatShareTarget? target,
+    required String section,
+    required String note,
+  }) async {
+    final UserRow? user;
+    try {
+      user = await ref.read(sessionProvider.future);
+    } catch (_) {
+      return ChatShareOutcome.unavailable;
+    }
+    // `chat._id`, not the local row id: the payload's `newsId` is what
+    // `isAlreadyShared` and the shared-destination map are both keyed by, and
+    // a chat the server has never seen has nothing to key on.
+    final chatId = chat.docId ?? '';
+    final viewInId = target?.id ?? '';
+    if (user == null || chatId.isEmpty || viewInId.isEmpty) {
+      return ChatShareOutcome.unavailable;
+    }
+
+    final voices = ref.read(voicesRepositoryProvider);
+    if (await voices.isAlreadyShared(chatId, viewInId)) {
+      return ChatShareOutcome.alreadyShared;
+    }
+
+    await voices.createFromShareMap(
+      payload: buildChatShareMap(
+        chat: chat,
+        note: note,
+        target: target,
+        section: section,
+        nowMillis: DateTime.now().millisecondsSinceEpoch,
+      ),
+      userId: user.couchId ?? user.id,
+      userName: user.name ?? '',
+      planetCode: user.planetCode,
+      parentCode: user.parentCode,
+    );
+
+    final config = ref.read(serverConfigProvider);
+    if (config != null) {
+      await ref
+          .read(voicesUploaderProvider)
+          .queuePending(config: config, userId: user.id);
+    }
+    ref.invalidate(sharedChatDestinationsProvider);
+    return ChatShareOutcome.shared;
+  }
+}
+
+final chatShareActionsProvider = Provider<ChatShareActions>(
+  ChatShareActions.new,
 );

--- a/flutter/lib/providers/chat_provider.dart
+++ b/flutter/lib/providers/chat_provider.dart
@@ -301,16 +301,29 @@ final chatShareTargetsProvider = FutureProvider<ChatShareTargets>((ref) async {
   final repo = ref.watch(teamsRepositoryProvider);
   final prefs = ref.watch(planetPrefsProvider);
 
-  final userId = session?.id;
+  // `currentUser?._id` — the CouchDB id, not the local row id. The two
+  // coincide for a synced account, but a member registered on this device
+  // keeps a locally minted `'<millis>'` id while their membership documents
+  // carry `org.couchdb.user:<name>`, and this is a *hard* filter: the row id
+  // would offer that user no teams at all and show them "Please join a Team".
+  // The write path below already uses `couchId ?? id`.
+  final userId = session?.couchId ?? session?.id;
   final teams = await _shareableTargets(repo, 'team', userId);
   final enterprises = await _shareableTargets(repo, 'enterprise', userId);
 
-  final communityName = prefs.communityName;
-  // `sharedPrefManager.getParentCode()`. Read from the live config notifier
-  // rather than straight off `PlanetPrefs`, which is the same value — the
-  // notifier is built from that pref — but is the port's canonical handle on
-  // it and is overridable.
-  final parentCode = ref.watch(serverConfigProvider)?.parentCode ?? '';
+  // `sharedPrefManager.getCommunityName()`, which is not a name: Kotlin writes
+  // the *configuration document's `code`* into it, once, from
+  // `SyncConfigurationCoordinator`. The port persists that same value as
+  // `ServerConfig.code`, and **nothing in `lib/` ever calls
+  // `PlanetPrefs.setCommunityName`** — so reading only the pref left
+  // `communityName` permanently empty, `community` permanently null, and the
+  // whole community branch of the share dialog unreachable in the running app,
+  // green tests and all, because the pref's only writer was a test. The pref
+  // still wins when something does set it, so the two agree if it is wired.
+  final config = ref.watch(serverConfigProvider);
+  final prefName = prefs.communityName;
+  final communityName = prefName.isNotEmpty ? prefName : (config?.code ?? '');
+  final parentCode = config?.parentCode ?? '';
   ChatShareTarget? community;
   if (communityName.trim().isNotEmpty && parentCode.trim().isNotEmpty) {
     final id = '$communityName@$parentCode';
@@ -359,6 +372,14 @@ ChatShareTarget _targetOf(TeamRow row) =>
 /// Port of `ChatViewModel.loadChatHistoryScreenData`'s
 /// `chatRepository.extractSharedViewInIds(newsMessages)` over
 /// `voicesRepository.getPlanetNewsMessages(currentUser?.planetCode)`.
+///
+/// Read it through [ChatShareActions.destinations], which recomputes it:
+/// Kotlin re-runs `getPlanetNewsMessages` + `extractSharedViewInIds` on every
+/// `refreshChatSignal` and on screen re-creation, so a value cached for the
+/// process lifetime would keep offering a destination that a sync from
+/// another device had already filled. (`isAlreadyShared` still refuses the
+/// duplicate at write time, but only after the user has walked the whole
+/// dialog flow.)
 final sharedChatDestinationsProvider = FutureProvider<Map<String, Set<String>>>(
   (ref) async {
     final session = await ref.watch(sessionProvider.future);
@@ -392,6 +413,13 @@ class ChatShareActions {
   ChatShareActions(this.ref);
 
   final Ref ref;
+
+  /// The already-shared map, recomputed. See [sharedChatDestinationsProvider]
+  /// for why the cached value is not good enough to open a dialog on.
+  /// `refresh`, not `invalidate` then `read`: `invalidate` only schedules the
+  /// rebuild, so a read in the same microtask still resolves the stale future.
+  Future<Map<String, Set<String>>> destinations() =>
+      ref.refresh(sharedChatDestinationsProvider.future);
 
   Future<ChatShareOutcome> share({
     required ChatRow chat,
@@ -429,6 +457,7 @@ class ChatShareActions {
       ),
       userId: user.couchId ?? user.id,
       userName: user.name ?? '',
+      userJson: VoicesRepository.authorJson(user),
       planetCode: user.planetCode,
       parentCode: user.parentCode,
     );

--- a/flutter/lib/providers/chat_provider.dart
+++ b/flutter/lib/providers/chat_provider.dart
@@ -306,7 +306,11 @@ final chatShareTargetsProvider = FutureProvider<ChatShareTargets>((ref) async {
   final enterprises = await _shareableTargets(repo, 'enterprise', userId);
 
   final communityName = prefs.communityName;
-  final parentCode = prefs.serverConfig?.parentCode ?? '';
+  // `sharedPrefManager.getParentCode()`. Read from the live config notifier
+  // rather than straight off `PlanetPrefs`, which is the same value — the
+  // notifier is built from that pref — but is the port's canonical handle on
+  // it and is overridable.
+  final parentCode = ref.watch(serverConfigProvider)?.parentCode ?? '';
   ChatShareTarget? community;
   if (communityName.trim().isNotEmpty && parentCode.trim().isNotEmpty) {
     final id = '$communityName@$parentCode';

--- a/flutter/lib/repository/chat_repository.dart
+++ b/flutter/lib/repository/chat_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import '../core/config/server_config.dart';
 import '../core/sync/sync_result.dart';
 import '../core/utils/text_utils.dart';
@@ -252,4 +254,111 @@ List<ChatRow> _fullConvoSearch({
     ...startsWith,
     ...contains,
   ];
+}
+
+/// The `viewIn` section a chat share is addressed to.
+///
+/// These are wire values, not labels. `ChatHistoryAdapter` passes
+/// `context.getString(R.string.teams)` / `R.string.enterprises` /
+/// `R.string.community` straight into [ChatSharePayload.buildShareMap] as the
+/// `section`, so on an Android device running in French the document reaches
+/// CouchDB with a French `viewIn[].section` — and
+/// `VoicesRepository.isVisibleToUser` matches `section == "community"`, so a
+/// community share made in a non-English locale is invisible in the community
+/// feed of both apps. The port writes the stable literals instead, which is
+/// what every *other* writer on both sides already does
+/// (`VoicesFragment` writes `"community"`, `TeamsVoicesFragment` writes
+/// `"teams"`, and the port's `createTeamPost` writes `"teams"`).
+///
+/// English is the only locale where this is observable as a difference at all,
+/// and there only for enterprises: `R.string.enterprises` is `"Enterprises"`
+/// where this writes `"enterprises"`. Nothing on either side reads that value —
+/// the only `section` comparison anywhere is against `"community"`, and it is
+/// case-insensitive.
+abstract final class ChatShareSection {
+  static const String community = 'community';
+  static const String teams = 'teams';
+  static const String enterprises = 'enterprises';
+}
+
+/// The share destination a chat is addressed to — a team, an enterprise, or
+/// the planet's community pseudo-team.
+///
+/// Port of the three fields of `model/TeamSummary.kt` that the share path
+/// reads: `_id` becomes `viewInId`, `teamType` becomes `messageType`, and
+/// `teamPlanetCode` becomes `messagePlanetCode`. [name] is the dialog label;
+/// note that it does *not* reach the payload — `News.getViewInJson` writes a
+/// `name` key read from `map["name"]`, which `buildShareMap` never sets, so
+/// the entry's name is null in the Kotlin too.
+class ChatShareTarget {
+  const ChatShareTarget({
+    required this.id,
+    required this.name,
+    this.teamType,
+    this.teamPlanetCode,
+  });
+
+  final String id;
+  final String name;
+  final String? teamType;
+
+  /// Null for every target the port builds today: the `teams` Drift table has
+  /// no `teamPlanetCode` column, so there is nothing to read it from. The
+  /// Kotlin sends `""` for a team document that omits the field and for the
+  /// synthesized community target, which is the same value this produces —
+  /// see `PHASE_140_NOTES.md` § "Reported, not fixed".
+  final String? teamPlanetCode;
+}
+
+/// Port of `model/ChatSharePayload.kt` — the `HashMap` a shared chat is
+/// posted as.
+///
+/// Pure and top-level so a test can pin the wire shape without a repository,
+/// and so the caller need not transitively watch `chatRepositoryProvider`
+/// (and through it `planetPrefsProvider`, unimplemented in the widget-test
+/// harness).
+///
+/// Two shapes are load-bearing and easy to lose:
+///
+/// - **Every value is a string**, the nested object included. `createdDate`
+///   and `updatedDate` are the millis *stringified*, and `conversations` is a
+///   JSON array encoded into a string and stored under a key of the outer
+///   JSON — which is why `News.createNews` re-parses it out of a string
+///   primitive rather than reading an array.
+/// - **A null title shares as `""`, not `"null"`.** Upstream `7167684` moved
+///   this out of the adapter, where it had been `"${chatHistory.title}".trim()`
+///   — a Kotlin string template of null renders the four characters `null`, so
+///   before that commit an untitled chat was shared under the title `null`.
+///   The current behaviour is what is ported.
+Map<String, String> buildChatShareMap({
+  required ChatRow chat,
+  required String note,
+  required ChatShareTarget? target,
+  required String section,
+  required int nowMillis,
+}) {
+  final conversations = ChatMapper.parseConversations(chat.conversations)
+      .map((c) => {'query': c.query ?? '', 'response': c.response ?? ''})
+      .toList(growable: false);
+
+  final news = <String, String>{
+    '_id': chat.docId ?? '',
+    '_rev': chat.rev ?? '',
+    'title': (chat.title ?? '').trim(),
+    'user': chat.user ?? '',
+    'aiProvider': chat.aiProvider ?? '',
+    'createdDate': '$nowMillis',
+    'updatedDate': '$nowMillis',
+    'conversations': jsonEncode(conversations),
+  };
+
+  return <String, String>{
+    'message': note,
+    'viewInId': target?.id ?? '',
+    'viewInSection': section,
+    'messageType': target?.teamType ?? '',
+    'messagePlanetCode': target?.teamPlanetCode ?? '',
+    'chat': 'true',
+    'news': jsonEncode(news),
+  };
 }

--- a/flutter/lib/repository/voices_repository.dart
+++ b/flutter/lib/repository/voices_repository.dart
@@ -210,11 +210,212 @@ class VoicesRepository {
   }
 
   /// Port of `getViewInJson`: an empty array unless a target was named.
+  ///
+  /// A null [name] omits the key rather than writing `"name": null`, which is
+  /// what the Kotlin produces: `addProperty("name", map["name"])` stores a
+  /// `JsonNull`, and `JsonUtils.gson` is a bare `Gson()` with `serializeNulls`
+  /// **off**, so the key is dropped at write time. The difference is not
+  /// cosmetic — [shareToCommunity] back-fills the first entry's name only when
+  /// `!first.containsKey('name')` (the Kotlin's `!obj.has("name")`, which is
+  /// true for an *absent* key and false for an explicit null), so an explicit
+  /// null would silently disable that back-fill for every post sharing this
+  /// helper.
   static String _viewInJson({String? id, String? section, String? name}) {
     if (id == null || id.isEmpty) return jsonEncode(const []);
     return jsonEncode([
-      {'_id': id, 'section': section, 'name': name},
+      {'_id': id, 'section': section, 'name': ?name},
     ]);
+  }
+
+  /// Port of the `map["news"]` branch of `News.createNews` — writes the row a
+  /// shared chat conversation becomes in the voices feed.
+  ///
+  /// [payload] is the map [buildChatShareMap] produced; the fields that come
+  /// from the signed-in user are passed alongside it, exactly as
+  /// `createNews(map, user, imageList)` takes them separately.
+  ///
+  /// Three pairings have to hold, and each has a test:
+  ///
+  /// - `docType = 'message'` and `createdOn = planetCode` are what
+  ///   [planetNewsMessages] selects on (`NewsDao.getPlanetMessages`), and that
+  ///   query is the only thing that feeds [extractSharedViewInIds]. Get either
+  ///   wrong and the share succeeds but the dialog never marks the
+  ///   destination as already shared.
+  /// - `newsId` is the shared chat's CouchDB `_id`, which is what
+  ///   [isAlreadyShared] looks a row up by.
+  /// - the row is left with no `_id`, so `pendingUploads` finds it and
+  ///   `VoicesUploader` delivers it. Nothing else would ever send it.
+  ///
+  /// One line of the Kotlin is deliberately **not** ported:
+  /// `newsObj?.replace("=", ":")` (`News.kt:187`), a fossil from when the
+  /// value was a `HashMap.toString()` (`{_id=abc}`) rather than JSON. In
+  /// Kotlin it is a provable no-op, and not because of anything in the source:
+  /// `JsonUtils.gson` is a bare `Gson()`, whose `htmlSafe` default escapes
+  /// `=` to `\u003d` inside every string, so the encoded payload contains no
+  /// `=` for the replace to find. Dart's `jsonEncode` emits `=` raw, so
+  /// carrying the line across would rewrite every `=` in the user's own
+  /// title and transcript — `2+2=4`, a URL query string, base64 padding —
+  /// and CouchDB would keep the damage. Behaviour is preserved by dropping
+  /// the line; `an "=" in conversation text survives the share` pins it.
+  Future<String> createFromShareMap({
+    required Map<String, String> payload,
+    required String userId,
+    required String userName,
+    String? userJson,
+    String? planetCode,
+    String? parentCode,
+  }) async {
+    final id = _createId();
+    final news = _decodeObject(payload['news']) ?? const <String, dynamic>{};
+    final conversations = _shareConversations(news['conversations']);
+
+    await _dao.upsert(
+      NewsEntriesCompanion.insert(
+        id: id,
+        message: Value(payload['message']),
+        time: Value(_now().millisecondsSinceEpoch),
+        createdOn: Value(planetCode),
+        avatar: const Value(''),
+        docType: const Value('message'),
+        userName: Value(userName),
+        parentCode: Value(parentCode),
+        messagePlanetCode: Value(payload['messagePlanetCode']),
+        messageType: Value(payload['messageType']),
+        sharedBy: const Value(''),
+        viewIn: Value(
+          _viewInJson(
+            id: payload['viewInId'],
+            section: payload['viewInSection'],
+            // `getViewInJson` reads `map["name"]`, which `buildShareMap` never
+            // writes, so the entry's name is null in the Kotlin too.
+            name: payload['name'],
+          ),
+        ),
+        // `String.toBoolean()`, which is case-insensitive and false for
+        // anything that is not "true".
+        chat: Value(payload['chat']?.toLowerCase() == 'true'),
+        updatedDate: Value(int.tryParse(payload['updatedDate'] ?? '') ?? 0),
+        userId: Value(userId),
+        replyTo: Value(payload['replyTo'] ?? ''),
+        user: Value(userJson),
+        imageUrls: const Value([]),
+        newsId: Value(JsonUtils.getString('_id', news)),
+        newsRev: Value(JsonUtils.getString('_rev', news)),
+        newsUser: Value(JsonUtils.getString('user', news)),
+        aiProvider: Value(JsonUtils.getString('aiProvider', news)),
+        newsTitle: Value(JsonUtils.getString('title', news)),
+        // Left null for an empty conversation list, matching the Kotlin's
+        // `if (!conversationsArray.isEmpty())` guard.
+        conversations: Value(
+          conversations.isEmpty ? null : jsonEncode(conversations),
+        ),
+        newsCreatedDate: Value(_shareMillis(news['createdDate'])),
+        newsUpdatedDate: Value(_shareMillis(news['updatedDate'])),
+      ),
+    );
+    return id;
+  }
+
+  /// The nested `conversations` value, normalized to `{query, response}` maps.
+  ///
+  /// It arrives as a JSON array *encoded into a string*, because every value
+  /// of the Kotlin payload is a `String`. The Kotlin re-parses it under
+  /// `conversationsElement.isJsonPrimitive && isString` and rebuilds each turn
+  /// from just those two keys, which is what this mirrors — an unparseable
+  /// value yields no conversations rather than throwing.
+  static List<Map<String, String>> _shareConversations(dynamic value) {
+    if (value is! String || value.isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(value);
+      if (decoded is! List) return const [];
+      return decoded
+          .whereType<Map<String, dynamic>>()
+          .map(
+            (turn) => {
+              'query': JsonUtils.getString('query', turn),
+              'response': JsonUtils.getString('response', turn),
+            },
+          )
+          .toList(growable: false);
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  /// `JsonUtils.getLong` over a value the payload stringified: a number is
+  /// taken as-is, a numeric string is parsed, anything else is 0.
+  static int _shareMillis(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value) ?? 0;
+    return 0;
+  }
+
+  /// Port of `VoicesRepositoryImpl.isAlreadyShared`.
+  ///
+  /// True when some voices row carrying this chat (`newsId == chatId`) already
+  /// names [viewInId] in its `viewIn`. The Kotlin tests the *raw JSON text*
+  /// for the substring `"_id":"<viewInId>"`, case-insensitively, rather than
+  /// parsing — kept, because Gson writes `viewIn` without spaces and the same
+  /// substring test is what decides whether the dialog offers the destination.
+  ///
+  /// The row lookup walks every voices row instead of a `WHERE newsId = ?`
+  /// query: `NewsDao` has no such method and adding one means editing a file
+  /// another lane owns this round. Same result, more rows read — see
+  /// `PHASE_140_NOTES.md` § "Reported, not fixed".
+  Future<bool> isAlreadyShared(String chatId, String viewInId) async {
+    final rows = await _dao.getAll();
+    final needle = '"_id":"$viewInId"'.toLowerCase();
+    return rows
+        .where((row) => row.newsId == chatId)
+        .any((row) => (row.viewIn ?? '').toLowerCase().contains(needle));
+  }
+
+  /// Port of `NewsDao.getPlanetMessages` — the planet's `message` rows, which
+  /// is the set [extractSharedViewInIds] is computed over.
+  ///
+  /// Both predicates are case-insensitive (`COLLATE NOCASE`), and an absent
+  /// planet code yields nothing rather than everything.
+  Future<List<NewsRow>> planetNewsMessages(String? planetCode) async {
+    if (planetCode == null || planetCode.isEmpty) return const [];
+    final wanted = planetCode.toLowerCase();
+    final rows = await _dao.getAll();
+    return rows
+        .where(
+          (row) =>
+              (row.docType ?? '').toLowerCase() == 'message' &&
+              (row.createdOn ?? '').toLowerCase() == wanted,
+        )
+        .toList(growable: false);
+  }
+
+  /// Port of `ChatRepositoryImpl.extractSharedViewInIds`: for each shared
+  /// chat, the set of destinations it has already been shared to.
+  ///
+  /// Keyed by the *chat's* CouchDB id (`newsId`), not the voices row's own id.
+  /// Rows with no `newsId` — every ordinary voice post — are dropped, and a
+  /// row whose `viewIn` will not parse contributes nothing rather than
+  /// failing the whole map.
+  static Map<String, Set<String>> extractSharedViewInIds(List<NewsRow> rows) {
+    final result = <String, Set<String>>{};
+    for (final row in rows) {
+      final newsId = row.newsId;
+      if (newsId == null) continue;
+      final ids = result.putIfAbsent(newsId, () => <String>{});
+      try {
+        final decoded = jsonDecode(row.viewIn ?? '');
+        if (decoded is! List) continue;
+        for (final element in decoded) {
+          if (element is! Map<String, dynamic>) continue;
+          final id = element['_id'];
+          if (id is String) ids.add(id);
+        }
+      } catch (_) {
+        // `groupBy` still yields the key with whatever the other rows
+        // contributed; only this row's ids are lost.
+      }
+    }
+    return result;
   }
 
   /// Port of `postReply`.

--- a/flutter/lib/repository/voices_repository.dart
+++ b/flutter/lib/repository/voices_repository.dart
@@ -227,6 +227,56 @@ class VoicesRepository {
     ]);
   }
 
+  /// The author object a locally authored `news` document carries.
+  ///
+  /// `News.createNews` sets `news.user = gson.toJson(user.serialize())`, and
+  /// `serializeNews` writes that object into the document. It is the **only**
+  /// author identity on a news document — there is no top-level `userId` or
+  /// `userName` key — and `NewsMapper.fromDoc` reads both back out of it, so a
+  /// post uploaded without it has no author on Planet *and* loses its author
+  /// locally on the next sync-in.
+  ///
+  /// This is `UserEntity.serialize()` minus two groups, deliberately:
+  ///
+  /// - the credential branch (`password` / `derived_key` / `salt` /
+  ///   `password_scheme`) and the device trio. `serialize()` is the body of
+  ///   the `_users` PUT, where those belong; a voices post is a public
+  ///   document and must never carry them. `UserMapper.toDoc` is that PUT
+  ///   body — do not reach for it here.
+  /// - the `_attachments` photo, which would embed the user's profile image
+  ///   in every post they author.
+  ///
+  /// Everything else matches `serialize()` field for field, including the
+  /// `_id`/`_rev` pair being written only for an account the server knows.
+  static String authorJson(UserRow user) {
+    final couchId = user.couchId;
+    return jsonEncode(<String, dynamic>{
+      if (couchId != null && couchId.isNotEmpty) ...{
+        '_id': couchId,
+        '_rev': user.rev,
+      },
+      'name': user.name,
+      'roles': user.rolesList,
+      'isUserAdmin': user.userAdmin,
+      'joinDate': user.joinDate,
+      'firstName': user.firstName,
+      'lastName': user.lastName,
+      'middleName': user.middleName,
+      'email': user.email,
+      'language': user.language,
+      'level': user.level,
+      'type': 'user',
+      'gender': user.gender,
+      'phoneNumber': user.phoneNumber,
+      'birthDate': user.dob,
+      'age': user.age,
+      'parentCode': user.parentCode,
+      'planetCode': user.planetCode,
+      'birthPlace': user.birthPlace,
+      'isArchived': user.isArchived,
+    });
+  }
+
   /// Port of the `map["news"]` branch of `News.createNews` — writes the row a
   /// shared chat conversation becomes in the voices feed.
   ///

--- a/flutter/lib/ui/chat/chat_history_screen.dart
+++ b/flutter/lib/ui/chat/chat_history_screen.dart
@@ -317,7 +317,7 @@ Future<void> startChatShare(
   final Map<String, Set<String>> destinations;
   try {
     targets = await ref.read(chatShareTargetsProvider.future);
-    destinations = await ref.read(sharedChatDestinationsProvider.future);
+    destinations = await ref.read(chatShareActionsProvider).destinations();
   } catch (_) {
     if (context.mounted) _showChatShareMessage(context, l10n.chatsUnavailable);
     return;
@@ -379,7 +379,10 @@ Future<void> startChatShare(
   _showChatShareMessage(context, switch (outcome) {
     ChatShareOutcome.shared => l10n.chatShared,
     ChatShareOutcome.alreadyShared => l10n.chatAlreadyShared,
-    ChatShareOutcome.unavailable => l10n.chatsUnavailable,
+    // Not `chatsUnavailable`: the chat is visibly on screen, and two of the
+    // three ways here — a chat the server has never seen, a null destination
+    // — have nothing to do with loading.
+    ChatShareOutcome.unavailable => l10n.chatCannotBeShared,
   });
 }
 

--- a/flutter/lib/ui/chat/chat_history_screen.dart
+++ b/flutter/lib/ui/chat/chat_history_screen.dart
@@ -178,6 +178,16 @@ class ChatHistoryScreen extends ConsumerWidget {
                               ),
                           ],
                         ),
+                        // `RowChatHistoryBinding.shareChat` — the per-row
+                        // share affordance. Without it every screen and
+                        // repository below is unreachable, which is the whole
+                        // reason the port had no chat share.
+                        trailing: IconButton(
+                          key: Key('share-chat-${chat.id}'),
+                          icon: const Icon(Icons.share),
+                          tooltip: l10n.shareChat,
+                          onPressed: () => startChatShare(context, ref, chat),
+                        ),
                         onTap: () {
                           ref
                               .read(chatConversationProvider.notifier)
@@ -276,5 +286,314 @@ class ChatHistoryScreen extends ConsumerWidget {
     } catch (_) {
       return null;
     }
+  }
+}
+
+/// Which branch of the share dialog the user picked.
+enum _ShareBranch { community, teams, enterprises }
+
+/// Port of `ChatHistoryAdapter.bindShareChat` and the two dialogs it opens.
+///
+/// The Kotlin flow is: an expandable list with a *community* group and a
+/// *team/enterprise* group; picking a group's child either opens the note
+/// dialog straight away (community) or a second dialog listing the teams or
+/// enterprises to pick from. A destination the chat has already been shared
+/// to shows a marker and is not tappable, and an empty team or enterprise
+/// list gets its own "please join one first" alert rather than an empty
+/// dialog.
+///
+/// The two providers are awaited, not read: nothing on this screen watches
+/// them, so `valueOrNull` would be null on the first tap and the dialog would
+/// silently offer no destinations. Both awaits are inside the `try`, because a
+/// future can reject where `valueOrNull` could not.
+@visibleForTesting
+Future<void> startChatShare(
+  BuildContext context,
+  WidgetRef ref,
+  ChatRow chat,
+) async {
+  final l10n = AppLocalizations.of(context);
+  final ChatShareTargets targets;
+  final Map<String, Set<String>> destinations;
+  try {
+    targets = await ref.read(chatShareTargetsProvider.future);
+    destinations = await ref.read(sharedChatDestinationsProvider.future);
+  } catch (_) {
+    if (context.mounted) _showChatShareMessage(context, l10n.chatsUnavailable);
+    return;
+  }
+  if (!context.mounted) return;
+
+  final sharedIds = destinations[chat.docId ?? ''] ?? const <String>{};
+  final community = targets.community;
+  final communityShared = community != null && sharedIds.contains(community.id);
+
+  final branch = await showDialog<_ShareBranch>(
+    context: context,
+    builder: (context) => _ShareBranchDialog(
+      hasCommunity: community != null,
+      communityShared: communityShared,
+    ),
+  );
+  if (branch == null || !context.mounted) return;
+
+  final ChatShareTarget? target;
+  final String section;
+  switch (branch) {
+    case _ShareBranch.community:
+      target = community;
+      section = ChatShareSection.community;
+    case _ShareBranch.teams:
+      section = ChatShareSection.teams;
+      target = await _pickShareTarget(
+        context,
+        title: l10n.teams,
+        emptyMessage: l10n.joinTeamFirst,
+        targets: targets.teams,
+        sharedIds: sharedIds,
+      );
+    case _ShareBranch.enterprises:
+      section = ChatShareSection.enterprises;
+      target = await _pickShareTarget(
+        context,
+        title: l10n.enterprises,
+        emptyMessage: l10n.joinEnterpriseFirst,
+        targets: targets.enterprises,
+        sharedIds: sharedIds,
+      );
+  }
+  if (target == null || !context.mounted) return;
+
+  final note = await showDialog<String>(
+    context: context,
+    builder: (context) => const _ShareNoteDialog(),
+  );
+  // Cancel writes nothing, as `setNegativeButton` does; an empty note is a
+  // deliberate share and still posts, because `add_note` is optional.
+  if (note == null || !context.mounted) return;
+
+  final outcome = await ref
+      .read(chatShareActionsProvider)
+      .share(chat: chat, target: target, section: section, note: note);
+  if (!context.mounted) return;
+  _showChatShareMessage(context, switch (outcome) {
+    ChatShareOutcome.shared => l10n.chatShared,
+    ChatShareOutcome.alreadyShared => l10n.chatAlreadyShared,
+    ChatShareOutcome.unavailable => l10n.chatsUnavailable,
+  });
+}
+
+void _showChatShareMessage(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
+}
+
+/// Second dialog: the teams or enterprises to share into.
+///
+/// Port of `showGrandChildRecyclerView`, including its empty branch — an
+/// alert naming the section rather than a list with nothing in it.
+Future<ChatShareTarget?> _pickShareTarget(
+  BuildContext context, {
+  required String title,
+  required String emptyMessage,
+  required List<ChatShareTarget> targets,
+  required Set<String> sharedIds,
+}) async {
+  if (targets.isEmpty) {
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: Text(emptyMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(MaterialLocalizations.of(context).okButtonLabel),
+          ),
+        ],
+      ),
+    );
+    return null;
+  }
+  return showDialog<ChatShareTarget>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            for (final target in targets)
+              _ShareTargetTile(
+                target: target,
+                // `TeamsSelectionAdapter.bind`: an already-shared destination
+                // shows the shared icon and has its click listener removed.
+                alreadyShared: sharedIds.contains(target.id),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(AppLocalizations.of(context).close),
+        ),
+      ],
+    ),
+  );
+}
+
+class _ShareTargetTile extends StatelessWidget {
+  const _ShareTargetTile({required this.target, required this.alreadyShared});
+
+  final ChatShareTarget target;
+  final bool alreadyShared;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      key: Key('share-target-${target.id}'),
+      leading: const Icon(Icons.groups_outlined),
+      title: Text(target.name),
+      trailing: alreadyShared ? const Icon(Icons.check) : null,
+      enabled: !alreadyShared,
+      onTap: alreadyShared ? null : () => Navigator.of(context).pop(target),
+    );
+  }
+}
+
+/// First dialog: the two collapsible destination groups.
+class _ShareBranchDialog extends StatefulWidget {
+  const _ShareBranchDialog({
+    required this.hasCommunity,
+    required this.communityShared,
+  });
+
+  /// False when the planet has no community name or parent code configured,
+  /// in which case `loadShareTargets` leaves `community` null and there is
+  /// nothing for the group to open.
+  final bool hasCommunity;
+  final bool communityShared;
+
+  @override
+  State<_ShareBranchDialog> createState() => _ShareBranchDialogState();
+}
+
+class _ShareBranchDialogState extends State<_ShareBranchDialog> {
+  bool _communityExpanded = false;
+  bool _teamsExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return AlertDialog(
+      content: SizedBox(
+        width: double.maxFinite,
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            ListTile(
+              key: const Key('share-group-community'),
+              title: Text(
+                l10n.shareWithCommunity,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              trailing: Icon(
+                _communityExpanded ? Icons.expand_less : Icons.expand_more,
+              ),
+              onTap: () =>
+                  setState(() => _communityExpanded = !_communityExpanded),
+            ),
+            if (_communityExpanded && widget.hasCommunity)
+              ListTile(
+                key: const Key('share-child-community'),
+                title: Text(l10n.community),
+                trailing: widget.communityShared
+                    ? const Icon(Icons.check)
+                    : null,
+                enabled: !widget.communityShared,
+                onTap: widget.communityShared
+                    ? null
+                    : () => Navigator.of(context).pop(_ShareBranch.community),
+              ),
+            ListTile(
+              key: const Key('share-group-team'),
+              title: Text(
+                l10n.shareWithTeamEnterprise,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              trailing: Icon(
+                _teamsExpanded ? Icons.expand_less : Icons.expand_more,
+              ),
+              onTap: () => setState(() => _teamsExpanded = !_teamsExpanded),
+            ),
+            if (_teamsExpanded) ...[
+              ListTile(
+                key: const Key('share-child-teams'),
+                title: Text(l10n.teams),
+                onTap: () => Navigator.of(context).pop(_ShareBranch.teams),
+              ),
+              ListTile(
+                key: const Key('share-child-enterprises'),
+                title: Text(l10n.enterprises),
+                onTap: () =>
+                    Navigator.of(context).pop(_ShareBranch.enterprises),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.close),
+        ),
+      ],
+    );
+  }
+}
+
+/// Port of `showEditTextAndShareButton` — the optional note carried as the
+/// post's `message`.
+class _ShareNoteDialog extends StatefulWidget {
+  const _ShareNoteDialog();
+
+  @override
+  State<_ShareNoteDialog> createState() => _ShareNoteDialogState();
+}
+
+class _ShareNoteDialogState extends State<_ShareNoteDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return AlertDialog(
+      content: TextField(
+        key: const Key('share-note-field'),
+        controller: _controller,
+        autofocus: true,
+        maxLines: null,
+        keyboardType: TextInputType.multiline,
+        decoration: InputDecoration(hintText: l10n.addNoteOptional),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.cancel),
+        ),
+        TextButton(
+          key: const Key('share-note-submit'),
+          onPressed: () => Navigator.of(context).pop(_controller.text),
+          child: Text(l10n.shareChat),
+        ),
+      ],
+    );
   }
 }

--- a/flutter/test/providers/chat_share_actions_test.dart
+++ b/flutter/test/providers/chat_share_actions_test.dart
@@ -1,0 +1,327 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/chat_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/chat_repository.dart';
+import 'package:myplanet/repository/voices_uploader.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  _TestServerConfigNotifier(this._config);
+  final ServerConfig? _config;
+  @override
+  ServerConfig? build() => _config;
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this._user);
+  final UserRow? _user;
+  @override
+  Future<UserRow?> build() async => _user;
+}
+
+/// The share *write* path, end to end against a real database: the Kotlin's
+/// `ChatHistoryFragment` gate, `shareChatToVoices`, and the enqueue the port
+/// adds in place of the Kotlin's full-table upload sweep.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  late AppDatabase db;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.memory();
+  });
+  tearDown(() => db.close());
+
+  Future<ProviderContainer> containerFor({UserRow? user}) async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(MockPlanetApi()),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
+        serverConfigProvider.overrideWith(
+          () => _TestServerConfigNotifier(config),
+        ),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(
+            user ?? buildUserRow(id: 'org.couchdb.user:ada', name: 'ada'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  ChatRow chat({String? docId = 'chat_1'}) => ChatRow(
+    id: 'c1',
+    docId: docId,
+    rev: '2-rev',
+    title: 'Tech Discussion',
+    user: 'ada',
+    aiProvider: 'openai',
+    conversations: '[{"query":"q","response":"r"}]',
+    lastUsed: 0,
+    isUploaded: false,
+  );
+
+  const team = ChatShareTarget(id: 'team_1', name: 'Bricklayers');
+
+  group('the share targets', () {
+    Future<void> seedTeams() => db.teamDao.upsertAll([
+      TeamsCompanion.insert(
+        id: 'team_1',
+        name: const Value('Bricklayers'),
+        type: const Value('team'),
+        teamType: const Value('local'),
+      ),
+      TeamsCompanion.insert(
+        id: 'team_2',
+        name: const Value('Bakers'),
+        type: const Value('team'),
+      ),
+      TeamsCompanion.insert(
+        id: 'ent_1',
+        name: const Value('Cooperative'),
+        type: const Value('enterprise'),
+      ),
+      TeamsCompanion.insert(
+        id: 'team_3',
+        name: const Value('Archived'),
+        type: const Value('team'),
+        status: const Value('archived'),
+      ),
+      TeamsCompanion.insert(
+        id: 'mem_1',
+        docType: const Value('membership'),
+        teamId: const Value('team_1'),
+        userId: const Value('org.couchdb.user:ada'),
+      ),
+      TeamsCompanion.insert(
+        id: 'mem_2',
+        docType: const Value('membership'),
+        teamId: const Value('ent_1'),
+        userId: const Value('org.couchdb.user:ada'),
+      ),
+    ]);
+
+    test('offers only the teams and enterprises the user belongs to', () async {
+      await seedTeams();
+      final container = await containerFor();
+
+      final targets = await container.read(chatShareTargetsProvider.future);
+      expect(targets.teams.map((t) => t.id), ['team_1']);
+      expect(targets.enterprises.map((t) => t.id), ['ent_1']);
+      // `teamType` is what becomes `messageType` on the wire.
+      expect(targets.teams.single.teamType, 'local');
+      expect(targets.teams.single.name, 'Bricklayers');
+    });
+
+    // `getShareableTeams` short-circuits an empty membership set to
+    // `emptyList()` rather than falling through to the whole catalog.
+    test('a user who belongs to nothing is offered nothing', () async {
+      await seedTeams();
+      final container = await containerFor(
+        user: buildUserRow(id: 'org.couchdb.user:bob', name: 'bob'),
+      );
+
+      final targets = await container.read(chatShareTargetsProvider.future);
+      expect(targets.teams, isEmpty);
+      expect(targets.enterprises, isEmpty);
+    });
+
+    test('the community is synthesized when no team document exists', () async {
+      final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+      await prefs.setCommunityName('lc');
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          planetApiProvider.overrideWithValue(MockPlanetApi()),
+          planetPrefsProvider.overrideWithValue(prefs),
+          serverConfigProvider.overrideWith(
+            () => _TestServerConfigNotifier(config.copyWith(parentCode: 'pc')),
+          ),
+          sessionProvider.overrideWith(
+            () => _TestSessionNotifier(
+              buildUserRow(id: 'org.couchdb.user:ada', name: 'ada'),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final targets = await container.read(chatShareTargetsProvider.future);
+      // `"<communityName>@<parentCode>"`, where communityName is the
+      // configuration `code` rather than a display name.
+      expect(targets.community?.id, 'lc@pc');
+      expect(targets.community?.name, 'lc');
+    });
+
+    test(
+      'no community name or parent code means no community target',
+      () async {
+        final container = await containerFor();
+        final targets = await container.read(chatShareTargetsProvider.future);
+        expect(targets.community, isNull);
+      },
+    );
+  });
+
+  test('a share writes the voices row and queues it for upload', () async {
+    final container = await containerFor();
+
+    final outcome = await container
+        .read(chatShareActionsProvider)
+        .share(
+          chat: chat(),
+          target: team,
+          section: ChatShareSection.teams,
+          note: 'worth a read',
+        );
+
+    expect(outcome, ChatShareOutcome.shared);
+
+    final rows = await db.newsDao.getAll();
+    expect(rows, hasLength(1));
+    expect(rows.single.newsId, 'chat_1');
+    expect(rows.single.message, 'worth a read');
+    expect(rows.single.chat, isTrue);
+
+    // The Kotlin uploads news by sweeping the whole table on every sync; the
+    // port has no such sweep, so a share that did not enqueue would sit on the
+    // device until some unrelated voices action rescued it.
+    final queued = await db.outboxDao.forItem(
+      VoicesUploader.type,
+      rows.single.id,
+    );
+    expect(queued, hasLength(1));
+    final payload = jsonDecode(queued.single.payload) as Map<String, dynamic>;
+    expect(payload['chat'], isTrue);
+    expect((payload['news'] as Map)['_id'], 'chat_1');
+  });
+
+  test('a second share of the same chat and target is refused', () async {
+    final container = await containerFor();
+    final actions = container.read(chatShareActionsProvider);
+
+    await actions.share(
+      chat: chat(),
+      target: team,
+      section: ChatShareSection.teams,
+      note: '',
+    );
+    final second = await actions.share(
+      chat: chat(),
+      target: team,
+      section: ChatShareSection.teams,
+      note: '',
+    );
+
+    expect(second, ChatShareOutcome.alreadyShared);
+    expect(await db.newsDao.getAll(), hasLength(1));
+  });
+
+  test('the same chat can still reach a different destination', () async {
+    final container = await containerFor();
+    final actions = container.read(chatShareActionsProvider);
+
+    await actions.share(
+      chat: chat(),
+      target: team,
+      section: ChatShareSection.teams,
+      note: '',
+    );
+    final second = await actions.share(
+      chat: chat(),
+      target: const ChatShareTarget(id: 'team_2', name: 'Bakers'),
+      section: ChatShareSection.teams,
+      note: '',
+    );
+
+    expect(second, ChatShareOutcome.shared);
+    expect(await db.newsDao.getAll(), hasLength(2));
+  });
+
+  // `ChatHistoryFragment:166-170` drops the tap when either id is empty, and
+  // says nothing at all. The gate is kept; the silence is not.
+  test('a chat the server has never seen is not shared', () async {
+    final container = await containerFor();
+
+    final outcome = await container
+        .read(chatShareActionsProvider)
+        .share(
+          chat: chat(docId: null),
+          target: team,
+          section: ChatShareSection.teams,
+          note: '',
+        );
+
+    expect(outcome, ChatShareOutcome.unavailable);
+    expect(await db.newsDao.getAll(), isEmpty);
+  });
+
+  test('a share with no destination is not shared', () async {
+    final container = await containerFor();
+
+    final outcome = await container
+        .read(chatShareActionsProvider)
+        .share(
+          chat: chat(),
+          target: null,
+          section: ChatShareSection.community,
+          note: '',
+        );
+
+    expect(outcome, ChatShareOutcome.unavailable);
+    expect(await db.newsDao.getAll(), isEmpty);
+  });
+
+  test('the destination map sees the share on the next read', () async {
+    final container = await containerFor(
+      user: buildUserRow(
+        id: 'org.couchdb.user:ada',
+        name: 'ada',
+      ).copyWith(planetCode: const Value('lc')),
+    );
+
+    expect(
+      await container.read(sharedChatDestinationsProvider.future),
+      isEmpty,
+    );
+
+    await container
+        .read(chatShareActionsProvider)
+        .share(
+          chat: chat(),
+          target: team,
+          section: ChatShareSection.teams,
+          note: '',
+        );
+
+    expect(await container.read(sharedChatDestinationsProvider.future), {
+      'chat_1': {'team_1'},
+    });
+  });
+}

--- a/flutter/test/providers/chat_share_actions_test.dart
+++ b/flutter/test/providers/chat_share_actions_test.dart
@@ -34,6 +34,11 @@ class _TestSessionNotifier extends SessionNotifier {
   Future<UserRow?> build() async => _user;
 }
 
+class _ThrowingSessionNotifier extends SessionNotifier {
+  @override
+  Future<UserRow?> build() async => throw StateError('no session');
+}
+
 /// The share *write* path, end to end against a real database: the Kotlin's
 /// `ChatHistoryFragment` gate, `shareChatToVoices`, and the enqueue the port
 /// adds in place of the Kotlin's full-table upload sweep.
@@ -152,7 +157,39 @@ void main() {
       expect(targets.enterprises, isEmpty);
     });
 
-    test('the community is synthesized when no team document exists', () async {
+    // Nothing in `lib/` calls `setCommunityName`, so the pref is empty in the
+    // running app and the community id has to come from the configuration
+    // `code` — the same value Kotlin's `SyncConfigurationCoordinator` writes
+    // into that pref. Setting the pref here instead fabricates a state
+    // production never reaches, and leaves the branch dead.
+    test('the community id comes from the configuration code', () async {
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          planetApiProvider.overrideWithValue(MockPlanetApi()),
+          planetPrefsProvider.overrideWithValue(
+            PlanetPrefs(await SharedPreferences.getInstance()),
+          ),
+          serverConfigProvider.overrideWith(
+            () => _TestServerConfigNotifier(
+              config.copyWith(code: 'lc', parentCode: 'pc'),
+            ),
+          ),
+          sessionProvider.overrideWith(
+            () => _TestSessionNotifier(
+              buildUserRow(id: 'org.couchdb.user:ada', name: 'ada'),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final targets = await container.read(chatShareTargetsProvider.future);
+      expect(targets.community?.id, 'lc@pc');
+      expect(targets.community?.name, 'lc');
+    });
+
+    test('an explicit community name pref still wins', () async {
       final prefs = PlanetPrefs(await SharedPreferences.getInstance());
       await prefs.setCommunityName('lc');
       final container = ProviderContainer(
@@ -189,6 +226,74 @@ void main() {
     );
   });
 
+  // `getTeamSummaries(currentUser?._id)`. A member registered on this device
+  // keeps a locally minted row id while their membership document carries the
+  // CouchDB id, and the membership filter is absolute — reading the row id
+  // here offers them nothing at all.
+  test('a member registered offline is still offered their teams', () async {
+    await db.teamDao.upsertAll([
+      TeamsCompanion.insert(
+        id: 'team_1',
+        name: const Value('Bricklayers'),
+        type: const Value('team'),
+      ),
+      TeamsCompanion.insert(
+        id: 'mem_1',
+        docType: const Value('membership'),
+        teamId: const Value('team_1'),
+        userId: const Value('org.couchdb.user:ada'),
+      ),
+    ]);
+    final container = await containerFor(
+      user: buildUserRow(
+        id: '1737000000000',
+        name: 'ada',
+      ).copyWith(couchId: const Value('org.couchdb.user:ada')),
+    );
+
+    final targets = await container.read(chatShareTargetsProvider.future);
+    expect(targets.teams.map((t) => t.id), ['team_1']);
+  });
+
+  // A share this device did not author — one a voices sync pulled in — must
+  // show up when the sheet is opened. Nothing invalidates the provider on that
+  // path, so `destinations()` has to recompute rather than read the cache;
+  // this is what pins the difference between `refresh` and a plain read.
+  test(
+    'a share arriving from elsewhere shows up without an invalidate',
+    () async {
+      final container = await containerFor(
+        user: buildUserRow(
+          id: 'org.couchdb.user:ada',
+          name: 'ada',
+        ).copyWith(planetCode: const Value('lc')),
+      );
+
+      final actions = container.read(chatShareActionsProvider);
+      expect(await actions.destinations(), isEmpty);
+
+      // Straight to the repository, as a sync-in would land it.
+      await container
+          .read(voicesRepositoryProvider)
+          .createFromShareMap(
+            payload: buildChatShareMap(
+              chat: chat(),
+              note: '',
+              target: team,
+              section: ChatShareSection.teams,
+              nowMillis: 1700000000000,
+            ),
+            userId: 'someone-else',
+            userName: 'bob',
+            planetCode: 'lc',
+          );
+
+      expect(await actions.destinations(), {
+        'chat_1': {'team_1'},
+      });
+    },
+  );
+
   test('a share writes the voices row and queues it for upload', () async {
     final container = await containerFor();
 
@@ -220,6 +325,48 @@ void main() {
     final payload = jsonDecode(queued.single.payload) as Map<String, dynamic>;
     expect(payload['chat'], isTrue);
     expect((payload['news'] as Map)['_id'], 'chat_1');
+  });
+
+  // `serializeNews` writes no top-level `userId`/`userName`: the nested `user`
+  // object is the only author identity a news document carries, and
+  // `NewsMapper.fromDoc` reads both back out of it — so a null here loses the
+  // author on Planet *and* on this device at the next sync-in.
+  test('the uploaded document names its author', () async {
+    final container = await containerFor(
+      user: buildUserRow(
+        id: 'org.couchdb.user:ada',
+        name: 'ada',
+        firstName: 'Ada',
+        email: 'ada@example.org',
+      ).copyWith(couchId: const Value('org.couchdb.user:ada')),
+    );
+
+    await container
+        .read(chatShareActionsProvider)
+        .share(
+          chat: chat(),
+          target: team,
+          section: ChatShareSection.teams,
+          note: '',
+        );
+
+    final row = (await db.newsDao.getAll()).single;
+    final queued = await db.outboxDao.forItem(VoicesUploader.type, row.id);
+    final payload = jsonDecode(queued.single.payload) as Map<String, dynamic>;
+    final author = payload['user'] as Map<String, dynamic>;
+
+    expect(author['_id'], 'org.couchdb.user:ada');
+    expect(author['name'], 'ada');
+    expect(author['firstName'], 'Ada');
+    expect(author['email'], 'ada@example.org');
+    expect(author['type'], 'user');
+    // `UserEntity.serialize()` carries these; a public voices document must
+    // not. `UserMapper.toDoc` is the `_users` PUT body — not this.
+    expect(author.containsKey('derived_key'), isFalse);
+    expect(author.containsKey('salt'), isFalse);
+    expect(author.containsKey('password'), isFalse);
+    expect(author.containsKey('password_scheme'), isFalse);
+    expect(author.containsKey('_attachments'), isFalse);
   });
 
   test('a second share of the same chat and target is refused', () async {
@@ -273,6 +420,34 @@ void main() {
         .read(chatShareActionsProvider)
         .share(
           chat: chat(docId: null),
+          target: team,
+          section: ChatShareSection.teams,
+          note: '',
+        );
+
+    expect(outcome, ChatShareOutcome.unavailable);
+    expect(await db.newsDao.getAll(), isEmpty);
+  });
+
+  // The `await` sits inside the enclosing `try` precisely because a future can
+  // reject where `valueOrNull` could not. Nothing pinned that until now.
+  test('a rejecting session is reported, not thrown', () async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(MockPlanetApi()),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        sessionProvider.overrideWith(_ThrowingSessionNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final outcome = await container
+        .read(chatShareActionsProvider)
+        .share(
+          chat: chat(),
           target: team,
           section: ChatShareSection.teams,
           note: '',

--- a/flutter/test/repository/chat_share_payload_test.dart
+++ b/flutter/test/repository/chat_share_payload_test.dart
@@ -1,0 +1,229 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/chat_repository.dart';
+
+/// Port of `app/src/test/.../model/ChatSharePayloadTest.kt`, plus the cases
+/// that test pins by omission.
+ChatRow _chat({
+  String id = 'local-1',
+  String? docId,
+  String? rev,
+  String? title,
+  String? user,
+  String? aiProvider,
+  String? conversations,
+}) => ChatRow(
+  id: id,
+  docId: docId,
+  rev: rev,
+  title: title,
+  user: user,
+  aiProvider: aiProvider,
+  conversations: conversations,
+  lastUsed: 0,
+  isUploaded: false,
+);
+
+const _now = 1700000000000;
+
+Map<String, dynamic> _news(Map<String, String> map) =>
+    jsonDecode(map['news']!) as Map<String, dynamic>;
+
+void main() {
+  test('the outer key set is exactly the seven the Kotlin writes', () {
+    final map = buildChatShareMap(
+      chat: _chat(
+        docId: 'chat_1',
+        rev: '1-rev',
+        title: 'Sample Chat',
+        user: 'user_1',
+        aiProvider: 'openai',
+      ),
+      note: 'Check this chat out',
+      target: null,
+      section: 'Teams',
+      nowMillis: _now,
+    );
+
+    expect(map.keys.toSet(), {
+      'message',
+      'viewInId',
+      'viewInSection',
+      'messageType',
+      'messagePlanetCode',
+      'chat',
+      'news',
+    });
+  });
+
+  test('a null target leaves the three team-derived keys empty', () {
+    final map = buildChatShareMap(
+      chat: _chat(),
+      note: 'Note text',
+      target: null,
+      section: 'Community',
+      nowMillis: _now,
+    );
+
+    expect(map['viewInId'], '');
+    expect(map['messageType'], '');
+    expect(map['messagePlanetCode'], '');
+    expect(map['viewInSection'], 'Community');
+    expect(map['message'], 'Note text');
+    expect(map['chat'], 'true');
+  });
+
+  test('a populated target fills viewInId, messageType and planet code', () {
+    final map = buildChatShareMap(
+      chat: _chat(),
+      note: 'Team note',
+      target: const ChatShareTarget(
+        id: 'team_123',
+        name: 'Test Team',
+        teamType: 'team',
+        teamPlanetCode: 'planet_xyz',
+      ),
+      section: ChatShareSection.teams,
+      nowMillis: _now,
+    );
+
+    expect(map['viewInId'], 'team_123');
+    expect(map['messageType'], 'team');
+    expect(map['messagePlanetCode'], 'planet_xyz');
+  });
+
+  test('null id, rev, user and provider serialize as empty strings', () {
+    final news = _news(
+      buildChatShareMap(
+        chat: _chat(),
+        note: 'test',
+        target: null,
+        section: 'test',
+        nowMillis: _now,
+      ),
+    );
+
+    expect(news['_id'], '');
+    expect(news['_rev'], '');
+    expect(news['user'], '');
+    expect(news['aiProvider'], '');
+    // Stringified, not numeric: every value of the Kotlin map is a String.
+    expect(news['createdDate'], '1700000000000');
+    expect(news['updatedDate'], '1700000000000');
+  });
+
+  // The behaviour upstream `7167684` changed. The adapter used to write
+  // `"${chatHistory.title}".trim()`, and a Kotlin string template of null
+  // renders the four characters `null`, so an untitled chat was shared under
+  // the title "null". `(chat.title ?: "").trim()` is what is ported.
+  test('an untitled chat shares as an empty title, never the word null', () {
+    final news = _news(
+      buildChatShareMap(
+        chat: _chat(title: null),
+        note: '',
+        target: null,
+        section: ChatShareSection.community,
+        nowMillis: _now,
+      ),
+    );
+
+    expect(news['title'], '');
+    expect(news['title'], isNot('null'));
+  });
+
+  test('a title is trimmed', () {
+    final news = _news(
+      buildChatShareMap(
+        chat: _chat(title: '  Tech Discussion \n'),
+        note: '',
+        target: null,
+        section: ChatShareSection.community,
+        nowMillis: _now,
+      ),
+    );
+
+    expect(news['title'], 'Tech Discussion');
+  });
+
+  test('conversations round-trip through the nested JSON string', () {
+    final map = buildChatShareMap(
+      chat: _chat(
+        docId: 'chat_100',
+        rev: '2-rev',
+        title: 'Tech Discussion',
+        conversations: jsonEncode([
+          {'query': 'What is Kotlin?', 'response': 'A programming language.'},
+          {'query': 'What is Android?', 'response': 'A mobile OS.'},
+        ]),
+      ),
+      note: 'Round trip test',
+      target: null,
+      section: ChatShareSection.community,
+      nowMillis: _now,
+    );
+
+    final conversations = _news(map)['conversations'];
+    // A *string*, not an array — `News.createNews` re-parses it out of a
+    // string primitive, and would find nothing if this were an array.
+    expect(conversations, isA<String>());
+
+    final decoded = jsonDecode(conversations as String) as List;
+    expect(decoded, hasLength(2));
+    expect(decoded[0]['query'], 'What is Kotlin?');
+    expect(decoded[0]['response'], 'A programming language.');
+    expect(decoded[1]['query'], 'What is Android?');
+    expect(decoded[1]['response'], 'A mobile OS.');
+  });
+
+  test('a turn with no response serializes it as an empty string', () {
+    final map = buildChatShareMap(
+      chat: _chat(
+        conversations: jsonEncode([
+          {'query': 'Only asked'},
+        ]),
+      ),
+      note: '',
+      target: null,
+      section: ChatShareSection.community,
+      nowMillis: _now,
+    );
+
+    final decoded = jsonDecode(_news(map)['conversations'] as String) as List;
+    expect(decoded.single, {'query': 'Only asked', 'response': ''});
+  });
+
+  test('a chat with no conversations yields an empty array, not "null"', () {
+    final map = buildChatShareMap(
+      chat: _chat(conversations: null),
+      note: '',
+      target: null,
+      section: ChatShareSection.community,
+      nowMillis: _now,
+    );
+
+    // Kotlin's `gson.toJson(null)` writes the four characters `null` here,
+    // which `News.createNews` then hands to `fromJson(..., JsonArray)` and
+    // dereferences — an uncaught NPE out of the share. `[]` is the same
+    // *meaning* with no crash.
+    expect(_news(map)['conversations'], '[]');
+  });
+
+  test('the section is carried verbatim', () {
+    for (final section in [
+      ChatShareSection.community,
+      ChatShareSection.teams,
+      ChatShareSection.enterprises,
+    ]) {
+      final map = buildChatShareMap(
+        chat: _chat(),
+        note: '',
+        target: null,
+        section: section,
+        nowMillis: _now,
+      );
+      expect(map['viewInSection'], section);
+    }
+  });
+}

--- a/flutter/test/repository/chat_share_payload_test.dart
+++ b/flutter/test/repository/chat_share_payload_test.dart
@@ -203,11 +203,21 @@ void main() {
       nowMillis: _now,
     );
 
-    // Kotlin's `gson.toJson(null)` writes the four characters `null` here,
-    // which `News.createNews` then hands to `fromJson(..., JsonArray)` and
-    // dereferences — an uncaught NPE out of the share. `[]` is the same
-    // *meaning* with no crash.
+    // Kotlin's `gson.toJson(null)` writes the four characters `null` here.
+    // `News.createNews` hands that to `fromJson(..., JsonArray)`, which
+    // raises `JsonSyntaxException` ("Expected a JsonArray but was JsonNull")
+    // — caught by the inner `catch (e: JsonSyntaxException)`, so the column
+    // is left null and nothing crashes. `[]` reaches the same end state
+    // without the throw.
     expect(_news(map)['conversations'], '[]');
+  });
+
+  // The wire values, not just "whatever was passed through". Kotlin passes the
+  // localised `strings.xml` string here; these literals are the deviation.
+  test('the sections are the stable lowercase literals', () {
+    expect(ChatShareSection.community, 'community');
+    expect(ChatShareSection.teams, 'teams');
+    expect(ChatShareSection.enterprises, 'enterprises');
   });
 
   test('the section is carried verbatim', () {

--- a/flutter/test/repository/chat_share_round_trip_test.dart
+++ b/flutter/test/repository/chat_share_round_trip_test.dart
@@ -129,6 +129,31 @@ void main() {
     },
   );
 
+  // `String.toBoolean()` is case-insensitive, and false for anything else.
+  test('the chat flag is read the way Kotlin reads it', () async {
+    Future<bool> chatFlagFor(String raw) async {
+      final payload = buildChatShareMap(
+        chat: chat(),
+        note: '',
+        target: team,
+        section: ChatShareSection.teams,
+        nowMillis: 1700000000000,
+      );
+      final id = await voices.createFromShareMap(
+        payload: {...payload, 'chat': raw},
+        userId: 'u1',
+        userName: 'ada',
+        planetCode: 'lc',
+      );
+      return (await database.newsDao.getById(id))!.chat;
+    }
+
+    expect(await chatFlagFor('true'), isTrue);
+    expect(await chatFlagFor('TRUE'), isTrue);
+    expect(await chatFlagFor('false'), isFalse);
+    expect(await chatFlagFor('yes'), isFalse);
+  });
+
   test('an empty conversation list leaves the column null', () async {
     final id = await share(row: chat(conversations: '[]'));
     expect((await database.newsDao.getById(id))!.conversations, isNull);

--- a/flutter/test/repository/chat_share_round_trip_test.dart
+++ b/flutter/test/repository/chat_share_round_trip_test.dart
@@ -1,0 +1,385 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/chat_repository.dart';
+import 'package:myplanet/repository/voices_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The pair, not the halves: a chat share is only worth anything if the row
+/// the writer produces is the row the "already shared" readers select, and if
+/// the uploader can find it. Every fixture here goes through
+/// [buildChatShareMap] into [VoicesRepository.createFromShareMap] rather than
+/// hand-faking the join.
+void main() {
+  late AppDatabase database;
+  late VoicesRepository voices;
+  var idCounter = 0;
+
+  setUp(() {
+    database = AppDatabase.memory();
+    idCounter = 0;
+    voices = VoicesRepository(
+      MockPlanetApi(),
+      database.newsDao,
+      now: () => DateTime.fromMillisecondsSinceEpoch(9000),
+      createId: () => 'local-${++idCounter}',
+    );
+  });
+  tearDown(() => database.close());
+
+  ChatRow chat({
+    String? docId = 'chat_1',
+    String? title = 'Tech Discussion',
+    String? conversations,
+  }) => ChatRow(
+    id: 'c1',
+    docId: docId,
+    rev: '2-rev',
+    title: title,
+    user: 'ada',
+    aiProvider: 'openai',
+    conversations:
+        conversations ??
+        jsonEncode([
+          {'query': 'What is Kotlin?', 'response': 'A language.'},
+        ]),
+    lastUsed: 0,
+    isUploaded: false,
+  );
+
+  const team = ChatShareTarget(
+    id: 'team_123',
+    name: 'Test Team',
+    teamType: 'team',
+    teamPlanetCode: 'planet_xyz',
+  );
+
+  Future<String> share({
+    ChatRow? row,
+    ChatShareTarget? target = team,
+    String section = ChatShareSection.teams,
+    String note = 'Have a look',
+    String planetCode = 'lc',
+  }) => voices.createFromShareMap(
+    payload: buildChatShareMap(
+      chat: row ?? chat(),
+      note: note,
+      target: target,
+      section: section,
+      nowMillis: 1700000000000,
+    ),
+    userId: 'u1',
+    userName: 'ada',
+    planetCode: planetCode,
+    parentCode: 'pc',
+  );
+
+  test('the row carries the note, destination and nested chat fields', () async {
+    final id = await share();
+    final row = (await database.newsDao.getById(id))!;
+
+    expect(row.message, 'Have a look');
+    expect(row.chat, isTrue);
+    expect(row.docType, 'message');
+    expect(row.createdOn, 'lc');
+    expect(row.parentCode, 'pc');
+    expect(row.userId, 'u1');
+    expect(row.userName, 'ada');
+    expect(row.sharedBy, '');
+    expect(row.replyTo, '');
+    expect(row.messageType, 'team');
+    expect(row.messagePlanetCode, 'planet_xyz');
+    // 0, and deliberately: `News.createNews` reads `map["updatedDate"]` from
+    // the *outer* map, which `buildShareMap` never writes — it only puts the
+    // millis in the nested `news` object. So the row's own `updatedDate` stays
+    // 0 while `newsUpdatedDate` carries the share time.
+    expect(row.updatedDate, 0);
+    // The row's own clock, not the payload's — `News.createNews` sets
+    // `time = Date().time` independently of `map["updatedDate"]`.
+    expect(row.time, 9000);
+
+    expect(row.newsId, 'chat_1');
+    expect(row.newsRev, '2-rev');
+    expect(row.newsTitle, 'Tech Discussion');
+    expect(row.newsUser, 'ada');
+    expect(row.aiProvider, 'openai');
+    expect(row.newsCreatedDate, 1700000000000);
+    expect(row.newsUpdatedDate, 1700000000000);
+    expect(jsonDecode(row.conversations!), [
+      {'query': 'What is Kotlin?', 'response': 'A language.'},
+    ]);
+
+    // `name` is *absent*, not null: `getViewInJson` writes `map["name"]`,
+    // which `buildShareMap` never sets, and Gson drops a null key.
+    expect(jsonDecode(row.viewIn!), [
+      {'_id': 'team_123', 'section': 'teams'},
+    ]);
+  });
+
+  test(
+    'an untitled chat is shared with an empty title, never "null"',
+    () async {
+      final id = await share(row: chat(title: null));
+      expect((await database.newsDao.getById(id))!.newsTitle, '');
+    },
+  );
+
+  test('an empty conversation list leaves the column null', () async {
+    final id = await share(row: chat(conversations: '[]'));
+    expect((await database.newsDao.getById(id))!.conversations, isNull);
+  });
+
+  // `News.kt:187` runs the nested JSON through `replace("=", ":")`. That is a
+  // no-op in Kotlin only because Gson's html-safe default escapes `=` to
+  // `\u003d`; `jsonEncode` does not, so a literal port would rewrite the
+  // user's own text.
+  test('an "=" in conversation text survives the share', () async {
+    final id = await share(
+      row: chat(
+        conversations: jsonEncode([
+          {'query': 'why is 2+2=4?', 'response': 'see https://x.test/?a=b'},
+        ]),
+      ),
+    );
+    final turns =
+        jsonDecode((await database.newsDao.getById(id))!.conversations!)
+            as List;
+    expect(turns.single['query'], 'why is 2+2=4?');
+    expect(turns.single['response'], 'see https://x.test/?a=b');
+  });
+
+  group('the already-shared readers see what the writer wrote', () {
+    test(
+      'a share is found by planetNewsMessages and mapped to its chat',
+      () async {
+        await share(target: team);
+
+        final rows = await voices.planetNewsMessages('lc');
+        expect(rows, hasLength(1));
+        expect(VoicesRepository.extractSharedViewInIds(rows), {
+          'chat_1': {'team_123'},
+        });
+      },
+    );
+
+    test(
+      'planetNewsMessages matches the planet code case-insensitively',
+      () async {
+        await share(planetCode: 'LC');
+        expect(await voices.planetNewsMessages('lc'), hasLength(1));
+      },
+    );
+
+    test(
+      'planetNewsMessages ignores another planet, and a null code',
+      () async {
+        await share(planetCode: 'other');
+        expect(await voices.planetNewsMessages('lc'), isEmpty);
+        expect(await voices.planetNewsMessages(null), isEmpty);
+        expect(await voices.planetNewsMessages(''), isEmpty);
+      },
+    );
+
+    test(
+      'isAlreadyShared is true for the destination and false for another',
+      () async {
+        await share(target: team);
+
+        expect(await voices.isAlreadyShared('chat_1', 'team_123'), isTrue);
+        expect(await voices.isAlreadyShared('chat_1', 'team_999'), isFalse);
+        expect(await voices.isAlreadyShared('chat_2', 'team_123'), isFalse);
+      },
+    );
+
+    test('two destinations for one chat both register', () async {
+      await share(target: team);
+      await share(
+        target: const ChatShareTarget(id: 'lc@pc', name: 'Community'),
+        section: ChatShareSection.community,
+      );
+
+      final ids = VoicesRepository.extractSharedViewInIds(
+        await voices.planetNewsMessages('lc'),
+      );
+      expect(ids['chat_1'], {'team_123', 'lc@pc'});
+    });
+
+    test('an ordinary voice post contributes no chat destinations', () async {
+      await voices.createPost(
+        message: 'hello',
+        userId: 'u1',
+        userName: 'ada',
+        planetCode: 'lc',
+      );
+      expect(
+        VoicesRepository.extractSharedViewInIds(
+          await voices.planetNewsMessages('lc'),
+        ),
+        isEmpty,
+      );
+    });
+
+    test('a row whose viewIn will not parse loses only its own ids', () async {
+      await share(target: team);
+      await database.newsDao.upsert(
+        NewsEntriesCompanion.insert(
+          id: 'broken',
+          newsId: const Value('chat_1'),
+          viewIn: const Value('{not json'),
+          docType: const Value('message'),
+          createdOn: const Value('lc'),
+        ),
+      );
+
+      final ids = VoicesRepository.extractSharedViewInIds(
+        await voices.planetNewsMessages('lc'),
+      );
+      expect(ids['chat_1'], {'team_123'});
+    });
+  });
+
+  group('the viewIn entry the share writes', () {
+    test('omits name, so a later community share can back-fill it', () async {
+      final id = await share(target: team);
+
+      final before =
+          jsonDecode((await database.newsDao.getById(id))!.viewIn!) as List;
+      expect((before.single as Map).containsKey('name'), isFalse);
+
+      // `shareNewsToCommunity` back-fills the first entry's name only when the
+      // key is absent — `!obj.has("name")` is false for an explicit null, so
+      // writing one would silently disable this.
+      await voices.shareToCommunity(
+        newsId: id,
+        userId: 'u1',
+        planetCode: 'lc',
+        parentCode: 'pc',
+        teamName: 'Test Team',
+      );
+
+      final after =
+          jsonDecode((await database.newsDao.getById(id))!.viewIn!) as List;
+      expect((after.first as Map)['name'], 'Test Team');
+    });
+
+    test('a named target still records its name', () async {
+      final id = await voices.createPost(
+        message: 'hi',
+        userId: 'u1',
+        userName: 'ada',
+        viewInId: 'team_1',
+        viewInSection: 'teams',
+        viewInName: 'Bricklayers',
+      );
+      final entries =
+          jsonDecode((await database.newsDao.getById(id))!.viewIn!) as List;
+      expect(entries.single, {
+        '_id': 'team_1',
+        'section': 'teams',
+        'name': 'Bricklayers',
+      });
+    });
+
+    test('no destination yields an empty array', () async {
+      final id = await share(target: null);
+      expect(
+        jsonDecode((await database.newsDao.getById(id))!.viewIn!),
+        isEmpty,
+      );
+    });
+  });
+
+  // `isAlreadyShared` is a case-*insensitive* substring match on the raw
+  // `viewIn` text, where `extractSharedViewInIds` parses and compares ids
+  // case-sensitively. The two disagreeing is the Kotlin's behaviour, not an
+  // oversight to unify.
+  test(
+    'isAlreadyShared matches the destination id case-insensitively',
+    () async {
+      await voices.createFromShareMap(
+        payload: buildChatShareMap(
+          chat: chat(),
+          note: '',
+          target: const ChatShareTarget(id: 'Team_1', name: 'T'),
+          section: ChatShareSection.teams,
+          nowMillis: 1700000000000,
+        ),
+        userId: 'u1',
+        userName: 'ada',
+        planetCode: 'lc',
+      );
+
+      expect(await voices.isAlreadyShared('chat_1', 'team_1'), isTrue);
+      expect(
+        VoicesRepository.extractSharedViewInIds(
+          await voices.planetNewsMessages('lc'),
+        )['chat_1'],
+        {'Team_1'},
+      );
+    },
+  );
+
+  // Planet-unscoped, unlike the checkmark cache: the Kotlin query has no
+  // `createdOn` filter.
+  test('isAlreadyShared ignores the planet the share was written on', () async {
+    await share(target: team, planetCode: 'somewhere-else');
+    expect(await voices.isAlreadyShared('chat_1', 'team_123'), isTrue);
+  });
+
+  test(
+    'a chat the server has never seen shares under an empty newsId',
+    () async {
+      final id = await share(row: chat(docId: null));
+      expect((await database.newsDao.getById(id))!.newsId, '');
+    },
+  );
+
+  group('the upload path', () {
+    test(
+      'a shared chat is pending, and its wire document keeps the chat',
+      () async {
+        final id = await share(target: team);
+
+        final pending = await voices.pendingUploads();
+        expect(pending.map((r) => r.id), contains(id));
+
+        final doc = VoicesRepository.serialize(
+          pending.firstWhere((r) => r.id == id),
+        );
+        expect(doc['chat'], isTrue);
+        expect(doc['message'], 'Have a look');
+        expect(doc['messageType'], 'team');
+        expect(doc['messagePlanetCode'], 'planet_xyz');
+        expect(doc['viewIn'], [
+          {'_id': 'team_123', 'section': 'teams'},
+        ]);
+
+        final news = doc['news'] as Map<String, dynamic>;
+        expect(news['_id'], 'chat_1');
+        expect(news['_rev'], '2-rev');
+        expect(news['title'], 'Tech Discussion');
+        expect(news['aiProvider'], 'openai');
+        expect(news['createdDate'], 1700000000000);
+        expect(news['conversations'], [
+          {'query': 'What is Kotlin?', 'response': 'A language.'},
+        ]);
+      },
+    );
+
+    test(
+      'a delivered share stops being pending and stays discoverable',
+      () async {
+        final id = await share(target: team);
+        await voices.markUploaded(id, 'news_1', '1-abc');
+
+        expect(await voices.pendingUploads(), isEmpty);
+        expect(await voices.isAlreadyShared('chat_1', 'team_123'), isTrue);
+      },
+    );
+  });
+}

--- a/flutter/test/ui/chat/chat_history_share_test.dart
+++ b/flutter/test/ui/chat/chat_history_share_test.dart
@@ -18,6 +18,13 @@ class _FakeShareActions implements ChatShareActions {
   Ref get ref => throw UnimplementedError();
   final calls = <Map<String, Object?>>[];
 
+  /// What the screen sees when it opens the sheet. The real one recomputes
+  /// `sharedChatDestinationsProvider` first; here the test supplies it.
+  Map<String, Set<String>> destinationMap = const {};
+
+  @override
+  Future<Map<String, Set<String>>> destinations() async => destinationMap;
+
   @override
   Future<ChatShareOutcome> share({
     required ChatRow chat,
@@ -70,7 +77,7 @@ void main() {
     ChatShareOutcome outcome = ChatShareOutcome.shared,
     List<ChatRow>? chats,
   }) async {
-    final actions = _FakeShareActions(outcome);
+    final actions = _FakeShareActions(outcome)..destinationMap = destinations;
     await tester.pumpWidget(
       wrapScreen(
         const ChatHistoryScreen(),
@@ -78,9 +85,6 @@ void main() {
           chatHistoryProvider.overrideWith((ref) async => chats ?? [_chat()]),
           chatConversationProvider.overrideWith(_StubChatNotifier.new),
           chatShareTargetsProvider.overrideWith((ref) async => targets),
-          sharedChatDestinationsProvider.overrideWith(
-            (ref) async => destinations,
-          ),
           chatShareActionsProvider.overrideWithValue(actions),
         ],
       ),
@@ -106,6 +110,36 @@ void main() {
 
     expect(find.byKey(const Key('share-chat-c1')), findsOneWidget);
     expect(find.byKey(const Key('share-chat-c2')), findsOneWidget);
+  });
+
+  // The awaits sit inside `startChatShare`'s `try` because a future can reject
+  // where `valueOrNull` could not. Nothing pinned that until now.
+  testWidgets('a rejecting targets provider does not take the screen down', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const ChatHistoryScreen(),
+        overrides: [
+          chatHistoryProvider.overrideWith((ref) async => [_chat()]),
+          chatConversationProvider.overrideWith(_StubChatNotifier.new),
+          chatShareTargetsProvider.overrideWith(
+            (ref) async => throw StateError('no targets'),
+          ),
+          sharedChatDestinationsProvider.overrideWith(
+            (ref) async => const <String, Set<String>>{},
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('share-chat-c1')));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Chats could not be loaded'), findsOneWidget);
+    expect(find.byKey(const Key('share-group-community')), findsNothing);
   });
 
   testWidgets('the share sheet offers the community and team groups', (
@@ -306,6 +340,25 @@ void main() {
       find.text('This chat has already been shared to this destination'),
       findsOneWidget,
     );
+  });
+
+  // Not "Chats could not be loaded": the chat is on screen, and two of the
+  // three ways to `unavailable` have nothing to do with loading.
+  testWidgets('an unshareable chat says so, not that chats failed to load', (
+    tester,
+  ) async {
+    await pump(tester, outcome: ChatShareOutcome.unavailable);
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-note-submit')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('This chat cannot be shared yet'), findsOneWidget);
+    expect(find.text('Chats could not be loaded'), findsNothing);
   });
 
   testWidgets('a planet with no community offers no community entry', (

--- a/flutter/test/ui/chat/chat_history_share_test.dart
+++ b/flutter/test/ui/chat/chat_history_share_test.dart
@@ -1,0 +1,322 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/chat_provider.dart';
+import 'package:myplanet/repository/chat_repository.dart';
+import 'package:myplanet/ui/chat/chat_history_screen.dart';
+
+import '../../support/widget_harness.dart';
+
+/// Records what the screen asked to share, and answers with a fixed outcome.
+class _FakeShareActions implements ChatShareActions {
+  _FakeShareActions(this.outcome);
+
+  final ChatShareOutcome outcome;
+
+  @override
+  Ref get ref => throw UnimplementedError();
+  final calls = <Map<String, Object?>>[];
+
+  @override
+  Future<ChatShareOutcome> share({
+    required ChatRow chat,
+    required ChatShareTarget? target,
+    required String section,
+    required String note,
+  }) async {
+    calls.add({
+      'chat': chat.docId,
+      'target': target?.id,
+      'section': section,
+      'note': note,
+    });
+    return outcome;
+  }
+}
+
+/// The tap handler reaches `chatRepositoryProvider` and through it
+/// `planetPrefsProvider`, which is unimplemented in this harness.
+class _StubChatNotifier extends ChatConversationNotifier {
+  @override
+  ChatConversationState build() => const ChatConversationState();
+
+  @override
+  Future<void> loadChat(String chatId) async {}
+}
+
+ChatRow _chat({String id = 'c1', String? docId = 'chat_1'}) => ChatRow(
+  id: id,
+  docId: docId,
+  title: 'Math help',
+  conversations: '[{"query":"Math help","response":"hello there"}]',
+  lastUsed: 0,
+  isUploaded: false,
+);
+
+const _team = ChatShareTarget(id: 'team_1', name: 'Bricklayers');
+const _enterprise = ChatShareTarget(id: 'ent_1', name: 'Bakery');
+const _community = ChatShareTarget(id: 'lc@pc', name: 'Community');
+
+void main() {
+  Future<_FakeShareActions> pump(
+    WidgetTester tester, {
+    ChatShareTargets targets = const ChatShareTargets(
+      community: _community,
+      teams: [_team],
+      enterprises: [_enterprise],
+    ),
+    Map<String, Set<String>> destinations = const {},
+    ChatShareOutcome outcome = ChatShareOutcome.shared,
+    List<ChatRow>? chats,
+  }) async {
+    final actions = _FakeShareActions(outcome);
+    await tester.pumpWidget(
+      wrapScreen(
+        const ChatHistoryScreen(),
+        overrides: [
+          chatHistoryProvider.overrideWith((ref) async => chats ?? [_chat()]),
+          chatConversationProvider.overrideWith(_StubChatNotifier.new),
+          chatShareTargetsProvider.overrideWith((ref) async => targets),
+          sharedChatDestinationsProvider.overrideWith(
+            (ref) async => destinations,
+          ),
+          chatShareActionsProvider.overrideWithValue(actions),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    return actions;
+  }
+
+  Future<void> openShareSheet(WidgetTester tester) async {
+    await tester.tap(find.byKey(const Key('share-chat-c1')));
+    await tester.pumpAndSettle();
+  }
+
+  // Reachability: the whole slice below is dead without this button.
+  testWidgets('every chat row offers a share action', (tester) async {
+    await pump(
+      tester,
+      chats: [
+        _chat(),
+        _chat(id: 'c2', docId: 'chat_2'),
+      ],
+    );
+
+    expect(find.byKey(const Key('share-chat-c1')), findsOneWidget);
+    expect(find.byKey(const Key('share-chat-c2')), findsOneWidget);
+  });
+
+  testWidgets('the share sheet offers the community and team groups', (
+    tester,
+  ) async {
+    await pump(tester);
+    await openShareSheet(tester);
+
+    expect(find.text('Share with community'), findsOneWidget);
+    expect(find.text('Share with team/enterprise'), findsOneWidget);
+    // Collapsed to start with, exactly as `generateFlatList` builds it with an
+    // empty `expandedGroups`.
+    expect(find.byKey(const Key('share-child-teams')), findsNothing);
+  });
+
+  testWidgets('sharing to a team carries the team, section and note', (
+    tester,
+  ) async {
+    final actions = await pump(tester);
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-team')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-teams')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bricklayers'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('share-target-team_1')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('share-note-field')),
+      'worth a read',
+    );
+    await tester.tap(find.byKey(const Key('share-note-submit')));
+    await tester.pumpAndSettle();
+
+    expect(actions.calls, [
+      {
+        'chat': 'chat_1',
+        'target': 'team_1',
+        'section': 'teams',
+        'note': 'worth a read',
+      },
+    ]);
+    expect(find.text('Chat shared'), findsOneWidget);
+  });
+
+  testWidgets('sharing to an enterprise uses the enterprises section', (
+    tester,
+  ) async {
+    final actions = await pump(tester);
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-team')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-enterprises')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-target-ent_1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-note-submit')));
+    await tester.pumpAndSettle();
+
+    expect(actions.calls.single['target'], 'ent_1');
+    expect(actions.calls.single['section'], 'enterprises');
+    // `add_note` is optional; an untouched field still shares.
+    expect(actions.calls.single['note'], '');
+  });
+
+  testWidgets('sharing to the community uses the community section', (
+    tester,
+  ) async {
+    final actions = await pump(tester);
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-note-submit')));
+    await tester.pumpAndSettle();
+
+    expect(actions.calls.single['target'], 'lc@pc');
+    expect(actions.calls.single['section'], 'community');
+  });
+
+  testWidgets('cancelling the note dialog shares nothing', (tester) async {
+    final actions = await pump(tester);
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(actions.calls, isEmpty);
+  });
+
+  testWidgets('an empty team list explains how to get one', (tester) async {
+    final actions = await pump(
+      tester,
+      targets: const ChatShareTargets(community: _community),
+    );
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-team')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-teams')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Please join a Team to share this chat'), findsOneWidget);
+    expect(actions.calls, isEmpty);
+  });
+
+  testWidgets('an empty enterprise list has its own message', (tester) async {
+    await pump(tester, targets: const ChatShareTargets(community: _community));
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-team')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-enterprises')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Please join an Enterprise to share this chat'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a destination the chat already reached cannot be picked', (
+    tester,
+  ) async {
+    final actions = await pump(
+      tester,
+      destinations: const {
+        'chat_1': {'team_1', 'lc@pc'},
+      },
+    );
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-community')));
+    await tester.pumpAndSettle();
+    // Still on the branch dialog: the disabled tile swallowed the tap.
+    expect(find.byKey(const Key('share-note-field')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('share-group-team')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-teams')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-target-team_1')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('share-note-field')), findsNothing);
+
+    expect(actions.calls, isEmpty);
+  });
+
+  testWidgets('another chat is unaffected by this one being shared', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      chats: [_chat(id: 'c2', docId: 'chat_2')],
+      destinations: const {
+        'chat_1': {'team_1'},
+      },
+    );
+    await tester.tap(find.byKey(const Key('share-chat-c2')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('share-group-team')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-teams')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-target-team_1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('share-note-field')), findsOneWidget);
+  });
+
+  testWidgets('a duplicate share is reported rather than posted twice', (
+    tester,
+  ) async {
+    await pump(tester, outcome: ChatShareOutcome.alreadyShared);
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-child-community')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('share-note-submit')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('This chat has already been shared to this destination'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a planet with no community offers no community entry', (
+    tester,
+  ) async {
+    await pump(tester, targets: const ChatShareTargets(teams: [_team]));
+    await openShareSheet(tester);
+
+    await tester.tap(find.byKey(const Key('share-group-community')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('share-child-community')), findsNothing);
+  });
+}


### PR DESCRIPTION
Lane C of the Phase 140 round. Draft — this is the integrator's inbound channel.

## The gap

Phase 133 checked upstream `7167684` ("smoother chat history model payload sharing") and found the port unaffected — but not because the port matches it. The port has **no chat share at all**: nothing built `ChatSharePayload.buildShareMap`, `chat_history_screen.dart` had no share action, and the `news` table's chat columns (`newsId`, `newsTitle`, `aiProvider`, `conversations`, …) had a reader and a serializer but no writer.

The share target is **voices**: a shared chat becomes a `news` document with `chat: true` and the conversation embedded under a nested `news` object, addressed via `viewIn` to a team, an enterprise, or the planet community. Every column it fills already existed on `NewsEntries`, so **no schema bump was needed**.

## What landed

- `buildChatShareMap` — pure, top-level in `chat_repository.dart`, alongside `ChatShareTarget` and `ChatShareSection`.
- `VoicesRepository.createFromShareMap` — the `map["news"]` branch of `News.createNews`, plus `isAlreadyShared`, `planetNewsMessages`, `extractSharedViewInIds` and `authorJson`.
- `chat_provider` — share targets, the shared-destination map, and a write path that enqueues for upload at share time.
- `chat_history_screen` — the per-row share affordance and the three dialogs the Kotlin opens.
- 8 new English l10n keys (`app_en.arb` only; other locales are Lane D's).
- **60 new tests** across four files. 24 mutations applied one at a time to green code; all 24 caught.

Two `parity-auditor` passes at `effort: max` ran, one on the Kotlin ground truth before implementing and one on the finished green code. Both found defects — including two the green tests structurally could not catch, and two wrong claims of mine.

## Two lines deliberately not carried across

Both documented at the code:

- `News.kt:187`'s `newsObj.replace("=", ":")`. It is a **no-op in Kotlin**, and not for any reason visible in the source: `JsonUtils.gson` is a bare `Gson()`, whose html-safe default escapes `=` to `=` inside every string. Dart's `jsonEncode` emits `=` raw, so a literal port would rewrite every `=` in the user's own title and transcript. Dropping the line *preserves* behaviour.
- The localised `viewInSection`. `ChatHistoryAdapter` passes `getString(R.string.teams)` straight to the wire, so a community share made on a non-English handset writes a translated `section` and is invisible in the community feed of both apps. The port writes stable literals, as every other writer on both sides already does.

## What the second audit found

- **Every chat share reached CouchDB with no author.** `serializeNews` writes no top-level `userId`/`userName` — the nested `user` object is the only author identity a news document carries, and `NewsMapper.fromDoc` reads both back out of it. Fixed with `VoicesRepository.authorJson` (`UserEntity.serialize()` minus the credential branch, the device trio and the photo).
- **The community branch was unreachable in the running app.** Nothing in `lib/` calls `PlanetPrefs.setCommunityName` — the pref's only writer was one of this phase's own tests, so `community` was permanently null. Now falls back to `ServerConfig.code`, which is the value Kotlin stores in that pref.
- A member registered offline was offered **no** teams (memberships were scoped by the local row id, not the CouchDB id — a hard filter here, unlike the sort-order use in `teams_provider`).

## Blocked on files other lanes own

Detailed with exact file, change and reason in `flutter/PHASE_140_NOTES.md` § "Reported, not fixed":

1. The `teams` Drift table has no `teamPlanetCode` column, so `messagePlanetCode` is always `""` (needs a `schemaVersion` bump — Lane A's).
2. `NewsDao` has no `getByNewsId`/`getPlanetMessages`; both are walked in Dart instead.
3. Six deviations want recording in `docs/kotlin-to-flutter-migration.md`.
4. **There is no periodic voices upload sweep.** Kotlin's `uploadNews()` is an unconditional full-table sweep from two workers; the port enqueues at write time and skips it when `serverConfigProvider` is null. This is the Phase 134 shape and it covers every port-authored voice, not just chat shares, so it wants its own slice.
5. `createPost`/`createTeamPost`/`postReply` still upload with `"user": null` — one argument each, in `voices_provider.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a2secAdSeWxkwpvABNoTs
