### PR TITLE
Phase 145 (Lane D): course step labels, the dead resources chevron, and non-member navigation

### DIFF
--- a/flutter/PHASE_145_NOTES.md
+++ b/flutter/PHASE_145_NOTES.md
@@ -23,7 +23,13 @@ the highest-yield source of work:
 3. Implement, each defect demonstrated failing first.
 4. Mutation-test every claim.
 5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
-   already-green code.
+   already-green code. **It found seven things**, and they are folded in below
+   rather than left in a transcript: one behavioural divergence documented as
+   parity, one guest hole the lane had declared closed while leaving the larger
+   half open **in its own file set**, a claim Phase 128 had already retracted
+   and this phase reinstated, a false justification for a `ref.watch`, three
+   miscounts, and four weak tests. That is six consecutive rounds in which the
+   second pass found something on green code.
 
 ## What the ground-truth audit changed
 
@@ -78,10 +84,25 @@ twice over exactly as Phase 128 said — no listener is ever attached, and
 at `:20`, referenced from no Kotlin. `btn_open` in the same container is dead
 with it.
 
-**So Phase 128's conclusion survives its own citation being wrong**, which is
-worth saying plainly: there is no live per-step *count* to diverge from, and
-also no live per-step *navigation*. What there is instead is a list the port
-cannot render.
+**Phase 128's conclusion was right and this phase briefly un-learned it.** The
+first draft of these notes said Phase 128 had cited the wrong function; it had
+not — it cited `setResourceButton` as the live analogue of *the chevron's
+promised navigation*, and it had already found `legacy_buttons_container` and
+already stated in terms that "there is no live Kotlin count". What is genuinely
+new here is only `setupInlineResources` / `autoDownloadResources` /
+`prefetchNextStepResources` as the real per-step UI.
+
+Worse, an earlier version of the test comment and of this file asserted that
+`CourseStepFragment` "shows the same number" the port's tile shows. **It does
+not** — that number goes to `btnResources`, which is GONE — and it is precisely
+the claim Phase 128 made and retracted *in the same paragraph*
+(`PHASE_128_NOTES.md:378-380`). Reinstating a retraction from memory is the
+same failure mode as the brief's off-by-one, one file further along. The count
+is kept because it is true and it is the only thing the screen can say about a
+step's resources, **not** because Kotlin shows it; when the list arrives it
+should replace the count rather than sit beside it. Phase 128's other still-live
+observation, unrecorded until now: `resourcesInStep` is an ICU plural, so
+`tool/arb_from_strings_xml.dart` can never derive a translation for it.
 
 ### Why the port cannot render it: a missing sync walk, not a missing widget
 
@@ -192,17 +213,36 @@ and no gate contradicts the only place Kotlin states a rule. Ported, because
 * reproducing the escape would mean modelling Android's fragment lifecycle, so a
   Flutter learner's navigation would depend on whether they had been away.
 
-**What a non-member sees on the last step is Finish, and that is Kotlin's answer
-rather than a choice.** The `else` branch never touches `finishStep`, and
-`bindCourse` has already run `setNavigationButtons()` (`:118`, `:464-473`),
-which shows Finish exactly when `position >= steps.size`. In Kotlin that state
-is reached by an **ex-member**: progress rows survive leaving a course
-(`leaveCourses` does not touch `course_progress`) and `position` is restored
-from them (`:104`, `:116`). The port has no resume-at-saved-step (Phase 139
-item 9), so it reaches the same state on a **one-step course**, where index 0 is
-also the last step — which is what the test drives, and what the pre-existing
-finish/rating tests in `take_course_screen_test.dart` were already relying on
-without anyone noticing they used a non-member course row.
+**Finish is not gated, and that is an invariant rather than a preference.** The
+`else` branch never touches `finishStep`; `setNavigationButtons()` (`:118`,
+`:464-473`) and the only other writers, `onResume:154-160` and
+`onClickNext:343-349`, all key on `position >= steps.size` alone. Gating it
+would break the case Kotlin genuinely has: an **ex-member** is restored to
+`position = currentStep` (`:104`, `:116`) from progress rows that survive
+leaving a course (`leaveCourses` touches `courses` and `removed_log` only), so
+somebody who finished a course and then left re-opens on the last page with
+Finish and neither Next nor Previous.
+
+**Where the port and Kotlin actually part company is the cover page, and the
+first draft of this file called that parity — the second audit was right to
+push.** Kotlin's *never*-member sits at `position = 0`, the cover page, where
+`0 >= steps.size` is false for any course with a step: they see no Finish
+either. The port has no cover page, so its index 0 is Kotlin's position 1; on a
+**one-step** course that is already the last step, and applying Kotlin's own
+rule at the position the learner is on yields Finish. So a learner who never
+joined a one-step course gets a Finish button Kotlin's cold open would not show
+them.
+
+That is the same structural difference Job 1 is about, surfacing a second time,
+and it is left standing: the alternative is to gate Finish on membership, which
+contradicts the invariant and takes the button from the ex-member Kotlin gives
+it to. Recorded as a divergence, not dressed up as parity.
+
+The **five** pre-existing finish/rating tests in `take_course_screen_test.dart`
+were non-member fixtures *by accident* — `buildCourseRow`'s default `userId` is
+empty — so from the moment the gate landed they were silently propping up this
+decision, and mutating it reddened all five instead of the one test that is
+about it. They are member rows now, and that mutation reds exactly one test.
 
 **The Previous gate is pinned by a real path, not a contrived one.** A
 non-member can never advance, so Previous is unreachable for them by
@@ -225,6 +265,30 @@ control, so its own gating stopped being incidental.
 `UserMapper.isGuest(user)` rather than `isGuestId(widget.userId)`: the former
 tests both id columns, which its own doc calls a deliberate widening.
 
+**Two corrections from the second audit, both mine.**
+
+*The claim was in the past tense and should not have been.* `UserMapper` says
+**nothing in the port creates a guest row at all**, so no user could take that
+tap today. This is hardening consistent with the port's other guest gates, not a
+live bug closed — and the notes and the code comment said otherwise.
+
+*And the lane closed the smaller half.* `CourseDetailScreen` has the **same**
+ungated toggle, in this lane's own file set, and its `_toggleMembership` calls
+`shelfRepository.upload` after the local write — so that copy reached the
+server where the one Phase 145 gated first only wrote locally. Now gated, and
+pinned: a mutation deleting the gate left the entire suite green until a test
+was written for it.
+
+**The gate is narrower than Kotlin's, and the narrowing is now the top reported
+item.** `UserEntity.isGuest()` is the id-prefix rule **or** a `guest` role
+without a `learner` role; `UserMapper.isGuest` implements only the first half.
+Its own doc names `TakeCourseFragment:212` — the exact site this phase ported —
+as one of three role-clause gates that "have no port counterpart yet", and says
+the role clause "belongs here as a second predicate beside this one — not folded
+into it". Landing that counterpart made the doc false. `user_mapper.dart` is
+outside this lane's file set, so the predicate and the doc line are reported
+rather than changed.
+
 **The `!containsUserId` half is deliberately not ported.** Kotlin hides this
 button from *members* too — `TakeCourseFragment` has no leave affordance at
 all — where the port keeps one, as `CourseDetailScreen` does. That is a port
@@ -236,18 +300,24 @@ beyond this brief. Named rather than folded in.
 | file | change |
 |---|---|
 | `lib/ui/courses/take_course_screen.dart` | the heading, the chevron, the nav gate, `canChangeMembership`, `_nextStepLock`'s gate removed |
-| `lib/ui/courses/course_detail_screen.dart` | **none** — see Job 2 |
+| `lib/ui/courses/course_detail_screen.dart` | the `!isGuest` gate on the membership toggle |
 | `test/ui/courses/step_label_test.dart` | new, 3 tests |
 | `test/ui/courses/step_resources_tile_test.dart` | new, 3 tests |
-| `test/ui/courses/non_member_navigation_test.dart` | new, 5 tests |
+| `test/ui/courses/non_member_navigation_test.dart` | new, 7 tests |
 | `test/ui/courses/step_next_lock_test.dart` | one existing test reshaped — see below |
+| `test/ui/courses/course_detail_screen_test.dart` | +2 tests pinning the guest gate |
+| `test/ui/courses/take_course_screen_test.dart` | 5 finish/rating fixtures made member rows |
 | `lib/l10n/app_en.arb` | **none** — no key added |
 
