### PR TITLE
Phase 144 (Lane C): voices upload sweep + author on every locally authored voice

### DIFF
--- a/flutter/PHASE_144_NOTES.md
+++ b/flutter/PHASE_144_NOTES.md
@@ -1,5 +1,325 @@
 # Phase 144 — the voices upload sweep and the missing author (Lane C)
 
-Two items from Phase 140's *Reported, not fixed* list, items 4 and 5.
+Two items from Phase 140's *Reported, not fixed* list — 4 and 5, both of which
+that lane had withdrawn from an over-strong earlier claim. The ground-truth
+`parity-auditor` pass then found a third defect bigger than either, and it is
+the one to read first.
 
-*(Work in progress — this file is filled in as the phase proceeds.)*
+## What landed
+
+| Fix | Where | Class |
+|---|---|---|
+| A periodic voices upload sweep, on both sync paths | `dashboard_sync_provider.dart`, `background_entrypoint.dart` | the safety net Kotlin has and the port did not (Phase 134) |
+| A send already on the wire is not re-enqueued | `voices_uploader.dart` | append replayed as a duplicate |
+| Every locally authored voice names its author | `voices_provider.dart` | sync-in rewriting a locally-authored column |
+| The session is awaited, not read | `voices_provider.dart` | `.valueOrNull` on an unwatched provider |
+| **A composed community post is addressed to the community** | `voices_provider.dart` | **reachability — the writer produced no value the reader matches** |
+| A team post carries `''`, not the author's planet code | `voices_provider.dart` | two port writers disagreeing about one field |
+| `authorJson` drops a null-valued key instead of writing `null` | `voices_repository.dart` | faithfulness to Gson's `serializeNulls` |
+
+**25 new tests** across three new files and two existing ones, counted from the
+runner. **19 mutations, 19 caught** — the list is at the bottom. Two
+`parity-auditor` passes at `effort: max` ran, one on the Kotlin ground truth
+before implementing and one on the finished green code.
+
+## The third defect: a community post nobody could see
+
+Found by the ground-truth pass, verified by hand against the Kotlin, and
+demonstrated failing before the fix.
+
+`VoicesFragment.btnSubmit` (`ui/voices/VoicesFragment.kt:137-148`) builds
+**four** keys before it calls `createNews`:
+
+```kotlin
+map["viewInId"] = "${user?.planetCode ?: ""}@${user?.parentCode ?: ""}"
+map["viewInSection"] = "community"
+map["messageType"] = "sync"
+map["messagePlanetCode"] = user?.planetCode ?: ""
+```
+
+`VoicesScreen._compose` called `createPost(message)` with the message alone. So
+`_viewInJson(id: null, …)` returned `"[]"`, and `isVisibleToUser` fell straight
+through its `viewIn == null || viewIn.isEmpty` guard to `false` — the
+`viewableBy == 'community'` shortcut above it does not fire either, because a
+locally composed post has no `viewableBy`. **The post the user just wrote was
+listed by nobody**: not in this app's community feed, and not on Planet, because
+`serialize` omits the `viewIn` key entirely for an empty list, so the uploaded
+document had no audience at all and a pull-back could not repair it.
+
+This is the Phase 113 shape exactly — *can the writer produce values the
+reader's predicate matches?* — and the tell was the same one: every existing
+community-feed test builds its rows through `cacheDocuments`, i.e. from a
+server document, so nothing had ever asked the writer and the reader about each
+other. `communityViewerIdentifier` was already in the file, three functions
+above the writer that needed it, ported and used only by the *reader*.
+
+Both halves of the identifier are interpolated unguarded, as Kotlin does: a
+user missing a code writes `"@"`, `"learning@"` or `"@earth"`, and an empty or
+`"@"` id is the planet-wide wildcard on both sides. So a guest-shaped account
+still reaches everyone rather than nobody, which a `trim`-and-skip would have
+broken. Pinned by *a user with no planet codes still addresses the community*.
+
+## Job 1 — the sweep
+
+**Kotlin has no write-time upload for a voice at all.** Composing one writes a
+`news` row and stops; the document reaches the server when
+`UploadManager.uploadNews()` next runs, from `AutoSyncWorker:130` and
+`UserDataWorker:40`, off nothing the post did. `getNewsForUpload()`
+(`VoicesRepositoryImpl.kt:36-48`) is `newsDao.getAll()` minus rows whose
+`userId` starts with `guest` — that five-character prefix is the *only* filter:
+no empty-message test, no `docType`, no `replyTo IS NULL`, no `chat` test.
+Replies, comments and chat shares all go up on every sweep.
+
+The port inverted the relation: `VoicesActions` enqueues at write time — better
+when it runs — and nothing swept. `VoicesActions.queuePending` returns 0 when
+`serverConfigProvider` is null, and every caller reports success regardless, so
+a voice composed before the server was configured sat on the handset until the
+same user happened to make some *other* voices write, because `queuePending` is
+an unscoped sweep that then rescues it incidentally. That path is now a test —
+*a voice composed with no server configured still goes out* — driven the way a
+user reaches it rather than by seeding the end state.
+
+`queuePendingVoices()` runs from `syncAll` immediately before
+`queuePendingSubmissions()`, which is the order both Kotlin workers have
+(`AutoSyncWorker:130` before `:136`; `UserDataWorker:40` before `:48`). It
+queues only: the unscoped drain at the end of `queuePendingSubmissions` carries
+these rows out in the same pass, and *syncAll delivers a voice nothing enqueued*
+pins that coupling end to end rather than trusting the adjacency.
+`sweepPendingVoices` is the headless half, called from `drainOutbox` and
+deliberately not from `syncSteps` — those run only for an `autoSync` task, with
+auto-sync enabled, and only when the interval is due, and
+`BackgroundWorkCoordinator` cancels the `autoSync` job outright for a user who
+turns auto-sync off, so a step there would never run for exactly the user most
+likely to have an undelivered post.
+
+Swallowed, and in its own `try`, following `UserDataWorker`'s per-arm
+`runCatching` rather than `AutoSyncWorker`'s single shared `try` (where an
+earlier arm throwing skips `uploadNews` silently — a Kotlin weakness, not a
+behaviour to reproduce). It is not hypothetical: `queuePending` reads device
+identity before it enqueues anything, and `PlatformDeviceIdentitySource.read`
+rethrows on an engine with no channel and no primed cache.
+
+### It cannot double-post — and one protection was missing
+
+Three protections, and only the first is Kotlin's:
+
+1. `markUploaded` stamps `_id`/`_rev` and clears `isEdited`, taking the row out
+   of `pendingUploads` — the port of `markNewsUploaded`.
+2. `OutboxRepository.enqueue` keys on `(uploadType, itemId)`, so a sweep over an
+   already-queued row refreshes it rather than adding a second.
+3. **New here:** `queuePending` now skips a row whose send is in flight.
+
+The third was a real gap, not a precaution. `enqueue` deliberately puts an
+`in_progress` row back to `pending` so a payload edited mid-flight is not lost,
+and `markCompleted` is `deleteIfInProgress` — so the send that succeeds moments
+later deletes nothing, the row survives `pending` with the same body, and the
+next drain posts a **second** `news` document. That reset is right for derived
+state, whose handler rebuilds; a voice with no `_id` is an append.
+`SubmissionsUploader` and `AdoptedSurveysUploader` both guard with
+`isInFlight`; `VoicesUploader` did not, and `dashboard_sync_provider` already
+*asserted* the guard existed in a doc comment. Reachable before this phase (any
+second voices write re-enqueues everything undelivered, including a row whose
+POST is on the wire) and systematic with the sweep.
+
+### The predicate divergence, decided rather than shipped silently
+
+`getNewsForUpload()` returns every non-guest row and re-sends it on every sync.
+Because `serializeNews` writes `_id`/`_rev` when non-null and `_bulk_docs`
+defaults to `new_edits=true`, that is an *update*, not a duplicate — but it
+churns a revision per post per sync. `VoicesRepository.pendingUploads` returns
+only rows that were never delivered or have been edited since.
+
+**Kept narrow, deliberately.** Every local mutation the port has sets
+`isEdited` — `editPost`, `shareToCommunity`, the un-share branch of
+`deletePost`, `toggleReaction` — so nothing a user can do leaves a changed row
+outside the set. What the narrow predicate gives up is Kotlin's *incidental*
+repair of a server-side divergence, which no reader on either side depends on.
+The claim about those four mutations was a comment nothing pinned; it now has
+a test (*every local mutation puts a delivered post back in the queue*), and
+mutating either of the two it did not already cover turns it red.
+
+## Job 2 — the author
+
+A `news` document carries **no** top-level `userId` or `userName`. I read the
+whole of `serializeNews` (`VoicesRepositoryImpl.kt:421-453`) to be sure: the
+nested `user` object is the sole author identity, and
+`buildNewsFromJson:386-389` reads the local row's `user`, `userId` *and*
+`userName` back out of that one object — unconditionally, so a document without
+it does not merely fail to set them, it **erases** what the row had. Kotlin sets
+it on every write path, because all four go through `News.createNews:181`.
+
+`VoicesRepository.authorJson` landed with the chat share in Phase 140 and the
+other three writers never used it, so every ordinary post, team post and reply
+the port authored uploaded anonymous and lost its author here at the next
+sync-in. One argument each.
+
+Tested as pairs, never as halves: each test drives the writer, takes the
+document the **outbox is actually holding**, and feeds that back through
+`cacheDocuments`. The erasure test additionally calls `markUploaded` first —
+without a server `_id` on the local row a pulled document lands *beside* it
+rather than over it, so an author-less pull looks harmless until the post has
+actually been delivered, which is the only state that matters.
+
+### The session read, found while wiring it
+
+All four `VoicesActions` writers read `ref.read(sessionProvider).valueOrNull` on
+a provider this file never watches, so the user was null until something else
+resolved it and the composed post was dropped with no error, no snackbar and no
+row — latent only because the router holds a `ref.listen`. Now awaited, with the
+`await` inside the enclosing `try`, because a future can reject where
+`valueOrNull` could not.
+
+**My first draft of that comment named the wrong screen**, and the
+implementation-audit pass caught it: it said `TeamVoicesScreen` touches
+`sessionProvider` nowhere at all. It does, transitively and load-bearingly — it
+watches `teamMembershipsProvider`, which watches the session, and its compose
+FAB only renders once a membership resolves. The screen with the live window is
+`VoicesScreen`, whose FAB is **ungated** and renders while
+`communityFeedProvider` is still loading. Corrected at the code. A citation is
+not a reading, even when the citation is to the port.
+
+## `messagePlanetCode` on a team post: `''`, not the author's
+
+The brief asked whether `user.planetCode` was defensible in the interim. It is
+not, and the port had already decided otherwise once.
+
+`TeamsVoicesFragment.kt:74-81` writes `team?.teamPlanetCode ?: ""` — the
+**team's** planet, not the author's. `MyTeam.kt:86` reads that field with
+`JsonUtils.getString`, which returns `""` for an absent key, so a team document
+that omits it yields `""` in Kotlin too. They coincide only for a team created
+on the user's own planet (`TeamsRepositoryImpl.kt:170,177,699`); for a team
+pulled from a parent or sibling planet they differ, and the port was stamping a
+planet code it had no basis for. `''` is the faithful interim value, it is the
+only value the port can produce without the `teamPlanetCode` column (Lane B's
+`tables.dart`, not mine), and it is what the port's own chat-share writer
+already sends for exactly this reason (`chat_repository.dart:306-310`). Phase
+140's complaint that the port had "two writers addressing the same team with two
+different values for one field" is closed by making the second agree with the
+first.
+
+## Reported, not fixed
+
+Each names the file, the change, and why it was not made here.
+
+1. **An enterprise voice post is labelled `team`.** Kotlin writes
+   `getEffectiveTeamType()` (`BaseTeamFragment.kt:94-96`) — the team's `type`,
+   so `"team"` **or `"enterprise"`**; the port hardcodes `'team'`. The fix is a
+   `teamType` argument on `createTeamPost` (my file) passed from
+   `lib/ui/teams/team_voices_screen.dart:89-101` (**not my file**), which
+   already has the `team` in scope and `TeamRow.type` on it. Adding the
+   parameter without the caller would ship a dead argument, so both halves want
+   one lane.
+2. **`addComment` writes an unauthored row, and the sweep now delivers it
+   reliably.** `voices_repository.dart:844` claims to port
+   `TeamsRepositoryImpl.addComment`; **there is no such Kotlin method** —
+   `grep -rn "fun addComment" app/src` is empty, and `messageType = "comment"`
+   appears nowhere in the Kotlin (Phase 74 records inline comments as a
+   port-original from unmerged issue #15112). The row carries no `user`, and
+   its caller, `lib/ui/teams/inline_comments.dart:131` (**not my file**), never
+   queues it. **Decided, not overlooked:** comments stay in `pendingUploads`.
+   They were already uploaded incidentally by the unscoped write-time
+   `queuePending`, so the sweep changes reliability, not the class of document
+   reaching CouchDB; excluding them would make comments device-local, a bigger
+   behaviour change with no ground truth to check it against. The author gap is
+   one argument on `addComment` plus one at that call site — the same shape as
+   Job 2, in a file this lane does not own. The stale doc comment should go with
+   it.
+3. **`voice_thread_screen._reply` has the `.valueOrNull` defect this phase fixed
+   four instances of.** `lib/ui/voices/voice_thread_screen.dart:67` reads the
+   session and returns early; the screen does not watch it. The reply is now
+   safe *inside* `VoicesActions.postReply`, but the screen's own early return
+   still drops the tap before it gets there. One-line fix in a file this lane
+   does not own.
+4. **`authorJson` omits `iterations`, which `UserEntity.serialize()` writes.**
+   `UserRow.iterations` exists (`tables.dart:31`) and `UserMapper` already ports
+   the blank/NaN-to-10 fallback (`user_mapper.dart:257`). Deliberately left out
+   rather than added: it is a PBKDF2 parameter and a voices post is a public
+   document, so adding it wants the same explicit judgement Phase 140 applied to
+   the credential branch, not a silent completion of the field list. Recorded so
+   "matches `serialize()` field for field" is not read as exhaustive.
+5. **Three duplicate/loss vectors in Kotlin's `uploadNews()` that the port must
+   not copy**, all found by the ground-truth pass:
+   (a) `UploadManager.kt:485-487` pairs responses to documents **positionally
+   and loops over the response length**, so a short response silently leaves the
+   tail unmarked and the next sweep re-creates them — `uploadTeams` ten lines up
+   detects exactly this and logs it;
+   (b) `RetryQueueWorker.kt:208-233` re-POSTs a failed news create and **never
+   writes the id back**, so a post composed offline can reach CouchDB twice;
+   (c) a per-document `{"error":"conflict"}` is queued as retryable, the retry
+   PUTs the same stale `_rev`, and `RetryQueueWorker.kt:234-238` treats the 409
+   as "already synced" — **the edit is discarded with a success log**.
+   The port's outbox has none of these shapes. Worth a line in
+   `docs/kotlin-to-flutter-migration.md` (**Lane A's file**) so a future harvest
+   does not port them as parity.
+6. **`markNewsUploaded` does not write back the message it uploaded.**
+   `uploadNews` appends `![](resources/<id>/<file>)` per image to the *outgoing*
+   message only (`UploadManager.kt:426,460,464`); the write-back
+   (`VoicesRepositoryImpl.kt:50-69`) sets `imageUrls`, `_id`, `_rev` and
+   `images` and leaves `message` alone, so a sweep before the next pull re-PUTs
+   the stripped message over the server's. A Kotlin bug; the port has no image
+   upload path yet, so there is nothing to diverge from — recorded before
+   someone ports the asymmetry along with the feature.
+7. **`uploadNewsActivities()` is dead code in Kotlin.** `uploadNews` ends by
+   calling it, but `NewsLogDao.insert` has **zero callers** in `app/src/main` —
+   the `news_log` table is never written. Do not build one for the port.
+8. **The port prunes `news`; Kotlin never does.**
+   `voices_repository.dart:1057` runs `deleteNotIn(docIds)` after a complete
+   walk, where `TransactionSyncManager.kt:220-223` calls `insertNewsList` and
+   nothing else — there is no delete on that table anywhere in the Kotlin.
+   `NewsDao.deleteNotIn` spares rows with a null `docId`, so an undelivered post
+   is safe; a delivered-but-locally-edited row whose server copy was removed is
+   not. Left alone: removing a prune is a behaviour change of its own and this
+   lane's brief is the delivery path. Belongs in the deviations list.
+9. **The `sharedBy` asymmetry recorded in two places does not exist.**
+   `docs/kotlin-to-flutter-migration.md:1183-1184` and
+   `lib/data/local/news_mapper.dart:87-89` both say `sharedBy` is "read from the
+   nested `news` object but written at the top level by `News.createNews`".
+   `createNews:165` sets a **column**, not a document key; the only place it
+   reaches a document is `serializeNews`'s nested object (`:449`), and
+   `buildNewsFromJson` reads it from the same nested object (`:417`). Kotlin is
+   symmetric. The port's behaviour is right and only the stated reason is wrong
+   — which is worth correcting, because someone could "fix" a non-existent
+   asymmetry on the strength of it.
+10. **Phase 140's items 1, 2, 3 and 6 are still open**, and all four are in
+    files this round assigned elsewhere (`tables.dart`, `app_database.dart`,
+    the migration doc). Item 1's `teamPlanetCode` column is what would let
+    `createTeamPost` and the chat share both send the *right* value rather than
+    agreeing on `''`.
+
+## Mutations run
+
+Each was applied alone to green code and reverted; all 19 were caught, and the
+test that caught each is named. Two of them exist because the mutation found a
+claim nothing pinned (13 and 14/15), which is the Phase 122 practice.
+
+| Mutation | Caught by |
+|---|---|
+| the sync-path sweep is not called from `syncAll` | 4 sweep tests |
+| the in-flight guard is removed | a re-enqueue mid-flight does not post a second voice |
+| the headless sweep is not called from `drainOutbox` | the headless path calls the voices sweep |
+| the headless sweep moves behind the drain | the same |
+| the sync-path sweep drops its `try`/`catch` | a sweep that throws does not fail the sync |
+| the headless sweep drops its `try`/`catch` | a throwing sweep is swallowed |
+| identity is read with nothing to queue | the sweep reads device identity only when it has rows |
+| `createPost` passes no author | 3 author tests |
+| `createTeamPost` passes no author | a team voice post names its author |
+| `postReply` passes no author | a reply names its author |
+| the session is read rather than awaited | 4 tests |
+| `authorJson` carries the credential branch | the author object carries no credentials |
+| `queuePending` reports the pending count | a send already on the wire is neither counted nor re-queued |
+| `toggleReaction` does not flag the row | every local mutation puts a delivered post back in the queue |
+| the un-share branch does not flag the row | the same, plus an existing community test |
+| `authorJson` writes explicit nulls | a field the user has not filled in is absent, not null |
+| `createPost` does not address the community | 3 community tests |
+| `createPost` keeps the default `messageType` | the composed post addresses the community on the wire |
+| `createTeamPost` claims the author planet code | a team post carries no planet code it cannot know |
+
+## Files touched
+
+`lib/repository/voices_repository.dart`, `lib/repository/voices_uploader.dart`,
+`lib/providers/voices_provider.dart`, `lib/providers/dashboard_sync_provider.dart`,
+`lib/background_entrypoint.dart`, and the tests for them.
+`lib/core/**` was **not** touched: `OutboxDrainScope` lives at
+`lib/ui/outbox_drain_scope.dart` and needed no step — the drain it triggers is
+unscoped, so it already carries whatever the sweeps queued.
+No schema change, no `app_database.dart`, no `tables.dart`.

--- a/flutter/PHASE_144_NOTES.md
+++ b/flutter/PHASE_144_NOTES.md
@@ -1,0 +1,5 @@
+# Phase 144 — the voices upload sweep and the missing author (Lane C)
+
+Two items from Phase 140's *Reported, not fixed* list, items 4 and 5.
+
+*(Work in progress — this file is filled in as the phase proceeds.)*

--- a/flutter/PHASE_144_NOTES.md
+++ b/flutter/PHASE_144_NOTES.md
@@ -17,8 +17,8 @@ the one to read first.
 | A team post carries `''`, not the author's planet code | `voices_provider.dart` | two port writers disagreeing about one field |
 | `authorJson` drops a null-valued key instead of writing `null` | `voices_repository.dart` | faithfulness to Gson's `serializeNulls` |
 
-**26 new tests** across three new files and two existing ones, counted from the
-runner. **20 mutations, 20 caught** — the list is at the bottom. Two
+**27 new tests** across three new files and two existing ones, counted from the
+runner. **26 mutations, 26 caught** — the list is at the bottom. Two
 `parity-auditor` passes at `effort: max` ran, one on the Kotlin ground truth
 before implementing and one on the finished green code.
 
@@ -91,10 +91,11 @@ user reaches it rather than by seeding the end state.
 
 `queuePendingVoices()` runs from `syncAll` immediately before
 `queuePendingSubmissions()`, which is the order both Kotlin workers have
-(`AutoSyncWorker:130` before `:136`; `UserDataWorker:40` before `:48`). It
-queues only: the unscoped drain at the end of `queuePendingSubmissions` carries
-these rows out in the same pass, and *syncAll delivers a voice nothing enqueued*
-pins that coupling end to end rather than trusting the adjacency.
+(`AutoSyncWorker:130` before `:136`; `UserDataWorker:40` before `:48`) — and
+which is now asserted rather than only asserted about, in both the foreground
+and the headless path. It queues **and drains**, unscoped, as
+`queuePendingSubmissions` does; see *What the implementation audit changed* for
+why relying on the neighbour's drain was not sound.
 `sweepPendingVoices` is the headless half, called from `drainOutbox` and
 deliberately not from `syncSteps` — those run only for an `autoSync` task, with
 auto-sync enabled, and only when the interval is due, and
@@ -108,6 +109,73 @@ earlier arm throwing skips `uploadNews` silently — a Kotlin weakness, not a
 behaviour to reproduce). It is not hypothetical: `queuePending` reads device
 identity before it enqueues anything, and `PlatformDeviceIdentitySource.read`
 rethrows on an engine with no channel and no primed cache.
+
+### What the implementation audit changed
+
+The second `parity-auditor` pass, on the finished green code, found one live
+defect and three documentation failures of the same class. All four are fixed;
+the rest of its findings are in *Reported, not fixed*.
+
+**The in-flight guard turned a mid-flight edit into permanent loss, and both
+reasons I gave for accepting that were wrong.** The comment said Kotlin "loses
+it identically". It does not: `getNewsForUpload` has no predicate beyond the
+guest prefix, and `markNewsUploaded` (`VoicesRepositoryImpl.kt:50-66`) writes
+back `imageUrls`, `_id`, `_rev` and `images` and touches no edit marker — so
+Kotlin's next sweep re-serializes the edited message with the fresh `_rev` and
+it lands as an update. The sentence was copied verbatim from
+`submissions_uploader.dart:64`, where it **is** true, because `SubmissionDao:44`
+clears `isUpdated` in the same statement that stamps the id and
+`getPendingSubmissions` filters on it. It does not transfer, because the narrow
+`pendingUploads` predicate is the port's own invention for voices. The second
+claim, that a lost edit is "recoverable", was wrong too: `NewsMapper.fromDoc`
+writes `message` unconditionally, so the next pull overwrites the user's text
+with the server's older copy and the edit is destroyed on the device as well.
+
+Concretely: compose a post offline, tap Sync, and edit it while the POST is on
+the wire. `queuePending` skips the in-flight row (correctly — a replay would
+fork the post), then `markUploaded` cleared `isEdited`, and with a `docId` now
+set the row fell out of `pendingUploads` for good. `markUploaded` now takes the
+document that actually went out and keeps the flag when the row no longer
+matches it (`payloadMatchesRow`), so the next sweep re-queues it carrying the
+`_id`/`_rev` just recorded — an update, not a duplicate. Whole documents are
+compared rather than a hand-listed set of columns, so a future writer touching
+a column nobody thought of is covered by construction.
+
+**The delivery coupling was not unconditional.** `queuePendingVoices` queued and
+relied on `queuePendingSubmissions` draining next. That drain sits *inside* its
+`try`, after `submissionsUploaderProvider.queuePending`, so anything throwing
+there is swallowed and the voices rows would wait for app resume. Hunk adjacency
+is not a guarantee — the same lesson the round's brief gives about two lanes
+sharing a file, arriving through one method calling another. It drains for
+itself now, which is also closer to Kotlin, whose sweep *posts*. The first cut's
+claim that a test "pins that coupling end to end" was false: that test drove
+only the happy path.
+
+**`addLabel` and `removeLabel` broke the enumeration.** "Every local mutation
+sets `isEdited`" listed four writers and missed two, which mutate `labels` — a
+column `serialize` sends — and set no flag. Harmless only because they have zero
+callers in `lib/`; Kotlin has a live labels UI and its sweep re-sends everything,
+so the day someone wires the chips up a label change would have been silently
+device-local. Both flagged, both now pinned.
+
+**Two mutations found claims nothing pinned** — the voices sweep's own drain and
+the label flags — which is the Phase 122 practice paying out again. One earlier
+mutation of mine was itself invalid: its anchor matched the *submissions* sweep
+first and reported a false negative. **Check that a mutation changed the line
+you meant.**
+
+Three citation slips are corrected at the code: `TeamsVoicesFragment.kt:81` not
+`:78`; `VoicesFragment.kt:140-143` not `:139-143`; and the empty-`viewIn`
+mechanism, which I described in four places as `isVisibleToUser` "falling
+through its empty-`viewIn` guard" when the value is the string `"[]"` — neither
+null nor empty, so it decodes to an empty list and `.any` returns false one
+branch later. Same outcome, wrong mechanism, copied four times. The
+"matches `serialize()` field for field" sentence in `authorJson` now names the
+`iterations` exception instead of leaving the correction in a notes file nobody
+reading the code will open. And the wrong claim about `TeamVoicesScreen` that
+this phase corrected **at the code** survived verbatim in the test comment for
+the very case it was about; that copy is fixed too. *A correction has to reach
+every copy of the claim.*
 
 ### It cannot double-post — and one protection was missing
 
@@ -290,7 +358,31 @@ Each names the file, the change, and why it was not made here.
    symmetric. The port's behaviour is right and only the stated reason is wrong
    — which is worth correcting, because someone could "fix" a non-existent
    asymmetry on the strength of it.
-10. **Phase 140's items 1, 2, 3 and 6 are still open**, and all four are in
+10. **The sweep decodes the whole `news` table every 15 minutes.**
+    `pendingUploads` is `_dao.getAll()` plus an in-memory filter — `NewsDao`
+    has no predicate query for it — and `drainOutbox` runs on **both** the
+    `autoSync` and the `maintenance` task, ahead of every gate, where
+    `maintenanceInterval` is 15 minutes. `sweepPendingSubmissions` is not
+    comparable: `SubmissionDao.pendingUploads` is an indexed query. Kotlin's
+    `getNewsForUpload` runs only from its two workers. Fix: a
+    `WHERE _id IS NULL OR _id = '' OR is_edited = 1` query on `NewsDao` in
+    `lib/data/local/app_database.dart` (**Lane B's file**, and this lane was
+    told to stop and report rather than assume the DAO gains methods). The
+    placement stands on its own reasoning; only the cost is unaddressed.
+11. **The reachability test's bounds are sound but one edit from unfailable.**
+    The slice ends at the first `@visibleForTesting`, so `sweepPendingVoices`'s
+    own declaration is excluded — verified by offset, not by eye. It stays that
+    way only while the doc comment above that annotation never writes
+    `sweepPendingVoices(` with an open paren. Ending the slice at the close of
+    `executeBackgroundTask` would be robust; left alone because the fix belongs
+    with `sweepPendingSubmissions`'s copy of the same test, and changing one
+    without the other is how the two drift.
+12. **`recoverStuck` does not run on foreground resume.** It runs at startup
+    only (`outbox_drain_scope.dart:51`), so a row left `in_progress` by a kill
+    mid-drain blocks its item's re-queue — now including a voice, via the new
+    in-flight guard — until the next launch or headless invocation. Bounded and
+    pre-existing; noted because the guard gives it one more way to matter.
+13. **Phase 140's items 1, 2, 3 and 6 are still open**, and all four are in
     files this round assigned elsewhere (`tables.dart`, `app_database.dart`,
     the migration doc). Item 1's `teamPlanetCode` column is what would let
     `createTeamPost` and the chat share both send the *right* value rather than
@@ -298,9 +390,16 @@ Each names the file, the change, and why it was not made here.
 
 ## Mutations run
 
-Each was applied alone to green code and reverted; all 20 were caught, and the
-test that caught each is named. Two of them exist because the mutation found a
-claim nothing pinned (13 and 14/15), which is the Phase 122 practice.
+Each was applied alone to green code and reverted; all 26 were caught, and the
+test that caught each is named. Four of them exist because the mutation found a
+claim nothing pinned — the `queued` counter, `toggleReaction`/the un-share
+branch, the voices sweep's own drain, and the two label writers — which is the
+Phase 122 practice. **One mutation was itself invalid**: its anchor matched the
+*submissions* sweep first and reported a false negative until it was re-aimed.
+Check that a mutation changed the line you meant.
+
+*Line numbers cited into `voices_repository.dart` in the sections above were
+taken before that file grew; treat them as approximate and grep the symbol.*
 
 | Mutation | Caught by |
 |---|---|
@@ -323,6 +422,12 @@ claim nothing pinned (13 and 14/15), which is the Phase 122 practice.
 | `createPost` does not address the community | 3 community tests |
 | `createPost` keeps the default `messageType` | the composed post addresses the community on the wire |
 | `createTeamPost` claims the author planet code | a team post carries no planet code it cannot know |
+| the sync-path sweep does not drain for itself | an edit made while the POST is on the wire |
+| `markUploaded` clears `isEdited` unconditionally | the same |
+| the handler does not tell `markUploaded` what it sent | the same |
+| `payloadMatchesRow` ignores every difference | the same |
+| `addLabel` does not flag the row | every local mutation puts a delivered post back in the queue |
+| `removeLabel` does not flag the row | the same |
 
 ## Files touched
 

--- a/flutter/PHASE_144_NOTES.md
+++ b/flutter/PHASE_144_NOTES.md
@@ -17,8 +17,8 @@ the one to read first.
 | A team post carries `''`, not the author's planet code | `voices_provider.dart` | two port writers disagreeing about one field |
 | `authorJson` drops a null-valued key instead of writing `null` | `voices_repository.dart` | faithfulness to Gson's `serializeNulls` |
 
-**25 new tests** across three new files and two existing ones, counted from the
-runner. **19 mutations, 19 caught** — the list is at the bottom. Two
+**26 new tests** across three new files and two existing ones, counted from the
+runner. **20 mutations, 20 caught** — the list is at the bottom. Two
 `parity-auditor` passes at `effort: max` ran, one on the Kotlin ground truth
 before implementing and one on the finished green code.
 
@@ -45,6 +45,16 @@ locally composed post has no `viewableBy`. **The post the user just wrote was
 listed by nobody**: not in this app's community feed, and not on Planet, because
 `serialize` omits the `viewIn` key entirely for an empty list, so the uploaded
 document had no audience at all and a pull-back could not repair it.
+
+**Two other readers key on the same entry, and both were wrong for a
+port-composed post.** `VoicesAdapter.canShare` is
+`news?.isCommunityNews != true` (`VoicesAdapter.kt:699`), so the port was
+offering a "share to community" action on a post Kotlin already treats as being
+*in* the community. And `getCommunityVoiceDates` — the challenge dialog's "post
+five community voices" counter from Phase 81 — filters on the same predicate,
+so **a user could post five voices from the port's own community screen and the
+challenge would still read zero**. Neither was reachable from the defect's own
+symptom; both are now pinned by *a composed post counts as a community voice*.
 
 This is the Phase 113 shape exactly — *can the writer produce values the
 reader's predicate matches?* — and the tell was the same one: every existing
@@ -288,7 +298,7 @@ Each names the file, the change, and why it was not made here.
 
 ## Mutations run
 
-Each was applied alone to green code and reverted; all 19 were caught, and the
+Each was applied alone to green code and reverted; all 20 were caught, and the
 test that caught each is named. Two of them exist because the mutation found a
 claim nothing pinned (13 and 14/15), which is the Phase 122 practice.
 

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -74,6 +74,14 @@ Future<bool> executeBackgroundTask(String taskName) async {
       // invocation without the sweep needing a drain of its own.
       drainOutbox: () async {
         if (config == null) return;
+        // Ahead of the submissions sweep, as both Kotlin workers have it
+        // (`AutoSyncWorker:130` before `:136`, `UserDataWorker:40` before
+        // `:48`). See [sweepPendingVoices].
+        await sweepPendingVoices(
+          container,
+          config: config,
+          userId: prefs.loggedInUserId,
+        );
         await sweepPendingSubmissions(
           container,
           config: config,
@@ -241,6 +249,55 @@ Future<bool> executeBackgroundTask(String taskName) async {
     return false;
   } finally {
     container.dispose();
+  }
+}
+
+/// The headless half of the voices safety net — see
+/// `DashboardSyncNotifier.queuePendingVoices`, which carries the Kotlin
+/// reading this is built on.
+///
+/// **Called from `drainOutbox`, deliberately not from `syncSteps`**, for the
+/// reason [sweepPendingSubmissions] gives at length: the step list runs only
+/// for an `autoSync` task, only with auto-sync enabled, and only when the
+/// interval is due, and `BackgroundWorkCoordinator` cancels the `autoSync` job
+/// outright for a user who turns auto-sync off — so a step there would never
+/// run at all for exactly the user most likely to have an undelivered post.
+/// Kotlin's `uploadNews()` has none of those gates.
+///
+/// Ordering is free here in a way it is not for submissions: nothing in the
+/// step list pulls `news` before this, and the voices pull that does exist
+/// (`DashboardSyncArea.voices`) writes a pulled document beside a locally
+/// authored row rather than over it — `NewsMapper.fromDoc` keys on the CouchDB
+/// `_id`, and an undelivered post has none. It is kept ahead of the drain for
+/// the reason that always holds: a row queued after the drain waits for the
+/// next invocation.
+///
+/// [userId] is nullable because Kotlin's sweep takes no user at all — the
+/// author travels in the document, and the outbox tag is nothing anyone reads
+/// back. A handset whose session has gone is precisely the one with an
+/// undelivered post on it.
+///
+/// Exposed because `executeBackgroundTask` needs a Flutter binding, real
+/// preferences and a WorkManager engine, so a body written inline in that
+/// closure is unreachable from a unit test.
+@visibleForTesting
+Future<void> sweepPendingVoices(
+  ProviderContainer container, {
+  required ServerConfig config,
+  required String? userId,
+}) async {
+  try {
+    await container
+        .read(voicesUploaderProvider)
+        .queuePending(config: config, userId: userId);
+  } catch (_) {
+    // Swallowed for the reason `sweepPendingSubmissions` is: a throwing
+    // `drainOutbox` adds `outboxDrain` to the runner's `failedSteps` and asks
+    // the OS to retry the whole task, and no Kotlin caller of `uploadNews()`
+    // does that — `UserDataWorker:40` wraps it in `runCatching` and still
+    // returns `Result.success()`. It is not hypothetical: `queuePending` reads
+    // device identity, which rethrows on an engine with no channel and no
+    // primed cache.
   }
 }
 

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -154,9 +154,6 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
 
     // Ahead of the submissions sweep, as both Kotlin workers have it
     // (`AutoSyncWorker:130` before `:136`, `UserDataWorker:40` before `:48`).
-    // It queues only; the unscoped drain at the end of
-    // [queuePendingSubmissions] is what carries these rows out in this same
-    // pass — the coupling `syncAll delivers a voice nothing enqueued` pins.
     await queuePendingVoices();
 
     // With the shelf push, ahead of the pulls. See [queuePendingSubmissions].
@@ -390,9 +387,16 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
   ///   device identity and `PlatformDeviceIdentitySource.read` rethrows on an
   ///   engine with no channel and no primed cache. A voice that cannot be
   ///   queued must not flip the sync to failed.
-  /// * **Queued, not drained, here.** [queuePendingSubmissions] follows
-  ///   immediately and its drain is unscoped, so these rows go out in this same
-  ///   pass. Draining twice would only add a redundant single-flight join.
+  /// * **Drained, not merely queued.** Kotlin's sweep *posts*; `queuePending`
+  ///   only queues, and the drain trigger is otherwise app resume. The first
+  ///   cut relied on [queuePendingSubmissions] running next with an unscoped
+  ///   drain — which it does, but that drain sits *inside* its `try`, after
+  ///   `submissionsUploaderProvider.queuePending`, so anything throwing there
+  ///   is swallowed and the voices rows wait for the next resume. Hunk
+  ///   adjacency is not a guarantee; this one drains for itself, as
+  ///   [queuePendingSubmissions] does, and `OutboxDrainer`'s single-flight
+  ///   guard makes the second pass cheap rather than redundant. Unscoped, for
+  ///   the reason spelled out there.
   ///
   /// **It cannot double-post.** Two protections, one of them Kotlin's:
   /// `markUploaded` stamps `_id`/`_rev` and clears `isEdited`, which takes the
@@ -406,9 +410,11 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
   /// sync — a `_rev`-carrying update, so it is not a duplicate, but it churns a
   /// revision per post per sync. [VoicesRepository.pendingUploads] returns only
   /// rows that were never delivered or have been edited since. Every local
-  /// mutation the port has sets `isEdited` (`editPost`, `shareToCommunity`, the
-  /// un-share branch of `deletePost`, `toggleReaction`), so nothing a user can
-  /// do leaves a changed row outside the set; what the narrower predicate gives
+  /// mutation the port has sets `isEdited` — `editPost`, `shareToCommunity`,
+  /// the un-share branch of `deletePost`, `toggleReaction`, and `addLabel` /
+  /// `removeLabel`, which are unreachable today and were flagged in the same
+  /// phase precisely so that stays true when someone wires them up — so
+  /// nothing a user can do leaves a changed row outside the set; what the narrower predicate gives
   /// up is Kotlin's incidental repair of a *server-side* divergence, which no
   /// reader on either side depends on. Widening it would refill the outbox with
   /// unchanged documents on every sync.
@@ -423,6 +429,9 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
       await ref
           .read(voicesUploaderProvider)
           .queuePending(config: config, userId: user?.id);
+      await ref
+          .read(outboxDrainerProvider)
+          .drain(authHeader: PersonalsUploader.authHeaderFor(config));
     } catch (_) {
       // Deliberately ignored — see above.
     }

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -152,6 +152,13 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
     // them for pressing the button.
     await ref.read(activityLogProvider).recordSyncChallengeAction();
 
+    // Ahead of the submissions sweep, as both Kotlin workers have it
+    // (`AutoSyncWorker:130` before `:136`, `UserDataWorker:40` before `:48`).
+    // It queues only; the unscoped drain at the end of
+    // [queuePendingSubmissions] is what carries these rows out in this same
+    // pass — the coupling `syncAll delivers a voice nothing enqueued` pins.
+    await queuePendingVoices();
+
     // With the shelf push, ahead of the pulls. See [queuePendingSubmissions].
     await queuePendingSubmissions();
 
@@ -346,6 +353,76 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
       await ref
           .read(outboxDrainerProvider)
           .drain(authHeader: PersonalsUploader.authHeaderFor(config));
+    } catch (_) {
+      // Deliberately ignored — see above.
+    }
+  }
+
+  /// Port of `uploadManager.uploadNews()` as the sync path's safety net.
+  ///
+  /// **Kotlin has no write-time upload for a voice at all.** Composing one
+  /// writes a `news` row and stops; the document reaches the server when
+  /// `UploadManager.uploadNews()` next runs, and that runs from
+  /// `AutoSyncWorker:130` and `UserDataWorker:40` off nothing the post did.
+  /// `VoicesRepositoryImpl.getNewsForUpload()` reads the whole table minus
+  /// guests, so a voice cannot be stranded there.
+  ///
+  /// The port inverted the relation: `VoicesActions` enqueues at write time —
+  /// better when it runs — and nothing swept. `VoicesActions.queuePending`
+  /// returns 0 when `serverConfigProvider` is null, and every caller reports
+  /// success regardless, so a voice composed before the server was configured
+  /// (or across a write that threw, or a process death between the row and the
+  /// enqueue) sat on the handset until the same user happened to make some
+  /// *other* voices write, because `queuePending` is an unscoped sweep that
+  /// then rescues it incidentally. Phase 134 found and fixed exactly this shape
+  /// for submissions; this is the voices half.
+  ///
+  /// The shape follows [queuePendingSubmissions], for the same readings:
+  ///
+  /// * **Unscoped.** `getNewsForUpload()` carries no `userId` predicate and
+  ///   `uploadNews()` takes no user — the author travels in the document. The
+  ///   session is only the outbox row's tag, hence the nullable `userId`.
+  /// * **Ungated.** Not conditional on `successCount > 0`: `UserDataWorker`
+  ///   sweeps inside its own `runCatching` and inspects no pull.
+  /// * **Its own `try`, and swallowed.** `UserDataWorker:40`'s per-step
+  ///   `runCatching` is the shape, not `AutoSyncWorker`'s shared `try` — and
+  ///   this can throw where Kotlin's cannot, because `queuePending` reads
+  ///   device identity and `PlatformDeviceIdentitySource.read` rethrows on an
+  ///   engine with no channel and no primed cache. A voice that cannot be
+  ///   queued must not flip the sync to failed.
+  /// * **Queued, not drained, here.** [queuePendingSubmissions] follows
+  ///   immediately and its drain is unscoped, so these rows go out in this same
+  ///   pass. Draining twice would only add a redundant single-flight join.
+  ///
+  /// **It cannot double-post.** Two protections, one of them Kotlin's:
+  /// `markUploaded` stamps `_id`/`_rev` and clears `isEdited`, which takes the
+  /// row out of [VoicesRepository.pendingUploads] — the port of
+  /// `markNewsUploaded`. The port adds two more:
+  /// `OutboxRepository.enqueue` keys on `(uploadType, itemId)`, and
+  /// [VoicesUploader.queuePending] skips a row whose send is in flight.
+  ///
+  /// **One divergence, now systematic rather than incidental, and deliberate.**
+  /// `getNewsForUpload()` returns *every* non-guest row and re-sends it on each
+  /// sync — a `_rev`-carrying update, so it is not a duplicate, but it churns a
+  /// revision per post per sync. [VoicesRepository.pendingUploads] returns only
+  /// rows that were never delivered or have been edited since. Every local
+  /// mutation the port has sets `isEdited` (`editPost`, `shareToCommunity`, the
+  /// un-share branch of `deletePost`, `toggleReaction`), so nothing a user can
+  /// do leaves a changed row outside the set; what the narrower predicate gives
+  /// up is Kotlin's incidental repair of a *server-side* divergence, which no
+  /// reader on either side depends on. Widening it would refill the outbox with
+  /// unchanged documents on every sync.
+  Future<void> queuePendingVoices() async {
+    final config = ref.read(serverConfigProvider);
+    if (config == null) return;
+    try {
+      // Awaited rather than read, and inside the `try`: this notifier never
+      // watches `sessionProvider`, so `.valueOrNull` would be null on any pass
+      // that reached here first, and the future can reject where it could not.
+      final user = await ref.read(sessionProvider.future);
+      await ref
+          .read(voicesUploaderProvider)
+          .queuePending(config: config, userId: user?.id);
     } catch (_) {
       // Deliberately ignored — see above.
     }

--- a/flutter/lib/providers/voices_provider.dart
+++ b/flutter/lib/providers/voices_provider.dart
@@ -181,12 +181,13 @@ class VoicesActions {
           planetCode: user.planetCode,
           parentCode: user.parentCode,
           // The four keys `VoicesFragment.btnSubmit` builds before it calls
-          // `createNews` (`ui/voices/VoicesFragment.kt:139-143`). Without them
-          // `_viewInJson` writes `"[]"`, `isVisibleToUser` falls through its
-          // empty-`viewIn` guard to false, and the post the user just composed
-          // is listed by nobody — not in this app's community feed, and not on
-          // Planet, where `serialize` omits the key entirely for an empty
-          // list. Both halves of the identifier are interpolated unguarded, as
+          // `createNews` (`ui/voices/VoicesFragment.kt:140-143`). Without them
+          // `_viewInJson` writes the string `"[]"` — which is neither null nor
+          // empty, so `isVisibleToUser` does not take its early guard: it
+          // decodes to an empty list and `.any` returns false. Either way the
+          // post the user just composed is listed by nobody — not in this
+          // app's community feed, and not on Planet, where `serialize` omits
+          // the key entirely for an empty list. Both halves of the identifier are interpolated unguarded, as
           // Kotlin does: an empty or `"@"` id is the planet-wide wildcard on
           // both sides, so a user missing a code still reaches everyone rather
           // than nobody.
@@ -221,7 +222,7 @@ class VoicesActions {
           parentCode: user.parentCode,
           messageType: 'team',
           // The **team's** planet code, not the author's:
-          // `TeamsVoicesFragment.kt:78` writes `team?.teamPlanetCode ?: ""`.
+          // `TeamsVoicesFragment.kt:81` writes `team?.teamPlanetCode ?: ""`.
           // The port's `Teams` table has no such column (reported against
           // `tables.dart`), and `MyTeam.kt:86` reads the field with
           // `JsonUtils.getString`, so a team document that omits it yields
@@ -328,12 +329,13 @@ class VoicesActions {
   Future<int> queuePending() async {
     final config = ref.read(serverConfigProvider);
     if (config == null) return 0;
+    // Awaited like the writers', though this one is only the outbox row's tag
+    // and nothing reads it back (`tables.dart:368`). `editPost` and
+    // `deletePost` reach here without having resolved the session, so a plain
+    // `.valueOrNull` tagged those rows null.
     return ref
         .read(voicesUploaderProvider)
-        .queuePending(
-          config: config,
-          userId: ref.read(sessionProvider).valueOrNull?.id,
-        );
+        .queuePending(config: config, userId: (await _author())?.id);
   }
 }
 

--- a/flutter/lib/providers/voices_provider.dart
+++ b/flutter/lib/providers/voices_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/config/server_config.dart';
 import '../core/sync/sync_result.dart';
 import '../data/local/app_database.dart';
+import '../repository/voices_repository.dart';
 import '../repository/voices_uploader.dart';
 import 'app_providers.dart';
 import 'session_provider.dart';
@@ -138,8 +139,31 @@ class VoicesActions {
 
   final Ref ref;
 
+  /// The session is **awaited**, and the `await` sits inside the `try`.
+  ///
+  /// This provider never watches `sessionProvider`, so
+  /// `ref.read(...).valueOrNull` was null until something else resolved it and
+  /// the composed post was dropped with no error, no snackbar and no row. In
+  /// the shipping app the router's `ref.listen` keeps it resolved, which is
+  /// what made this latent rather than visible. The `await` is inside the
+  /// `try` because a future can reject where `valueOrNull` could not.
+  ///
+  /// The screen with the live window is `VoicesScreen`, whose compose FAB is
+  /// **ungated** and renders while `communityFeedProvider` is still loading.
+  /// `TeamVoicesScreen` is not it, contrary to an earlier draft of this
+  /// comment: it watches `teamMembershipsProvider`, which watches
+  /// `sessionProvider`, and only renders its FAB once a membership resolved —
+  /// which needs a resolved session. Both are safe now; only one ever wasn't.
+  Future<UserRow?> _author() async {
+    try {
+      return await ref.read(sessionProvider.future);
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<String?> createPost(String message) async {
-    final user = ref.read(sessionProvider).valueOrNull;
+    final user = await _author();
     if (user == null) return null;
     final id = await ref
         .read(voicesRepositoryProvider)
@@ -147,8 +171,32 @@ class VoicesActions {
           message: message,
           userId: user.couchId ?? user.id,
           userName: user.name ?? '',
+          // The nested `user` object is the **only** author identity a news
+          // document carries — there is no top-level `userId`/`userName` on
+          // the wire — and `NewsMapper.fromDoc` reads all three local columns
+          // back out of it. Without this the post uploads anonymously *and*
+          // loses its author here at the next sync-in. Kotlin sets it on every
+          // write path (`News.createNews`: `news.user = gson.toJson(...)`).
+          userJson: VoicesRepository.authorJson(user),
           planetCode: user.planetCode,
           parentCode: user.parentCode,
+          // The four keys `VoicesFragment.btnSubmit` builds before it calls
+          // `createNews` (`ui/voices/VoicesFragment.kt:139-143`). Without them
+          // `_viewInJson` writes `"[]"`, `isVisibleToUser` falls through its
+          // empty-`viewIn` guard to false, and the post the user just composed
+          // is listed by nobody — not in this app's community feed, and not on
+          // Planet, where `serialize` omits the key entirely for an empty
+          // list. Both halves of the identifier are interpolated unguarded, as
+          // Kotlin does: an empty or `"@"` id is the planet-wide wildcard on
+          // both sides, so a user missing a code still reaches everyone rather
+          // than nobody.
+          messageType: 'sync',
+          messagePlanetCode: user.planetCode,
+          viewInId: communityViewerIdentifier(
+            planetCode: user.planetCode,
+            parentCode: user.parentCode,
+          ),
+          viewInSection: 'community',
         );
     await queuePending();
     return id;
@@ -160,7 +208,7 @@ class VoicesActions {
     required String teamName,
     required String message,
   }) async {
-    final user = ref.read(sessionProvider).valueOrNull;
+    final user = await _author();
     if (user == null) return null;
     final id = await ref
         .read(voicesRepositoryProvider)
@@ -168,10 +216,21 @@ class VoicesActions {
           message: message,
           userId: user.couchId ?? user.id,
           userName: user.name ?? '',
+          userJson: VoicesRepository.authorJson(user),
           planetCode: user.planetCode,
           parentCode: user.parentCode,
           messageType: 'team',
-          messagePlanetCode: user.planetCode,
+          // The **team's** planet code, not the author's:
+          // `TeamsVoicesFragment.kt:78` writes `team?.teamPlanetCode ?: ""`.
+          // The port's `Teams` table has no such column (reported against
+          // `tables.dart`), and `MyTeam.kt:86` reads the field with
+          // `JsonUtils.getString`, so a team document that omits it yields
+          // `""` in Kotlin too — `''` is the faithful interim value.
+          // `user.planetCode` was a claim about a team that may have been
+          // created on another planet, and it disagreed with the port's own
+          // chat-share writer, which already sends `''` here
+          // (`chat_repository.dart:306-310`).
+          messagePlanetCode: '',
           viewInId: teamId,
           viewInSection: 'teams',
           viewInName: teamName,
@@ -184,7 +243,7 @@ class VoicesActions {
     required String parentId,
     required String message,
   }) async {
-    final user = ref.read(sessionProvider).valueOrNull;
+    final user = await _author();
     if (user == null) return null;
     final id = await ref
         .read(voicesRepositoryProvider)
@@ -193,6 +252,7 @@ class VoicesActions {
           message: message,
           userId: user.couchId ?? user.id,
           userName: user.name ?? '',
+          userJson: VoicesRepository.authorJson(user),
           planetCode: user.planetCode,
           parentCode: user.parentCode,
         );
@@ -247,7 +307,7 @@ class VoicesActions {
   /// configured community as the fallback — the same effective-code rule the
   /// Kotlin applies against its preferences.
   Future<bool> shareToCommunity(String newsId, {String teamName = ''}) async {
-    final user = ref.read(sessionProvider).valueOrNull;
+    final user = await _author();
     if (user == null) return false;
     final config = ref.read(serverConfigProvider);
     final shared = await ref

--- a/flutter/lib/repository/voices_repository.dart
+++ b/flutter/lib/repository/voices_repository.dart
@@ -246,8 +246,12 @@ class VoicesRepository {
   /// - the `_attachments` photo, which would embed the user's profile image
   ///   in every post they author.
   ///
-  /// Everything else matches `serialize()` field for field, including the
-  /// `_id`/`_rev` pair being written only for an account the server knows.
+  /// Everything else matches `serialize()` field for field **except**
+  /// `iterations` (`UserEntity.kt:83-88`), which is left out deliberately: it
+  /// is a PBKDF2 parameter and a voices post is a public document, so adding
+  /// it wants the same explicit judgement as the credential branch rather
+  /// than a silent completion of the field list. The `_id`/`_rev` pair is
+  /// written only for an account the server knows, as `serialize()` has it.
   ///
   /// **A null value drops its key rather than writing `null`.** `createNews`
   /// serializes with `JsonUtils.gson`, a bare `Gson()` whose `serializeNulls`
@@ -740,8 +744,19 @@ class VoicesRepository {
     // duplicate. Deduplicated here: the label set drives filter chips, and a
     // repeat renders a second identical chip that cannot be told apart.
     if (row.labels.contains(label)) return;
+    // Flagged like every other local mutation, and for the same reason: the
+    // `labels` column goes on the wire ([serialize]), Kotlin's sweep re-sends
+    // the whole table so a Kotlin label change reaches the server, and this
+    // port only uploads rows that are new or edited. Nothing calls this yet —
+    // which is exactly why the flag belongs here now rather than being
+    // discovered missing by whoever wires the label chips up.
     await _dao.upsert(
-      row.toCompanion(false).copyWith(labels: Value([...row.labels, label])),
+      row
+          .toCompanion(false)
+          .copyWith(
+            labels: Value([...row.labels, label]),
+            isEdited: const Value(true),
+          ),
     );
   }
 
@@ -758,6 +773,8 @@ class VoicesRepository {
                   .where((entry) => entry != label)
                   .toList(growable: false),
             ),
+            // See [addLabel].
+            isEdited: const Value(true),
           ),
     );
   }
@@ -806,14 +823,35 @@ class VoicesRepository {
   ///
   /// Clearing `imageUrls` is what marks the attachments as delivered; the
   /// server's `images` array replaces them.
+  ///
+  /// [delivered] is the document that actually went on the wire. When the row
+  /// has changed since that payload was captured, the send carried a
+  /// **superseded body** and the row is not in sync with the server, so
+  /// `isEdited` is left set and the next sweep re-queues it — this time with
+  /// the `_id`/`_rev` just recorded, so it lands as an update rather than a
+  /// second document.
+  ///
+  /// Without this, clearing the flag unconditionally is a silent loss.
+  /// [VoicesUploader.queuePending] leaves an in-flight row alone so an append
+  /// is not replayed, so an edit made while the POST is on the wire is never
+  /// queued; clearing `isEdited` on arrival then drops the row out of
+  /// [pendingUploads] for good, and `NewsMapper.fromDoc` writes `message`
+  /// unconditionally, so the next pull overwrites the user's text with the
+  /// server's older copy — destroyed on the device as well as never sent.
+  /// **Kotlin does not lose it**: `getNewsForUpload` has no predicate beyond
+  /// the guest prefix and `markNewsUploaded` touches no edit marker, so its
+  /// next sweep re-serializes the edited message with the fresh `_rev`. This
+  /// is the port's narrow predicate paying for itself, not a Kotlin quirk.
   Future<void> markUploaded(
     String id,
     String docId,
     String rev, {
     List<dynamic> images = const [],
+    Map<String, dynamic>? delivered,
   }) async {
     final row = await _dao.getById(id);
     if (row == null) return;
+    final superseded = delivered != null && !payloadMatchesRow(delivered, row);
     await _dao.upsert(
       row
           .toCompanion(false)
@@ -822,9 +860,30 @@ class VoicesRepository {
             rev: Value(rev),
             images: Value(jsonEncode(images)),
             imageUrls: const Value([]),
-            isEdited: const Value(false),
+            isEdited: Value(superseded),
           ),
     );
+  }
+
+  /// Whether [payload] still describes [row] — i.e. nothing local changed
+  /// between the payload being captured and now.
+  ///
+  /// Compares whole documents rather than a hand-listed set of mutable
+  /// columns, so a future writer touching a column nobody thought of here is
+  /// covered by construction. Three keys are excluded: `_id` and `_rev`,
+  /// which the send is in the middle of establishing, and the origin fields
+  /// [VoicesUploader.queuePending] stamps on after serializing. Key order is
+  /// comparable because both maps come from [serialize], and the spread that
+  /// adds the origin fields appends rather than reorders.
+  static bool payloadMatchesRow(Map<String, dynamic> payload, NewsRow row) {
+    bool established(String key) =>
+        key == '_id' || key == '_rev' || key == 'androidId' || key == 'app';
+    Map<String, dynamic> comparable(Map<String, dynamic> doc) => {
+      for (final entry in doc.entries)
+        if (!established(entry.key)) entry.key: entry.value,
+    };
+    return jsonEncode(comparable(payload)) ==
+        jsonEncode(comparable(serialize(row)));
   }
 
   /// Port of `VoicesRepositoryImpl.updateReaction` — toggles a user's emoji

--- a/flutter/lib/repository/voices_repository.dart
+++ b/flutter/lib/repository/voices_repository.dart
@@ -248,31 +248,42 @@ class VoicesRepository {
   ///
   /// Everything else matches `serialize()` field for field, including the
   /// `_id`/`_rev` pair being written only for an account the server knows.
+  ///
+  /// **A null value drops its key rather than writing `null`.** `createNews`
+  /// serializes with `JsonUtils.gson`, a bare `Gson()` whose `serializeNulls`
+  /// is off, so `addProperty("middleName", null)` writes nothing at all — a
+  /// user with no middle name produces an object with no `middleName` key.
+  /// This is the same rule [_viewInJson] twelve lines up already applies, and
+  /// applying it in one place and not the other was an inconsistency inside
+  /// one file. Nothing on either side reads these with a `has`/`containsKey`
+  /// test today, unlike `viewIn`'s `name`, so this is faithfulness rather than
+  /// a fix — but the next reader of `_viewInJson` should not find a
+  /// counter-example sitting beside it.
   static String authorJson(UserRow user) {
     final couchId = user.couchId;
     return jsonEncode(<String, dynamic>{
       if (couchId != null && couchId.isNotEmpty) ...{
         '_id': couchId,
-        '_rev': user.rev,
+        if (user.rev != null) '_rev': user.rev,
       },
-      'name': user.name,
+      'name': ?user.name,
       'roles': user.rolesList,
       'isUserAdmin': user.userAdmin,
       'joinDate': user.joinDate,
-      'firstName': user.firstName,
-      'lastName': user.lastName,
-      'middleName': user.middleName,
-      'email': user.email,
-      'language': user.language,
-      'level': user.level,
+      'firstName': ?user.firstName,
+      'lastName': ?user.lastName,
+      'middleName': ?user.middleName,
+      'email': ?user.email,
+      'language': ?user.language,
+      'level': ?user.level,
       'type': 'user',
-      'gender': user.gender,
-      'phoneNumber': user.phoneNumber,
-      'birthDate': user.dob,
-      'age': user.age,
-      'parentCode': user.parentCode,
-      'planetCode': user.planetCode,
-      'birthPlace': user.birthPlace,
+      'gender': ?user.gender,
+      'phoneNumber': ?user.phoneNumber,
+      'birthDate': ?user.dob,
+      'age': ?user.age,
+      'parentCode': ?user.parentCode,
+      'planetCode': ?user.planetCode,
+      'birthPlace': ?user.birthPlace,
       'isArchived': user.isArchived,
     });
   }

--- a/flutter/lib/repository/voices_uploader.dart
+++ b/flutter/lib/repository/voices_uploader.dart
@@ -33,7 +33,11 @@ class VoicesUploader {
   ///
   /// Safe to call repeatedly: [OutboxRepository.enqueue] keys on
   /// `(uploadType, itemId)`, so a post already queued has its payload refreshed
-  /// rather than being posted twice.
+  /// rather than being posted twice, and a post whose send is already on the
+  /// wire is skipped outright — see the loop.
+  ///
+  /// Returns the number of posts queued by *this* call, so a caller can tell
+  /// "nothing to send" from "everything was already in flight".
   ///
   /// `VoicesRepositoryImpl.serializeNews` gained `addDocumentOrigin()` in
   /// `27c0470`, a pure addition — `androidId` and `app` are both new on the
@@ -50,7 +54,28 @@ class VoicesUploader {
     final endpoint = endpointFor(config);
     final pending = await _voices.pendingUploads();
     final identity = pending.isEmpty ? null : await _identity.read();
+    var queued = 0;
     for (final row in pending) {
+      // A send already on the wire is left alone. [OutboxRepository.enqueue]
+      // would put it back to `pending` to preserve a mid-flight payload edit,
+      // and `markCompleted` only deletes an `in_progress` row — so the send
+      // that succeeds moments later deletes nothing, the row survives with the
+      // same body, and the next drain posts a **second** `news` document. That
+      // reset is right for derived state, whose handler rebuilds from the
+      // database; a voice with no `_id` yet is an append and replaying it
+      // duplicates the post.
+      //
+      // Reachable without the sweep and systematic with it: [queuePending] is
+      // unscoped, so any second write — another post, an edit, a reaction —
+      // re-enqueues every undelivered row, including one whose POST is in
+      // flight. The cost is the narrow window where the post is edited while
+      // its POST is on the wire: `markUploaded` clears `isEdited` on success,
+      // so that edit leaves the pending set. Kotlin loses it identically
+      // (`markNewsUploaded` writes the row back with no edited flag at all),
+      // and a later edit is a `_rev`-carrying update rather than a new
+      // document, so a lost edit is recoverable where a duplicate is not.
+      if (await _outbox.isInFlight(type, row.id)) continue;
+      queued++;
       await _outbox.enqueue(
         uploadType: type,
         itemId: row.id,
@@ -62,7 +87,7 @@ class VoicesUploader {
         userId: userId,
       );
     }
-    return pending.length;
+    return queued;
   }
 
   /// The [OutboxHandler] for [type].

--- a/flutter/lib/repository/voices_uploader.dart
+++ b/flutter/lib/repository/voices_uploader.dart
@@ -118,6 +118,10 @@ class VoicesUploader {
         couchId,
         rev,
         images: images is List ? images : const [],
+        // The body that actually went out. A row mutated while this POST was
+        // on the wire keeps its `isEdited` flag, because [queuePending]
+        // declined to re-queue it and nothing else would.
+        delivered: payload,
       );
     }
     return result;

--- a/flutter/test/providers/pending_voices_sweep_test.dart
+++ b/flutter/test/providers/pending_voices_sweep_test.dart
@@ -1,0 +1,415 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/background_entrypoint.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/system/device_identity.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/dashboard_sync_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/voices_provider.dart';
+import 'package:myplanet/repository/voices_uploader.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+/// Phase 144, Job 1. Kotlin reaches the server for a locally authored voice
+/// from a **sweep**: `UploadManager.uploadNews()` reads
+/// `VoicesRepositoryImpl.getNewsForUpload()` — the whole `news` table minus
+/// guests — and `AutoSyncWorker:130` and `UserDataWorker:40` run it on a
+/// schedule, off nothing the post itself did. There is no write-time upload in
+/// the Kotlin at all: composing a voice writes a row and waits for the sync.
+///
+/// The port inverted that. `VoicesActions` enqueues at write time — better
+/// when it runs — and **nothing swept**, so a voice whose one enqueue never
+/// ran sat on the handset indefinitely. `VoicesActions.queuePending` returns 0
+/// when `serverConfigProvider` is null (there is no endpoint to queue
+/// against) while its callers still report success, which is one way to reach
+/// that state without any failure being visible.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  late AppDatabase db;
+  late MockPlanetApi api;
+
+  setUpAll(() {
+    registerFallbackValue(config);
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+  });
+  tearDown(() => db.close());
+
+  Future<PlanetPrefs> testPrefs() async =>
+      PlanetPrefs(await SharedPreferences.getInstance());
+
+  Future<ProviderContainer> containerFor({
+    DeviceIdentitySource identity = testDeviceIdentity,
+    ServerConfig? serverConfig = config,
+  }) async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(await testPrefs()),
+        deviceIdentitySourceProvider.overrideWithValue(identity),
+        serverConfigProvider.overrideWith(
+          () => _TestServerConfigNotifier(serverConfig),
+        ),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(
+            buildUserRow(id: 'org.couchdb.user:ada', name: 'ada'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  void acceptPosts() {
+    var posts = 0;
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((_) async {
+      posts++;
+      return NetworkSuccess<Map<String, dynamic>>({
+        'id': 'server-id-$posts',
+        'rev': '$posts-rev',
+      });
+    });
+  }
+
+  /// The reported state: a voice row on the handset with no `_id` and **no**
+  /// outbox row — the post whose one write-time enqueue never ran.
+  Future<String> seedStrandedVoice(ProviderContainer container) async {
+    final id = await container
+        .read(voicesRepositoryProvider)
+        .createPost(
+          message: 'The well is dry',
+          userId: 'org.couchdb.user:ada',
+          userName: 'ada',
+        );
+    expect(await db.outboxDao.forItem(VoicesUploader.type, id), isEmpty);
+    return id;
+  }
+
+  group('foreground sync centre', () {
+    test('syncAll delivers a voice nothing enqueued', () async {
+      final container = await containerFor();
+      final id = await seedStrandedVoice(container);
+      acceptPosts();
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      final row = await container.read(voicesRepositoryProvider).getById(id);
+      expect(
+        row?.docId,
+        'server-id-1',
+        reason:
+            'the sync path is the safety net Kotlin has in uploadNews(); the '
+            'voice must reach the server without another write happening to '
+            'sweep it up',
+      );
+      expect(row?.rev, '1-rev');
+    });
+
+    test('a voice composed with no server configured still goes out', () async {
+      // `VoicesActions.queuePending` returns 0 when `serverConfigProvider` is
+      // null, and `createPost` reports success anyway. That is the state the
+      // gap leaves behind, reached the way a user reaches it.
+      final unconfigured = await containerFor(serverConfig: null);
+      final id = await unconfigured
+          .read(voicesActionsProvider)
+          .createPost('The well is dry');
+      expect(id, isNotNull, reason: 'the post was reported as saved');
+      expect(await db.outboxDao.forItem(VoicesUploader.type, id!), isEmpty);
+
+      final configured = await containerFor();
+      acceptPosts();
+      await configured.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(
+        (await configured.read(voicesRepositoryProvider).getById(id))?.docId,
+        'server-id-1',
+      );
+    });
+
+    test('the sweep runs even when every table pull fails', () async {
+      // `UserDataWorker:40` sweeps inside its own `runCatching` and inspects
+      // no pull, so the sweep is not conditional on one succeeding — unlike
+      // the telemetry uploads beside it, which are gated on `successCount`.
+      final container = await containerFor();
+      final id = await seedStrandedVoice(container);
+      acceptPosts();
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(container.read(dashboardSyncProvider).successCount, 0);
+      expect(
+        (await container.read(voicesRepositoryProvider).getById(id))?.docId,
+        'server-id-1',
+      );
+    });
+
+    test('the write-time enqueue and the sweep post one document', () async {
+      final container = await containerFor();
+      acceptPosts();
+      // The write-time call site, exactly as `voices_screen:88` makes it.
+      final id = await container
+          .read(voicesActionsProvider)
+          .createPost('The well is dry');
+      expect(
+        await db.outboxDao.forItem(VoicesUploader.type, id!),
+        hasLength(1),
+      );
+
+      // The sweep's own enqueue over the same still-undelivered row. The first
+      // of the two protections: `OutboxRepository.enqueue` keys on
+      // `(uploadType, itemId)`, so it refreshes the queued row rather than
+      // adding a second. Kotlin has no equivalent — its only defence is the
+      // predicate below.
+      await container.read(dashboardSyncProvider.notifier).queuePendingVoices();
+      expect(
+        await db.outboxDao.forItem(VoicesUploader.type, id),
+        hasLength(1),
+        reason: 'a sweep over an already-queued voice must not add a row',
+      );
+
+      await container
+          .read(outboxDrainerProvider)
+          .drain(authHeader: 'Basic test');
+      verify(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).called(1);
+
+      // The second protection, and Kotlin's only one: `markNewsUploaded`
+      // stamps `_id`/`_rev` and clears the edited flag, which takes the row
+      // out of `pendingUploads`. A later sweep is a no-op, not a duplicate.
+      expect(
+        await container.read(voicesRepositoryProvider).pendingUploads(),
+        isEmpty,
+      );
+      await container.read(dashboardSyncProvider.notifier).queuePendingVoices();
+      verifyNoMoreInteractions(api);
+    });
+
+    test('a re-enqueue mid-flight does not post a second voice', () async {
+      // `OutboxRepository.enqueue` puts an `in_progress` row back to `pending`
+      // so a payload edited mid-flight is not lost, and `markCompleted` is
+      // `deleteIfInProgress` — so the send that just succeeded deletes
+      // nothing, the row survives `pending` with the same body, and the next
+      // drain posts a **second** `news` document. Right for derived state,
+      // wrong for an append, and a voice with no `_id` is an append.
+      //
+      // Reachable as soon as a sweep drains while the app is interactive: the
+      // sync centre puts the POST on the wire and the user composes another
+      // voice during it, whose `VoicesActions.queuePending` is unscoped.
+      final container = await containerFor();
+      final id = await seedStrandedVoice(container);
+      final uploader = container.read(voicesUploaderProvider);
+      var posts = 0;
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async {
+        posts++;
+        await uploader.queuePending(config: config, userId: 'ada');
+        return NetworkSuccess<Map<String, dynamic>>({
+          'id': 'server-id-$posts',
+          'rev': '$posts-rev',
+        });
+      });
+
+      await container.read(dashboardSyncProvider.notifier).queuePendingVoices();
+      await container
+          .read(outboxDrainerProvider)
+          .drain(authHeader: 'Basic test');
+      // Whatever the resume drain does next must not re-send it.
+      await container
+          .read(outboxDrainerProvider)
+          .drain(authHeader: 'Basic test');
+
+      expect(posts, 1, reason: 'the voice was posted twice');
+      expect(
+        await db.outboxDao.forItem(VoicesUploader.type, id),
+        isEmpty,
+        reason: 'a delivered append must leave no replayable row behind',
+      );
+      expect(
+        (await container.read(voicesRepositoryProvider).getById(id))?.docId,
+        'server-id-1',
+      );
+    });
+
+    test('a sweep that throws does not fail the sync', () async {
+      final container = await containerFor(identity: _ThrowingIdentitySource());
+      await seedStrandedVoice(container);
+      final identity =
+          container.read(deviceIdentitySourceProvider)
+              as _ThrowingIdentitySource;
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(
+        identity.reads,
+        greaterThan(0),
+        reason: 'the sweep never got far enough to throw',
+      );
+      final state = container.read(dashboardSyncProvider);
+      expect(state.running, isFalse);
+      expect(state.finishedAt, isNotNull);
+      expect(state.completedCount, DashboardSyncArea.values.length);
+    });
+
+    test('the sweep reads device identity only when it has rows', () async {
+      final identity = _CountingIdentitySource();
+      final container = await containerFor(identity: identity);
+
+      await container.read(dashboardSyncProvider.notifier).queuePendingVoices();
+
+      expect(
+        identity.reads,
+        0,
+        reason:
+            '`queuePending` only reads identity when it has rows to queue, so '
+            'a pass with nothing to send makes no platform-channel call',
+      );
+    });
+  });
+
+  /// **Reachability, not behaviour.** [sweepPendingVoices] is exercised
+  /// directly below, which is the shape Phase 113 warned about: a function can
+  /// be ported, tested and green while nothing in the app calls it.
+  /// `executeBackgroundTask` needs a Flutter binding, real preferences and a
+  /// WorkManager engine, so its wiring is read from source instead.
+  ///
+  /// The bounds matter: the slice ends at `@visibleForTesting`, which is where
+  /// the top-level declarations begin, so the function's *own* declaration
+  /// cannot satisfy the `contains` — the failure mode Phase 134 found in its
+  /// own first cut.
+  test('the headless path calls the voices sweep from drainOutbox', () {
+    final source = File('lib/background_entrypoint.dart').readAsStringSync();
+    final wiring = source.substring(
+      source.indexOf('BackgroundTaskRunner('),
+      source.indexOf('@visibleForTesting'),
+    );
+
+    expect(
+      wiring,
+      contains('sweepPendingVoices('),
+      reason: 'nothing in the headless path calls sweepPendingVoices',
+    );
+
+    final swept = wiring.indexOf('sweepPendingVoices(');
+    final drained = wiring.indexOf('drainer.drain(');
+    expect(drained, greaterThan(-1), reason: 'drainer.drain moved');
+    expect(
+      swept,
+      lessThan(drained),
+      reason:
+          'the sweep must queue before the drain that carries it, or the rows '
+          'wait for the next invocation',
+    );
+    expect(
+      swept,
+      lessThan(wiring.indexOf('syncSteps:')),
+      reason:
+          'the sweep must stay in drainOutbox rather than move into '
+          'syncSteps: those run only for an autoSync task, with auto-sync '
+          'enabled, and only when the interval is due — three gates Kotlin '
+          "ServerReachabilityWorker's network-reconnection sweep has none of",
+    );
+  });
+
+  group('headless path', () {
+    test('sweepPendingVoices queues a stranded voice', () async {
+      final container = await containerFor();
+      final id = await seedStrandedVoice(container);
+
+      await sweepPendingVoices(container, config: config, userId: null);
+
+      expect(await db.outboxDao.forItem(VoicesUploader.type, id), hasLength(1));
+    });
+
+    test('a throwing sweep is swallowed', () async {
+      final container = await containerFor(identity: _ThrowingIdentitySource());
+      await seedStrandedVoice(container);
+
+      await expectLater(
+        sweepPendingVoices(container, config: config, userId: null),
+        completes,
+      );
+    });
+  });
+}
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Reproduces the one failure `PlatformDeviceIdentitySource.read` really has:
+/// a headless WorkManager engine with no primed cache rethrows
+/// (`device_identity.dart:89`), and `queuePending` reads identity before it
+/// enqueues anything.
+class _ThrowingIdentitySource implements DeviceIdentitySource {
+  int reads = 0;
+
+  @override
+  Future<DeviceIdentity> read() async {
+    reads++;
+    throw StateError('no platform channel and no primed cache');
+  }
+}
+
+class _CountingIdentitySource implements DeviceIdentitySource {
+  int reads = 0;
+
+  @override
+  Future<DeviceIdentity> read() async {
+    reads++;
+    return testDeviceIdentity.read();
+  }
+}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  _TestServerConfigNotifier(this._config);
+
+  final ServerConfig? _config;
+
+  @override
+  ServerConfig? build() => _config;
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this._user);
+
+  final UserRow? _user;
+
+  @override
+  Future<UserRow?> build() async => _user;
+}

--- a/flutter/test/providers/pending_voices_sweep_test.dart
+++ b/flutter/test/providers/pending_voices_sweep_test.dart
@@ -183,12 +183,15 @@ void main() {
         hasLength(1),
       );
 
-      // The sweep's own enqueue over the same still-undelivered row. The first
-      // of the two protections: `OutboxRepository.enqueue` keys on
-      // `(uploadType, itemId)`, so it refreshes the queued row rather than
-      // adding a second. Kotlin has no equivalent — its only defence is the
-      // predicate below.
-      await container.read(dashboardSyncProvider.notifier).queuePendingVoices();
+      // The sweep's own enqueue over the same still-undelivered row, taken at
+      // the uploader rather than through `queuePendingVoices`, which drains as
+      // well as queues. The first of the three protections:
+      // `OutboxRepository.enqueue` keys on `(uploadType, itemId)`, so it
+      // refreshes the queued row rather than adding a second. Kotlin has no
+      // equivalent — its only defence is the predicate below.
+      await container
+          .read(voicesUploaderProvider)
+          .queuePending(config: config, userId: 'ada');
       expect(
         await db.outboxDao.forItem(VoicesUploader.type, id),
         hasLength(1),
@@ -268,6 +271,80 @@ void main() {
       );
     });
 
+    test('an edit made while the POST is on the wire still goes out', () async {
+      // The cost of the in-flight guard, and it must not be a loss.
+      //
+      // Kotlin does **not** lose this edit: `getNewsForUpload()` has no
+      // predicate beyond the guest prefix, and `markNewsUploaded`
+      // (`VoicesRepositoryImpl.kt:50-66`) writes back `imageUrls`, `_id`,
+      // `_rev` and `images` and touches no edit marker — so the next
+      // `uploadNews()` re-serializes the edited message with the fresh `_rev`
+      // and it reaches the server as an update. The port's narrower
+      // `pendingUploads` predicate means `markUploaded` clearing `isEdited`
+      // would drop the row out of the pending set for good, and
+      // `NewsMapper.fromDoc` writes `message` unconditionally, so the next
+      // pull would overwrite the user's text with the server's older copy —
+      // the edit destroyed on the device as well as never sent.
+      final container = await containerFor();
+      final id = await seedStrandedVoice(container);
+      final repository = container.read(voicesRepositoryProvider);
+      final posted = <Map<String, dynamic>>[];
+      var posts = 0;
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((invocation) async {
+        posts++;
+        posted.add(invocation.positionalArguments[1] as Map<String, dynamic>);
+        if (posts == 1) {
+          // The user edits the post while its POST is in flight, exactly as
+          // `VoicesActions.editPost` does — repository write, then the
+          // unscoped re-queue the guard declines.
+          await repository.editPost(newsId: id, message: 'The pump is broken');
+          await container
+              .read(voicesUploaderProvider)
+              .queuePending(config: config, userId: 'ada');
+        }
+        return NetworkSuccess<Map<String, dynamic>>({
+          'id': 'server-id',
+          'rev': '$posts-rev',
+        });
+      });
+
+      await container.read(dashboardSyncProvider.notifier).queuePendingVoices();
+
+      expect(posts, 1, reason: 'the guard let a duplicate onto the wire');
+      expect(
+        (await repository.getById(id))?.message,
+        'The pump is broken',
+        reason: 'the local text is the fixture for the rest of this test',
+      );
+      expect(
+        (await repository.pendingUploads()).map((row) => row.id),
+        contains(id),
+        reason:
+            'the send carried a superseded body, so the row is not in sync '
+            'with the server and must stay queueable',
+      );
+
+      // And the next sweep delivers it as an **update**, not a duplicate:
+      // the row now carries the server id, so the payload does too.
+      await container.read(dashboardSyncProvider.notifier).queuePendingVoices();
+
+      expect(posts, 2);
+      expect(posted.last['message'], 'The pump is broken');
+      expect(
+        posted.last['_id'],
+        'server-id',
+        reason: 'a second create would fork the post on the server',
+      );
+      expect(posted.last['_rev'], '1-rev');
+      expect(await repository.pendingUploads(), isEmpty);
+    });
+
     test('a sweep that throws does not fail the sync', () async {
       final container = await containerFor(identity: _ThrowingIdentitySource());
       await seedStrandedVoice(container);
@@ -316,6 +393,14 @@ void main() {
   /// own first cut.
   test('the headless path calls the voices sweep from drainOutbox', () {
     final source = File('lib/background_entrypoint.dart').readAsStringSync();
+    // Bounded to the runner's argument list. The end bound is the *first*
+    // `@visibleForTesting`, which is where the top-level declarations begin,
+    // so `sweepPendingVoices`'s own declaration cannot satisfy the `contains`
+    // below — the failure mode Phase 134 found in its own first cut, where the
+    // range ran to end of file and the assertion could never fail. It stays
+    // sound only while the doc comment above that annotation does not itself
+    // write `sweepPendingVoices(`; the assertion on `sweepPendingSubmissions(`
+    // below would catch a slip, since both names live under the same rule.
     final wiring = source.substring(
       source.indexOf('BackgroundTaskRunner('),
       source.indexOf('@visibleForTesting'),
@@ -329,7 +414,17 @@ void main() {
 
     final swept = wiring.indexOf('sweepPendingVoices(');
     final drained = wiring.indexOf('drainer.drain(');
+    final submissions = wiring.indexOf('sweepPendingSubmissions(');
     expect(drained, greaterThan(-1), reason: 'drainer.drain moved');
+    expect(
+      swept,
+      lessThan(submissions),
+      reason:
+          'both Kotlin workers run uploadNews() before uploadSubmissions() '
+          '(AutoSyncWorker:130 before :136, UserDataWorker:40 before :48), '
+          'and the doc comments cite that ordering as the reason for the '
+          'placement — a claim nothing asserted until now',
+    );
     expect(
       swept,
       lessThan(drained),

--- a/flutter/test/providers/voices_author_round_trip_test.dart
+++ b/flutter/test/providers/voices_author_round_trip_test.dart
@@ -1,0 +1,338 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/voices_provider.dart';
+import 'package:myplanet/repository/voices_uploader.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+/// Phase 144, Job 2. A `news` document carries **no** top-level `userId` or
+/// `userName`: the nested `user` object is the only author identity on it, and
+/// `NewsMapper.fromDoc` reads the local row's `user`, `userId` *and* `userName`
+/// back out of that one object. Kotlin sets it on every write path
+/// (`News.createNews` → `news.user = gson.toJson(user.serialize())`).
+///
+/// `VoicesRepository.authorJson` landed with the chat share in Phase 140 and
+/// the other three writers never used it, so every ordinary voice post, team
+/// post and reply the port authored uploaded with `"user": null` — anonymous
+/// on Planet, and stripped of its author on this device at the next sync-in.
+///
+/// These are round-trip tests on purpose: each drives the writer, takes the
+/// document the uploader actually queued, and feeds *that* back through the
+/// sync-in path. A fixture that fabricates the document would prove nothing
+/// about the pair.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  late AppDatabase db;
+  late MockPlanetApi api;
+
+  setUpAll(() {
+    registerFallbackValue(config);
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+  });
+  tearDown(() => db.close());
+
+  final ada = buildUserRow(
+    id: 'local-ada',
+    name: 'ada',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    email: 'ada@example.org',
+  ).copyWith(couchId: const Value('org.couchdb.user:ada'));
+
+  Future<ProviderContainer> containerFor({UserRow? user}) async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
+        serverConfigProvider.overrideWith(() => _TestServerConfigNotifier()),
+        sessionProvider.overrideWith(() => _TestSessionNotifier(user ?? ada)),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  /// The document the outbox is actually holding for [id] — what would go on
+  /// the wire, not a re-serialization of the row.
+  Future<Map<String, dynamic>> queuedDocument(String id) async {
+    final rows = await db.outboxDao.forItem(VoicesUploader.type, id);
+    expect(rows, hasLength(1), reason: 'nothing was queued for $id');
+    return jsonDecode(rows.single.payload) as Map<String, dynamic>;
+  }
+
+  /// The sync-in half: the server hands the document straight back, with the
+  /// `_id`/`_rev` CouchDB would have stamped on it.
+  Future<void> pullBack(
+    ProviderContainer container,
+    Map<String, dynamic> document, {
+    required String docId,
+  }) => container.read(voicesRepositoryProvider).cacheDocuments([
+    {...document, '_id': docId, '_rev': '1-rev'},
+  ]);
+
+  void expectAuthored(Map<String, dynamic> document) {
+    final author = document['user'];
+    expect(
+      author,
+      isA<Map<String, dynamic>>(),
+      reason:
+          'the nested `user` object is the only author identity a news '
+          'document carries',
+    );
+    expect((author as Map<String, dynamic>)['_id'], 'org.couchdb.user:ada');
+    expect(author['name'], 'ada');
+  }
+
+  Future<void> expectAuthorSurvivesPull(
+    ProviderContainer container,
+    String id, {
+    required String docId,
+  }) async {
+    final document = await queuedDocument(id);
+    expectAuthored(document);
+
+    await pullBack(container, document, docId: docId);
+
+    final row = await container.read(voicesRepositoryProvider).getById(id);
+    expect(
+      row?.userId,
+      'org.couchdb.user:ada',
+      reason: 'the pull read the author back out of the document it sent',
+    );
+    expect(row?.userName, 'ada');
+    expect(row?.user, isNotNull);
+  }
+
+  test('an ordinary voice post names its author, and keeps it', () async {
+    final container = await containerFor();
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+
+    await expectAuthorSurvivesPull(container, id!, docId: 'server-1');
+  });
+
+  test('a team voice post names its author, and keeps it', () async {
+    final container = await containerFor();
+    final id = await container
+        .read(voicesActionsProvider)
+        .createTeamPost(
+          teamId: 'team-1',
+          teamName: 'Water',
+          message: 'The pump needs parts',
+        );
+
+    await expectAuthorSurvivesPull(container, id!, docId: 'server-2');
+  });
+
+  test('a reply names its author, and keeps it', () async {
+    final container = await containerFor();
+    final parent = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+    final id = await container
+        .read(voicesActionsProvider)
+        .postReply(parentId: parent!, message: 'Since when?');
+
+    await expectAuthorSurvivesPull(container, id!, docId: 'server-3');
+  });
+
+  test('the author object carries no credentials', () async {
+    // A voices post is a **public** document. `authorJson` is
+    // `UserEntity.serialize()` minus the credential branch, the device trio
+    // and the `_attachments` photo; `UserMapper.toDoc` is the `_users` PUT
+    // body and must never be reached for here.
+    final container = await containerFor(
+      user: ada.copyWith(
+        password: const Value('hunter2'),
+        derivedKey: const Value('deadbeef'),
+        salt: const Value('c0ffee'),
+      ),
+    );
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+
+    final author = (await queuedDocument(id!))['user'] as Map<String, dynamic>;
+    for (final forbidden in const [
+      'password',
+      'derived_key',
+      'salt',
+      'password_scheme',
+      '_attachments',
+    ]) {
+      expect(
+        author.containsKey(forbidden),
+        isFalse,
+        reason: 'a public news document must not carry $forbidden',
+      );
+    }
+  });
+
+  test('a field the user has not filled in is absent, not null', () async {
+    // `News.createNews` serializes with `JsonUtils.gson`, a bare `Gson()` whose
+    // `serializeNulls` is off, so `addProperty("middleName", null)` writes
+    // nothing at all. `_viewInJson` in the same file already applies that rule
+    // — and there it is load-bearing, because `shareToCommunity` back-fills on
+    // `!containsKey('name')`. Applying it to one writer and not the other left
+    // a counter-example sitting twelve lines away.
+    final container = await containerFor(
+      user: buildUserRow(
+        id: 'local-bare',
+        name: 'bare',
+      ).copyWith(couchId: const Value('org.couchdb.user:bare')),
+    );
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+
+    final author = (await queuedDocument(id!))['user'] as Map<String, dynamic>;
+    for (final absent in const [
+      'middleName',
+      'birthPlace',
+      'age',
+      'phoneNumber',
+      '_rev',
+    ]) {
+      expect(
+        author.containsKey(absent),
+        isFalse,
+        reason: 'Gson drops a null-valued key; $absent was written as null',
+      );
+    }
+    // The non-nullable columns still go out, because Kotlin writes them too.
+    expect(author['type'], 'user');
+    expect(author['isUserAdmin'], isFalse);
+    expect(author['roles'], isEmpty);
+  });
+
+  test('a pulled document with no author clears the local author', () async {
+    // The loss this fix closes, demonstrated from the reader's side: the
+    // mapper writes `user`, `userId` and `userName` unconditionally, so an
+    // author-less document does not merely fail to set them — it erases what
+    // the local row had. Same shape as Phase 74's reactions and Phase 56's
+    // security data.
+    final container = await containerFor();
+    final repository = container.read(voicesRepositoryProvider);
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+    final document = await queuedDocument(id!);
+    expectAuthored(document);
+    // Delivered, so the row now carries the server id the pull matches on —
+    // the state every uploaded post reaches, and the only one in which a
+    // pulled document can overwrite local columns at all.
+    await repository.markUploaded(id, 'server-4', '1-rev');
+
+    await pullBack(container, {...document}..remove('user'), docId: 'server-4');
+
+    final row = await repository.getById(id);
+    expect(
+      row?.userId,
+      isNull,
+      reason:
+          'the mapper writes the author columns unconditionally, so an '
+          'author-less document erases what the local row had — which is '
+          'exactly what an author-less *upload* got back on the next sync',
+    );
+    expect(row?.userName, isNull);
+    expect(row?.user, isNull);
+  });
+
+  test('a session that never resolves does not swallow the post', () async {
+    // `VoicesActions` read `ref.read(sessionProvider).valueOrNull` on a
+    // provider nothing here watches — `team_voices_screen` never touches
+    // `sessionProvider` at all — so the user was null, the early return
+    // dropped the composed post with no error and no row, and the app was
+    // saved only by the router's `ref.listen`. The `await` also has to sit
+    // inside the enclosing `try`, because a future can reject where
+    // `valueOrNull` could not.
+    final container = await containerFor();
+    final id = await container
+        .read(voicesActionsProvider)
+        .createTeamPost(
+          teamId: 'team-1',
+          teamName: 'Water',
+          message: 'The pump needs parts',
+        );
+
+    expect(id, isNotNull, reason: 'the team post was dropped');
+    expect(
+      (await container.read(voicesRepositoryProvider).getById(id!))?.message,
+      'The pump needs parts',
+    );
+  });
+
+  test('a rejecting session is reported, not thrown', () async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
+        serverConfigProvider.overrideWith(() => _TestServerConfigNotifier()),
+        sessionProvider.overrideWith(_RejectingSessionNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      await container.read(voicesActionsProvider).createPost('The well is dry'),
+      isNull,
+    );
+  });
+}
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  @override
+  ServerConfig? build() => const ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this._user);
+
+  final UserRow? _user;
+
+  @override
+  Future<UserRow?> build() async => _user;
+}
+
+class _RejectingSessionNotifier extends SessionNotifier {
+  @override
+  Future<UserRow?> build() async => throw StateError('no session');
+}

--- a/flutter/test/providers/voices_author_round_trip_test.dart
+++ b/flutter/test/providers/voices_author_round_trip_test.dart
@@ -266,14 +266,25 @@ void main() {
     expect(row?.user, isNull);
   });
 
-  test('a session that never resolves does not swallow the post', () async {
+  test('a session not yet resolved does not swallow the post', () async {
     // `VoicesActions` read `ref.read(sessionProvider).valueOrNull` on a
-    // provider nothing here watches — `team_voices_screen` never touches
-    // `sessionProvider` at all — so the user was null, the early return
-    // dropped the composed post with no error and no row, and the app was
-    // saved only by the router's `ref.listen`. The `await` also has to sit
-    // inside the enclosing `try`, because a future can reject where
-    // `valueOrNull` could not.
+    // provider it never watches, so the user was null until something else
+    // resolved it, the early return dropped the composed post with no error
+    // and no row, and the app was saved only by the router's `ref.listen`.
+    //
+    // The screen with the live window is `VoicesScreen`, whose compose FAB is
+    // ungated and renders while `communityFeedProvider` is still loading —
+    // **not** `TeamVoicesScreen`, which an earlier draft of this comment named
+    // and which does reach the session, through `teamMembershipsProvider`, and
+    // gates its FAB on a resolved membership. The correction was made at the
+    // code and this copy of the claim outlived it by one commit.
+    //
+    // The `await` also has to sit inside the enclosing `try`, because a future
+    // can reject where `valueOrNull` could not — the test below.
+    //
+    // The name says *not yet* resolved: an `AsyncNotifier`'s first
+    // synchronous read is `AsyncLoading` even for a `build` that completes
+    // immediately, which is the window this reproduces.
     final container = await containerFor();
     final id = await container
         .read(voicesActionsProvider)

--- a/flutter/test/providers/voices_community_visibility_test.dart
+++ b/flutter/test/providers/voices_community_visibility_test.dart
@@ -165,6 +165,42 @@ void main() {
     ]);
   });
 
+  test('a composed post counts as a community voice', () async {
+    // Two other readers key on the same `viewIn` community entry, and both
+    // were wrong for a port-composed post before the writer was fixed.
+    //
+    // `getCommunityVoiceDates` is the challenge dialog's "post five community
+    // voices" counter (Phase 81, port of `getCommunityVoiceDates`), and it
+    // filters on `isCommunityNews` — so a user could post five voices from the
+    // port's own community screen and the challenge would still read zero.
+    //
+    // The other is `VoicesAdapter.canShare`, which is
+    // `news?.isCommunityNews != true` (`VoicesAdapter.kt:699`): the port was
+    // offering a "share to community" action on a post that Kotlin already
+    // treats as being in the community. `voices_screen.dart:121` reads it.
+    final container = await containerFor(
+      user: ada.copyWith(
+        planetCode: const Value('learning'),
+        parentCode: const Value('earth'),
+      ),
+    );
+    final repository = container.read(voicesRepositoryProvider);
+
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+
+    expect(
+      await repository.getCommunityVoiceDates(0, 1 << 62, null),
+      hasLength(1),
+      reason: 'the challenge task could not be completed from this screen',
+    );
+    expect(
+      VoicesRepository.isCommunityNews((await repository.getById(id!))!),
+      isTrue,
+    );
+  });
+
   test('a team post carries no planet code it cannot know', () async {
     // `TeamsVoicesFragment.kt:78` writes `team?.teamPlanetCode ?: ""` — the
     // **team's** planet, not the author's. The port's `Teams` table has no

--- a/flutter/test/providers/voices_community_visibility_test.dart
+++ b/flutter/test/providers/voices_community_visibility_test.dart
@@ -1,0 +1,212 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/providers/voices_provider.dart';
+import 'package:myplanet/repository/voices_repository.dart';
+import 'package:myplanet/repository/voices_uploader.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+/// Phase 144. Found by the ground-truth `parity-auditor` pass, not by the two
+/// jobs this lane opened on.
+///
+/// `VoicesFragment.btnSubmit` (`ui/voices/VoicesFragment.kt:137-148`) builds
+/// **four** keys before it calls `createNews`:
+///
+/// ```kotlin
+/// map["viewInId"] = "${user?.planetCode ?: ""}@${user?.parentCode ?: ""}"
+/// map["viewInSection"] = "community"
+/// map["messageType"] = "sync"
+/// map["messagePlanetCode"] = user?.planetCode ?: ""
+/// ```
+///
+/// The port's community composer called `createPost(message)` with the message
+/// alone, so `_viewInJson(id: null, …)` returned `"[]"` and
+/// [VoicesRepository.isVisibleToUser] fell through its `viewIn == null ||
+/// viewIn.isEmpty` guard to `false` — `viewableBy` is null on a locally
+/// composed post, so the shortcut above it does not fire either. The post was
+/// written, listed nowhere, and uploaded as a document with no audience at all,
+/// because `serialize` omits `viewIn` for an empty list.
+///
+/// That is the Phase 113 shape: the writer could not produce a value the
+/// reader's predicate matches. Every fixture in the existing feed tests
+/// hand-built its rows through `cacheDocuments`, which is why the pair was
+/// never asked about.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+
+  setUpAll(() => registerFallbackValue(<String, dynamic>{}));
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+  });
+  tearDown(() => db.close());
+
+  final ada = buildUserRow(
+    id: 'local-ada',
+    name: 'ada',
+  ).copyWith(couchId: const Value('org.couchdb.user:ada'));
+
+  Future<ProviderContainer> containerFor({UserRow? user}) async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
+        serverConfigProvider.overrideWith(() => _TestServerConfigNotifier()),
+        sessionProvider.overrideWith(() => _TestSessionNotifier(user ?? ada)),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<Map<String, dynamic>> queuedDocument(String id) async {
+    final rows = await db.outboxDao.forItem(VoicesUploader.type, id);
+    expect(rows, hasLength(1), reason: 'nothing was queued for $id');
+    return jsonDecode(rows.single.payload) as Map<String, dynamic>;
+  }
+
+  test('a composed community post appears in the community feed', () async {
+    final container = await containerFor(
+      user: ada.copyWith(
+        planetCode: const Value('learning'),
+        parentCode: const Value('earth'),
+      ),
+    );
+
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+
+    final feed = await container
+        .read(voicesRepositoryProvider)
+        .watchCommunityFeed(
+          communityViewerIdentifier(
+            planetCode: 'learning',
+            parentCode: 'earth',
+          ),
+        )
+        .first;
+    expect(
+      feed.map((row) => row.id),
+      contains(id),
+      reason:
+          'the author cannot see their own community post — the writer '
+          'produces no value `isVisibleToUser` can match',
+    );
+  });
+
+  test('the composed post addresses the community on the wire', () async {
+    final container = await containerFor(
+      user: ada.copyWith(
+        planetCode: const Value('learning'),
+        parentCode: const Value('earth'),
+      ),
+    );
+
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+    final document = await queuedDocument(id!);
+
+    expect(
+      document['viewIn'],
+      [
+        {'_id': 'learning@earth', 'section': 'community'},
+      ],
+      reason:
+          'a document with no viewIn is invisible in Planet\'s community view '
+          'too, and a pull-back cannot repair it',
+    );
+    // `"sync"` is the literal `VoicesFragment` writes, and it is what
+    // distinguishes a community post from a `"team"` one.
+    expect(document['messageType'], 'sync');
+    expect(document['messagePlanetCode'], 'learning');
+  });
+
+  test('a user with no planet codes still addresses the community', () async {
+    // Kotlin interpolates both halves unguarded, so a user missing either
+    // writes `"@"`, `"learning@"` or `""@earth"` — and `isVisibleToUser`
+    // treats an empty or `"@"` id as the planet-wide wildcard on both sides.
+    // A guest-shaped account must not silently lose its post instead.
+    final container = await containerFor();
+
+    final id = await container
+        .read(voicesActionsProvider)
+        .createPost('The well is dry');
+
+    final feed = await container
+        .read(voicesRepositoryProvider)
+        .watchCommunityFeed(
+          communityViewerIdentifier(planetCode: null, parentCode: null),
+        )
+        .first;
+    expect(feed.map((row) => row.id), contains(id));
+    expect((await queuedDocument(id!))['viewIn'], [
+      {'_id': '@', 'section': 'community'},
+    ]);
+  });
+
+  test('a team post carries no planet code it cannot know', () async {
+    // `TeamsVoicesFragment.kt:78` writes `team?.teamPlanetCode ?: ""` — the
+    // **team's** planet, not the author's. The port's `Teams` table has no
+    // such column (reported against `tables.dart`, which this lane does not
+    // own), and `MyTeam.kt:86` reads it with `JsonUtils.getString`, so a
+    // document that omits the field yields `""` in Kotlin too. `''` is
+    // therefore the faithful interim value; `user.planetCode` is a *claim*
+    // about a team that may have been created on another planet, and it
+    // disagreed with the port's own chat-share writer, which already sends
+    // `''` for exactly this reason (`chat_repository.dart:306-310`).
+    final container = await containerFor(
+      user: ada.copyWith(planetCode: const Value('learning')),
+    );
+
+    final id = await container
+        .read(voicesActionsProvider)
+        .createTeamPost(
+          teamId: 'team-1',
+          teamName: 'Water',
+          message: 'The pump needs parts',
+        );
+
+    expect((await queuedDocument(id!))['messagePlanetCode'], '');
+  });
+}
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  @override
+  ServerConfig? build() => const ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this._user);
+
+  final UserRow? _user;
+
+  @override
+  Future<UserRow?> build() async => _user;
+}

--- a/flutter/test/repository/voices_repository_test.dart
+++ b/flutter/test/repository/voices_repository_test.dart
@@ -644,6 +644,24 @@ void main() {
       ]);
       expect(await repository.pendingUploads(), isEmpty);
 
+      // `addLabel`/`removeLabel` have no caller in `lib/` yet — which is why
+      // they are here. They mutate `labels`, which `serialize` sends, and
+      // Kotlin's sweep re-sends the whole table, so a label change reaches the
+      // server there. Flagged in Phase 144 so that stays true the day the
+      // label chips get wired, rather than being discovered missing then.
+      await repository.addLabel('server-1', 'important');
+      expect(
+        await repository.pendingUploads(),
+        hasLength(1),
+        reason: 'a label that never uploads is device-local',
+      );
+      await repository.markUploaded('server-1', 'server-1', '2-rev');
+
+      await repository.removeLabel('server-1', 'important');
+      expect(await repository.pendingUploads(), hasLength(1));
+      await repository.markUploaded('server-1', 'server-1', '3-rev');
+      expect(await repository.pendingUploads(), isEmpty);
+
       await repository.toggleReaction('server-1', '👍', 'user-1');
       expect(
         await repository.pendingUploads(),
@@ -651,7 +669,7 @@ void main() {
         reason: 'a reaction that never uploads is invisible to everyone else',
       );
 
-      await repository.markUploaded('server-1', 'server-1', '2-rev');
+      await repository.markUploaded('server-1', 'server-1', '4-rev');
       expect(await repository.pendingUploads(), isEmpty);
 
       // The un-share branch: two entries, deleted from the community feed, so

--- a/flutter/test/repository/voices_repository_test.dart
+++ b/flutter/test/repository/voices_repository_test.dart
@@ -624,6 +624,46 @@ void main() {
       expect(await repository.pendingUploads(), hasLength(1));
     });
 
+    test('every local mutation puts a delivered post back in the queue', () async {
+      // Phase 144. The narrower predicate is what makes the new sync-path
+      // sweep cheap — `getNewsForUpload()` re-sends the whole table on every
+      // sync — and it is only safe while *every* local mutation flags the row.
+      // `editPost` and `shareToCommunity` have their own tests above; these are
+      // the other two, and a mutation that forgets the flag is a post whose
+      // change never reaches the server at all.
+      await repository.cacheDocuments([
+        {
+          '_id': 'server-1',
+          'docType': 'message',
+          'message': 'Synced',
+          'viewIn': [
+            {'_id': 'team-1', 'section': 'teams'},
+            {'_id': 'planet@parent', 'section': 'community', 'sharedDate': 5},
+          ],
+        },
+      ]);
+      expect(await repository.pendingUploads(), isEmpty);
+
+      await repository.toggleReaction('server-1', '👍', 'user-1');
+      expect(
+        await repository.pendingUploads(),
+        hasLength(1),
+        reason: 'a reaction that never uploads is invisible to everyone else',
+      );
+
+      await repository.markUploaded('server-1', 'server-1', '2-rev');
+      expect(await repository.pendingUploads(), isEmpty);
+
+      // The un-share branch: two entries, deleted from the community feed, so
+      // the row survives with the community entry stripped.
+      expect(await repository.deletePost('server-1'), 0);
+      expect(
+        await repository.pendingUploads(),
+        hasLength(1),
+        reason: 'an un-share that never uploads leaves the post shared',
+      );
+    });
+
     test('never queues a guest post', () async {
       // A guest has no CouchDB user document, so the server rejects it.
       await repository.createPost(

--- a/flutter/test/repository/voices_uploader_test.dart
+++ b/flutter/test/repository/voices_uploader_test.dart
@@ -101,6 +101,34 @@ void main() {
     expect(await voices.pendingUploads(), isEmpty);
   });
 
+  test('a send already on the wire is neither counted nor re-queued', () async {
+    // Phase 144. `OutboxRepository.enqueue` puts an `in_progress` row back to
+    // `pending` so a payload edited mid-flight is not lost, and `markCompleted`
+    // is `deleteIfInProgress` — so the send that succeeds moments later deletes
+    // nothing, the row survives with the same body, and the next drain posts a
+    // **second** `news` document. A voice with no `_id` is an append, so that
+    // is a duplicate rather than an edit.
+    final id = await seedPost();
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+    final claimed = (await outbox.due()).single;
+    await outbox.markInProgress(claimed.id);
+
+    expect(
+      await uploader.queuePending(config: config, userId: 'user-1'),
+      0,
+      reason: 'a post whose POST is on the wire must be left alone',
+    );
+    final rows = await database.outboxDao.forItem(VoicesUploader.type, id);
+    expect(rows, hasLength(1));
+    expect(
+      rows.single.status,
+      'in_progress',
+      reason:
+          'the re-enqueue would have reset it to pending, which is what makes '
+          'the row survive `markCompleted` and replay',
+    );
+  });
+
   test('a success without id/rev fails rather than dropping the row', () async {
     await seedPost();
     await uploader.queuePending(config: config, userId: 'user-1');

--- a/flutter/test/repository/voices_uploader_test.dart
+++ b/flutter/test/repository/voices_uploader_test.dart
@@ -42,6 +42,13 @@ void main() {
   });
   tearDown(() => database.close());
 
+  /// What `OutboxDrainer` hands the handler: the operation's own stored
+  /// payload, decoded. Passing `const {}` instead would read as "the row
+  /// changed while the POST was on the wire", which is a real branch of
+  /// `markUploaded` and not what these tests are about.
+  Map<String, dynamic> payloadOf(OutboxRow operation) =>
+      jsonDecode(operation.payload) as Map<String, dynamic>;
+
   Future<String> seedPost() =>
       voices.createPost(message: 'Hello', userId: 'user-1', userName: 'Ada');
 
@@ -93,7 +100,7 @@ void main() {
       }),
     );
 
-    await uploader.handler(operation, const {}, 'Basic dGVzdA==');
+    await uploader.handler(operation, payloadOf(operation), 'Basic dGVzdA==');
 
     final row = await voices.getById(id);
     expect(row?.docId, 'remote-1');
@@ -141,7 +148,11 @@ void main() {
       ),
     ).thenAnswer((_) async => NetworkSuccess<Map<String, dynamic>>(const {}));
 
-    final result = await uploader.handler(operation, const {}, null);
+    final result = await uploader.handler(
+      operation,
+      payloadOf(operation),
+      null,
+    );
 
     expect(result, isA<NetworkError<Map<String, dynamic>>>());
     expect(await voices.pendingUploads(), hasLength(1));
@@ -168,7 +179,7 @@ void main() {
 
     // The endpoint no longer authenticates, so the header is the only
     // credential; matching it with `any()` would hide a null.
-    await uploader.handler(operation, const {}, 'Basic dGVzdA==');
+    await uploader.handler(operation, payloadOf(operation), 'Basic dGVzdA==');
 
     expect(seen, 'Basic dGVzdA==');
   });


### PR DESCRIPTION
Lane C of the Phase 144 parallel round. Takes items 4 and 5 from Phase 140's *Reported, not fixed* list; the two `parity-auditor` passes then surfaced two further defects, one of them larger than either briefed job.

Full write-up in `flutter/PHASE_144_NOTES.md`, including thirteen **Reported, not fixed** items for the integrator and the next round.

## What landed

| Fix | Where | Class |
|---|---|---|
| A periodic voices upload sweep, on both sync paths | `dashboard_sync_provider.dart`, `background_entrypoint.dart` | the safety net Kotlin has and the port did not (Phase 134) |
| A send already on the wire is not re-enqueued | `voices_uploader.dart` | append replayed as a duplicate |
| **A mid-flight edit survives that guard** | `voices_repository.dart` | **silent loss the guard itself introduced** |
| Every locally authored voice names its author | `voices_provider.dart` | sync-in rewriting a locally-authored column |
| The session is awaited, not read | `voices_provider.dart` | `.valueOrNull` on an unwatched provider |
| **A composed community post is addressed to the community** | `voices_provider.dart` | **reachability — the writer produced no value the reader matches** |
| A team post carries `''`, not the author's planet code | `voices_provider.dart` | two port writers disagreeing about one field |
| `addLabel`/`removeLabel` flag the row like every other mutation | `voices_repository.dart` | the predicate's enumeration was incomplete |
| `authorJson` drops a null-valued key instead of writing `null` | `voices_repository.dart` | faithfulness to Gson's `serializeNulls` |

**The two the audits found are the ones to read.**

*A composed community post was invisible to everyone.* `VoicesFragment.btnSubmit` builds four keys before calling `createNews`; the port's composer passed the message alone, so `viewIn` was `"[]"` and no reader could match it — not the feed, not Planet, not the share-action gate, and not the Phase 81 challenge dialog's "post five community voices" counter, which could never advance from that screen.

*The in-flight guard turned a mid-flight edit into permanent loss*, and both reasons the comment gave for accepting it were wrong. Kotlin does **not** lose it — `getNewsForUpload` has no predicate beyond the guest prefix and `markNewsUploaded` touches no edit marker. The sentence was copied from `submissions_uploader.dart`, where it *is* true; it does not transfer, because the narrow `pendingUploads` predicate is the port's own invention for voices. `markUploaded` now takes the document that actually went out and keeps `isEdited` when the row no longer matches it, so the next sweep re-queues it with the `_id`/`_rev` just recorded — an update, not a duplicate.

## Verification

- 27 new tests across three new files and two existing ones; **2,599 pass**.
- **26 mutations run and caught.** Four tests exist *because* a mutation found a claim nothing pinned. One mutation was itself invalid — its anchor matched the submissions sweep first and reported a false negative until re-aimed.
- Two `parity-auditor` passes at `effort: max`: one on the Kotlin ground truth before implementing, one on the finished green code. Both found things; the second found a live loss path and three documentation failures of the same class.
- Gate green: `dart format --set-exit-if-changed`, `flutter analyze`, `flutter test`.

## Scope

No schema change; `app_database.dart` and `tables.dart` untouched (Lane B's). `lib/core/**` untouched — `OutboxDrainScope` lives at `lib/ui/outbox_drain_scope.dart` and needed no step. One item is explicitly parked for Lane B: `pendingUploads` is a full-table scan and wants a `NewsDao` predicate query (notes, item 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDGe4ZuphWbntkwUXQ7JVh