-`course_detail_screen.dart` is in the file set and is deliberately unchanged.
-Both things Job 2 sent me to look at there turned out to be absent (the chevron)
-or unportable (the resource list). The one real gap the audit surfaced in it is
-reported below rather than fixed, because it is a display decision beyond the
-three jobs.
+**`course_detail_screen.dart` was going to be "deliberately unchanged", and the
+second audit was right that this was the wrong call.** Both things *Job 2* sent
+me to look at there were absent (the chevron) or unportable (the resource
+list) — but the lane had just decided, in Job 3, that an ungated membership
+button is a defect, and this file has the same one, in a copy that **uploads**.
+Checking a file against the job you arrived with is not the same as checking it
+against what you learned while you were there. The remaining gap in it
+(item 3, the step tile's subtitle) is genuinely a display decision beyond the
+three jobs and stays reported.
 
 **One existing test changed shape**, `step_next_lock_test.dart`'s *a learner who
 has not joined is not locked*. It tapped Next and asserted the page moved,
@@ -268,14 +338,27 @@ Every fix reverted, every test replayed.
 | 3 | restore the resource tile's `trailing:` chevron | *the resource count offers no chevron to tap* |
 | 4 | drop the `isMyCourse` gate on Next | 4 tests, across two files |
 | 5 | drop the `isMyCourse` gate on Previous | *leaving the course part-way…* |
-| 6 | Finish gated on `isMyCourse` too | *a non-member on the last step still sees Finish*, plus 3 pre-existing finish/rating tests in `take_course_screen_test.dart` |
-| 7 | drop `canChangeMembership` on the join/leave button | *a guest gets no navigation and no join button* |
+| 6 | Finish gated on `isMyCourse` too | *a non-member on the last step still sees Finish* — **1 test, after the five accidental non-member fixtures were made members**; it reddened 5 before |
+| 7 | drop `canChangeMembership` on the join/leave button | 2 guest tests |
 | 8 | re-add the membership gate to `_nextStepLock` | **nothing** — deliberately; see above |
+| 9 | drop the `!isGuest` gate on `CourseDetailScreen`'s toggle | **nothing, until a test was written** — see below |
 
 Mutation 8 is recorded as a **non-red on purpose**. The lock's gate is
 unreachable once the button is gated, so nothing can pin it; that is the reason
 it was removed rather than kept as belt-and-braces, and stating it here is
 cheaper than the next lane rediscovering that an untestable line exists.
+
+**Mutation 9 was a non-red by accident, which is the different thing.** The
+`CourseDetailScreen` guest gate shipped with nothing pinning it — a fix that
+reads as coverage and is not. Two tests in `course_detail_screen_test.dart` now
+red it. Rows 6 and 7 also moved after the audit: row 6 from five reds to one
+(the fixtures were the problem, not the gate), row 7 from one to two (the guest
+test was split, because the original put a guest on an *unjoined* course where
+three of its four assertions followed from non-membership and would have held
+with `canChangeMembership` deleted). The discriminating case is a guest who
+**is** in `course.userId`: Kotlin's `updateNavigationVisibility:257` keys on
+`containsUserId` with no guest exception while `setCourseData` keys on both, so
+that learner gets the navigation and not the button.
 
 ## Integrator
 
@@ -283,14 +366,40 @@ cheaper than the next lane rediscovering that an untestable line exists.
 Phases 128 and 139 there is no derivation hand-off.
 
 One thing to know: **`courseDetails` is now an orphan template key.** Nothing in
-`lib/` reads it after this diff. It carries real ar/es/fr translations, and
-deleting it means editing all five locale files plus `humanReviewed` in
-`test/l10n/placeholder_integrity_test.dart` — outside this lane's file set.
-Phase 128 left `takeTest` in the same state; this makes two.
+`lib/` reads it after this diff.
+
+The first draft of this paragraph said it "carries real ar/es/fr translations"
+and that deleting it touches five locale files. **Both were wrong**, and this
+project's vocabulary makes the first one matter: ar and fr are `"x-mt": true`,
+unreviewed machine translation, and only **es** is a human translation; ne and
+so do not have the key at all. So deleting it touches **three** locale files and
+moves only the `es` entry in `humanReviewed`
+(`test/l10n/placeholder_integrity_test.dart`). Outside this lane's file set
+either way. Phase 128 left `takeTest` in the same state; this makes two.
+
+**Also for Lane A**, whoever holds `user_mapper.dart`: its `isGuest` doc names
+`TakeCourseFragment:212` as a role-clause gate with "no port counterpart yet".
+This phase landed that counterpart, so the line is now false — see *Reported*
+item 1.
 
 ## Reported, not fixed
 
-1. **The port never ingests a course step's resources**, so `noOfResources` is a
+1. **`UserMapper.isGuest` is missing Kotlin's role clause, and this phase made
+   its doc stale.** `UserEntity.isGuest()` is
+   `_id.startsWith("guest_") || (hasGuestRole && !hasLearnerRole)`;
+   `UserMapper.isGuest` implements only the first disjunct. Its doc explains
+   why — every port gate so far was a counterpart of Kotlin's narrower
+   `id.startsWith` family — and names three role-clause gates that "have no port
+   counterpart yet": `TeamFragment:235`, `CoursesFragment:135` and
+   **`TakeCourseFragment:212`**. Phase 145 ported the third. So the doc asserts
+   something false, and both new guest gates are narrower than their Kotlin
+   originals: a user with `roles: ["guest"]`, no `learner`, and an ordinary
+   `org.couchdb.user:` id gets a join button Kotlin withholds. Unreachable today
+   (no port writer creates a guest row), certain as documentation rot. The doc
+   also says where the fix goes: **a second predicate beside `isGuest`, not
+   folded into it**, or the settings and voices gates silently widen past their
+   Kotlin counterparts. `user_mapper.dart` is outside this lane's file set.
+2. **The port never ingests a course step's resources**, so `noOfResources` is a
    count of rows it does not hold. Kotlin's courses walk buffers each embedded
    resource document (`queueCourseResources`, `CoursesRepositoryImpl.kt:687`,
    `:792-798`) and drains it into `my_library` stamped with `courseId` and
@@ -311,7 +420,7 @@ Phase 128 left `takeTest` in the same state; this makes two.
      Kotlin's `Base64(stepElement.toString())`;
    * `my_library` gains two columns, so it needs a **schema bump**, and it is
      not in `localAuthorityTables` — confirm that before writing the migration.
-2. **`course_detail_screen.dart:204` shows the wrong datum.**
+3. **`course_detail_screen.dart:204` shows the wrong datum.**
    `CoursesStepsAdapter.bind` (`:51-55`) sets the step row's second line from
    `R.string.test_size` — *"This test has %d questions"* — with
    `step.questionCount`, and hides it unless the row is expanded (`:57-63`). The
@@ -323,7 +432,7 @@ Phase 128 left `takeTest` in the same state; this makes two.
    answered for the lock, since `questionCount` is
    `examDao.getFirstByStepId(stepId)?.noOfQuestions` and can name a *survey's*
    count under a "test" label.
-3. **The port has no join prompt.** `setCourseData:219-229` puts a *do you want
+4. **The port has no join prompt.** `setCourseData:219-229` puts a *do you want
    to join this course?* dialog in front of a non-member on open, once per
    ViewModel (`hasOfferedJoinDialog`), whose positive action joins and
    immediately restores navigation. With Job 3's gate landed, the port shows a
@@ -334,7 +443,7 @@ Phase 128 left `takeTest` in the same state; this makes two.
    `maybeShowJoinDialog`/`onCourseDetailContentReady`/`JOIN_DIALOG_FALLBACK_MS`
    are dead (`pendingJoinDialog` is never set true anywhere), and the dialog
    shows unconditionally at `:228`.
-4. **Kotlin's non-member gate fails open and the port's does not**, so this is a
+5. **Kotlin's non-member gate fails open and the port's does not**, so this is a
    deviation for `docs/kotlin-to-flutter-migration.md`'s *Faithful quirks /
    deliberate deviations* list rather than parity. Text: *"`TakeCourseFragment`
    hides Next and Previous from a non-member in `updateNavigationVisibility`,
@@ -343,31 +452,31 @@ Phase 128 left `takeTest` in the same state; this makes two.
    the first resume. The port applies the stated rule permanently."* That file
    is Lane A's this round. Phase 128 item 5 left the same kind of hand-off and
    it is still outstanding, so this is the second entry queued for that list.
-5. **A 0-step course diverges.** Kotlin's `bindCourse:111-114` hides both
+6. **A 0-step course diverges.** Kotlin's `bindCourse:111-114` hides both
    buttons and then `:118` evaluates `0 >= 0` as true and shows **Finish** — to
    members, non-members and guests alike. The port renders `l10n.noDataAvailable`
    and never reaches `_NavigationBar`. Benign, and the port's is the better
    behaviour; recorded because it is the one place the Finish rule above does
    not transfer.
-6. **`TakeCourseFragment` has no leave affordance and the port has one.**
+7. **`TakeCourseFragment` has no leave affordance and the port has one.**
    `setCourseData`'s `else` (`:230-232`) hides `btnRemove` for a member as well
    as a guest. The port keeps *Remove from my courses* here, as
    `CourseDetailScreen` does. A port addition, left alone — removing a working
    capability is not a parity fix — but it is the other half of the
    `canChangeMembership` gate and belongs with it.
-7. **The port does not resume a course at the learner's saved step** — Phase 139
+8. **The port does not resume a course at the learner's saved step** — Phase 139
    item 9, still open, and it is what makes the non-member Finish state above
    reachable in Kotlin but not in the port. Related: `TakeCourseScreen.build`'s
    clamp still moves the index during `build` without driving the controller
    (Phase 139 item 10).
-8. **`SubmissionDao.countCompletedByUserAndExamId` was routed to Lane B this
+9. **`SubmissionDao.countCompletedByUserAndExamId` was routed to Lane B this
    round** and `_isStepCompleted` still filters in Dart. Not touched here, as
    briefed; `_nextStepLock` was edited for the membership gate only and
    `_isStepCompleted` is untouched.
-9. **Cosmetic, and named so nobody "fixes" it twice.** Kotlin's heading renders
+10. **Cosmetic, and named so nobody "fixes" it twice.** Kotlin's heading renders
    `STEP 3/5` — `R.string.step` is the lowercase `"step"` and `tv_step` carries
    `android:textAllCaps="true"` (`fragment_take_course.xml:66`) — and its Next
    button reads lowercase `next`. The port renders `Step 3` beside a separate
    `3 / 5` counter. Same numbers, different typography; not worth a change.
-10. **Phase 139 items 1 and 5–14 are otherwise unchanged**, as are Phase 135
+11. **Phase 139 items 1 and 5–14 are otherwise unchanged**, as are Phase 135
     items 5, 7, 9, 10 and 11.

--- a/flutter/PHASE_145_NOTES.md
+++ b/flutter/PHASE_145_NOTES.md
@@ -294,9 +294,12 @@ Phase 128 left `takeTest` in the same state; this makes two.
    count of rows it does not hold. Kotlin's courses walk buffers each embedded
    resource document (`queueCourseResources`, `CoursesRepositoryImpl.kt:687`,
    `:792-798`) and drains it into `my_library` stamped with `courseId` and
-   `stepId` (`flushPendingCourseResources`, `:819-851`, run from
-   `TransactionSyncManager.kt:302`); `CourseMapper._parseSteps` keeps only the
-   length. **This is the item behind Job 2** and it blocks three readers at
+   `stepId` (`flushPendingCourseResources`, `:819-851`); `CourseMapper
+   ._parseSteps` keeps only the length. **The drain has two call sites**, not
+   one: `TransactionSyncManager.kt:302`, per batch inside the `"courses"` walk,
+   and `CoursesRepositoryImpl.kt:508`. A port needs both or an equivalent, since
+   the walk's own call is what makes a step's resources available before the
+   sync finishes. **This is the item behind Job 2** and it blocks three readers at
    once: the inline per-step resource list (`setupInlineResources`), the
    course-level download button (`setResourceButton`, `getCourseResources`'s
    `WHERE courseId = ?`), and the step's auto-download and next-step prefetch.

--- a/flutter/PHASE_145_NOTES.md
+++ b/flutter/PHASE_145_NOTES.md
@@ -1,14 +1,368 @@
 # Phase 145 — the step label, the dead chevron, and the non-member navigation question
 
 Lane D of a four-lane round. Three jobs, all from previous rounds'
-*Reported, not fixed* lists:
+*Reported, not fixed* lists — the seventh consecutive round where that list was
+the highest-yield source of work:
 
-1. `_ProgressSection` labels step 1 "Course Details" and every other step off by
-   one (Phase 139 item 3).
-2. The resources tile has a chevron with no `onTap`, in both
-   `take_course_screen.dart` and `course_detail_screen.dart` (Phase 128 item 1,
+1. `_ProgressSection` labels step 1 "Course Details" (Phase 139 item 3).
+2. The step's resource count has a chevron with no `onTap` (Phase 128 item 1,
    restated as Phase 139 item 4).
-3. `_NavigationBar` shows Next and Previous to a non-member where Kotlin's
-   `updateNavigationVisibility` hides both (Phase 139 item 2).
+3. `_NavigationBar` shows Next and Previous to a non-member where
+   `updateNavigationVisibility:256-270` hides both (Phase 139 item 2).
 
-*(work in progress — this file is written as the phase goes)*
+## Method
+
+1. Read the Kotlin by hand: `TakeCourseFragment`, `CoursesPagerAdapter`,
+   `CourseStepFragment`, `CourseDetailFragment`, `CoursesStepsAdapter`,
+   `BaseContainerFragment.setResourceButton`, `CoursesRepositoryImpl`'s course
+   parse and its `pendingCourseResources` drain, plus the three layouts.
+2. A `parity-auditor` pass at `effort: max` on **14 lettered claims** about that
+   reading, before touching Dart. It confirmed eleven, corrected two and
+   **refuted one outright** — the refuted one had already been written into a
+   test file as a rationale, which is exactly why the pass runs first.
+3. Implement, each defect demonstrated failing first.
+4. Mutation-test every claim.
+5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
+   already-green code.
+
+## What the ground-truth audit changed
+
+### The brief was wrong about Job 1, and the shape of the error is familiar
+
+The brief said the label "is off by one against `stepNumber` for every other
+step". **It is not**, and this is the *"a brief propagates the previous round's
+mistakes as efficiently as its facts"* pattern again.
+
+Kotlin's pager **does** have a cover page. `CoursesPagerAdapter.getItemCount()`
+is `steps.size + 1`, `createFragment(0)` builds a `CourseDetailFragment` and
+`createFragment(p > 0)` builds the step at `steps[p - 1]` with
+`stepNumber = p` (`:40-60`); `getItemId(0)` is even a distinct sentinel,
+`COURSE_DETAIL_ID = 0L`. So Kotlin position `p ≥ 1` shows step index `p - 1`
+and `updateStepDisplay` reads `step p/N`.
+
+The port has no cover page — it reaches the course description through its own
+`CourseDetailScreen` route — so **port index `i` is Kotlin position `i + 1`**,
+and `l10n.stepNumber(currentStep + 1)` is right at every index. Checked in both
+directions: at `i = N-1` Kotlin is at position `N` and reads `step N/N`, the
+port reads `Step N`. The counter and the progress bar already agreed too.
+
+**Only the `== 0` branch was ever wrong**, and it was wrong under *either*
+premise: with a cover page, index 1 would be step 1 and `stepNumber(2)` would be
+the off-by-one the brief describes; without one, index 0 is a real step wearing
+the cover page's heading. The fix is to delete the branch, not to renumber, and
+the tests are written so that "fixing" the `else` to `currentStep` reds them —
+because that would have renumbered every step in the app.
+
+Worth knowing while you are there: `"Course Details"` is a bare literal in
+`TakeCourseFragment.kt:194` with **no `strings.xml` key**, untranslated in all
+six Kotlin locales. The port's `l10n.courseDetails` was a port-only string and
+is now an orphan key (see *Integrator*).
+
+### Job 2's live Kotlin counterpart is not the one two rounds of notes named
+
+Phase 128 named `BaseContainerFragment.setResourceButton`, reached from
+`CourseDetailFragment`, and Phase 139 repeated it. That button is live, but it
+is **course-level**: `state.resources` ← `CourseDetailModel.resources` ←
+`getCourseOnlineResources(courseId)` → `MyLibraryDao`'s
+`WHERE courseId = :courseId`. It is not a step's resources, and its click opens
+the multi-select download sheet rather than a viewer.
+
+The per-step Kotlin UI **is not a button at all**. `CourseStepFragment
+.setupInlineResources()` (`:176-194`) shows `tvResourcesHeader` and binds
+`rvInlineResources` to an `InlineResourceAdapter` whose rows call
+`openResource(library)`, with `autoDownloadResources()` (`:196-213`) and
+`prefetchNextStepResources()` (`:215-230`) alongside. `btnResources` is dead
+twice over exactly as Phase 128 said — no listener is ever attached, and
+`setListeners` sets it GONE at `:292` — and the audit found the container too:
+`legacy_buttons_container` in `fragment_course_step.xml:14`, `visibility="gone"`
+at `:20`, referenced from no Kotlin. `btn_open` in the same container is dead
+with it.
+
+**So Phase 128's conclusion survives its own citation being wrong**, which is
+worth saying plainly: there is no live per-step *count* to diverge from, and
+also no live per-step *navigation*. What there is instead is a list the port
+cannot render.
+
+### Why the port cannot render it: a missing sync walk, not a missing widget
+
+Kotlin knows a step's resources because the courses walk writes them.
+`parseCourse` calls `queueCourseResources(courseId, stepId, …)` per step
+(`CoursesRepositoryImpl.kt:687`), buffering each embedded resource **document**
+(`:792-798`); `flushPendingCourseResources` (`:819-851`) upserts them into
+`my_library` through `MyLibrary.insertMyLibrary`, and `getAllStepResources`
+reads them back with `myLibraryDao.getByStepId`.
+
+`CourseMapper._parseSteps` keeps `resources.length` as `noOfResources` and
+**discards the documents**. `MyLibraryTable` has no `stepId` column — and, the
+audit corrected me here, **no `courseId` column either**, which my first reading
+of `tables.dart` got wrong by matching a `courseId` line belonging to the next
+table. So the number on the tile describes rows the port does not hold, on
+either axis.
+
+That is a Phase 119-class finding: a walk Kotlin runs that the port never had,
+found by asking Job 2's third reachability question — *does anything navigate
+here?* — and getting "there is nowhere to navigate to". Removing the chevron is
+the whole of the fix available in this lane's files; the walk is reported below.
+
+### Job 3: one claim refuted, and it was already written into a test
+
+I claimed a resumed non-member gets Next back for **exactly one tap**, because
+the resulting `onPageSelected` would call `updateNavigationVisibility` and hide
+it again. **Refuted.** `viewPager2.currentItem += 1` dispatches `onPageSelected`
+*synchronously* — `setCurrentItemInternal` → `ScrollEventAdapter
+.notifyProgrammaticScroll` → `dispatchSelected(target)` on a changed target — so
+`updateNavigationVisibility` runs **inside** line `:372`, and `:373`
+(`previousStep` VISIBLE) and `:375` → `onClickNext():347` (`nextStep` VISIBLE)
+then undo it. The non-member ends the gesture with *both* buttons and keeps
+them.
+
+The androidx source is not in this repository, so that half is the auditor's
+citation rather than something I verified here. What **is** checkable locally
+corroborates the ordering it depends on: `onClickNext()` is called *after* the
+increment and reads `viewPager2.currentItem` (`:342`), while `onClickPrevious()`
+is called *before* the decrement and reads `currentItem - 1` (`:353`) — both
+correct only if the item index updates synchronously inside the setter, which is
+the same statement that precedes `notifyProgrammaticScroll`.
+
+Two further corrections from the same pass:
+
+* **The restore is not exam-specific.** `onPause:164-169` stamps
+  `lastPositionBeforeExam` on *every* pause, so backgrounding the app is enough.
+  And when the saved position is `0` the `> 0` test fails and it falls through
+  to `currentItem`, still reaching the `else` at `:157-160` — so a non-member
+  sitting on the cover page gets Next after a home-button round trip.
+* **`steps` can be initialised before a first `onResume` after all.** My claim
+  that it cannot was right only for a cold open. `collectLatestWhenStarted` is
+  `repeatOnLifecycle(STARTED)` on `Dispatchers.Main.immediate` and the ViewModel
+  survives configuration change, so after a rotation or a back-stack pop the
+  `Success` state is delivered during `onStart` and `bindCourse` runs before
+  that instance's `onResume`.
+
+Net: **in the shipping Android app the non-member gate holds on a cold open and
+not afterwards.**
+
+## Job 1 — the heading
+
+`_ProgressSection` renders `l10n.stepNumber(currentStep + 1)` unconditionally.
+Three tests, each pairing the heading with the **title of the page actually
+rendered** — the Phase 139 lesson, since the heading and the counter are both
+driven by `currentStep` and agreed with each other while disagreeing with the
+`PageView` for four phases.
+
+The one-step case is the one to keep in mind: with a single step, index 0 is the
+only page there is, so `Course Details` was the only heading that course ever
+showed.
+
+## Job 2 — the chevron
+
+`trailing: const Icon(Icons.chevron_right)` removed from the resource-count
+tile. The count stays: it is true (it is the length of the step document's
+`resources` array) and `CourseStepFragment` shows the same number. The two tiles
+below keep their chevrons, because those two navigate.
+
+**Phase 128's item said the chevron was in `course_detail_screen.dart` too and
+Phase 139 repeated it. It is not, and was not.** `_StepTile` there is an
+`ExpansionTile` whose count is a subtitle and whose trailing arrow expands the
+description — an honest affordance. Pinned by a test rather than left as a
+second unchecked claim.
+
+## Job 3 — the non-member gate, ported
+
+`_NavigationBar` gains `isMyCourse` gates on Next and Previous, and the copy
+Phase 139 had put on `_nextStepLock` is **removed**, so that method now reads
+like `changeNextButtonState`, which has no membership test of its own. One
+documented deviation collapses into fidelity.
+
+**The decision, stated as a decision.** Both options deviate from something: the
+gate is stricter than the shipping app in every session after the first resume,
+and no gate contradicts the only place Kotlin states a rule. Ported, because
+
+* `updateNavigationVisibility` is the only site expressing an intent, while all
+  three writes that undo it are doing something else — restoring after a
+  lifecycle event, or swapping Next for Finish at the end of the list — and each
+  is a **partial copy of the member branch written without its `else`**;
+* the same method that hides the buttons puts a *do you want to join this
+  course?* dialog in front of a non-member (`setCourseData:219-229`), which is a
+  design statement about whose screen this is;
+* nothing is actually lost in the port: `CourseDetailScreen`, the screen a
+  learner arrives from, lists every step with its description and its exam
+  button, and the join button sits in this very bar;
+* reproducing the escape would mean modelling Android's fragment lifecycle, so a
+  Flutter learner's navigation would depend on whether they had been away.
+
+**What a non-member sees on the last step is Finish, and that is Kotlin's answer
+rather than a choice.** The `else` branch never touches `finishStep`, and
+`bindCourse` has already run `setNavigationButtons()` (`:118`, `:464-473`),
+which shows Finish exactly when `position >= steps.size`. In Kotlin that state
+is reached by an **ex-member**: progress rows survive leaving a course
+(`leaveCourses` does not touch `course_progress`) and `position` is restored
+from them (`:104`, `:116`). The port has no resume-at-saved-step (Phase 139
+item 9), so it reaches the same state on a **one-step course**, where index 0 is
+also the last step — which is what the test drives, and what the pre-existing
+finish/rating tests in `take_course_screen_test.dart` were already relying on
+without anyone noticing they used a non-member course row.
+
+**The Previous gate is pinned by a real path, not a contrived one.** A
+non-member can never advance, so Previous is unreachable for them by
+navigation — which would have made its gate dead code. It is observable the
+other way round: a member on step 2 taps *Remove from my courses*, and both
+buttons go. Kotlin does the same, `addRemoveCourse`'s success path calling
+`setCourseData()` → `updateNavigationVisibility()` (`:445`, `:237`).
+
+### The guest button, found by the audit and fixed here
+
+`setCourseData:216-232` shows `btnRemove` for `!isGuest && !containsUserId`
+only. The port offered the join/leave button unconditionally, and for a guest
+that was worse than inert: `_toggleMembership` bails only on a null `userId`,
+and the guest row has one, so the tap **wrote a shelf membership Kotlin does not
+allow a guest to write**. `canChangeMembership` now gates it on
+`UserMapper.isGuest`. This is Job 2's principle applied to a second affordance
+in the same widget — with the gate on Next, that button is a non-member's only
+control, so its own gating stopped being incidental.
+
+`UserMapper.isGuest(user)` rather than `isGuestId(widget.userId)`: the former
+tests both id columns, which its own doc calls a deliberate widening.
+
+**The `!containsUserId` half is deliberately not ported.** Kotlin hides this
+button from *members* too — `TakeCourseFragment` has no leave affordance at
+all — where the port keeps one, as `CourseDetailScreen` does. That is a port
+addition rather than a defect, and removing a working capability is a decision
+beyond this brief. Named rather than folded in.
+
+## Files touched
+
+| file | change |
+|---|---|
+| `lib/ui/courses/take_course_screen.dart` | the heading, the chevron, the nav gate, `canChangeMembership`, `_nextStepLock`'s gate removed |
+| `lib/ui/courses/course_detail_screen.dart` | **none** — see Job 2 |
+| `test/ui/courses/step_label_test.dart` | new, 3 tests |
+| `test/ui/courses/step_resources_tile_test.dart` | new, 3 tests |
+| `test/ui/courses/non_member_navigation_test.dart` | new, 5 tests |
+| `test/ui/courses/step_next_lock_test.dart` | one existing test reshaped — see below |
+| `lib/l10n/app_en.arb` | **none** — no key added |
+
+`course_detail_screen.dart` is in the file set and is deliberately unchanged.
+Both things Job 2 sent me to look at there turned out to be absent (the chevron)
+or unportable (the resource list). The one real gap the audit surfaced in it is
+reported below rather than fixed, because it is a display decision beyond the
+three jobs.
+
+**One existing test changed shape**, `step_next_lock_test.dart`'s *a learner who
+has not joined is not locked*. It tapped Next and asserted the page moved,
+pinning the membership test Phase 139 had put on the lock. With the gate moved
+to the button there is no Next to tap, so it now asserts the **absence of
+Next** — which is what keeps it able to fail: re-adding a gate to `_nextStepLock`
+leaves it green (the lock is unreachable on that path either way), while
+dropping the gate in `_NavigationBar` reds it immediately.
+
+## Mutation testing
+
+Every fix reverted, every test replayed.
+
+| # | mutation | reds |
+|---|---|---|
+| 1 | restore `currentStep == 0 ? l10n.courseDetails : …` | 2 tests |
+| 2 | `stepNumber(currentStep + 1)` → `stepNumber(currentStep)` | 3 tests |
+| 3 | restore the resource tile's `trailing:` chevron | *the resource count offers no chevron to tap* |
+| 4 | drop the `isMyCourse` gate on Next | 3 tests, across two files |
+| 5 | drop the `isMyCourse` gate on Previous | *leaving the course part-way…* |
+| 6 | Finish gated on `isMyCourse` too | *a non-member on the last step still sees Finish* + 3 pre-existing finish tests |
+| 7 | drop `canChangeMembership` on the join/leave button | *a guest gets no navigation and no join button* |
+| 8 | re-add the membership gate to `_nextStepLock` | **nothing** — deliberately; see above |
+
+Mutation 8 is recorded as a **non-red on purpose**. The lock's gate is
+unreachable once the button is gated, so nothing can pin it; that is the reason
+it was removed rather than kept as belt-and-braces, and stating it here is
+cheaper than the next lane rediscovering that an untestable line exists.
+
+## Integrator
+
+**Nothing to run.** No ARB key is added and no locale file is touched, so unlike
+Phases 128 and 139 there is no derivation hand-off.
+
+One thing to know: **`courseDetails` is now an orphan template key.** Nothing in
+`lib/` reads it after this diff. It carries real ar/es/fr translations, and
+deleting it means editing all five locale files plus `humanReviewed` in
+`test/l10n/placeholder_integrity_test.dart` — outside this lane's file set.
+Phase 128 left `takeTest` in the same state; this makes two.
+
+## Reported, not fixed
+
+1. **The port never ingests a course step's resources**, so `noOfResources` is a
+   count of rows it does not hold. Kotlin's courses walk buffers each embedded
+   resource document (`queueCourseResources`, `CoursesRepositoryImpl.kt:687`,
+   `:792-798`) and drains it into `my_library` stamped with `courseId` and
+   `stepId` (`flushPendingCourseResources`, `:819-851`, run from
+   `TransactionSyncManager.kt:302`); `CourseMapper._parseSteps` keeps only the
+   length. **This is the item behind Job 2** and it blocks three readers at
+   once: the inline per-step resource list (`setupInlineResources`), the
+   course-level download button (`setResourceButton`, `getCourseResources`'s
+   `WHERE courseId = ?`), and the step's auto-download and next-step prefetch.
+   Three constraints for whoever takes it, from the audit:
+   * write `stepId`/`courseId` **only when non-blank** (`MyLibrary.kt:229-234`),
+     so the plain resources walk cannot clear the course link on a re-pull —
+     the Phase 56 / 74 / 98 shape;
+   * key on the port's own `CourseMapper.stepIdFor` (`'$courseId:$index'`), not
+     Kotlin's `Base64(stepElement.toString())`;
+   * `my_library` gains two columns, so it needs a **schema bump**, and it is
+     not in `localAuthorityTables` — confirm that before writing the migration.
+2. **`course_detail_screen.dart:204` shows the wrong datum.**
+   `CoursesStepsAdapter.bind` (`:51-55`) sets the step row's second line from
+   `R.string.test_size` — *"This test has %d questions"* — with
+   `step.questionCount`, and hides it unless the row is expanded (`:57-63`). The
+   port's subtitle is `resourcesInStep(step.noOfResources)`: a different number,
+   always visible, and per item 1 one the port cannot substantiate. This
+   sharpens Phase 139 item 5, which concluded there was "nothing to fix today"
+   because the port "has no analogue" — it does, it is just showing something
+   else in the same slot. Whoever ports it meets the row-pick question Phase 139
+   answered for the lock, since `questionCount` is
+   `examDao.getFirstByStepId(stepId)?.noOfQuestions` and can name a *survey's*
+   count under a "test" label.
+3. **The port has no join prompt.** `setCourseData:219-229` puts a *do you want
+   to join this course?* dialog in front of a non-member on open, once per
+   ViewModel (`hasOfferedJoinDialog`), whose positive action joins and
+   immediately restores navigation. With Job 3's gate landed, the port shows a
+   non-member a step they cannot leave and a button they must work out for
+   themselves. Not built here because it is a new affordance rather than one of
+   the three jobs, and because the ViewModel-scoped "offered once" state has no
+   port equivalent. Note two things inside that Kotlin **not** to port:
+   `maybeShowJoinDialog`/`onCourseDetailContentReady`/`JOIN_DIALOG_FALLBACK_MS`
+   are dead (`pendingJoinDialog` is never set true anywhere), and the dialog
+   shows unconditionally at `:228`.
+4. **Kotlin's non-member gate fails open and the port's does not**, so this is a
+   deviation for `docs/kotlin-to-flutter-migration.md`'s *Faithful quirks /
+   deliberate deviations* list rather than parity. Text: *"`TakeCourseFragment`
+   hides Next and Previous from a non-member in `updateNavigationVisibility`,
+   but `onResume:158`, `onClick:373` and `onClickNext:347` all restore them
+   without a membership test, so in the shipping app the gate holds only until
+   the first resume. The port applies the stated rule permanently."* That file
+   is Lane A's this round. Phase 128 item 5 left the same kind of hand-off and
+   it is still outstanding, so this is the second entry queued for that list.
+5. **A 0-step course diverges.** Kotlin's `bindCourse:111-114` hides both
+   buttons and then `:118` evaluates `0 >= 0` as true and shows **Finish** — to
+   members, non-members and guests alike. The port renders `l10n.noDataAvailable`
+   and never reaches `_NavigationBar`. Benign, and the port's is the better
+   behaviour; recorded because it is the one place the Finish rule above does
+   not transfer.
+6. **`TakeCourseFragment` has no leave affordance and the port has one.**
+   `setCourseData`'s `else` (`:230-232`) hides `btnRemove` for a member as well
+   as a guest. The port keeps *Remove from my courses* here, as
+   `CourseDetailScreen` does. A port addition, left alone — removing a working
+   capability is not a parity fix — but it is the other half of the
+   `canChangeMembership` gate and belongs with it.
+7. **The port does not resume a course at the learner's saved step** — Phase 139
+   item 9, still open, and it is what makes the non-member Finish state above
+   reachable in Kotlin but not in the port. Related: `TakeCourseScreen.build`'s
+   clamp still moves the index during `build` without driving the controller
+   (Phase 139 item 10).
+8. **`SubmissionDao.countCompletedByUserAndExamId` was routed to Lane B this
+   round** and `_isStepCompleted` still filters in Dart. Not touched here, as
+   briefed; `_nextStepLock` was edited for the membership gate only and
+   `_isStepCompleted` is untouched.
+9. **Cosmetic, and named so nobody "fixes" it twice.** Kotlin's heading renders
+   `STEP 3/5` — `R.string.step` is the lowercase `"step"` and `tv_step` carries
+   `android:textAllCaps="true"` (`fragment_take_course.xml:66`) — and its Next
+   button reads lowercase `next`. The port renders `Step 3` beside a separate
+   `3 / 5` counter. Same numbers, different typography; not worth a change.
+10. **Phase 139 items 1 and 5–14 are otherwise unchanged**, as are Phase 135
+    items 5, 7, 9, 10 and 11.

--- a/flutter/PHASE_145_NOTES.md
+++ b/flutter/PHASE_145_NOTES.md
@@ -1,0 +1,14 @@
+# Phase 145 — the step label, the dead chevron, and the non-member navigation question
+
+Lane D of a four-lane round. Three jobs, all from previous rounds'
+*Reported, not fixed* lists:
+
+1. `_ProgressSection` labels step 1 "Course Details" and every other step off by
+   one (Phase 139 item 3).
+2. The resources tile has a chevron with no `onTap`, in both
+   `take_course_screen.dart` and `course_detail_screen.dart` (Phase 128 item 1,
+   restated as Phase 139 item 4).
+3. `_NavigationBar` shows Next and Previous to a non-member where Kotlin's
+   `updateNavigationVisibility` hides both (Phase 139 item 2).
+
+*(work in progress — this file is written as the phase goes)*

--- a/flutter/PHASE_145_NOTES.md
+++ b/flutter/PHASE_145_NOTES.md
@@ -161,10 +161,12 @@ tile. The count stays: it is true (it is the length of the step document's
 below keep their chevrons, because those two navigate.
 
 **Phase 128's item said the chevron was in `course_detail_screen.dart` too and
-Phase 139 repeated it. It is not, and was not.** `_StepTile` there is an
-`ExpansionTile` whose count is a subtitle and whose trailing arrow expands the
-description — an honest affordance. Pinned by a test rather than left as a
-second unchecked claim.
+Phase 139 repeated it. It is not, and was not** — `git log --all -S chevron --
+flutter/lib/ui/courses/course_detail_screen.dart` returns nothing, so no commit
+on any branch ever added or removed one there. `_StepTile` is an `ExpansionTile`
+whose count is a subtitle and whose trailing arrow expands the description — an
+honest affordance. Pinned by a test rather than left as a second unchecked
+claim.
 
 ## Job 3 — the non-member gate, ported
 
@@ -264,9 +266,9 @@ Every fix reverted, every test replayed.
 | 1 | restore `currentStep == 0 ? l10n.courseDetails : …` | 2 tests |
 | 2 | `stepNumber(currentStep + 1)` → `stepNumber(currentStep)` | 3 tests |
 | 3 | restore the resource tile's `trailing:` chevron | *the resource count offers no chevron to tap* |
-| 4 | drop the `isMyCourse` gate on Next | 3 tests, across two files |
+| 4 | drop the `isMyCourse` gate on Next | 4 tests, across two files |
 | 5 | drop the `isMyCourse` gate on Previous | *leaving the course part-way…* |
-| 6 | Finish gated on `isMyCourse` too | *a non-member on the last step still sees Finish* + 3 pre-existing finish tests |
+| 6 | Finish gated on `isMyCourse` too | *a non-member on the last step still sees Finish*, plus 3 pre-existing finish/rating tests in `take_course_screen_test.dart` |
 | 7 | drop `canChangeMembership` on the join/leave button | *a guest gets no navigation and no join button* |
 | 8 | re-add the membership gate to `_nextStepLock` | **nothing** — deliberately; see above |
 

--- a/flutter/lib/ui/courses/course_detail_screen.dart
+++ b/flutter/lib/ui/courses/course_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../data/local/app_database.dart';
+import '../../data/local/user_mapper.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/courses_providers.dart';
@@ -90,6 +91,8 @@ class _CourseBody extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final isMyCourse = userId != null && course.userId.contains(userId);
+    final user = ref.watch(sessionProvider).valueOrNull;
+    final isGuest = user != null && UserMapper.isGuest(user);
     final target = (type: 'course', itemId: course.id);
     final rating = ref.watch(ratingSummaryProvider(target)).valueOrNull;
 
@@ -136,13 +139,27 @@ class _CourseBody extends ConsumerWidget {
                 icon: const Icon(Icons.play_arrow),
                 label: Text(l10n.takeCourse),
               ),
-              FilledButton.tonalIcon(
-                onPressed: () => _toggleMembership(ref, joined: !isMyCourse),
-                icon: Icon(
-                  isMyCourse ? Icons.bookmark_remove : Icons.bookmark_add,
+              // Gated on `!isGuest`, as `TakeCourseFragment.setCourseData`
+              // (`:216-232`) gates `btnRemove` — Kotlin offers the membership
+              // button to a signed-in non-guest and to nobody else.
+              //
+              // **This is the more consequential of the port's two copies**,
+              // and Phase 145 gated the other one first. `take_course_screen`'s
+              // `_toggleMembership` writes locally; this one writes *and*
+              // pushes the shelf, so an ungated guest tap here reached the
+              // server. The guard is `UserMapper.isGuest`, whose id-prefix rule
+              // no port writer can currently satisfy — so this is hardening
+              // rather than a live bug closed, and it is narrower than
+              // `UserEntity.isGuest()`, which is that rule *or* a `guest` role
+              // without a `learner` role. See `PHASE_145_NOTES.md`.
+              if (!isGuest)
+                FilledButton.tonalIcon(
+                  onPressed: () => _toggleMembership(ref, joined: !isMyCourse),
+                  icon: Icon(
+                    isMyCourse ? Icons.bookmark_remove : Icons.bookmark_add,
+                  ),
+                  label: Text(isMyCourse ? l10n.leaveCourse : l10n.joinCourse),
                 ),
-                label: Text(isMyCourse ? l10n.leaveCourse : l10n.joinCourse),
-              ),
               OutlinedButton.icon(
                 onPressed: () => showDialog<void>(
                   context: context,

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../data/local/app_database.dart';
+import '../../data/local/user_mapper.dart';
 import '../../l10n/app_localizations.dart';
 
 import '../../providers/courses_providers.dart';
@@ -235,7 +236,16 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
     final currentStep = widget.currentStep;
     final onStepChanged = widget.onStepChanged;
     final isMyCourse = _isMyCourse;
-    final lock = _nextStepLock(currentStep, isMyCourse);
+    final lock = _nextStepLock(currentStep);
+
+    // `setCourseData:216-232` shows `btnRemove` for `!isGuest && !containsUserId`
+    // only, so Kotlin offers the membership button to a signed-in non-member
+    // and to nobody else. Watched rather than derived from `widget.userId`,
+    // because `UserMapper.isGuest` deliberately tests both id columns where
+    // `isGuestId` tests one; the parent already watches this provider, so the
+    // value is resolved by the time this builds.
+    final user = ref.watch(sessionProvider).valueOrNull;
+    final canChangeMembership = user != null && !UserMapper.isGuest(user);
 
     // The recording moved to [_recordCurrentStep], which covers this and the
     // step the screen opens on alike.
@@ -322,6 +332,7 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
           currentStep: currentStep,
           totalSteps: steps.length,
           isMyCourse: isMyCourse,
+          canChangeMembership: canChangeMembership,
           onPrevious: currentStep > 0 ? () => goToStep(currentStep - 1) : null,
           onNext: currentStep < steps.length - 1 ? onNext : null,
           onFinish: () => _onFinish(context, ref),
@@ -348,23 +359,22 @@ class _CourseContentState extends ConsumerState<_CourseContent> {
   ///  * **A step index out of range**, which is `steps.getOrNull(position - 1)`
   ///    returning null and `isStepCompleted(null, …)` answering true (`:317`,
   ///    `SubmissionsRepositoryImpl.kt:360`).
-  ///  * **A course the learner has not joined — and this one is a deviation,
-  ///    named rather than assumed.** `changeNextButtonState` has no membership
-  ///    test; Kotlin's is on the button, `updateNavigationVisibility:256-270`
-  ///    hiding Next and Previous outright for a non-member. But that is not
-  ///    Kotlin's last word: `onResume:154-160` makes Next visible again with
-  ///    no membership test, and `position` is restored from the learner's
-  ///    saved progress (`:116`), so somebody who joined, made progress, left
-  ///    the course and came back *can* meet the lock there. This port gates
-  ///    the lock instead of the button, because the port's `_NavigationBar`
-  ///    has no membership gate at all (see `PHASE_139_NOTES.md`) — so the
-  ///    effect matches Kotlin's intended rule and diverges from its `onResume`
-  ///    slip. It also keeps the lock consistent with the step tile, which
-  ///    `_StepContent` hides for a non-member: a learner cannot be blocked by
-  ///    an assessment the screen is not offering them.
-  StepNextLock? _nextStepLock(int currentStep, bool isMyCourse) {
+  ///
+  /// **There is deliberately no membership test here, and there used to be
+  /// one.** `changeNextButtonState` has none either: Kotlin's membership test
+  /// is on the button, `updateNavigationVisibility:256-270` hiding Next and
+  /// Previous outright for a non-member. Phase 139 put a copy of that test on
+  /// the lock because `_NavigationBar` had no gate at all, and recorded it as
+  /// a deviation. Phase 145 moved the gate to `_NavigationBar`, where Kotlin
+  /// keeps it, so the copy is gone and this method reads like its original.
+  ///
+  /// The consequence is worth stating rather than leaving to be rediscovered:
+  /// a non-member has no Next to tap, so this value is computed and discarded
+  /// for them. If `_NavigationBar`'s gate is ever relaxed, the lock becomes
+  /// live for a learner whose assessment tile `_StepContent` is not showing —
+  /// which is the state Phase 139's gate existed to avoid.
+  StepNextLock? _nextStepLock(int currentStep) {
     if (course.id != _mandatorySurveyCourseId) return null;
-    if (!isMyCourse) return null;
     if (currentStep < 0 || currentStep >= steps.length) return null;
     final step = steps[currentStep];
     // The same key `_StepContent` builds, so the tile's post-return
@@ -517,9 +527,10 @@ class _ProgressSection extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              // `updateStepDisplay` (`TakeCourseFragment.kt:184-193`): the
-              // heading is `"Course Details"` at pager position 0 and
-              // `"Step p/N"` at every later position.
+              // `updateStepDisplay` (`TakeCourseFragment.kt:192-197`): the
+              // heading is the bare literal `"Course Details"` at pager
+              // position 0 and `setStepText(position, steps.size)` — `"step
+              // p/N"` — at every later position.
               //
               // **Kotlin's pager has a cover page and this one does not**, and
               // that is the whole reason the `position == 0` branch does not
@@ -790,6 +801,7 @@ class _NavigationBar extends StatelessWidget {
     required this.currentStep,
     required this.totalSteps,
     required this.isMyCourse,
+    required this.canChangeMembership,
     required this.onPrevious,
     required this.onNext,
     required this.onFinish,
@@ -798,7 +810,81 @@ class _NavigationBar extends StatelessWidget {
 
   final int currentStep;
   final int totalSteps;
+
+  /// Gates Next and Previous, which is where `updateNavigationVisibility`
+  /// (`TakeCourseFragment.kt:256-270`) gates them:
+  ///
+  /// ```kotlin
+  /// if (containsUserId) { … } else {
+  ///     binding.nextStep.visibility = View.GONE
+  ///     binding.previousStep.visibility = View.GONE
+  /// }
+  /// ```
+  ///
+  /// A learner who has not joined the course can read the step they opened on
+  /// and nothing else; the join button beside these is how they get further,
+  /// and Kotlin additionally puts a *do you want to join this course* dialog in
+  /// front of them (`setCourseData`). Joining restores the buttons on both
+  /// sides — Kotlin re-runs `setCourseData()` from `addRemoveCourse`'s success
+  /// path, and here the course stream re-emits.
+  ///
+  /// **Kotlin's own last word on this is not the rule above, and the
+  /// difference is deliberately not ported.** Three later writes put the
+  /// buttons back without consulting membership: `onResume:158` sets
+  /// `nextStep` VISIBLE, and `onClick`'s next arm sets `previousStep` VISIBLE
+  /// at `:373` with `onClickNext():347` setting `nextStep` VISIBLE at `:375`.
+  /// The first of those is not exam-specific — `onPause:164-169` stamps
+  /// `lastPositionBeforeExam` on **every** pause, so backgrounding the app is
+  /// enough — and it fires on every resume once a successful bind has
+  /// assigned `steps`. So in the shipping Android app **the gate holds on a
+  /// cold open and not afterwards.**
+  ///
+  /// How long it survives a Next tap after that turns on whether
+  /// `viewPager2.currentItem += 1` dispatches `onPageSelected` (and with it
+  /// `updateNavigationVisibility`) synchronously, before `:373`/`:375` run, or
+  /// afterwards. ViewPager2's `setCurrentItemInternal` calls
+  /// `ScrollEventAdapter.notifyProgrammaticScroll`, which dispatches the
+  /// selection synchronously on a changed target — under that reading the
+  /// buttons stay for the rest of the fragment's life; under the other they
+  /// go again on the next page selection. **That is not in this repository to
+  /// read and the decision here does not rest on it**, because either way the
+  /// gate is gone after a resume.
+  ///
+  /// It is ported anyway, as the intent rather than the effect, and the port
+  /// is therefore *stricter* than the shipping app in any session after the
+  /// first resume. The reasons: `updateNavigationVisibility` is the only place
+  /// Kotlin states a rule, while all three writes that undo it are doing
+  /// something else — restoring after a lifecycle event, or swapping
+  /// Next for Finish at the end of the list — and each is a partial copy of
+  /// the *member* branch written without its `else`. And the same method that
+  /// hides these puts a *do you want to join this course* dialog in front of a
+  /// non-member (`setCourseData:219-229`), which is a design statement about
+  /// whose screen this is. Reproducing the escape would also mean modelling
+  /// Android's fragment lifecycle, so a Flutter learner's navigation would
+  /// depend on whether they had been away.
+  ///
+  /// Phase 139 read the same lines from the other side, when the gate was on
+  /// the lock, and reached the same conclusion.
   final bool isMyCourse;
+
+  /// Whether the join/leave button is offered at all.
+  ///
+  /// `setCourseData:216-232` shows `btnRemove` only for `!isGuest &&
+  /// !containsUserId`, so in Kotlin a guest gets no membership button — and
+  /// `updateNavigationVisibility` gives them no navigation either, since it
+  /// keys on `containsUserId` alone with no guest exception. The port offered
+  /// the button unconditionally, which for a guest meant a control that
+  /// **would have worked**: `_toggleMembership` bails only on a null
+  /// `userId`, and the guest row has one, so tapping it wrote shelf
+  /// membership Kotlin does not allow a guest to write.
+  ///
+  /// **The `!containsUserId` half is deliberately not ported.** Kotlin hides
+  /// this button from members too, so `TakeCourseFragment` has no leave
+  /// affordance at all; the port keeps one, as `CourseDetailScreen` does. That
+  /// is a port addition rather than a defect, and taking it away is a
+  /// capability decision rather than a parity fix — see `PHASE_145_NOTES.md`.
+  final bool canChangeMembership;
+
   final VoidCallback? onPrevious;
   final VoidCallback? onNext;
   final VoidCallback onFinish;
@@ -823,35 +909,55 @@ class _NavigationBar extends StatelessWidget {
       child: SafeArea(
         child: Row(
           children: [
-            // Leave/Join button
-            OutlinedButton.icon(
-              onPressed: onToggleMembership,
-              icon: Icon(
-                isMyCourse ? Icons.bookmark_remove : Icons.bookmark_add,
+            // Leave/Join button — see [canChangeMembership].
+            if (canChangeMembership)
+              OutlinedButton.icon(
+                onPressed: onToggleMembership,
+                icon: Icon(
+                  isMyCourse ? Icons.bookmark_remove : Icons.bookmark_add,
+                ),
+                label: Text(isMyCourse ? l10n.leaveCourse : l10n.joinCourse),
               ),
-              label: Text(isMyCourse ? l10n.leaveCourse : l10n.joinCourse),
-            ),
             const Spacer(),
-            // Previous button
-            if (onPrevious != null)
+            // Previous button. Hidden for a non-member with Next, per
+            // [isMyCourse] above; also hidden on the first step, which is
+            // `previousStep.visibility = if (position == 0) GONE else VISIBLE`
+            // one line up in the same Kotlin method — the port's index 0 is
+            // Kotlin's position 1, but there is no cover page behind it to go
+            // back to, so the first step is where Previous stops either way.
+            if (isMyCourse && onPrevious != null)
               FilledButton.tonalIcon(
                 onPressed: onPrevious,
                 icon: const Icon(Icons.arrow_back),
                 label: Text(l10n.previous),
               ),
             const SizedBox(width: 8),
-            // Next/Finish button
-            if (currentStep < totalSteps - 1 && onNext != null)
-              FilledButton.icon(
-                onPressed: onNext,
-                icon: const Icon(Icons.arrow_forward),
-                label: Text(l10n.next),
-              )
-            else
+            // Next / Finish.
+            //
+            // `updateNavigationVisibility` splits these by `position >=
+            // steps.size` — Finish on the last step, Next before it — and the
+            // port's `currentStep >= totalSteps - 1` is the same test under
+            // the index mapping. `onNext` is null on exactly that step, so the
+            // two conditions were redundant and only one is kept.
+            //
+            // **Finish is not gated on membership and Next is**, which looks
+            // like an oversight and is Kotlin's own shape. The `else` branch
+            // sets `nextStep` and `previousStep` GONE and never mentions
+            // `finishStep`, so the button keeps whatever
+            // `setNavigationButtons` (`:464-473`) left it — visible exactly
+            // when `position >= steps.size`. Reachable here on a one-step
+            // course, where the first step is also the last.
+            if (currentStep >= totalSteps - 1)
               FilledButton.icon(
                 onPressed: onFinish,
                 icon: const Icon(Icons.check),
                 label: Text(l10n.finish),
+              )
+            else if (isMyCourse)
+              FilledButton.icon(
+                onPressed: onNext,
+                icon: const Icon(Icons.arrow_forward),
+                label: Text(l10n.next),
               ),
           ],
         ),

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -517,10 +517,30 @@ class _ProgressSection extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
+              // `updateStepDisplay` (`TakeCourseFragment.kt:184-193`): the
+              // heading is `"Course Details"` at pager position 0 and
+              // `"Step p/N"` at every later position.
+              //
+              // **Kotlin's pager has a cover page and this one does not**, and
+              // that is the whole reason the `position == 0` branch does not
+              // belong here. `CoursesPagerAdapter.getItemCount()` is
+              // `steps.size + 1`; `createFragment(0)` builds a
+              // `CourseDetailFragment` and `createFragment(p > 0)` builds the
+              // step at `steps[p - 1]` with `stepNumber = p`
+              // (`CoursesPagerAdapter.kt:40-60`). The port reaches the course
+              // description through its own `CourseDetailScreen` route
+              // instead, so `PageView.builder` has `itemCount: steps.length`
+              // and **port index `i` is Kotlin position `i + 1`**. Special
+              // casing index 0 therefore labelled a real step with the cover
+              // page's heading, and on a one-step course it was the only
+              // heading the course ever showed.
+              //
+              // `currentStep + 1` is right for every index under that mapping
+              // — it is the number `_StepContent` draws in the step header,
+              // the number in the `n / N` counter beside this, and the
+              // `stepNum` the assessment tiles push at the exam screen.
               Text(
-                currentStep == 0
-                    ? l10n.courseDetails
-                    : l10n.stepNumber(currentStep + 1),
+                l10n.stepNumber(currentStep + 1),
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               Text(
@@ -634,13 +654,41 @@ class _StepContent extends ConsumerWidget {
             CourseMarkdownBody(data: step.description!),
             const SizedBox(height: 16),
           ],
-          // Resources count
+          // Resources count.
+          //
+          // **A count, and deliberately nothing more.** This tile used to
+          // carry `trailing: Icon(Icons.chevron_right)` with no `onTap` — a
+          // disclosure arrow for a screen nothing implements, reported by
+          // Phase 128 and unchanged through Phase 139. The two tiles below
+          // keep their chevrons because they navigate.
+          //
+          // Kotlin's per-step resources UI is not a button: `btnResources` is
+          // dead twice over (no listener is ever attached, and `setListeners`
+          // sets it `View.GONE`), and what a step actually shows is an inline
+          // list — `CourseStepFragment.setupInlineResources()` binding
+          // `rvInlineResources` to an `InlineResourceAdapter` whose rows call
+          // `openResource(library)`, with `autoDownloadResources()` and
+          // `prefetchNextStepResources()` alongside. The course-level button
+          // Phase 128 cited (`BaseContainerFragment.setResourceButton`) is
+          // live but belongs to `CourseDetailFragment` and lists the whole
+          // course's resources, not a step's.
+          //
+          // **The port cannot render either of those yet, and the blocker is
+          // the data, not the widget.** Kotlin knows a step's resources
+          // because `queueCourseResources` writes each embedded resource
+          // document into `my_library` stamped with its `courseId` and
+          // `stepId` (`CoursesRepositoryImpl.kt:687`, `:794`) and
+          // `getAllStepResources` reads them back with
+          // `myLibraryDao.getByStepId`. `CourseMapper._parseSteps` keeps
+          // `resources.length` and discards the documents; `my_library` has no
+          // `stepId` column and `MyLibraryMapper` writes no `courseId`. So the
+          // number here describes rows the port does not hold. Restoring a tap
+          // target means porting that walk first — see `PHASE_145_NOTES.md`.
           if (step.noOfResources > 0) ...[
             Card(
               child: ListTile(
                 leading: const Icon(Icons.folder_outlined),
                 title: Text(l10n.resourcesInStep(step.noOfResources)),
-                trailing: const Icon(Icons.chevron_right),
               ),
             ),
             const SizedBox(height: 8),

--- a/flutter/test/ui/courses/course_detail_screen_test.dart
+++ b/flutter/test/ui/courses/course_detail_screen_test.dart
@@ -25,6 +25,18 @@ class _TestSessionNotifier extends SessionNotifier {
   Future<UserRow?> build() async => user;
 }
 
+UserRow _guest() => UserRow(
+  id: 'guest_ada',
+  couchId: 'guest_ada',
+  rev: '1-a',
+  name: 'ada',
+  rolesList: const [],
+  userAdmin: false,
+  joinDate: 0,
+  isArchived: false,
+  isUpdated: false,
+);
+
 UserRow _user() => UserRow(
   id: 'user-1',
   couchId: 'org.couchdb.user:ada',
@@ -282,4 +294,40 @@ void main() {
       expect(find.widgetWithText(FilledButton, 'Take exam'), findsOneWidget);
     },
   );
+  group('the membership button is gated on guest, as `setCourseData` is', () {
+    // `TakeCourseFragment.setCourseData:216-232` shows `btnRemove` for
+    // `!isGuest && !containsUserId` only. Phase 145 gated the copy on
+    // `take_course_screen` first and left this one, which is **the more
+    // consequential of the two**: that one's `_toggleMembership` writes
+    // locally, while this one writes *and* calls `shelfRepository.upload`, so
+    // an ungated guest tap here reached the server.
+    //
+    // Written because the first cut of the fix was pinned by nothing — a
+    // mutation that deleted the gate left the whole suite green.
+
+    testWidgets('a guest is offered no join button', (tester) async {
+      await pumpScreen(
+        tester,
+        course: buildCourseRow(id: 'course-1', courseTitle: 'Algebra'),
+        overrides: [
+          sessionProvider.overrideWith(() => _TestSessionNotifier(_guest())),
+        ],
+      );
+
+      expect(find.text('Add to my courses'), findsNothing);
+      expect(find.text('Remove from my courses'), findsNothing);
+      // The rest of the screen is unaffected — Kotlin's guest still reads the
+      // course, and `CourseDetailFragment` has no membership button at all.
+      expect(find.text('Algebra'), findsWidgets);
+    });
+
+    testWidgets('a signed-in learner still gets one', (tester) async {
+      await pumpScreen(
+        tester,
+        course: buildCourseRow(id: 'course-1', courseTitle: 'Algebra'),
+      );
+
+      expect(find.text('Add to my courses'), findsOneWidget);
+    });
+  });
 }

--- a/flutter/test/ui/courses/non_member_navigation_test.dart
+++ b/flutter/test/ui/courses/non_member_navigation_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -29,18 +30,40 @@ import '../../support/widget_harness.dart';
 /// `_nextStepLock` reads like `changeNextButtonState`, which has no membership
 /// test of its own.
 ///
-/// **What a non-member sees on the last step is Finish, and that is Kotlin's
-/// answer rather than a choice.** The `else` branch above never touches
-/// `finishStep`, and `bindCourse` has already run `setNavigationButtons()`
-/// (`:118`, `:464-473`), which shows Finish exactly when `position >=
-/// steps.size`. So the button survives the hiding. In the port that state is
-/// reachable on a one-step course, where index 0 is the last step.
+/// **Finish is not gated, and the reason is an invariant rather than a
+/// preference.** The `else` branch above never touches `finishStep`, and
+/// `bindCourse` has already run `setNavigationButtons()` (`:118`, `:464-473`),
+/// which shows Finish exactly when `position >= steps.size` — as do the only
+/// other writers, `onResume:154-160` and `onClickNext:343-349`. Membership
+/// never enters it. Gating Finish would break the case Kotlin genuinely has: an
+/// **ex-member** is restored to `position = currentStep` (`:104`, `:116`) from
+/// progress rows that survive leaving a course (`leaveCourses` touches
+/// `courses` and `removed_log` only), so somebody who completed a course and
+/// then left re-opens on the last page and sees Finish with no Next and no
+/// Previous.
+///
+/// **Where the port and Kotlin part company is the cover page, not the gate,
+/// and an earlier draft of this file called that parity.** Kotlin's
+/// *never*-member is placed at `position = 0` — the `CourseDetailFragment`
+/// cover page — where `0 >= steps.size` is false for any course with a step,
+/// so they see no Finish either. The port has no cover page, so its index 0 is
+/// Kotlin's position 1; on a **one-step** course that is already the last step,
+/// and applying Kotlin's own rule at the position the learner is actually on
+/// yields Finish. So a learner who never joined a one-step course gets a
+/// Finish button here that Kotlin's cold open would not show them.
+///
+/// That is the same structural difference `step_label_test.dart` is about,
+/// surfacing a second time, and it is left as it is: the alternative is to gate
+/// Finish on membership, which would contradict the invariant above and take
+/// the button away from the ex-member Kotlin gives it to. Recorded in
+/// `PHASE_145_NOTES.md` as a divergence rather than dressed up as parity.
 ///
 /// **What is deliberately not ported is the way Kotlin's own gate leaks.**
-/// Three later writes put the buttons back without consulting membership:
-/// `onResume:158` sets `nextStep` VISIBLE, `onClick`'s next arm sets
-/// `previousStep` VISIBLE at `:373`, and `onClickNext():347` sets `nextStep`
-/// VISIBLE at `:375`. The first is not exam-specific — `onPause:164-169`
+/// **Five** later writes put the buttons back without consulting membership:
+/// `onResume:158`, `onClick`'s next arm at `:373` (`previousStep`),
+/// `onClickNext:347` (`nextStep`, called from `:375`), and `onClickPrevious`
+/// at `:356` and `:359`, which set `nextStep` VISIBLE on both arms of its own
+/// `if`. The first is not exam-specific — `onPause:164-169`
 /// stamps `lastPositionBeforeExam` on **every** pause, so backgrounding the
 /// app is enough — and it fires on every resume once a successful bind has
 /// assigned `steps`. So in the shipping Android app the gate holds on a cold
@@ -138,13 +161,44 @@ void main() {
     expect(find.text('Add to my courses'), findsOneWidget);
   });
 
-  testWidgets('a guest gets no navigation and no join button', (tester) async {
-    // Kotlin gives a guest neither: `updateNavigationVisibility:257` keys on
-    // `containsUserId` with no guest exception, and `setCourseData:230-232`
-    // hides `btnRemove` for a guest. The port used to offer the button to
-    // everyone, and for a guest it was worse than inert — `_toggleMembership`
-    // bails only on a null `userId` and the guest row has one, so the tap
-    // wrote a shelf membership Kotlin does not allow a guest to write.
+  testWidgets('a guest who has joined keeps navigation but gets no join '
+      'button', (tester) async {
+    // **The discriminating case, and the first cut of this test did not have
+    // it.** That version put a guest on an *unjoined* course, where three of
+    // its four assertions followed from non-membership and only one touched
+    // the guest rule at all — it would have passed with `canChangeMembership`
+    // deleted in every respect but one.
+    //
+    // Kotlin's two gates read different things and this is where they
+    // disagree: `updateNavigationVisibility:257` keys on `containsUserId`
+    // alone, with **no** guest exception, while `setCourseData:216-232` shows
+    // `btnRemove` for `!isGuest && !containsUserId`. So a guest whose id is in
+    // `course.userId` gets the navigation and not the button.
+    await pumpCourse(
+      tester,
+      courses: Stream.value(
+        buildCourseRow(
+          id: 'course-1',
+          courseTitle: 'Algebra',
+          userId: const ['guest_ada'],
+        ),
+      ),
+      userId: 'guest_ada',
+    );
+
+    expect(find.text('Next'), findsOneWidget, reason: 'membership, not guest');
+    expect(find.text('Add to my courses'), findsNothing);
+    expect(find.text('Remove from my courses'), findsNothing);
+  });
+
+  testWidgets('a guest who has not joined gets nothing at all', (tester) async {
+    // The port used to offer the membership button to everyone. For a guest
+    // that was not merely inert: `_toggleMembership` bails only on a null
+    // `userId` and a guest row has one, so the tap would have written shelf
+    // membership Kotlin does not allow a guest to write — and the copy on
+    // `CourseDetailScreen`, gated in the same phase, would have pushed it to
+    // the server. Hardening rather than a live bug closed, since no port
+    // writer currently creates a guest row at all (`UserMapper` says so).
     await pumpCourse(
       tester,
       courses: Stream.value(courseRow(joined: false)),
@@ -154,7 +208,6 @@ void main() {
     expect(find.text('Step title 0'), findsOneWidget);
     expect(find.text('Next'), findsNothing);
     expect(find.text('Add to my courses'), findsNothing);
-    expect(find.text('Remove from my courses'), findsNothing);
   });
 
   testWidgets('a member keeps Next', (tester) async {
@@ -194,6 +247,102 @@ void main() {
     // `position < steps.size` that is GONE.
     expect(find.text('Finish'), findsNothing);
     expect(find.text('Step title 1'), findsOneWidget);
+  });
+
+  testWidgets('joining brings the navigation back', (tester) async {
+    // **The audit's gap, and it was a real one.** Every other test in this
+    // file overrides `courseProvider` with a stream, which
+    // `_toggleMembership`'s `ref.invalidate(courseProvider)` cannot move — so
+    // the *leave* direction was covered by pushing a row at the provider and
+    // the *join* direction was covered by a doc comment asserting "joining
+    // restores the buttons on both sides" and nothing else.
+    //
+    // This one taps the button and lets the real Drift stream re-emit, which
+    // is the port's equivalent of `addRemoveCourse`'s success path calling
+    // `setCourseData()` → `updateNavigationVisibility()` (`:445`, `:237`).
+    final db = AppDatabase.memory();
+    addTearDown(db.close);
+    await db.courseDao.upsertAll(
+      [
+        buildCourseCompanion(
+          id: 'course-1',
+          courseTitle: 'Algebra',
+          userId: const [],
+        ),
+      ],
+      [
+        for (var i = 0; i < 3; i++)
+          CourseStepsCompanion.insert(
+            id: 's$i',
+            courseId: const Value('course-1'),
+            stepTitle: Value('Step title $i'),
+            stepIndex: Value(i),
+          ),
+      ],
+    );
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') router.push('/take');
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (context) => const TakeCourseScreen(courseId: 'course-1'),
+        },
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          appDatabaseProvider.overrideWithValue(db),
+          sessionProvider.overrideWith(
+            () => _Session(buildUserRow(id: 'user-1', name: 'ada')),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Next'), findsNothing, reason: 'not joined yet');
+
+    await tester.tap(find.text('Add to my courses'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Next'), findsOneWidget);
+    expect(find.text('Remove from my courses'), findsOneWidget);
+
+    // Two timers outlive the assertions here, and only one of them is the
+    // obvious one.
+    //
+    // `_toggleMembership` ends in a SnackBar whose four-second dismiss timer
+    // `pumpAndSettle` does **not** clear — the trap
+    // `step_next_lock_test.dart`'s `letSnackBarExpire` exists for. Pumping it
+    // out is necessary and was not sufficient: the survivor is a
+    // *zero*-duration timer from Drift itself,
+    // `StreamQueryStore.markAsClosed` via `QueryStream._onCancelOrPause`,
+    // scheduled when `ref.invalidate(courseProvider)` cancels the old query
+    // stream. It is created during teardown, after the last pump a test body
+    // can reach, so no amount of pumping inside the body clears it and the
+    // test dies on `'!timersPending'` with its expectations already green —
+    // another hang-shaped failure that says nothing about the code.
+    //
+    // Unmounting first moves the disposal inside the test, which is why
+    // `course_progress_on_open_test.dart` — the other file here that lets a
+    // real Drift stream reach a screen — carries the same helper.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump(const Duration(seconds: 1));
   });
 
   testWidgets('a non-member on the last step still sees Finish', (

--- a/flutter/test/ui/courses/non_member_navigation_test.dart
+++ b/flutter/test/ui/courses/non_member_navigation_test.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/courses_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/ui/courses/take_course_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/widget_harness.dart';
+
+/// `updateNavigationVisibility` (`TakeCourseFragment.kt:256-270`) — a learner
+/// who has not joined the course gets no Next and no Previous.
+///
+/// ```kotlin
+/// if (containsUserId) { … } else {
+///     binding.nextStep.visibility = View.GONE
+///     binding.previousStep.visibility = View.GONE
+/// }
+/// ```
+///
+/// The port had no membership test on either button, which is why Phase 139
+/// had to put one on the *lock* instead and record it as a deviation. The gate
+/// now sits where Kotlin puts it and the lock's copy is gone, so
+/// `_nextStepLock` reads like `changeNextButtonState`, which has no membership
+/// test of its own.
+///
+/// **What a non-member sees on the last step is Finish, and that is Kotlin's
+/// answer rather than a choice.** The `else` branch above never touches
+/// `finishStep`, and `bindCourse` has already run `setNavigationButtons()`
+/// (`:118`, `:464-473`), which shows Finish exactly when `position >=
+/// steps.size`. So the button survives the hiding. In the port that state is
+/// reachable on a one-step course, where index 0 is the last step.
+///
+/// **What is deliberately not ported is the way Kotlin's own gate leaks.**
+/// Three later writes put the buttons back without consulting membership:
+/// `onResume:158` sets `nextStep` VISIBLE, `onClick`'s next arm sets
+/// `previousStep` VISIBLE at `:373`, and `onClickNext():347` sets `nextStep`
+/// VISIBLE at `:375`. The first is not exam-specific — `onPause:164-169`
+/// stamps `lastPositionBeforeExam` on **every** pause, so backgrounding the
+/// app is enough — and it fires on every resume once a successful bind has
+/// assigned `steps`. So in the shipping Android app the gate holds on a cold
+/// open and not afterwards.
+///
+/// An earlier draft of this file said the restored Next survived exactly one
+/// tap, because `onPageSelected` would re-hide the buttons. **That was wrong
+/// in a way worth recording**: `viewPager2.currentItem += 1` dispatches
+/// `onPageSelected` — and with it `updateNavigationVisibility` —
+/// synchronously, *before* `:373` and `:375` run, so those two lines undo the
+/// hiding rather than being undone by it. (ViewPager2's
+/// `setCurrentItemInternal` calls `ScrollEventAdapter.notifyProgrammaticScroll`,
+/// which dispatches the selection inline on a changed target. That source is
+/// not in this repository; what *is* checkable here is that `onClickNext`
+/// reads the post-increment `currentItem` at `:342` while `onClickPrevious`
+/// reads `currentItem - 1` at `:353`, which only works if the item index
+/// updates synchronously inside the setter.) The correction does not change
+/// the decision, because under either reading the gate is gone after a
+/// resume — but it does change how the port compares: **the port is stricter
+/// than the shipping app**, not merely tidier.
+///
+/// It is ported anyway, as the intent rather than the effect, because
+/// `updateNavigationVisibility` is the only place Kotlin states a rule while
+/// each of the three writes that undo it is doing something else — restoring
+/// after a lifecycle event, or swapping Next for Finish at the end of the
+/// list — and each is a partial copy of the *member* branch written without
+/// its `else`. The same method that hides these also puts a *do you want to
+/// join this course?* dialog in front of a non-member
+/// (`setCourseData:219-229`). Recorded in `PHASE_145_NOTES.md`.
+void main() {
+  Future<void> pumpCourse(
+    WidgetTester tester, {
+    required Stream<CourseRow> courses,
+    int stepCount = 3,
+    String userId = 'user-1',
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    final steps = [
+      for (var i = 0; i < stepCount; i++)
+        buildStepRow(id: 's$i', stepTitle: 'Step title $i', stepIndex: i),
+    ];
+
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') router.push('/take');
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (context) => const TakeCourseScreen(courseId: 'course-1'),
+        },
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          sessionProvider.overrideWith(
+            () => _Session(buildUserRow(id: userId, name: 'ada')),
+          ),
+          courseProvider('course-1').overrideWith((ref) => courses),
+          courseStepsProvider(
+            'course-1',
+          ).overrideWith((ref) => Stream.value(steps)),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  CourseRow courseRow({required bool joined}) => buildCourseRow(
+    id: 'course-1',
+    courseTitle: 'Algebra',
+    userId: joined ? const ['user-1'] : const [],
+  );
+
+  testWidgets('a learner who has not joined gets no Next', (tester) async {
+    // Pre-fix: Next was on screen and moved the page, so somebody who had
+    // never joined could walk a course Kotlin will not let them walk.
+    await pumpCourse(tester, courses: Stream.value(courseRow(joined: false)));
+
+    expect(find.text('Step title 0'), findsOneWidget, reason: 'step 1 renders');
+    expect(find.text('Next'), findsNothing);
+    // The way forward is still on screen. Kotlin shows a button here too
+    // (`btnRemove`, text `R.string.join` — "Join") and additionally puts a
+    // join dialog in front of them; the port has the button and not the
+    // dialog.
+    expect(find.text('Add to my courses'), findsOneWidget);
+  });
+
+  testWidgets('a guest gets no navigation and no join button', (tester) async {
+    // Kotlin gives a guest neither: `updateNavigationVisibility:257` keys on
+    // `containsUserId` with no guest exception, and `setCourseData:230-232`
+    // hides `btnRemove` for a guest. The port used to offer the button to
+    // everyone, and for a guest it was worse than inert — `_toggleMembership`
+    // bails only on a null `userId` and the guest row has one, so the tap
+    // wrote a shelf membership Kotlin does not allow a guest to write.
+    await pumpCourse(
+      tester,
+      courses: Stream.value(courseRow(joined: false)),
+      userId: 'guest_ada',
+    );
+
+    expect(find.text('Step title 0'), findsOneWidget);
+    expect(find.text('Next'), findsNothing);
+    expect(find.text('Add to my courses'), findsNothing);
+    expect(find.text('Remove from my courses'), findsNothing);
+  });
+
+  testWidgets('a member keeps Next', (tester) async {
+    await pumpCourse(tester, courses: Stream.value(courseRow(joined: true)));
+
+    expect(find.text('Next'), findsOneWidget);
+    expect(find.text('Remove from my courses'), findsOneWidget);
+  });
+
+  testWidgets('leaving the course part-way takes both buttons away', (
+    tester,
+  ) async {
+    // The one path on which the **Previous** gate is observable, and it is a
+    // real one rather than a contrivance: Leave course sits in this very
+    // navigation bar, and Kotlin's `addRemoveCourse` success path calls
+    // `setCourseData()` → `updateNavigationVisibility()` for exactly this
+    // reason. Without it the port would carry a Previous gate nothing could
+    // ever exercise.
+    final courses = StreamController<CourseRow>();
+    addTearDown(courses.close);
+    courses.add(courseRow(joined: true));
+
+    await pumpCourse(tester, courses: courses.stream);
+
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+    expect(find.text('Step title 1'), findsOneWidget);
+    expect(find.text('Previous'), findsOneWidget);
+
+    courses.add(courseRow(joined: false));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Previous'), findsNothing);
+    expect(find.text('Next'), findsNothing);
+    // Still the middle step, so no Finish either: Kotlin's `else` branch
+    // leaves `finishStep` as `setNavigationButtons` left it, and at
+    // `position < steps.size` that is GONE.
+    expect(find.text('Finish'), findsNothing);
+    expect(find.text('Step title 1'), findsOneWidget);
+  });
+
+  testWidgets('a non-member on the last step still sees Finish', (
+    tester,
+  ) async {
+    // `updateNavigationVisibility`'s non-member branch never touches
+    // `finishStep`, and `setNavigationButtons` (`:464-473`) has already made
+    // it visible for `position >= steps.size`. A one-step course is where the
+    // port can reach that state, since index 0 is the last step.
+    await pumpCourse(
+      tester,
+      courses: Stream.value(courseRow(joined: false)),
+      stepCount: 1,
+    );
+
+    expect(find.text('Finish'), findsOneWidget);
+    expect(find.text('Next'), findsNothing);
+    expect(find.text('Previous'), findsNothing);
+  });
+}
+
+class _Session extends SessionNotifier {
+  _Session(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}

--- a/flutter/test/ui/courses/step_label_test.dart
+++ b/flutter/test/ui/courses/step_label_test.dart
@@ -12,7 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../support/widget_harness.dart';
 
 /// `_ProgressSection`'s heading, against `TakeCourseFragment.updateStepDisplay`
-/// (`TakeCourseFragment.kt:184-193`).
+/// (`TakeCourseFragment.kt:192-197`).
 ///
 /// **Kotlin's pager carries a cover page and the port's does not, and that one
 /// structural difference is the whole of this file.**

--- a/flutter/test/ui/courses/step_label_test.dart
+++ b/flutter/test/ui/courses/step_label_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/courses_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/ui/courses/take_course_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/widget_harness.dart';
+
+/// `_ProgressSection`'s heading, against `TakeCourseFragment.updateStepDisplay`
+/// (`TakeCourseFragment.kt:184-193`).
+///
+/// **Kotlin's pager carries a cover page and the port's does not, and that one
+/// structural difference is the whole of this file.**
+/// `CoursesPagerAdapter.getItemCount()` is `steps.size + 1`, `createFragment(0)`
+/// builds a `CourseDetailFragment` and `createFragment(p > 0)` builds the step
+/// at `steps[p - 1]` with `stepNumber = p` (`CoursesPagerAdapter.kt:40-60`). So
+/// Kotlin position `p` shows step index `p - 1`, and `updateStepDisplay` reads
+/// `"Course Details"` at 0 and `"Step p/N"` at every `p >= 1`.
+///
+/// The port's `PageView.builder` has `itemCount: steps.length` and no cover
+/// page, so **port index `i` is Kotlin position `i + 1`** and the heading at
+/// index `i` must be `Step ${i + 1}`. `_ProgressSection` special-cased index 0
+/// to `l10n.courseDetails` — Kotlin's cover-page branch, on a pager that has no
+/// cover page — so the first step of every course announced itself as the
+/// course description while rendering step 1.
+///
+/// **The `else` branch was already right, and the brief that sent me here said
+/// it was off by one.** It is not: `l10n.stepNumber(currentStep + 1)` is
+/// exactly `i + 1` under the mapping above, and it agrees with `_StepContent`'s
+/// own `stepNumber: index + 1`, with the `n / N` counter beside it, and with
+/// the `stepNum` both tiles push at the exam screen. Only the `== 0` branch
+/// ever disagreed with the page under it. The pins below are written so that
+/// changing the `else` branch to `currentStep` reds them too, because a "fix"
+/// that made the fossil's premise true everywhere would have renumbered every
+/// step in the app.
+///
+/// Every assertion pairs the heading with the **title of the step actually
+/// rendered**. That is not thoroughness, it is the lesson of Phase 139: the
+/// heading and the counter are both driven by `currentStep`, so they agreed
+/// with each other while disagreeing with the `PageView` for four phases. A
+/// heading assertion alone cannot see that.
+void main() {
+  Future<void> pumpCourse(
+    WidgetTester tester, {
+    required List<String> stepTitles,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    final steps = [
+      for (var i = 0; i < stepTitles.length; i++)
+        buildStepRow(id: 's$i', stepTitle: stepTitles[i], stepIndex: i),
+    ];
+
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') router.push('/take');
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (context) => const TakeCourseScreen(courseId: 'course-1'),
+        },
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          sessionProvider.overrideWith(
+            () => _Session(buildUserRow(id: 'user-1', name: 'ada')),
+          ),
+          courseProvider('course-1').overrideWith(
+            (ref) => Stream.value(
+              buildCourseRow(
+                id: 'course-1',
+                courseTitle: 'Algebra',
+                userId: const ['user-1'],
+              ),
+            ),
+          ),
+          courseStepsProvider(
+            'course-1',
+          ).overrideWith((ref) => Stream.value(steps)),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapNext(WidgetTester tester) async {
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('the first step is labelled Step 1, not Course Details', (
+    tester,
+  ) async {
+    // Pre-fix: `Course Details` was on screen above a page titled `First`,
+    // and `Step 1` appeared nowhere.
+    await pumpCourse(tester, stepTitles: const ['First', 'Second', 'Third']);
+
+    expect(find.text('First'), findsOneWidget, reason: 'the rendered page');
+    expect(find.text('Step 1'), findsOneWidget);
+    expect(find.text('1 / 3'), findsOneWidget);
+    expect(find.text('Course Details'), findsNothing);
+  });
+
+  testWidgets('every later step names the step under it', (tester) async {
+    await pumpCourse(tester, stepTitles: const ['First', 'Second', 'Third']);
+
+    await tapNext(tester);
+    expect(find.text('Second'), findsOneWidget, reason: 'the rendered page');
+    expect(find.text('First'), findsNothing);
+    expect(find.text('Step 2'), findsOneWidget);
+    expect(find.text('2 / 3'), findsOneWidget);
+
+    await tapNext(tester);
+    expect(find.text('Third'), findsOneWidget, reason: 'the rendered page');
+    expect(find.text('Step 3'), findsOneWidget);
+    expect(find.text('3 / 3'), findsOneWidget);
+  });
+
+  testWidgets('a one-step course reads Step 1 of 1', (tester) async {
+    // The degenerate case the fossil hid completely: with a single step,
+    // index 0 is the only page there is, so `Course Details` was the only
+    // heading the course ever showed.
+    await pumpCourse(tester, stepTitles: const ['Only']);
+
+    expect(find.text('Only'), findsOneWidget);
+    expect(find.text('Step 1'), findsOneWidget);
+    expect(find.text('1 / 1'), findsOneWidget);
+    expect(find.text('Course Details'), findsNothing);
+  });
+}
+
+class _Session extends SessionNotifier {
+  _Session(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}

--- a/flutter/test/ui/courses/step_next_lock_test.dart
+++ b/flutter/test/ui/courses/step_next_lock_test.dart
@@ -526,7 +526,6 @@ void main() {
       expect(find.textContaining('take test'), findsNothing);
       expect(find.text('Next'), findsNothing);
       expect(onStep(1, 2), findsOneWidget);
-      expect(find.textContaining('please complete'), findsNothing);
     });
   });
 

--- a/flutter/test/ui/courses/step_next_lock_test.dart
+++ b/flutter/test/ui/courses/step_next_lock_test.dart
@@ -497,26 +497,36 @@ void main() {
       expect(find.textContaining('please complete'), findsNothing);
     });
 
-    testWidgets('a learner who has not joined is not locked', (tester) async {
-      // A deviation, pinned so it is a decision rather than a drift.
-      // `changeNextButtonState` has no membership test — Kotlin's is on the
-      // button (`updateNavigationVisibility:256-270` hides Next for a
-      // non-member) — but `onResume:154-160` puts Next back with no such test,
-      // so a returning ex-member *can* meet Kotlin's lock. The port has no
-      // membership gate on Next at all, so the gate went on the lock: a
-      // learner cannot be blocked by an assessment `_StepContent` is not
-      // offering them.
+    testWidgets('a learner who has not joined never meets the lock', (
+      tester,
+    ) async {
+      // **This test changed shape in Phase 145 and the change is the point.**
+      // It used to tap Next and assert the page moved, pinning a membership
+      // test that Phase 139 had put on the *lock* — a deviation, since
+      // `changeNextButtonState` has no membership test of its own. Kotlin's
+      // membership test is on the button
+      // (`updateNavigationVisibility:256-270`), and Phase 145 moved the port's
+      // there too. So the lock is no longer reachable for a non-member for
+      // the reason Kotlin makes it unreachable: there is no Next.
+      //
+      // Asserting on the *absence of Next* rather than on a page move is what
+      // keeps this able to fail. Re-adding a membership test to
+      // `_nextStepLock` would leave every assertion here green, because the
+      // lock is dead code on this path either way; dropping the gate in
+      // `_NavigationBar` reds it immediately.
       await pumpCourse(
         tester,
         joined: false,
         db: await seed(courseDoc(courseId: mandatoryCourseId, exam: examDoc())),
       );
 
-      // The tile is hidden for a non-member, which is the reason.
+      // The tile is hidden for a non-member too (`CourseStepFragment
+      // .onViewCreated`'s `!userHasCourse` arm), so nothing on this screen
+      // offers the assessment the lock would be holding them to.
       expect(find.textContaining('take test'), findsNothing);
-      await tapNext(tester);
-
-      expect(onStep(2, 2), findsOneWidget);
+      expect(find.text('Next'), findsNothing);
+      expect(onStep(1, 2), findsOneWidget);
+      expect(find.textContaining('please complete'), findsNothing);
     });
   });
 

--- a/flutter/test/ui/courses/step_resources_tile_test.dart
+++ b/flutter/test/ui/courses/step_resources_tile_test.dart
@@ -118,12 +118,14 @@ void main() {
               buildStepRow(id: 's0', stepTitle: 'First', noOfResources: 3),
             ]),
           ),
-          ratingSummaryProvider((type: 'course', itemId: 'course-1'))
-              .overrideWith(
-                (ref) => Stream.value(
-                  const RatingSummary(average: 0, total: 0, userRating: null),
-                ),
-              ),
+          ratingSummaryProvider((
+            type: 'course',
+            itemId: 'course-1',
+          )).overrideWith(
+            (ref) => Stream.value(
+              const RatingSummary(average: 0, total: 0, userRating: null),
+            ),
+          ),
         ],
       ),
     );

--- a/flutter/test/ui/courses/step_resources_tile_test.dart
+++ b/flutter/test/ui/courses/step_resources_tile_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/courses_providers.dart';
+import 'package:myplanet/providers/ratings_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/ratings_repository.dart';
+import 'package:myplanet/ui/courses/course_detail_screen.dart';
+import 'package:myplanet/ui/courses/take_course_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/widget_harness.dart';
+
+/// The step's resource count, and the chevron that used to sit beside it.
+///
+/// `_StepContent` rendered `ListTile(title: resourcesInStep(n), trailing:
+/// Icon(Icons.chevron_right))` with **no `onTap`** — a disclosure arrow
+/// promising a screen nothing implements, reported by Phase 128 as its item 1
+/// and still there in Phase 139. The other two tiles on that page keep their
+/// chevrons, because those two navigate.
+///
+/// **Kotlin has nothing for the arrow to open, and the reason is worth having
+/// in a test file rather than only in a notes file.** Phase 128 named
+/// `BaseContainerFragment.setResourceButton` as the live analogue; that button
+/// is real but it is **course-level**, bound once from `CourseDetailFragment`
+/// out of `CourseDetailModel.resources` (`CourseDetailFragment.kt:91`,
+/// `CoursesRepositoryImpl.kt:137`). The per-step counterpart is
+/// `CourseStepFragment.btnResources`, which is dead twice over — no listener is
+/// ever attached to it and `setListeners()` sets it `View.GONE`. What
+/// `CourseStepFragment` actually shows for a step's resources is not a button
+/// at all but an inline list (`setupInlineResources()`, `tvResourcesHeader` +
+/// `rvInlineResources`, each row opening `openResource(library)`).
+///
+/// The port cannot render that list today and this is the reachability
+/// question, not a styling one: Kotlin knows a step's resources because
+/// `queueCourseResources` writes every embedded resource document into
+/// `my_library` stamped with its `courseId` and `stepId`
+/// (`CoursesRepositoryImpl.kt:687`, `:794`), and `getAllStepResources` reads
+/// them back with `myLibraryDao.getByStepId`. The port's `CourseMapper`
+/// keeps `resources.length` and **discards the documents**, its
+/// `my_library` table has no `stepId` column at all, and `MyLibraryMapper`
+/// writes no `courseId` either — so `noOfResources` is a number about rows the
+/// port does not have. Until that walk exists there is nowhere for a tap to
+/// go, which is why the fix here is to stop advertising one.
+void main() {
+  Future<Override> prefsOverride() async {
+    SharedPreferences.setMockInitialValues({});
+    return planetPrefsProvider.overrideWithValue(
+      PlanetPrefs(await SharedPreferences.getInstance()),
+    );
+  }
+
+  Future<void> pumpTakeCourse(WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              final router = GoRouter.of(context);
+              final location = router
+                  .routerDelegate
+                  .currentConfiguration
+                  .last
+                  .matchedLocation;
+              if (location != '/take') router.push('/take');
+            });
+            return const Scaffold(body: Text('ROOT_PAGE'));
+          },
+        ),
+        pushTargets: {
+          '/take': (context) => const TakeCourseScreen(courseId: 'course-1'),
+        },
+        overrides: [
+          await prefsOverride(),
+          sessionProvider.overrideWith(
+            () => _Session(buildUserRow(id: 'user-1', name: 'ada')),
+          ),
+          courseProvider('course-1').overrideWith(
+            (ref) => Stream.value(
+              buildCourseRow(
+                id: 'course-1',
+                courseTitle: 'Algebra',
+                userId: const ['user-1'],
+              ),
+            ),
+          ),
+          courseStepsProvider('course-1').overrideWith(
+            (ref) => Stream.value([
+              buildStepRow(id: 's0', stepTitle: 'First', noOfResources: 3),
+            ]),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pumpCourseDetail(WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const CourseDetailScreen(courseId: 'course-1'),
+        overrides: [
+          await prefsOverride(),
+          sessionProvider.overrideWith(
+            () => _Session(buildUserRow(id: 'user-1', name: 'ada')),
+          ),
+          courseProvider('course-1').overrideWith(
+            (ref) => Stream.value(
+              buildCourseRow(id: 'course-1', courseTitle: 'Algebra'),
+            ),
+          ),
+          courseStepsProvider('course-1').overrideWith(
+            (ref) => Stream.value([
+              buildStepRow(id: 's0', stepTitle: 'First', noOfResources: 3),
+            ]),
+          ),
+          ratingSummaryProvider((type: 'course', itemId: 'course-1'))
+              .overrideWith(
+                (ref) => Stream.value(
+                  const RatingSummary(average: 0, total: 0, userRating: null),
+                ),
+              ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('the step still says how many resources it has', (tester) async {
+    // The count itself is not the defect and must survive the fix — it is the
+    // one thing the port does know, and `CourseStepFragment` shows the same
+    // number (`R.string.resources_size`, from `data.resources.size`).
+    await pumpTakeCourse(tester);
+
+    expect(find.text('3 resources'), findsOneWidget);
+  });
+
+  testWidgets('the resource count offers no chevron to tap', (tester) async {
+    // Pre-fix: one `chevron_right` on a step whose only tile is the resource
+    // count. This step carries no exam and no survey, so the two tiles that
+    // legitimately own a chevron are absent and the finder is unambiguous.
+    await pumpTakeCourse(tester);
+
+    expect(find.byIcon(Icons.chevron_right), findsNothing);
+  });
+
+  testWidgets('the course-detail step tile offers none either', (tester) async {
+    // Phase 128's item said the dead chevron was in "both" screens and
+    // Phase 139 repeated it. **It is not in this one** — `_StepTile` is an
+    // `ExpansionTile` whose count is a subtitle and whose trailing arrow does
+    // what it says, expanding the description. Pinned rather than assumed,
+    // because the claim survived two rounds of notes unchecked.
+    await pumpCourseDetail(tester);
+
+    expect(find.text('3 resources'), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right), findsNothing);
+  });
+}
+
+class _Session extends SessionNotifier {
+  _Session(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}

--- a/flutter/test/ui/courses/step_resources_tile_test.dart
+++ b/flutter/test/ui/courses/step_resources_tile_test.dart
@@ -28,7 +28,7 @@ import '../../support/widget_harness.dart';
 /// `BaseContainerFragment.setResourceButton` as the live analogue; that button
 /// is real but it is **course-level**, bound once from `CourseDetailFragment`
 /// out of `CourseDetailModel.resources` (`CourseDetailFragment.kt:91`,
-/// `CoursesRepositoryImpl.kt:137`). The per-step counterpart is
+/// `CoursesRepositoryImpl.kt:136`). The per-step counterpart is
 /// `CourseStepFragment.btnResources`, which is dead twice over — no listener is
 /// ever attached to it and `setListeners()` sets it `View.GONE`. What
 /// `CourseStepFragment` actually shows for a step's resources is not a button
@@ -42,9 +42,9 @@ import '../../support/widget_harness.dart';
 /// (`CoursesRepositoryImpl.kt:687`, `:794`), and `getAllStepResources` reads
 /// them back with `myLibraryDao.getByStepId`. The port's `CourseMapper`
 /// keeps `resources.length` and **discards the documents**, its
-/// `my_library` table has no `stepId` column at all, and `MyLibraryMapper`
-/// writes no `courseId` either — so `noOfResources` is a number about rows the
-/// port does not have. Until that walk exists there is nowhere for a tap to
+/// `my_library` table has neither a `stepId` nor a `courseId` column, and no
+/// port mapper writes step-resource provenance at all — so `noOfResources` is
+/// a number about rows the port does not have. Until that walk exists there is nowhere for a tap to
 /// go, which is why the fix here is to stop advertising one.
 void main() {
   Future<Override> prefsOverride() async {
@@ -133,9 +133,24 @@ void main() {
   }
 
   testWidgets('the step still says how many resources it has', (tester) async {
-    // The count itself is not the defect and must survive the fix — it is the
-    // one thing the port does know, and `CourseStepFragment` shows the same
-    // number (`R.string.resources_size`, from `data.resources.size`).
+    // The count survives the fix, but **not** because Kotlin shows it.
+    //
+    // An earlier draft of this comment said `CourseStepFragment` "shows the
+    // same number". It does not, and the mistake has a history worth naming:
+    // that is precisely the claim **Phase 128 made and retracted in the same
+    // paragraph** (`PHASE_128_NOTES.md:378-380`, *"there is no live Kotlin
+    // count"*), and Phase 145 reinstated it from memory. The number is written
+    // to `btnResources` at `CourseStepFragment.kt:121-122` and the button is
+    // GONE at `:292`, inside a container that is `visibility="gone"`. The only
+    // per-step resources UI Kotlin renders is `tv_resources_header`, whose
+    // text is the bare `@string/resources` with **no count**, above the list.
+    //
+    // So the count is a port presentation of data the port does hold (the
+    // step document's `resources` array length), standing in for a list it
+    // cannot build until the walk in `PHASE_145_NOTES.md` item 1 lands. It is
+    // kept because it is true and it is the only thing the screen can say
+    // about a step's resources; when the list arrives it should replace this,
+    // not sit beside it.
     await pumpTakeCourse(tester);
 
     expect(find.text('3 resources'), findsOneWidget);

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -102,7 +102,19 @@ void main() {
           sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
           courseProvider('course-1').overrideWith(
             (ref) => Stream.value(
-              buildCourseRow(id: 'course-1', courseTitle: 'Algebra'),
+              // A **member** row, deliberately. These fixtures used
+              // `buildCourseRow`'s default empty `userId` and so were
+              // non-members by accident, which was harmless until Phase 145
+              // gated the navigation bar on membership: from then on five
+              // tests named for a learner finishing a course were silently
+              // propping up the *ungated Finish* decision, and mutating that
+              // gate reddened all five instead of the one test that is
+              // actually about it (`non_member_navigation_test.dart`).
+              buildCourseRow(
+                id: 'course-1',
+                courseTitle: 'Algebra',
+                userId: const ['user-1'],
+              ),
             ),
           ),
           courseStepsProvider('course-1').overrideWith(
@@ -274,7 +286,11 @@ void main() {
           sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
           courseProvider(mandatoryCourseId).overrideWith(
             (ref) => Stream.value(
-              buildCourseRow(id: mandatoryCourseId, courseTitle: 'Onboarding'),
+              buildCourseRow(
+                id: mandatoryCourseId,
+                courseTitle: 'Onboarding',
+                userId: const ['user-1'],
+              ),
             ),
           ),
           courseStepsProvider(mandatoryCourseId).overrideWith(
@@ -376,7 +392,11 @@ void main() {
           sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
           courseProvider(mandatoryCourseId).overrideWith(
             (ref) => Stream.value(
-              buildCourseRow(id: mandatoryCourseId, courseTitle: 'Onboarding'),
+              buildCourseRow(
+                id: mandatoryCourseId,
+                courseTitle: 'Onboarding',
+                userId: const ['user-1'],
+              ),
             ),
           ),
           courseStepsProvider(mandatoryCourseId).overrideWith(


### PR DESCRIPTION
Lane D of the Phase 145 four-lane round. Three jobs, all from previous rounds' *Reported, not fixed* lists. Gate green locally (format, `flutter analyze`, **2588 tests**). Full write-up in `flutter/PHASE_145_NOTES.md`.

## Job 1 — step 1 was labelled "Course Details"

`_ProgressSection` rendered `currentStep == 0 ? l10n.courseDetails : l10n.stepNumber(currentStep + 1)`. **Kotlin's pager really does have a cover page** — `CoursesPagerAdapter.getItemCount()` is `steps.size + 1`, `createFragment(0)` is a `CourseDetailFragment`, `getItemId(0)` is even a distinct sentinel. The port reaches the description through its own `CourseDetailScreen` route and its `PageView` has no cover page, so index 0 is a real step wearing the cover page's heading; on a one-step course that was the only heading the course ever showed.

**The brief was wrong that the `else` branch is off by one.** Port index `i` is Kotlin position `i + 1`, so `stepNumber(currentStep + 1)` is right at every index. Only the `== 0` branch ever disagreed with the page under it. Tests pin both directions, and each pairs the heading with the *rendered step title* rather than the counter — the two are driven by the same `currentStep` and agreed with each other while disagreeing with the `PageView` for four phases.

## Job 2 — the resource count's dead chevron

Removed. The count stays; the two tiles below keep their chevrons because those navigate.

Corrections to the standing notes: the live per-step Kotlin counterpart is `setupInlineResources`'s tappable list, **not** `setResourceButton` (that button is real but course-level); and the chevron was never in `course_detail_screen.dart` (`git log --all -S chevron` on that file returns nothing).

**Why the list can't be ported — a missing sync walk, reported not fixed.** Kotlin's courses walk drains each embedded step-resource *document* into `my_library` stamped with `courseId`/`stepId`; `CourseMapper` keeps only `resources.length` and the port's table has neither column. So `noOfResources` counts rows the port doesn't hold, and three Kotlin readers are blocked at once. Needs a schema bump.

## Job 3 — the non-member gate, ported

Next and Previous now gate on `isMyCourse`, where `updateNavigationVisibility:267-270` gates them. Phase 139's copy of that gate on `_nextStepLock` is **removed**, so it reads like `changeNextButtonState`, which has no membership test — one documented deviation collapses into fidelity.

- **Finish is deliberately not gated** — Kotlin's `else` branch never touches `finishStep`, and gating it would take the button from the ex-member Kotlin gives it to.
- **The join/leave button is gated on `!isGuest`** (`setCourseData:216-232`), on **both** screens. For a guest the port's button wasn't merely inert: `_toggleMembership` bails only on a null `userId` and a guest row has one.
- **Kotlin's own gate fails open** — five later writes restore the buttons with no membership test, and `onPause` stamps the restore position on *every* pause, so it holds on a cold open and not afterwards. The port applies the stated rule permanently: a deviation, named at the code and queued for the migration doc.

## Method, and what the audits caught

Two `parity-auditor` passes at `effort: max`. The first, on the Kotlin ground truth before any Dart, **refuted** a claim I'd already written into a test file as the rationale for the whole decision. The second, on finished green code, found seven more — the two that mattered were mine:

- **I reinstated a claim Phase 128 had explicitly retracted** (that `CourseStepFragment` renders the resource count — it doesn't; it goes to a GONE button) and used it as the reason to keep the tile.
- **I declared `course_detail_screen.dart` "deliberately unchanged"** after checking it against the job I arrived with rather than what I'd learned while there. It had the same ungated membership button Job 3 had just decided was a defect — in the copy that calls `shelfRepository.upload`, so the larger hole. Now gated, and pinned: my first mutation of that gate left the whole suite green.

Also corrected: a false "the parent watches it, so it's resolved" justification; three membership-blind Kotlin writes are five; two transposed line numbers; and the Finish-for-a-never-member case is a divergence from the absent cover page, which I had documented as parity.

Nine mutations recorded, including two non-reds — one deliberate and explained, one accidental and since fixed. Five finish/rating fixtures were non-member rows *by accident* and were propping up the ungated-Finish decision; now member rows, and that mutation reds exactly the one test about it.

## For the integrator

**Nothing to run** — no ARB key added, no locale file touched. Two things to know:

- `courseDetails` is now an orphan template key. ar/fr are `"x-mt": true`, only **es** is a human translation, ne/so don't have it — so deleting it touches three locale files, not five, and moves only the `es` entry in `humanReviewed`.
- `UserMapper.isGuest`'s doc names `TakeCourseFragment:212` as a role-clause gate with "no port counterpart yet". This phase landed that counterpart, so the line is now false, and both new guest gates are narrower than Kotlin's. Reported item 1, with the fix the doc itself specifies (a second predicate beside `isGuest`, not folded into it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5GJ17nNMfYKgtThC2RX1E