### PR TITLE
fix(flutter): preserve the survey tables across a schema bump (Phase 143, Lane B)

### DIFF
--- a/flutter/PHASE_104_NOTES.md
+++ b/flutter/PHASE_104_NOTES.md
@@ -39,7 +39,12 @@ type: DriftSqlType.string, defaultValue: Constant('[]'))` before and after, so
 the DDL is byte-identical and no migration step exists to write. Rows an
 earlier build wrote decode as a choice whose text is that flattened literal —
 not a crash — until the next surveys sync rewrites them; `survey_questions` is
-a pure cache and is not in `localAuthorityTables`. Nothing else under
+a pure cache and is not in `localAuthorityTables`. **The second half is false
+since Phase 143**: it is preserved now, because the same table stores an
+adopted team survey clone's questions, which exist nowhere else until the
+clone publishes. The converter argument is unaffected — a converter swap still
+changes no DDL — but a *column* added here now needs a hand-written
+`_addColumnIfMissing` step. Nothing else under
 `lib/data/local/` changed shape.
 
 ### What each consumer was doing with the corrupted value

--- a/flutter/PHASE_106_NOTES.md
+++ b/flutter/PHASE_106_NOTES.md
@@ -250,6 +250,13 @@ to allocate.
   `hasOtherOption` column on `survey_questions`, which is not a preserved
   table, so `createAll` rebuilds it and the cost is a schema bump with no
   hand-written step.
+  **False since Phase 143**, which added `surveys` and `survey_questions` to
+  `localAuthorityTables` so an adopted-but-unpublished team survey clone
+  survives a bump. `createAll` no longer alters either table: a new column on
+  `survey_questions` needs its own `_addColumnIfMissing` step, and
+  `migration_test.dart`'s frozen-DDL guard fails until it has one. Corrected
+  here rather than only in the later notes, because this is the sentence a
+  lane taking `hasOtherOption` would read.
 - **`createDraft` bypasses `AnswerShape`** and writes its entries verbatim. It
   has no question rows and so cannot resolve a label, and no Kotlin
   counterpart — nothing in Kotlin creates a submission whose `parent` is a bare

--- a/flutter/PHASE_138_NOTES.md
+++ b/flutter/PHASE_138_NOTES.md
@@ -364,6 +364,17 @@ predicate. No `_addColumnIfMissing` step: `surveys` is not in
 `if (from < 47)` branch is present and deliberately empty, so the next reader
 sees the version was considered rather than forgotten.
 
+> **Superseded by Phase 143.** `surveys` and `survey_questions` *are* in
+> `localAuthorityTables` now — which is the item this phase filed under
+> *Reported, not fixed* below, and it is closed. So `createAll` no longer
+> alters either table: the `from < 47` branch is not empty (it adds
+> `needs_sync` by hand and backfills the flag for clones this device can prove
+> it authored), and **any future column on either table needs its own
+> `_addColumnIfMissing` step**, before `createAll` if an index names it. The
+> paragraph above is the migration instruction a lane reading about
+> `Surveys.needsSync` would follow, which is why it is corrected here rather
+> than only in the later notes.
+
 **Nine existing `SurveyRow(...)` fixtures in seven test files gained
 `needsSync: false`** — a non-nullable Drift column is a required argument on the
 row class. Three are under `test/ui/`, which is the nearest this lane came to
@@ -396,6 +407,12 @@ Gate green: `dart format` clean, `flutter analyze` clean, **2479 tests pass**
 ## Reported, not fixed
 
 ### A schema bump still destroys an unpublished clone, and `submissions` outlives it
+
+> **Closed by Phase 143.** Both tables are preserved; the v35 and v47 columns
+> have hand-written steps that run before `createAll`; and the leak this
+> section's author worried about is handled by requiring the adoption marker
+> rather than by trusting the clone id. Left in place because the reasoning
+> below is what the next round was briefed from.
 
 **The one this phase creates the expectation for and does not close.** `surveys`
 and `survey_questions` are **not** in `localAuthorityTables`, while

--- a/flutter/PHASE_143_NOTES.md
+++ b/flutter/PHASE_143_NOTES.md
@@ -1,18 +1,325 @@
-# Phase 143 — the schema bump destroys an unpublished survey clone, and `submissions` outlives it
+# Phase 143 — the schema bump destroyed an unpublished survey clone, and `submissions` outlived it
 
-Lane B of a four-lane round. The brief is Phase 138's own *Reported, not fixed*
-entry — written by the lane that created the expectation and deliberately did
-not close it.
+Lane B of a four-lane round. The brief was Phase 138's own *Reported, not fixed*
+entry, written by the lane that created the expectation and deliberately did not
+close it. It was precise and it was right about the defect; it was **incomplete
+about the fix**, in a way that would have deferred the data loss rather than
+prevented it. That is the round's lesson and it is in *Job 2* below.
 
-**Status: in progress.**
+## Method
 
-## The hole
+1. Read the migration path and both tables by hand, plus drift's own
+   `Migrator.createAll`/`createIndex` in the pub cache and the generated
+   `Index` statements — not the notes' description of them.
+2. A `parity-auditor` pass at `effort: max` on the **ground truth**, before any
+   Dart, asking six numbered questions. It confirmed the schema history,
+   confirmed the index-ordering hazard empirically, **found a data-loss defect
+   in the plan itself**, corrected my intended answer to the v47 question, and
+   named two stale claims elsewhere in the tree.
+3. Implement, each defect demonstrated failing first.
+4. **Ten mutations**, each applied alone to green code and reverted. Nine
+   redded immediately; one survived and is written up below, because a surviving
+   mutation is the only kind worth reporting.
+5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
+   already-green code.
 
-Phase 138 stopped `SurveyDao.deleteNotIn` destroying an adopted team survey
-clone on the next sync. `surveys` and `survey_questions` are still not in
-`localAuthorityTables`, while `submissions`, `submission_answers` and
-`submission_questions` all are — so a schema bump on a handset that has adopted
-but not published drops the clone and its questions and *keeps* the members'
-answer sheets. The same orphaning, reachable by an upgrade instead of a sync.
+## Job 1 — both survey tables join `localAuthorityTables`
 
-Notes are written as the work lands; see *Reported, not fixed* at the end.
+`surveys` and `survey_questions` were not preserved while `submissions`,
+`submission_answers` and `submission_questions` all are. So a schema bump on a
+handset that had adopted a team survey but not yet published it dropped the
+clone and its questions and **kept** the members' answer sheets — the same
+orphaning Phase 138 removed from the sync path, reachable by an upgrade.
+
+Demonstrated failing first, in
+`test/data/local/survey_clone_survives_schema_bump_test.dart`, which drives the
+production path rather than fabricating one: the source survey comes out of
+`SurveyMapper.fromCourseDoc` reading a course document shaped like the server's,
+the clone is minted by `SurveysRepository.adoptSurvey`, and the answer sheet by
+`createBulkSurveySubmissions`.
+
+```
+adoptSurvey -> clone + question rows + a member's sheet
+onUpgrade(46 -> 47)
+  clone row      null          <- gone
+  question rows  []            <- gone
+  answer sheet   still there   <- the asymmetry
+```
+
+By the project's operative test — ***can a sync restore this?***, not *is it
+local?* — the tables qualify: a **published** clone comes back on the next
+`exams` walk, an **unpublished** one exists nowhere else. That is the `feedback`
+argument verbatim. The mechanism is the `teams` precedent: preserve the whole
+table and let the next walk's `deleteNotIn` evict the stale cache half, which it
+already does for the question rows **in the same transaction** — so the pair
+moves together and no question row is orphaned. Preserving only one of the two
+*would* have orphaned; they had to land together.
+
+### This is not a parity fix, and the notes should stop implying it is
+
+Worth stating plainly, because the framing was wrong in my own head until the
+ground-truth pass. Kotlin's `RoomModule` builds with
+`fallbackToDestructiveMigration(true)` (`RoomModule.kt:57-61`) and there are no
+`Migration` objects anywhere in the tree; `StepExam`, `ExamQuestion`,
+`Submission` and `Answer` are all in the same `@Database`
+(`AppDatabase.kt:124-127`). **Kotlin drops all four together and therefore
+cannot reach this orphaning at all** — the sheets die with the survey. The
+asymmetry this phase removes is one the *port* created for itself when it
+preserved `submissions`. The deviation is licensed (`localAuthorityTables`
+exists for exactly this) and it is the better behaviour, but it is a deviation,
+not a gap.
+
+## Job 2 — the `needsSync` default would have deferred the loss, not prevented it
+
+**The defect the ground-truth pass found in the plan, and the most valuable
+thing here.**
+
+`Surveys.needsSync` arrived at v47, so a pre-v47 install has no such column and
+preservation means `createAll` will not add it — hence a hand-written
+`_addColumnIfMissing`. The column default is `false`, which is right for every
+row the server sent. But for a clone adopted on a v46 build it is the worst of
+both states:
+
+* invisible to `SurveyDao.pendingAdoptedSurveys()` (`needsSync = true`), so it
+  never publishes; **and**
+* outside `SurveyDao.deleteNotIn`'s spare clause
+  (`stepId IS NULL AND needsSync = false`), so the very next surveys walk
+  deletes it and its questions and orphans the sheets.
+
+Preserving the table would have moved the loss from the upgrade to the first
+sync after it. **A fix that relocates a data loss reads exactly like a fix that
+removes one**, and the only thing that separated them was asking what the row's
+state is *after* the migration rather than whether it survived it.
+
+So the flag is backfilled — and the port can do here what Phase 138 said it
+could not, because **the port's clone id is deterministic where Kotlin's is
+random**: `adoptSurvey` mints `'${surveyId}_$teamId'`
+(`surveys_repository.dart:105`; its one production caller,
+`team_surveys_screen.dart:121`, passes no `createId`) while
+`SurveysRepositoryImpl.kt:85` uses `UUID.randomUUID()`. That id equality is a
+*positive identification* of a row this device authored, which is precisely
+what Phase 138 lacked when it rejected `_rev IS NULL`.
+
+```sql
+UPDATE surveys SET needs_sync = 1
+WHERE source_survey_id IS NOT NULL
+  AND team_id IS NOT NULL
+  AND _rev IS NULL
+  AND step_id IS NULL
+  AND id = source_survey_id || '_' || team_id
+```
+
+Two conjuncts are deliberately redundant (`x || NULL` is NULL, so the id
+equality already fails without a `source_survey_id` or a `team_id`) and are kept
+to say plainly that the repair is about a team adoption and nothing else — the
+v45 health repair sets that precedent for a redundant conjunct kept for clarity.
+
+## Job 3 — the index-ordering hazard, which is why the steps run before `createAll`
+
+Not in the brief, and it would have shipped a **launch-loop crash** on any
+device below v35.
+
+`onUpgrade` drops the caches, then `DROP INDEX IF EXISTS` for every index, then
+`m.createAll()`, then the hand-written column steps. `createAll` emits
+`CREATE TABLE IF NOT EXISTS` — which no-ops on a preserved table — but a
+**bare** `CREATE INDEX`, taken verbatim from the generated `Index`
+(`app_database.g.dart:30793`:
+`'CREATE INDEX surveys_course_id ON surveys (course_id)'`). Every index was just
+dropped, so every one is recreated. `surveys_course_id` names `course_id`, which
+`surveys` only gained at v35. On an older device the preserved table has no such
+column, the `CREATE INDEX` raises `no such column: course_id`, and it throws out
+of `onUpgrade` — which propagates from `beforeOpen`, so the database never opens
+and the failure repeats on every launch.
+
+The fix is ordering, not the statement: both survey blocks run **before**
+`createAll`. That in turn needs two guards, because a pre-`createAll` step
+cannot assume its table exists (an upgrade from a version predating the table):
+`_addColumnIfMissing` now returns early on an empty `PRAGMA table_info`, and a
+new `_tableExists` wraps the block containing the raw `UPDATE`, which has no
+such tolerance of its own.
+
+**No other preserved table is exposed to this today**, and I checked rather than
+assumed: of the nine hand-written columns (`chat_history.is_uploaded`,
+`users.is_updated`/`age`/`birth_place`, `teams.image_name`,
+`team_tasks.is_notified`/`sync`/`link`, `news.reactions`), none appears in a
+`@TableIndex`. `feedback_is_uploaded` is the near miss — an indexed column on a
+preserved table — but `feedback.is_uploaded` has never needed a step. The rule
+is now written at the reconciliation block: **check for an index before adding a
+step after `createAll`.**
+
+## Job 4 — a test that fails when the next column is forgotten
+
+The stated cost of preservation is that `createAll` does not ALTER a preserved
+table, and *forgetting a step does not fail loudly* — it leaves the column
+absent on every existing install and breaks every query naming it. That cost is
+what kept Phase 138 from doing this, so it had to be paid down rather than
+inherited.
+
+`migration_test.dart` now carries **frozen** `CREATE TABLE` literals for
+`surveys` (pre-v35 and pre-v47) and `survey_questions`, installed over the
+freshly-created tables the way an on-device upgrade would find them, and asserts
+after the upgrade that `PRAGMA table_info` contains every column drift declares.
+The literals are frozen **on purpose and the comment says so**: a future column
+is absent from the literal and absent from the migration, therefore absent from
+the PRAGMA, therefore red. Keeping the literal in step with the table would turn
+the guard into coverage that cannot fail.
+
+**Verified by mutation, not by argument** — a `phantomMutation` column added to
+`SurveyQuestions` (the table with *no* steps at all), codegen re-run, suite red;
+column removed, codegen re-run, suite green.
+
+The literals also carry the drift guard the `team_tasks` precedent has and my
+first cut lacked: `frozenSurveyColumns` and `migratedSurveyColumns` are checked
+for **exact equality** against the live table before the literal is installed,
+so a *renamed or removed* column fails at the fixture. The `containsAll`
+assertions catch an addition; only this catches a rename.
+
+## Job 5 — the three DAO queries other lanes reported as blocked on this file
+
+Added, with their call-site swaps reported rather than half-done.
+
+* **`SubmissionDao.countCompletedByUserAndExamId`** (`SubmissionDao.kt:24`).
+  Three things Phase 139's item spelled out and I took as written: **no `type`
+  predicate** (Kotlin's count has none, so adopting it closes a divergence
+  rather than preserving one), **the `LIKE` pattern is not escaped** (Kotlin
+  interpolates the raw exam id; escaping would make the port *stricter*), and a
+  **NULL status must not count** — `NOT (status = 'pending')` is NULL for a NULL
+  status and `WHERE NULL` excludes the row, which is the same three-valued
+  outcome `status != 'pending'` gives and the opposite of what a Dart
+  `status != 'pending'` filter does.
+* **`NewsDao.getByNewsId`** (`NewsDao.kt:74`) — case-**sensitive**, because that
+  query carries no `COLLATE NOCASE` where its neighbours do.
+* **`NewsDao.getPlanetMessages`** (`NewsDao.kt:57-58`) — both comparisons folded
+  with `lower()`, the idiom the rest of the DAO already uses for
+  `COLLATE NOCASE`.
+
+## The v47 question, answered: that window is closed
+
+The brief asked for a stated decision on handsets already upgraded to v47.
+**There is no honest repair; the window is closed.** Four reasons, in order of
+how decisive they are, and the third is the one that changed my answer.
+
+1. **The population is empty.** `app/` is the shipping app and the Flutter port
+   has not shipped. v47 landed last round on the migration branch, so no handset
+   has ever run that upgrade. Everything below is why the answer would still be
+   no if it had.
+2. **The rows are gone.** `DROP TABLE`, not a soft delete. Nothing in the
+   database holds the clone.
+3. **Re-adopting through the UI is blocked, and the port blocks it itself.** My
+   intended answer was "the recovery path is re-adoption, and it works because
+   the clone id is deterministic" — the sheets would re-attach, since
+   `parentId` is `'<cloneId>@<courseId>'` and a fresh adopt mints the same
+   `cloneId`. **False.** `SurveysRepository.adoptableTeamSurveys`
+   (`surveys_repository.dart:63-76`) excludes every `_parentSurveyId` among the
+   team's submissions, and the adoption **marker** submission is one of them.
+   That faithfully ports `getAdoptableTeamSurveys` (`:256-266`) — but in Kotlin
+   it never bites, because a Room bump drops the submissions too and the source
+   becomes adoptable again. **The port's preservation of `submissions` is what
+   closes its own repair path.** Found by the ground-truth audit, not by me.
+4. **Reconstruction would trade a closed loss for an open leak.** The only
+   surviving trace is a submission's `parent` blob, and it is thin: the
+   bulk-sent sheets `getOrCreateSurveySubmission` writes carry no `parent` and
+   no question rows at all, and `createSurveyDraft` stores question **labels
+   only**. Publishing a survey rebuilt from that would POST a document the
+   device did not author to `exams` under the user's credentials — the exact
+   leak `Surveys.needsSync` was introduced to close.
+
+Doing nothing costs nothing further: the sheets survive, and an already-answered
+sheet stays reviewable from `submission_questions` where it has rows.
+
+## `schemaVersion` stays at 47 — the allocated 48 is unspent
+
+Decided from the migration code, as the brief asked. Changing
+`localAuthorityTables` membership alters no DDL, and `onUpgrade` runs only when
+the version increases — so a bump would drop the caches for no reason and
+discard unsynced writes in every non-preserved table. The preservation takes
+effect at the *next* bump, whoever spends it. **48 is free.**
+
+## The mutation that survived
+
+Nine of ten redded on the first try. The tenth: removing `AND step_id IS NULL`
+from the backfill broke nothing, because every step-joined row in my fixture
+also lacked a `source_survey_id`, so the id-shape clause already excluded it.
+
+Rather than delete the conjunct as dead, I looked for the row that makes it
+load-bearing, and it is producible: **a clone that published and was then
+attached to a course step on Planet.** The courses walk writes it back with the
+clone's own id and `sourceSurveyId`, with a `stepId`, and with `rev` NULL — a
+course document's embedded survey is a sub-object and carries no `_rev` of its
+own (the ownership conflict Phase 138 recorded at `SurveyMapper._build`). So it
+satisfies the id shape *and* the rev clause, and `step_id IS NULL` is the only
+thing stopping the backfill re-publishing a document the server already has.
+That row is now in the fixture, and the mutation reds.
+
+**A surviving mutation is a question about the predicate, not just about the
+test.** The answer here was a fixture row; it could as easily have been a
+conjunct to delete.
+
+## Reported, not fixed
+
+1. **`lib/repository/submissions_repository.dart:2140-2143` is now false.** Its
+   `AnswerShape.forQuestion` doc-comment says closing the `hasOtherOption` gap
+   needs a column on `survey_questions`, "That table is not in
+   `localAuthorityTables`, so `createAll` rebuilds it and the column costs only
+   a schema bump, no hand-written step." After this phase it costs a bump **and**
+   a hand-written `_addColumnIfMissing` step. Outside this lane's file set, so
+   recorded rather than edited; the equivalent claim in `PHASE_106_NOTES.md:250`
+   *is* corrected in place, because nobody else touches historical notes. The
+   replacement sentence, for whoever applies it: *"That table is in
+   `localAuthorityTables` since Phase 143, so `createAll` will not alter it: the
+   column costs a schema bump **and** a hand-written `_addColumnIfMissing` step,
+   and `migration_test.dart`'s frozen-DDL guard fails until it has one."*
+   `PHASE_123_NOTES.md:108-110` records the same three columns as still owed, so
+   this is a live target, not a hypothetical one.
+2. **`_isStepCompleted` should call the new DAO method.** The query is in
+   `SubmissionDao` now; its caller is in
+   `flutter/lib/ui/courses/take_course_screen.dart`, **Lane D's file**. The swap
+   replaces a read-all-then-filter-in-Dart with
+   `countCompletedByUserAndExamId(userId, examId) > 0`, and it **changes
+   behaviour in the port's favour**: the Dart filter has a `type` predicate that
+   Kotlin's count does not, so the swap closes a divergence. Adding the DAO
+   method without the swap leaves it with zero callers — deliberate, since half
+   a pair across two lanes is worse than a clean handover.
+3. **`isAlreadyShared` and `planetNewsMessages` should call the new NewsDao
+   queries.** Same shape: the queries are in, the callers are in
+   `flutter/lib/repository/voices_repository.dart`, **Lane C's file**. Both
+   currently walk `getAll()` and filter in Dart. Same result set, more rows
+   read; not a correctness defect.
+4. **A stale step-joined survey row is now unbounded.** New accretion this phase
+   creates, and it is recorded at the preserved-set comment too.
+   `SurveyDao.deleteNotIn` only ever considers rows with `stepId IS NULL`, and a
+   step join is released only by `SurveyDao.releaseStepJoinsForCourse`, which
+   `CoursesRepository` calls for the course documents **on the current page**
+   (`courses_repository.dart:277-289`). A course deleted server-side is on no
+   page, so nothing nulls its surveys' `stepId` and the prune can never reach
+   them — the bump used to sweep them and no longer does. Concrete input: delete
+   a course carrying a step survey on Planet; the courses walk's `deleteNotIn`
+   removes the course row and the `surveys`/`survey_questions` rows persist
+   across every future sync and every future bump. Not a correctness defect (the
+   rows are unreachable from the UI once the step tile is gone) but it is
+   unbounded, and it is the argument for giving `releaseStepJoinsForCourse` a
+   whole-table sweep rather than a per-page one.
+5. **Two self-healing paths lost their second line of defence.**
+   `SurveysRepository.sync` runs `deleteNotIn` only
+   `if (total == 0 || complete)` (`surveys_repository.dart:402-405`), so on a
+   handset whose surveys walk never completes, stale rows now persist
+   indefinitely where the bump used to clear them. And `tables.dart:587-593`
+   relies on "the next surveys sync rewrites them" for rows an older build wrote
+   through the pre-Phase-104 `choices` converter — still true, but the bump was
+   previously a second guarantee and is not any more.
+6. **`surveys.rev` still has two writers that disagree about who owns it**,
+   unchanged from Phase 138's report. `SurveyMapper._build` writes
+   `rev: Value(...)` unconditionally, so a course document's embedded copy
+   clobbers the `exams` walk's authoritative `_rev` with NULL, where
+   `ExamMapper.fromDoc` uses `_presentOrAbsent` for exactly this hazard.
+   `survey_mapper.dart` is outside this lane's set. It matters more after this
+   phase than before it: the backfill's `_rev IS NULL` conjunct now reads that
+   column on the upgrade path. It is safe as written — the id-shape and
+   `step_id` conjuncts carry the identification, and the phase's own fixture
+   pins the one row where a NULL `rev` from the courses walk would otherwise
+   have mattered — but a round that changes `SurveyMapper`'s rev handling should
+   re-read the backfill.
+7. **The `submissions` sweep's `parentId` shape is worth one more look.** Not
+   touched, and not obviously wrong; noted because Phase 125 found the compound
+   `'$surveyId@$courseId'` key disagreement the expensive way and this phase's
+   fixtures now depend on that shape in two files.

--- a/flutter/PHASE_143_NOTES.md
+++ b/flutter/PHASE_143_NOTES.md
@@ -1,0 +1,18 @@
+# Phase 143 — the schema bump destroys an unpublished survey clone, and `submissions` outlives it
+
+Lane B of a four-lane round. The brief is Phase 138's own *Reported, not fixed*
+entry — written by the lane that created the expectation and deliberately did
+not close it.
+
+**Status: in progress.**
+
+## The hole
+
+Phase 138 stopped `SurveyDao.deleteNotIn` destroying an adopted team survey
+clone on the next sync. `surveys` and `survey_questions` are still not in
+`localAuthorityTables`, while `submissions`, `submission_answers` and
+`submission_questions` all are — so a schema bump on a handset that has adopted
+but not published drops the clone and its questions and *keeps* the members'
+answer sheets. The same orphaning, reachable by an upgrade instead of a sync.
+
+Notes are written as the work lands; see *Reported, not fixed* at the end.

--- a/flutter/PHASE_143_NOTES.md
+++ b/flutter/PHASE_143_NOTES.md
@@ -17,9 +17,9 @@ prevented it. That is the round's lesson and it is in *Job 2* below.
    in the plan itself**, corrected my intended answer to the v47 question, and
    named two stale claims elsewhere in the tree.
 3. Implement, each defect demonstrated failing first.
-4. **Ten mutations**, each applied alone to green code and reverted. Nine
-   redded immediately; one survived and is written up below, because a surviving
-   mutation is the only kind worth reporting.
+4. **Fourteen mutations**, each applied alone to green code and reverted.
+   Thirteen redded immediately; one survived and is written up below, because a
+   surviving mutation is the only kind worth reporting.
 5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
    already-green code.
 
@@ -193,6 +193,15 @@ Added, with their call-site swaps reported rather than half-done.
   with `lower()`, the idiom the rest of the DAO already uses for
   `COLLATE NOCASE`.
 
+All three have no callers yet, so `test/data/local/dao_query_semantics_test.dart`
+pins the SQL semantics their doc-comments claim — and pins two of them against
+the **raw Kotlin statement** run on the same rows, rather than against my
+reading of it. The three-valued cases are why: a NULL status, a null `userId`,
+a NULL `docType`. Also pinned: `getByNewsId`'s case-sensitivity, and that an
+exam id containing a quote cannot inject (drift binds the `LIKE` pattern as a
+parameter, so the deliberate non-escaping is a *matching* looseness and not an
+injection one). Four mutations, four reds.
+
 ## The v47 question, answered: that window is closed
 
 The brief asked for a stated decision on handsets already upgraded to v47.
@@ -237,7 +246,7 @@ effect at the *next* bump, whoever spends it. **48 is free.**
 
 ## The mutation that survived
 
-Nine of ten redded on the first try. The tenth: removing `AND step_id IS NULL`
+Thirteen of fourteen redded on the first try. The other one: removing `AND step_id IS NULL`
 from the backfill broke nothing, because every step-joined row in my fixture
 also lacked a `source_survey_id`, so the id-shape clause already excluded it.
 

--- a/flutter/PHASE_143_NOTES.md
+++ b/flutter/PHASE_143_NOTES.md
@@ -17,9 +17,9 @@ prevented it. That is the round's lesson and it is in *Job 2* below.
    in the plan itself**, corrected my intended answer to the v47 question, and
    named two stale claims elsewhere in the tree.
 3. Implement, each defect demonstrated failing first.
-4. **Fifteen mutations**, each applied alone to green code and reverted.
-   Fourteen redded immediately; one survived and is written up below, because a
-   surviving mutation is the only kind worth reporting.
+4. **Nineteen mutations**, each applied alone to green code and reverted.
+   Seventeen redded immediately; **two survived**, and both are written up
+   below, because a surviving mutation is the only kind worth reporting.
 5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
    already-green code.
 
@@ -109,21 +109,69 @@ WHERE source_survey_id IS NOT NULL
   AND id = source_survey_id || '_' || team_id
 ```
 
-**One row satisfies every conjunct without being local work**, found by the
-implementation audit and accepted rather than predicated away. A clone another
-handset published, attached to a course step on Planet, has its authoritative
-`_rev` clobbered to NULL by the courses walk — `SurveyMapper._build` assigns
-`rev` unconditionally and a course sub-object carries none, which is Phase
-138's unfixed two-writer conflict — and once the course stops naming it,
-`releaseStepJoinsForCourse` nulls `stepId` as well. There is no local
-discriminator left, because `rev` is the only column that records "the server
-has this" and it is exactly the column those two writers disagree about;
-`courseId IS NULL` would miss a genuine clone of a course-attached survey, since
-`adoptSurvey` copies `courseId`. The cost is bounded and self-clearing: the POST
-takes a 409 and Phase 138's `_adoptExistingDocument` records the winning rev and
-clears the flag. One POST and one GET, once, after which the row rejoins the
-prune — **pinned as a pair**, not asserted, because each half passing alone is
-the shape this project keeps getting wrong.
+### The first cut of that predicate was a data leak, and I argued my way past it once
+
+**The most important thing in this phase, and it took two audit passes plus a
+retraction to land.**
+
+The implementation audit found that the id shape is *not* authorship. A team's
+clone that is shared **publicly** is served back under that very id by
+`/api/public/surveys/<teamId>/<surveyId>` — the deep link's `surveyId` *is* the
+clone — and `saveSurveyFromPublicApi` stores it with `sourceSurveyId`, `teamId`,
+no `stepId`, and a `rev` that is NULL whenever the remote Planet omits `_rev`
+(`surveyParentDocument` emits `_rev` only for a non-null rev, and `Surveys.rev`'s
+own doc-comment states every public-API survey has none). All five conjuncts.
+
+**And the harm was not the bounded kind.** The document lives on the *link's
+origin* planet while `AdoptedSurveysUploader.endpointFor` POSTs to the
+*configured* server, which has no document under that id — so the POST
+**succeeds**, publishing a survey this device never authored into the user's own
+`exams` database, under their credentials, stamped with this handset's origin
+fields. Verbatim the leak `Surveys.needsSync` was introduced to close, reopened
+for one upgrade by the migration that installs the column.
+
+I had already met a *different* row with the same shape — a published clone
+Planet attached to a course step, whose `rev` the courses walk clobbers — and
+**written it up as an accepted misfire**, reasoning that the 409 arm makes it
+self-clearing. That reasoning was sound for that row and wrong as a policy, and
+the public-API row is the one it does not cover. The retraction is the lesson:
+***"this misfire is harmless" is a claim about one producer, and there is always
+another producer.*** The right question was never "how bad is this misfire" but
+"what evidence do I actually have that this row is mine".
+
+There is such evidence, and it is local, single-writer and already preserved:
+`adoptSurvey` writes an **adoption marker** submission beside every clone
+(`createSurveyAdoptionSubmission` — `parentId` is the *source* id, `teamId` the
+team). So the predicate gains an `EXISTS` conjunct, which is what the v45 health
+repair's own decisive conjunct is too:
+
+```sql
+  AND EXISTS (SELECT 1 FROM submissions AS marker
+              WHERE marker.parent_id = surveys.source_survey_id
+                AND marker.team_id   = surveys.team_id)
+```
+
+**`rev` could never have carried this weight**, and that is the general point:
+it is the one column two sync walks disagree about the ownership of (Phase 138's
+unfixed `surveys.rev` item), so a predicate leaning on it inherits that
+ambiguity. The marker has exactly one writer.
+
+The conjunct closes **both** routes, which is how you can tell it is the right
+shape rather than a patch: where the marker is present on the course-step row,
+both leaders genuinely adopted, the deterministic ids converge *by design*, and
+the 409 arm reconciles them — so the mitigation I over-generalised turns out to
+be exactly right for the case it actually covers. And it fails safe in its one
+wrong direction: `adoptSurvey` writes the clone before returning early on an
+empty `userId`, so such a clone has no marker and is not flagged, leaving it
+unpublished — the state it was already in — rather than publishing something
+foreign.
+
+**Both halves of the marker match are load-bearing, and one was pinned by
+nothing** until a mutation said so. Dropping `marker.team_id = surveys.team_id`
+broke no test, because no fixture had the ordinary case: two teams adopt the same
+shared survey, and one of them shares its clone publicly. A marker for that
+source exists, so a `parentId`-only match flags the *other team's* document. Now
+pinned.
 
 Two conjuncts are deliberately redundant (`x || NULL` is NULL, so the id
 equality already fails without a `source_survey_id` or a `team_id`) and are kept
@@ -187,8 +235,25 @@ column removed, codegen re-run, suite green.
 The literals also carry the drift guard the `team_tasks` precedent has and my
 first cut lacked: `frozenSurveyColumns` and `migratedSurveyColumns` are checked
 for **exact equality** against the live table before the literal is installed,
-so a *renamed or removed* column fails at the fixture. The `containsAll`
-assertions catch an addition; only this catches a rename.
+so a new column fails at the *fixture* rather than at the outcome — the earliest
+and clearest place to be told a step is owed.
+
+**And the column *names* were not enough**, which the implementation audit
+caught with a case I had not thought of: a column whose **type** changes keeps
+its name, no `_addColumnIfMissing` step can ALTER a type, and every assertion in
+the file stays green while an upgraded device carries `TEXT` and a fresh one
+`INTEGER`. So the fixture now compares the **DDL text** SQLite actually holds
+against the frozen literal — which is what those literals claim to be, and the
+claim was previously unchecked. Verified by changing `passingPercentage` from
+`text()` to `integer()`, re-running codegen, and watching it red with
+*"the frozen surveys DDL no longer matches what drift creates"*.
+
+My justification comment for the exact-equality check was also simply wrong, in
+both halves, and is corrected in place: a *rename* does **not** slip past
+`containsAll` (the new name is absent after the upgrade, so it reds anyway), and
+a *removal* does slip past but is harmless, because drift maps columns by name
+and an extra column on an upgraded table is ignored. The check's real value is
+the early, specific failure — not catching a case the outcome assertions miss.
 
 ## Job 5 — the three DAO queries other lanes reported as blocked on this file
 
@@ -260,9 +325,13 @@ the version increases — so a bump would drop the caches for no reason and
 discard unsynced writes in every non-preserved table. The preservation takes
 effect at the *next* bump, whoever spends it. **48 is free.**
 
-## The mutation that survived
+## The two mutations that survived
 
-Fourteen of fifteen redded on the first try. The other one: removing `AND step_id IS NULL`
+Seventeen of nineteen redded on the first try. Both survivors were the same
+lesson from opposite ends — a conjunct nothing pinned — and neither was dead
+code once I looked for the row that needed it.
+
+**First:** removing `AND step_id IS NULL`
 from the backfill broke nothing, because every step-joined row in my fixture
 also lacked a `source_survey_id`, so the id-shape clause already excluded it.
 
@@ -276,12 +345,34 @@ satisfies the id shape *and* the rev clause, and `step_id IS NULL` is the only
 thing stopping the backfill re-publishing a document the server already has.
 That row is now in the fixture, and the mutation reds.
 
+**Second**, and after the marker conjunct landed: dropping
+`marker.team_id = surveys.team_id` from it broke nothing. The fixtures had no
+case where a marker exists for the source survey but for a *different* team —
+which is the ordinary situation, not a corner: two teams adopt the same shared
+survey, and one shares its clone publicly. A `parentId`-only match then flags
+the other team's document, which is the leak again by a shorter route. Now
+pinned, through the production `saveSurveyFromPublicApi`.
+
 **A surviving mutation is a question about the predicate, not just about the
-test.** The answer here was a fixture row; it could as easily have been a
-conjunct to delete.
+test.** Both times the answer was a fixture row rather than a conjunct to
+delete — and both times the missing row was one a *producer-driven* fixture
+would have had. The first cut's negative set was six hand-written
+`INSERT INTO surveys` statements described in the comment as "shapes taken from
+their producers, not invented"; they were reasoned from each producer's first
+write and stopped there. That is this project's own "a fixture that fabricates a
+join is not evidence" rule, applied to the negative set, and it is the reason
+the public-API leak survived my first implementation *and* my first mutation
+round.
 
 ## Reported, not fixed
 
+0. **`docs/kotlin-to-flutter-migration.md` and `CLAUDE.md` both list four
+   preserved tables against the real 27.** Pre-existing staleness rather than
+   something this phase broke, but the migration doc's *preserved-table test*
+   section is the one a lane is told to read before touching this set, and it
+   names `outbox`, `my_personal`, `removed_log` and `my_life` only. Lane A owns
+   `docs/kotlin-to-flutter-migration.md` this round and `CLAUDE.md` is nobody's,
+   so both are reported. One line each would do it.
 1. **`lib/repository/submissions_repository.dart:2140-2143` is now false.** Its
    `AnswerShape.forQuestion` doc-comment says closing the `hasOtherOption` gap
    needs a column on `survey_questions`, "That table is not in
@@ -320,10 +411,20 @@ conjunct to delete.
    them — the bump used to sweep them and no longer does. Concrete input: delete
    a course carrying a step survey on Planet; the courses walk's `deleteNotIn`
    removes the course row and the `surveys`/`survey_questions` rows persist
-   across every future sync and every future bump. Not a correctness defect (the
-   rows are unreachable from the UI once the step tile is gone) but it is
-   unbounded, and it is the argument for giving `releaseStepJoinsForCourse` a
-   whole-table sweep rather than a per-page one.
+   across every future sync and every future bump.
+   **My first write-up called these rows "unreachable from the UI once the step
+   tile is gone", and the implementation audit showed that is false.**
+   `surveysProvider` filters `watchAll()` through
+   `SurveysRepository.individualSurveys()`, whose predicate is
+   `!row.teamShareAllowed && (row.teamId ?? '').isEmpty` — **no `stepId` or
+   `courseId` test at all** — so an orphaned step survey with no team is listed
+   at `/life/surveys` and is tappable, forever. The *visibility* matches Kotlin
+   (`ExamDao.getByType("surveys")` has no filter either), but Kotlin's Room bump
+   drops the table and self-cleans where the port's no longer does. So this is
+   a user-visible accretion, not a hidden one, and it is the argument for giving
+   `releaseStepJoinsForCourse` a whole-table sweep rather than a per-page one.
+   Corrected here because the sentence I got wrong is the one that decided this
+   was not worth fixing.
 5. **Two self-healing paths lost their second line of defence.**
    `SurveysRepository.sync` runs `deleteNotIn` only
    `if (total == 0 || complete)` (`surveys_repository.dart:402-405`), so on a
@@ -343,7 +444,31 @@ conjunct to delete.
    as `ExamMapper.fromDoc` already does — would close that misfire as a side
    effect rather than needing a predicate change here. That makes it the
    highest-value item on this list.
-7. **The `submissions` sweep's `parentId` shape is worth one more look.** Not
+7. **`survey_clone_survives_schema_bump_test.dart`'s `from: 47` default means
+   its three original tests exercise no migration step.** `to` is
+   `schemaVersion`, which is 47, so no `from <` branch fires: those three cover
+   the `localAuthorityTables` membership change, the index drop-and-rebuild and
+   `createAll` not clobbering a preserved table — and would stay green if every
+   step this phase adds were deleted. That is deliberate (they are the
+   *preservation* tests, and the newer tests in the same file use `from: 46`),
+   but `migration_test.dart`'s frozen fixtures are the only thing that will
+   catch a forgotten step on the **next** bump. Worth knowing before trusting
+   the file's name.
+8. **`getPlanetMessages` folds the argument with Dart's Unicode-aware
+   `toLowerCase()` and the column with SQLite's ASCII-only `LOWER()`.** So a
+   planet code containing a non-ASCII letter matches in Kotlin
+   (`COLLATE NOCASE` on both sides) and not in the port. The idiom is
+   pre-existing throughout `NewsDao` (three other queries do the same), so this
+   is inherited rather than introduced, and unreachable while planet codes are
+   ASCII. Fixing it properly means `COLLATE NOCASE` in raw SQL rather than
+   `lower()`.
+9. **`NewsDao.getPlanetMessages` takes a non-nullable `String` with no
+   empty-string guard**, matching Kotlin, where
+   `VoicesRepository.planetNewsMessages(String? planetCode)` returns `const []`
+   for null-or-empty. That guard is the port's own. Whoever does the call-site
+   swap must keep it — a naive `getPlanetMessages(planetCode!)` turns a null
+   into a crash.
+10. **The `submissions` sweep's `parentId` shape is worth one more look.** Not
    touched, and not obviously wrong; noted because Phase 125 found the compound
    `'$surveyId@$courseId'` key disagreement the expensive way and this phase's
    fixtures now depend on that shape in two files.

--- a/flutter/PHASE_143_NOTES.md
+++ b/flutter/PHASE_143_NOTES.md
@@ -17,8 +17,8 @@ prevented it. That is the round's lesson and it is in *Job 2* below.
    in the plan itself**, corrected my intended answer to the v47 question, and
    named two stale claims elsewhere in the tree.
 3. Implement, each defect demonstrated failing first.
-4. **Fourteen mutations**, each applied alone to green code and reverted.
-   Thirteen redded immediately; one survived and is written up below, because a
+4. **Fifteen mutations**, each applied alone to green code and reverted.
+   Fourteen redded immediately; one survived and is written up below, because a
    surviving mutation is the only kind worth reporting.
 5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
    already-green code.
@@ -108,6 +108,22 @@ WHERE source_survey_id IS NOT NULL
   AND step_id IS NULL
   AND id = source_survey_id || '_' || team_id
 ```
+
+**One row satisfies every conjunct without being local work**, found by the
+implementation audit and accepted rather than predicated away. A clone another
+handset published, attached to a course step on Planet, has its authoritative
+`_rev` clobbered to NULL by the courses walk — `SurveyMapper._build` assigns
+`rev` unconditionally and a course sub-object carries none, which is Phase
+138's unfixed two-writer conflict — and once the course stops naming it,
+`releaseStepJoinsForCourse` nulls `stepId` as well. There is no local
+discriminator left, because `rev` is the only column that records "the server
+has this" and it is exactly the column those two writers disagree about;
+`courseId IS NULL` would miss a genuine clone of a course-attached survey, since
+`adoptSurvey` copies `courseId`. The cost is bounded and self-clearing: the POST
+takes a 409 and Phase 138's `_adoptExistingDocument` records the winning rev and
+clears the flag. One POST and one GET, once, after which the row rejoins the
+prune — **pinned as a pair**, not asserted, because each half passing alone is
+the shape this project keeps getting wrong.
 
 Two conjuncts are deliberately redundant (`x || NULL` is NULL, so the id
 equality already fails without a `source_survey_id` or a `team_id`) and are kept
@@ -246,7 +262,7 @@ effect at the *next* bump, whoever spends it. **48 is free.**
 
 ## The mutation that survived
 
-Thirteen of fourteen redded on the first try. The other one: removing `AND step_id IS NULL`
+Fourteen of fifteen redded on the first try. The other one: removing `AND step_id IS NULL`
 from the backfill broke nothing, because every step-joined row in my fixture
 also lacked a `source_survey_id`, so the id-shape clause already excluded it.
 
@@ -321,13 +337,12 @@ conjunct to delete.
    `rev: Value(...)` unconditionally, so a course document's embedded copy
    clobbers the `exams` walk's authoritative `_rev` with NULL, where
    `ExamMapper.fromDoc` uses `_presentOrAbsent` for exactly this hazard.
-   `survey_mapper.dart` is outside this lane's set. It matters more after this
-   phase than before it: the backfill's `_rev IS NULL` conjunct now reads that
-   column on the upgrade path. It is safe as written — the id-shape and
-   `step_id` conjuncts carry the identification, and the phase's own fixture
-   pins the one row where a NULL `rev` from the courses walk would otherwise
-   have mattered — but a round that changes `SurveyMapper`'s rev handling should
-   re-read the backfill.
+   `survey_mapper.dart` is outside this lane's set. **It is now load-bearing
+   where it was not**: it is the sole reason the v47 backfill has a reachable
+   misfire at all (see *Job 2*), and fixing it — `_presentOrAbsent` for `rev`,
+   as `ExamMapper.fromDoc` already does — would close that misfire as a side
+   effect rather than needing a predicate change here. That makes it the
+   highest-value item on this list.
 7. **The `submissions` sweep's `parentId` shape is worth one more look.** Not
    touched, and not obviously wrong; noted because Phase 125 found the compound
    `'$surveyId@$courseId'` key disagreement the expensive way and this phase's

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -340,14 +340,23 @@ class AppDatabase extends _$AppDatabase {
         // deletes it and its questions and orphans the members' answer sheets.
         //
         // So the flag is backfilled for the rows this device can *positively*
-        // identify as its own, which the port can do and Kotlin cannot: the
-        // port's clone id is deterministic — `'${surveyId}_$teamId'`
-        // (`SurveysRepository.adoptSurvey`, whose one production caller passes no
-        // `createId`) — where Kotlin mints `UUID.randomUUID()`
-        // (`SurveysRepositoryImpl.kt:85`). Phase 138 rejected `_rev IS NULL` as
-        // an authorship test and was right to; the id equality is the
-        // discriminator here, and the rev clause only keeps an already-published
-        // clone from being re-queued.
+        // identify as its own. Two facts do that together, and the second is
+        // the load-bearing one:
+        //
+        //  * the port's clone id is deterministic — `'${surveyId}_$teamId'`
+        //    (`SurveysRepository.adoptSurvey`, whose one production caller
+        //    passes no `createId`) — where Kotlin mints `UUID.randomUUID()`
+        //    (`SurveysRepositoryImpl.kt:86`), so the shape is at least
+        //    *recognisable*; and
+        //  * `adoptSurvey` leaves an **adoption marker** submission beside the
+        //    clone, which is the actual evidence of local authorship.
+        //
+        // The id shape alone is not authorship, and the first cut of this
+        // backfill assumed it was — see the `EXISTS` conjunct below for the
+        // document that shape belongs to and what POSTing it would have done.
+        // Phase 138 rejected `_rev IS NULL` as an authorship test and was right
+        // to; the rev clause here only keeps an already-published clone from
+        // being re-queued.
         //
         // Every conjunct earns its place, and two are deliberately redundant:
         //
@@ -389,7 +398,10 @@ class AppDatabase extends _$AppDatabase {
             'AND team_id IS NOT NULL '
             'AND _rev IS NULL '
             'AND step_id IS NULL '
-            "AND id = source_survey_id || '_' || team_id",
+            "AND id = source_survey_id || '_' || team_id "
+            'AND EXISTS (SELECT 1 FROM submissions AS marker '
+            'WHERE marker.parent_id = surveys.source_survey_id '
+            'AND marker.team_id = surveys.team_id)',
           );
         }
       }
@@ -3060,13 +3072,21 @@ class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
   /// table; the port's split puts the whole query here, and the `exams` table
   /// needs no counterpart because `adoptSurvey` writes only to [Surveys].
   ///
-  /// **Both clauses matter, and the second is the load-bearing one.**
+  /// **The port asks neither of Kotlin's clauses, and that is the point.**
   /// `sourceSurveyId` is not a local-authorship marker: the courses walk reads
   /// it straight off a server-embedded survey (`survey_mapper.dart:163-167`),
-  /// so an adopted copy that Planet itself published carries it too. Only
-  /// `rev IS NULL` separates "this device minted it and nobody else has it"
-  /// from "the server sent it" — the same conjunction Phase 136 had to restore
-  /// in `hasUnfinishedSurveys` after shipping half of it.
+  /// so an adopted copy Planet itself published carries it too. And `rev IS
+  /// NULL` cannot stand in for "nobody else has it" here the way it does in
+  /// Kotlin, because the port's mappers use `getStringOrNull`: absent becomes
+  /// NULL, which is true of every course-embedded and every public-API survey.
+  /// Phase 138 found that predicate POSTing another team's private copy under
+  /// the signed-in user's credentials, which is why [Surveys.needsSync] exists
+  /// and why the body below is one clause on a flag with one writer.
+  ///
+  /// (An earlier revision of this comment ended "Only `rev IS NULL` separates
+  /// this device minted it from the server sent it" — arguing for the very
+  /// predicate the column beneath it was introduced to replace, directly above
+  /// a body that does not use it.)
   Future<List<SurveyRow>> pendingAdoptedSurveys() =>
       (select(surveys)..where((row) => row.needsSync.equals(true))).get();
 
@@ -3115,10 +3135,13 @@ class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
   /// insert-only — `bulkInsertExamsFromSync` upserts and nothing in the tree
   /// ever deletes from that table.
   ///
-  /// The exemption is scoped to `rev IS NULL` rather than to every clone, so it
-  /// lapses the moment [markUploaded] runs: once the document exists, the walk
-  /// that names it keeps it and a walk that stops naming it is reporting a
-  /// deletion this prune should honour.
+  /// The exemption is scoped to `needsSync` rather than to every clone, so it
+  /// lapses the moment [markUploaded] runs — that call clears the flag as it
+  /// records the rev: once the document exists, the walk that names it keeps it
+  /// and a walk that stops naming it is reporting a deletion this prune should
+  /// honour. (This said "scoped to `rev IS NULL`" until Phase 143; the body has
+  /// been `stepId IS NULL AND needsSync = 0` since Phase 138 shipped the flag,
+  /// so the file carried two descriptions of one predicate.)
   Future<int> deleteNotIn(List<String> ids) => transaction(() async {
     final keep = ids.toSet();
     final all =

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -364,6 +364,23 @@ class AppDatabase extends _$AppDatabase {
         //    nothing — `x || NULL` is NULL, so the id equality already fails for
         //    either — and are kept to say plainly that this repair is about a
         //    team adoption and nothing else.
+        //
+        // **One row satisfies all of it without being local work, and it is
+        // accepted rather than predicated away.** A clone another handset
+        // published, attached to a course step on Planet, has its
+        // authoritative `_rev` clobbered to NULL by the courses walk
+        // (`SurveyMapper._build` assigns `rev` unconditionally and a course
+        // sub-object carries none — the two-writer conflict Phase 138
+        // recorded); once the course document stops naming it,
+        // `releaseStepJoinsForCourse` nulls `stepId` too, and every conjunct
+        // holds. `rev` is the only column that records "the server has this",
+        // and it is exactly the column those two writers disagree about, so
+        // there is no local discriminator left: `courseId IS NULL` would miss
+        // a genuine clone of a course-attached survey, since `adoptSurvey`
+        // copies `courseId`. The cost is bounded and self-clearing — the POST
+        // takes a 409 and `AdoptedSurveysUploader._adoptExistingDocument`
+        // records the winning rev and clears the flag, once. Pinned as a pair
+        // in `survey_clone_survives_schema_bump_test.dart`.
         if (from < 47) {
           await _addColumnIfMissing(m, surveys, surveys.needsSync);
           await customStatement(

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -126,7 +126,7 @@ class AppDatabase extends _$AppDatabase {
   /// a join the shelf has not yet pushed. Preserving it leaves stale server
   /// rows behind, which the next sync prunes through `deleteNotIn` — a cost
   /// worth paying to keep un-uploaded meetups. [Surveys] and [SurveyQuestions]
-  /// carry no local writes at all and are dropped with the rest.
+  /// are the same hybrid for the same reason — see their entry below.
   ///
   /// [NewsEntries] is the same hybrid: a post or reply composed offline exists
   /// only in this table until the outbox delivers it and it adopts a CouchDB
@@ -229,6 +229,44 @@ class AppDatabase extends _$AppDatabase {
     // counterpart exists — so a schema bump would silently discard the
     // user's completed-challenge state.
     'user_challenge_actions',
+    // Mixed, and the mixture is the whole argument. Almost every row is the
+    // `exams` cache, but `SurveysRepository.adoptSurvey` mints a team's
+    // private clone of a shared survey locally — a row the server has never
+    // seen, carrying [Surveys.needsSync] until `AdoptedSurveysUploader`
+    // publishes it — and writes its question set alongside. By the operative
+    // test (*can a sync restore this?*, not *is it local?*) the answer splits
+    // exactly there: a published clone comes back on the next `exams` walk, an
+    // unpublished one exists nowhere else.
+    //
+    // Phase 138 spared that clone from [SurveyDao.deleteNotIn] and left the
+    // identical loss reachable by an upgrade: `submissions`,
+    // `submission_answers` and `submission_questions` are all preserved, so
+    // dropping these two destroyed the survey and **kept** the members'
+    // answer sheets. Preserving them takes the `teams` route — keep the whole
+    // table, let the next walk's `deleteNotIn` evict the stale cache half,
+    // which it already does for the question rows in the same transaction.
+    //
+    // The price is that `createAll` cannot ALTER a preserved table, so every
+    // future column on either one needs a hand-written [_addColumnIfMissing]
+    // step below — and for `surveys` that step must run *before* `createAll`.
+    // See the reconciliation block for why, and
+    // `migration_test.dart`'s frozen-DDL guard for what fails if it is
+    // forgotten.
+    //
+    // A second, smaller price: a **step-joined** row is now unbounded.
+    // [SurveyDao.deleteNotIn] only ever considers rows with `stepId IS NULL`,
+    // and a step join is released only by
+    // [SurveyDao.releaseStepJoinsForCourse], which the courses walk calls for
+    // the course documents on the current page. A course deleted server-side
+    // is on no page, so nothing nulls its surveys' `stepId` and the prune can
+    // never reach them — the bump used to sweep them and no longer does. They
+    // are unreachable from the UI (the step tile is gone with the course), so
+    // this is accretion rather than a correctness defect; recorded because it
+    // is new, and because it is the argument for giving
+    // `releaseStepJoinsForCourse` a whole-table sweep rather than a per-page
+    // one.
+    'surveys',
+    'survey_questions',
   };
 
   @override
@@ -250,6 +288,100 @@ class AppDatabase extends _$AppDatabase {
           await customStatement('DROP INDEX IF EXISTS ${entity.entityName}');
         }
       }
+
+      // Preserved-table columns an *index* names have to be reconciled here,
+      // before `createAll` — not with the rest of the hand-written steps
+      // below.
+      //
+      // `createAll` emits `CREATE TABLE IF NOT EXISTS`, which no-ops on a
+      // preserved table, but a **bare** `CREATE INDEX` (drift's generated
+      // `Index` carries the literal statement; see `createIndex`). The indexes
+      // were all just dropped, so every one is recreated — and
+      // `surveys_course_id` names `course_id`, which `surveys` only gained at
+      // v35. On a device older than that the preserved table has no such
+      // column and the `CREATE INDEX` aborts the whole upgrade. Adding the
+      // column first is the fix; ordering, not the statement, was the bug.
+      //
+      // No other preserved table is exposed to this: of the columns added by
+      // hand below, none of `chat_history.is_uploaded`, `users.is_updated`,
+      // `users.age`, `users.birth_place`, `teams.image_name`,
+      // `team_tasks.is_notified`, `team_tasks.sync`, `team_tasks.link` or
+      // `news.reactions` appears in a `@TableIndex`. Check that before adding
+      // a step after `createAll`.
+
+      // Both blocks below run before `createAll`, so neither may assume
+      // `surveys` exists: an upgrade from a version predating the table would
+      // find nothing to alter or update, and `createAll` is about to build it
+      // complete. [_addColumnIfMissing] tolerates that on its own; the raw
+      // `UPDATE` in the second block does not, which is what this guards.
+      if (await _tableExists('surveys')) {
+        // v35 added `courseId` and `stepId` to `Surveys`, with the
+        // `surveys_course_id` index on the first, so course-attached surveys
+        // could be modelled. Both are nullable with no backfill to do: a row
+        // written before v35 belonged to no course document, which is what NULL
+        // says.
+        if (from < 35) {
+          await _addColumnIfMissing(m, surveys, surveys.courseId);
+          await _addColumnIfMissing(m, surveys, surveys.stepId);
+        }
+
+        // v47 added `Surveys.needsSync`, the local-authorship flag an adopted
+        // team clone is published on. The column default is `false`, which is
+        // right for every row the server sent — marking those pending would POST
+        // the whole survey cache to `exams` under the user's credentials, the
+        // leak [Surveys.needsSync] exists to prevent.
+        //
+        // **But the default alone would defer this phase's data loss rather than
+        // prevent it.** Preserving the table saves a clone adopted on a pre-v47
+        // build from the bump, and then `needsSync = false` puts it in the worst
+        // of both states: invisible to [SurveyDao.pendingAdoptedSurveys], so it
+        // never publishes, and outside [SurveyDao.deleteNotIn]'s spare clause
+        // (`stepId IS NULL AND needsSync = 0`), so the very next surveys walk
+        // deletes it and its questions and orphans the members' answer sheets.
+        //
+        // So the flag is backfilled for the rows this device can *positively*
+        // identify as its own, which the port can do and Kotlin cannot: the
+        // port's clone id is deterministic — `'${surveyId}_$teamId'`
+        // (`SurveysRepository.adoptSurvey`, whose one production caller passes no
+        // `createId`) — where Kotlin mints `UUID.randomUUID()`
+        // (`SurveysRepositoryImpl.kt:85`). Phase 138 rejected `_rev IS NULL` as
+        // an authorship test and was right to; the id equality is the
+        // discriminator here, and the rev clause only keeps an already-published
+        // clone from being re-queued.
+        //
+        // Every conjunct earns its place, and two are deliberately redundant:
+        //
+        //  * `id = source_survey_id || '_' || team_id` — the identification.
+        //    Only `adoptSurvey` mints that shape. A Kotlin-authored clone is a
+        //    UUID and fails it.
+        //  * `_rev IS NULL` — a clone [SurveyDao.markUploaded] has recorded is a
+        //    cache row again, and re-flagging it would POST a second copy.
+        //  * `step_id IS NULL` — `adoptSurvey` withholds `stepId` deliberately
+        //    (see the call), and this is what excludes a course-embedded survey,
+        //    whose `_rev` is NULL for a reason that has nothing to do with
+        //    authorship (a sub-object carries none).
+        //  * `source_survey_id IS NOT NULL` and `team_id IS NOT NULL` add
+        //    nothing — `x || NULL` is NULL, so the id equality already fails for
+        //    either — and are kept to say plainly that this repair is about a
+        //    team adoption and nothing else.
+        if (from < 47) {
+          await _addColumnIfMissing(m, surveys, surveys.needsSync);
+          await customStatement(
+            'UPDATE surveys SET needs_sync = 1 '
+            'WHERE source_survey_id IS NOT NULL '
+            'AND team_id IS NOT NULL '
+            'AND _rev IS NULL '
+            'AND step_id IS NULL '
+            "AND id = source_survey_id || '_' || team_id",
+          );
+        }
+      }
+
+      // `SurveyQuestions` has never gained or lost a column. The `choices`
+      // converter swap (Phase 104) changed the Dart type and not the DDL —
+      // `TEXT NOT NULL DEFAULT '[]'` before and after — so it needs no step,
+      // and `survey_id`/`position` are structural, present in every shape the
+      // table has ever had. A future column here needs a step of its own.
 
       // Recreates the dropped caches and anything newly added. Note this does
       // not *alter* a preserved table, so changing the shape of one of
@@ -406,23 +538,18 @@ class AppDatabase extends _$AppDatabase {
         await _addColumnIfMissing(m, teamTasks, teamTasks.sync);
         await _addColumnIfMissing(m, teamTasks, teamTasks.link);
       }
-
-      // v47 adds `Surveys.needsSync`, the local-authorship flag an adopted
-      // team clone is published on. No hand-written step: `surveys` is not in
-      // [_localAuthorityTables], so it is dropped above and `createAll`
-      // recreates it with the column. Which also means the bump itself
-      // destroys an unpublished clone — pre-existing for this table and
-      // recorded in the phase notes, not something this column changes.
-      //
-      // The default is `false`, which is correct for every row a re-sync
-      // refills: a survey the server sent is not this device's to publish.
-      if (from < 47) {
-        // Deliberately empty. Kept as an explicit branch so the next reader
-        // sees that v47 was considered here and needs nothing, rather than
-        // wondering whether a step was forgotten.
-      }
     },
   );
+
+  /// Whether the running database has a table of this name.
+  ///
+  /// `PRAGMA table_info` returns no rows for a table SQLite does not have, and
+  /// SQLite has no zero-column table, so an empty result is the test. Needed by
+  /// the reconciliation steps that run *before* `createAll` — see there.
+  Future<bool> _tableExists(String name) async {
+    final rows = await customSelect('PRAGMA table_info($name)').get();
+    return rows.isNotEmpty;
+  }
 
   /// Adds [column] to [table] unless the running database already has it.
   ///
@@ -431,6 +558,12 @@ class AppDatabase extends _$AppDatabase {
   /// `ALTER TABLE ADD COLUMN` on a database that already has it is an error,
   /// hence the check — an upgrade that spans several versions would otherwise
   /// abort partway.
+  ///
+  /// An absent table is also a no-op, which is what makes a call safe *before*
+  /// `createAll` — `PRAGMA table_info` on a table SQLite does not have returns
+  /// no rows, and `createAll` is about to create it complete. Without this an
+  /// upgrade from a version predating the table would `ALTER` something that
+  /// does not exist and abort.
   Future<void> _addColumnIfMissing(
     Migrator m,
     TableInfo<Table, dynamic> table,
@@ -439,6 +572,7 @@ class AppDatabase extends _$AppDatabase {
     final existing = await customSelect(
       'PRAGMA table_info(${table.actualTableName})',
     ).get();
+    if (existing.isEmpty) return;
     final names = existing.map((row) => row.read<String>('name')).toSet();
     if (names.contains(column.name)) return;
     await m.addColumn(table, column);
@@ -2418,6 +2552,57 @@ class SubmissionDao extends DatabaseAccessor<AppDatabase>
     return row.read(count) ?? 0;
   }
 
+  /// Port of `SubmissionDao.countCompletedByUserAndExamId`
+  /// (`SubmissionDao.kt:24`), which `SubmissionsRepositoryImpl.isStepCompleted`
+  /// reads to decide whether a course step's assessment has been answered:
+  ///
+  /// ```sql
+  /// SELECT COUNT(*) FROM submissions WHERE userId IS :userId
+  ///   AND parentId LIKE '%' || :examId || '%' AND status != 'pending'
+  /// ```
+  ///
+  /// Three things about it are deliberate, and each was got wrong in a draft
+  /// somewhere:
+  ///
+  ///  * **No `type` predicate.** Kotlin's count has none, so a *survey*
+  ///    submission whose `parentId` contains the exam id satisfies it. The
+  ///    port's caller picks its table by type and then filtered in Dart, which
+  ///    is stricter than Kotlin; taking the query as written closes that
+  ///    divergence rather than preserving it.
+  ///  * **The `LIKE` pattern is not escaped.** Kotlin concatenates the raw exam
+  ///    id, so `%` and `_` inside one are wildcards and the match is
+  ///    ASCII-case-insensitive. Escaping would make the port *stricter* than
+  ///    Kotlin — the opposite of the looseness a `contains` was chosen to
+  ///    preserve. Unreachable in practice while `parentId` is minted from the
+  ///    same `exam.id` through `examParentId`, which is why it is a comment and
+  ///    not a defect.
+  ///  * **A NULL `status` does not count.** `NOT (status = 'pending')` is NULL
+  ///    for a NULL status, and `WHERE NULL` excludes the row — the same
+  ///    three-valued outcome `status != 'pending'` gives. A Dart
+  ///    `status != 'pending'` filter would have counted it.
+  ///
+  /// `userId IS :userId` is null-safe, so a null argument matches the rows with
+  /// no user rather than nothing at all.
+  Future<int> countCompletedByUserAndExamId(
+    String? userId,
+    String examId,
+  ) async {
+    final count = submissions.id.count();
+    final userMatch = userId == null
+        ? submissions.userId.isNull()
+        : submissions.userId.equals(userId);
+    final row =
+        await (selectOnly(submissions)
+              ..addColumns([count])
+              ..where(
+                userMatch &
+                    submissions.parentId.like('%$examId%') &
+                    submissions.status.equals('pending').not(),
+              ))
+            .getSingle();
+    return row.read(count) ?? 0;
+  }
+
   /// Port of `AnswerDao.getBySubmissionIds` — every answer for [submissionIds]
   /// in one read, so the progress calc totalises mistakes without N queries.
   Future<List<SubmissionAnswerRow>> answersForSubmissions(
@@ -3256,6 +3441,27 @@ class NewsDao extends DatabaseAccessor<AppDatabase> with _$NewsDaoMixin {
       (select(newsEntries)
             ..where((r) => r.replyTo.lower().equals(newsId.toLowerCase()))
             ..orderBy([(r) => OrderingTerm.desc(r.time)]))
+          .get();
+
+  /// Port of `NewsDao.getByNewsId` (`NewsDao.kt:74`),
+  /// `WHERE newsId = :chatId` — every `news` row carrying a chat's id.
+  /// Case-**sensitive**: that query has no `COLLATE NOCASE`, unlike the
+  /// `docType` ones below it. `VoicesRepository.isAlreadyShared` walked
+  /// `getAll()` and filtered in Dart for want of this.
+  Future<List<NewsRow>> getByNewsId(String chatId) =>
+      (select(newsEntries)..where((r) => r.newsId.equals(chatId))).get();
+
+  /// Port of `NewsDao.getPlanetMessages` (`NewsDao.kt:57-58`),
+  /// `WHERE docType = 'message' COLLATE NOCASE AND createdOn = :planetCode
+  /// COLLATE NOCASE`. Both comparisons are folded with `lower()`, the idiom the
+  /// rest of this DAO uses for `COLLATE NOCASE` — equivalent for ASCII, which
+  /// is all NOCASE itself folds.
+  Future<List<NewsRow>> getPlanetMessages(String planetCode) =>
+      (select(newsEntries)..where(
+            (r) =>
+                r.docType.lower().equals('message') &
+                r.createdOn.lower().equals(planetCode.toLowerCase()),
+          ))
           .get();
 
   /// Case-sensitive, unlike [replies] — `getDirectReplies` omits the

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -518,6 +518,14 @@ class Meetups extends Table {
 }
 
 /// Port of survey-shaped rows from `model/StepExam.kt` (`exams` database).
+///
+/// **Preserved across a schema bump** — see
+/// [AppDatabase.localAuthorityTables] for why, and note the consequence before
+/// adding a column here: `createAll` does not ALTER a preserved table, so a new
+/// column needs a hand-written `_addColumnIfMissing` step in `onUpgrade`, and
+/// it must run *before* `createAll` if any `@TableIndex` names it (a bare
+/// `CREATE INDEX` on a missing column aborts the whole upgrade).
+/// `migration_test.dart`'s frozen-DDL fixture fails until the step exists.
 @DataClassName('SurveyRow')
 @TableIndex(name: 'surveys_created_date', columns: {#createdDate})
 @TableIndex(name: 'surveys_course_id', columns: {#courseId})
@@ -574,6 +582,12 @@ class Surveys extends Table {
 }
 
 /// Questions embedded in an `exams` CouchDB survey document.
+///
+/// **Preserved across a schema bump**, with [Surveys] and for the same reason:
+/// an adopted team clone's questions exist nowhere else until the clone
+/// publishes. The two must stay preserved together — preserving only one
+/// orphans the other. Adding a column here needs a hand-written
+/// `_addColumnIfMissing` step; see [Surveys] above.
 @DataClassName('SurveyQuestionRow')
 @TableIndex(name: 'survey_questions_survey', columns: {#surveyId, #position})
 class SurveyQuestions extends Table {

--- a/flutter/test/data/local/dao_query_semantics_test.dart
+++ b/flutter/test/data/local/dao_query_semantics_test.dart
@@ -1,0 +1,138 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+
+/// The three DAO queries Phase 143 added have no callers yet — their call sites
+/// are other lanes' files — so these pin the SQL semantics their doc-comments
+/// claim, and pin two of them against the **raw Kotlin statement** run on the
+/// same rows rather than against a reading of it.
+///
+/// The three-valued cases are the point. A Dart `status != 'pending'` filter
+/// counts a NULL status and SQL does not; a `userId ?? ''` fallback matches
+/// nothing where `userId IS NULL` matches the anonymous rows.
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase.memory());
+  tearDown(() => db.close());
+
+  test('a NULL status does not count, as SQL != gives', () async {
+    await db.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 's-null',
+        userId: const Value('ada'),
+        parentId: const Value('exam-1@ada'),
+      ), // status absent -> NULL
+      SubmissionsCompanion.insert(
+        id: 's-pending',
+        userId: const Value('ada'),
+        parentId: const Value('exam-1@ada'),
+        status: const Value('pending'),
+      ),
+      SubmissionsCompanion.insert(
+        id: 's-complete',
+        userId: const Value('ada'),
+        parentId: const Value('exam-1@ada'),
+        status: const Value('complete'),
+      ),
+    ]);
+    expect(
+      await db.submissionDao.countCompletedByUserAndExamId('ada', 'exam-1'),
+      1,
+    );
+    // The raw Kotlin statement, for comparison.
+    final raw = await db
+        .customSelect(
+          "SELECT COUNT(*) AS c FROM submissions WHERE user_id IS 'ada' "
+          "AND parent_id LIKE '%' || 'exam-1' || '%' AND status != 'pending'",
+        )
+        .getSingle();
+    expect(raw.read<int>('c'), 1);
+  });
+
+  test('a null userId matches the rows with no user, as IS does', () async {
+    await db.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 's-anon',
+        parentId: const Value('exam-1'),
+        status: const Value('complete'),
+      ),
+      SubmissionsCompanion.insert(
+        id: 's-ada',
+        userId: const Value('ada'),
+        parentId: const Value('exam-1'),
+        status: const Value('complete'),
+      ),
+    ]);
+    expect(
+      await db.submissionDao.countCompletedByUserAndExamId(null, 'exam-1'),
+      1,
+    );
+    expect(
+      await db.submissionDao.countCompletedByUserAndExamId('ada', 'exam-1'),
+      1,
+    );
+  });
+
+  test("an exam id with a quote does not inject", () async {
+    await db.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 's-1',
+        userId: const Value('ada'),
+        parentId: const Value("ex'am"),
+        status: const Value('complete'),
+      ),
+    ]);
+    expect(
+      await db.submissionDao.countCompletedByUserAndExamId('ada', "ex'am"),
+      1,
+    );
+    expect(
+      await db.submissionDao.countCompletedByUserAndExamId(
+        'ada',
+        "' OR 1=1 --",
+      ),
+      0,
+    );
+  });
+
+  test(
+    'getPlanetMessages folds case on both columns; NULL matches neither',
+    () async {
+      await db.newsDao.upsert(
+        NewsEntriesCompanion.insert(
+          id: 'n-1',
+          docType: const Value('MESSAGE'),
+          createdOn: const Value('EARTH'),
+        ),
+      );
+      await db.newsDao.upsert(
+        NewsEntriesCompanion.insert(id: 'n-2'),
+      ); // both NULL
+      await db.newsDao.upsert(
+        NewsEntriesCompanion.insert(
+          id: 'n-3',
+          docType: const Value('message'),
+          createdOn: const Value('mars'),
+        ),
+      );
+      expect((await db.newsDao.getPlanetMessages('earth')).map((r) => r.id), [
+        'n-1',
+      ]);
+      final raw = await db
+          .customSelect(
+            "SELECT id FROM news WHERE doc_type = 'message' COLLATE NOCASE "
+            "AND created_on = 'earth' COLLATE NOCASE",
+          )
+          .get();
+      expect(raw.map((r) => r.read<String>('id')), ['n-1']);
+    },
+  );
+
+  test('getByNewsId is case-sensitive, as the Kotlin query is', () async {
+    await db.newsDao.upsert(
+      NewsEntriesCompanion.insert(id: 'n-1', newsId: const Value('Chat-1')),
+    );
+    expect((await db.newsDao.getByNewsId('Chat-1')).map((r) => r.id), ['n-1']);
+    expect(await db.newsDao.getByNewsId('chat-1'), isEmpty);
+  });
+}

--- a/flutter/test/data/local/migration_test.dart
+++ b/flutter/test/data/local/migration_test.dart
@@ -1136,6 +1136,8 @@ void main() {
       'search_activity',
       'achievements',
       'user_challenge_actions',
+      'surveys',
+      'survey_questions',
     };
     expect(
       AppDatabase.localAuthorityTables,
@@ -1144,16 +1146,356 @@ void main() {
     );
   });
 
-  test('a survey cache is dropped, carrying no local writes', () async {
+  // `surveys` and `survey_questions` used to be dropped here, and the test
+  // above this one asserted it. They are preserved now — an adopted team
+  // survey clone that has not published exists nowhere else — so the rule the
+  // rest of the file pins applies instead: the row survives the bump, and the
+  // next walk's `deleteNotIn` evicts the stale cache half.
+  //
+  // The clone path itself is driven end-to-end through the production
+  // `adoptSurvey` in `survey_clone_survives_schema_bump_test.dart`; these two
+  // cover the DAO-level shape and the upgrade path's column reconciliation.
+  test(
+    'a survey the server sent survives the bump, walk-pruned after',
+    () async {
+      await database.surveyDao.upsertAll(
+        [SurveysCompanion.insert(id: 'survey-1', name: const Value('Survey'))],
+        const {
+          'survey-1': [
+            SurveyQuestionsCompanion(
+              id: Value('survey-1:q1'),
+              surveyId: Value('survey-1'),
+              header: Value('How was it?'),
+              position: Value(0),
+            ),
+          ],
+        },
+      );
+      // `isNull`/`isNotNull` are ambiguous here — drift exports its own.
+      expect(await database.surveyDao.getById('survey-1'), isA<SurveyRow>());
+
+      await runUpgrade();
+
+      expect(
+        await database.surveyDao.getById('survey-1'),
+        isA<SurveyRow>(),
+        reason: 'the migration no longer decides which survey rows are stale',
+      );
+      expect(await database.surveyDao.questionsFor('survey-1'), hasLength(1));
+
+      // The walk does, and it takes the question rows in the same transaction.
+      await database.surveyDao.deleteNotIn(const []);
+
+      expect(await database.surveyDao.getById('survey-1'), equals(null));
+      expect(await database.surveyDao.questionsFor('survey-1'), isEmpty);
+    },
+  );
+
+  /// The `surveys` and `survey_questions` DDL **frozen** at v47, the last
+  /// version that shipped before either table became preserved, minus the
+  /// columns later versions added.
+  ///
+  /// **Do not update these literals when a column is added to either table.**
+  /// They are the fixture that makes a forgotten [_addColumnIfMissing] step
+  /// fail loudly: a new Drift column absent from this text and absent from the
+  /// migration is absent from `PRAGMA table_info` after the upgrade, and the
+  /// two tests below say so. Keeping the literal in step with the table would
+  /// turn them into coverage that cannot fail — the thing Phase 122 fixed by
+  /// hand and Phase 134 found again.
+  ///
+  /// `_rev` is quoted because it is a drift-named column; the rest matches what
+  /// `Migrator.createTable` emits, `CHECK` constraints included, so a device
+  /// that upgrades is indistinguishable from one created fresh.
+  const surveysDdlBeforeV35 =
+      'CREATE TABLE "surveys" ("id" TEXT NOT NULL, "_rev" TEXT NULL, '
+      '"name" TEXT NULL, "description" TEXT NULL, '
+      '"created_date" INTEGER NOT NULL DEFAULT 0, '
+      '"updated_date" INTEGER NOT NULL DEFAULT 0, '
+      '"adoption_date" INTEGER NOT NULL DEFAULT 0, '
+      '"created_by" TEXT NULL, "total_marks" INTEGER NOT NULL DEFAULT 0, '
+      '"passing_percentage" TEXT NULL, "source_planet" TEXT NULL, '
+      '"is_from_nation" INTEGER NOT NULL DEFAULT 0 '
+      'CHECK ("is_from_nation" IN (0, 1)), "team_id" TEXT NULL, '
+      '"team_share_allowed" INTEGER NOT NULL DEFAULT 0 '
+      'CHECK ("team_share_allowed" IN (0, 1)), '
+      '"source_survey_id" TEXT NULL, PRIMARY KEY ("id"))';
+
+  const surveyQuestionsDdlFrozen =
+      'CREATE TABLE "survey_questions" ("id" TEXT NOT NULL, '
+      '"survey_id" TEXT NOT NULL, "question_id" TEXT NULL, '
+      '"header" TEXT NULL, "body" TEXT NULL, "type" TEXT NULL, '
+      '"choices" TEXT NOT NULL DEFAULT \'[]\', '
+      '"required" INTEGER NOT NULL DEFAULT 0 CHECK ("required" IN (0, 1)), '
+      '"position" INTEGER NOT NULL, PRIMARY KEY ("id"))';
+
+  /// The same literal with v35's two columns and without v47's — the shape a
+  /// handset running the last shipped build actually has on disk, and the one
+  /// the `needs_sync` backfill has to work from.
+  const surveysDdlBeforeV47 =
+      'CREATE TABLE "surveys" ("id" TEXT NOT NULL, "_rev" TEXT NULL, '
+      '"name" TEXT NULL, "description" TEXT NULL, '
+      '"created_date" INTEGER NOT NULL DEFAULT 0, '
+      '"updated_date" INTEGER NOT NULL DEFAULT 0, '
+      '"adoption_date" INTEGER NOT NULL DEFAULT 0, '
+      '"created_by" TEXT NULL, "total_marks" INTEGER NOT NULL DEFAULT 0, '
+      '"passing_percentage" TEXT NULL, "source_planet" TEXT NULL, '
+      '"is_from_nation" INTEGER NOT NULL DEFAULT 0 '
+      'CHECK ("is_from_nation" IN (0, 1)), "team_id" TEXT NULL, '
+      '"team_share_allowed" INTEGER NOT NULL DEFAULT 0 '
+      'CHECK ("team_share_allowed" IN (0, 1)), '
+      '"source_survey_id" TEXT NULL, "course_id" TEXT NULL, '
+      '"step_id" TEXT NULL, PRIMARY KEY ("id"))';
+
+  /// The columns the frozen literals carry, and the three the migration steps
+  /// are responsible for adding on top of them.
+  ///
+  /// Checked against the live table before the literals are installed, the way
+  /// [recreateTeamTasksWithoutV46Columns] checks its own hand-written shape.
+  /// There is no v34 schema artefact to read, so a *renamed or removed*
+  /// `Surveys` column would otherwise slip past the `containsAll` assertions
+  /// below — those catch an addition, not a rename. Exact equality here means a
+  /// new column fails at the fixture, before the outcome assertion, which is
+  /// the earliest and clearest place to be told a step is owed.
+  const frozenSurveyColumns = {
+    'id',
+    '_rev',
+    'name',
+    'description',
+    'created_date',
+    'updated_date',
+    'adoption_date',
+    'created_by',
+    'total_marks',
+    'passing_percentage',
+    'source_planet',
+    'is_from_nation',
+    'team_id',
+    'team_share_allowed',
+    'source_survey_id',
+  };
+  const migratedSurveyColumns = {'course_id', 'step_id', 'needs_sync'};
+
+  Future<Set<String>> columnsOf(String table) async {
+    final rows = await database.customSelect('PRAGMA table_info($table)').get();
+    return rows.map((row) => row.read<String>('name')).toSet();
+  }
+
+  /// Replaces the freshly-created tables with a frozen historical shape, the
+  /// way an on-device upgrade would find them. Dropping a table drops its
+  /// indexes, so `surveys_course_id` goes with the pre-v35 one — which is the
+  /// point: `createAll` recreates it with a bare `CREATE INDEX`, and that
+  /// aborts unless `course_id` is back by then.
+  Future<void> installSurveyShape(String surveysDdl) async {
+    await database.customStatement('SELECT 1');
+    expect(
+      await columnsOf('surveys'),
+      frozenSurveyColumns.union(migratedSurveyColumns),
+      reason: 'the frozen literals below have drifted from the live table',
+    );
+    await database.customStatement('DROP TABLE surveys');
+    await database.customStatement('DROP TABLE survey_questions');
+    await database.customStatement(surveysDdl);
+    await database.customStatement(surveyQuestionsDdlFrozen);
+  }
+
+  Future<void> installSurveyShapeBeforeV35() =>
+      installSurveyShape(surveysDdlBeforeV35);
+
+  test('a preserved survey table gains every column it is missing', () async {
+    await installSurveyShapeBeforeV35();
+    // A clone as a pre-v35 device would hold it: no course join, no rev.
+    await database.customStatement(
+      "INSERT INTO surveys (id, name, source_survey_id, team_id) "
+      "VALUES ('survey-1_team-1', 'Water needs - Team One', "
+      "'survey-1', 'team-1')",
+    );
+    await database.customStatement(
+      "INSERT INTO survey_questions (id, survey_id, header, position) "
+      "VALUES ('survey-1_team-1:q1', 'survey-1_team-1', 'How was it?', 0)",
+    );
+
+    await runUpgrade(from: 34);
+
+    expect(
+      await columnsOf('surveys'),
+      containsAll(database.surveys.$columns.map((column) => column.name)),
+      reason:
+          'a column with no migration step is absent on every upgrade, '
+          'and every query naming it fails — silently, until now',
+    );
+    expect(
+      await columnsOf('survey_questions'),
+      containsAll(
+        database.surveyQuestions.$columns.map((column) => column.name),
+      ),
+    );
+    // The row was preserved, not recreated — the whole reason for the steps.
+    final survivor = await database.surveyDao.getById('survey-1_team-1');
+    expect(survivor?.name, 'Water needs - Team One');
+    expect(survivor?.sourceSurveyId, 'survey-1');
+    expect(
+      await database.surveyDao.questionsFor('survey-1_team-1'),
+      hasLength(1),
+    );
+    // And the v47 step's backfill recognised it as this device's own work, so
+    // it publishes rather than sitting unswept until a prune reaches it. The
+    // rows that must *not* be flagged are covered separately below.
+    expect(
+      (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+      ['survey-1_team-1'],
+    );
+  });
+
+  // Inserts the four rows the `needs_sync` backfill has to tell apart, into a
+  // pre-v47 `surveys` table (so no `needs_sync` column to set). Shapes taken
+  // from their producers, not invented:
+  //
+  //  * `adoptSurvey` mints `id = '<sourceSurveyId>_<teamId>'` with an explicit
+  //    `_rev = null` and no `stepId` (`surveys_repository.dart:105`, `:144`).
+  //  * A survey the `exams` walk sent carries no `sourceSurveyId`.
+  //  * An adopted copy *Planet* published carries a `_rev`, and Kotlin mints
+  //    its clone ids with `UUID.randomUUID()`
+  //    (`SurveysRepositoryImpl.kt:85`), so it cannot match the id shape.
+  //  * A course-embedded survey carries a `stepId` from the courses walk.
+  //  * And the adversarial one, `survey-3_team-1`: a clone that *published*
+  //    and was then attached to a course step on Planet. The courses walk
+  //    writes it back with the clone's own id and `sourceSurveyId`, with a
+  //    `stepId`, and with `rev` NULL — a course document's embedded survey is
+  //    a sub-object and carries no `_rev` of its own (the ownership conflict
+  //    Phase 138 recorded at `SurveyMapper._build`). So it matches the id
+  //    shape *and* the rev clause, and `step_id IS NULL` is the only thing
+  //    that keeps the backfill from re-publishing a document the server
+  //    already has.
+  Future<void> insertPreV47SurveyRows() async {
+    await database.customStatement(
+      'INSERT INTO surveys (id, name, _rev, source_survey_id, team_id, '
+      'step_id, course_id) VALUES '
+      "('survey-1_team-1', 'Water needs - Team One', NULL, 'survey-1', "
+      "'team-1', NULL, 'course-1'), "
+      "('survey-1', 'Water needs', '3-server', NULL, NULL, NULL, NULL), "
+      "('a1b2c3d4-uuid', 'Kotlin clone', NULL, 'survey-1', 'team-2', "
+      'NULL, NULL), '
+      "('survey-9_team-1', 'Published clone', '2-abc', 'survey-9', "
+      "'team-1', NULL, NULL), "
+      "('survey-5', 'Step survey', NULL, NULL, NULL, 'course-1:0', "
+      "'course-1'), "
+      "('survey-3_team-1', 'Published clone on a step', NULL, 'survey-3', "
+      "'team-1', 'course-1:0', 'course-1')",
+    );
+  }
+
+  test(
+    'a clone adopted before v47 is handed to the uploader, not the prune',
+    () async {
+      // The defect this closes: preserving the table saves the row from the
+      // bump, and `needs_sync` then defaults to 0 — so
+      // `pendingAdoptedSurveys()` cannot see it and `deleteNotIn`'s spare clause
+      // (`stepId IS NULL AND needsSync = 0`) no longer covers it. The very next
+      // surveys walk deletes it. The loss would have been deferred, not
+      // prevented.
+      await installSurveyShape(surveysDdlBeforeV47);
+      await insertPreV47SurveyRows();
+
+      await runUpgrade(from: 46);
+
+      expect(
+        (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+        ['survey-1_team-1'],
+        reason:
+            'the id shape is a positive identification of a local clone — '
+            'and it is one Kotlin cannot make, since its clone ids are UUIDs',
+      );
+
+      // Which is also what keeps it out of the prune's reach.
+      await database.surveyDao.deleteNotIn(['survey-1', 'survey-9_team-1']);
+      expect(
+        await database.surveyDao.getById('survey-1_team-1'),
+        isA<SurveyRow>(),
+      );
+    },
+  );
+
+  test('the backfill leaves every row it cannot positively identify', () async {
+    await installSurveyShape(surveysDdlBeforeV47);
+    await insertPreV47SurveyRows();
+
+    await runUpgrade(from: 46);
+
+    // Flagging any of these would POST a survey this device did not author to
+    // `exams` under the user's credentials — the leak `Surveys.needsSync`
+    // exists to prevent, recreated by the repair meant to use it.
+    for (final id in const [
+      'survey-1',
+      'a1b2c3d4-uuid',
+      'survey-9_team-1',
+      'survey-5',
+      'survey-3_team-1',
+    ]) {
+      final row = await database.surveyDao.getById(id);
+      expect(row, isA<SurveyRow>(), reason: '$id was dropped');
+      expect(row!.needsSync, isFalse, reason: '$id must not be published');
+    }
+  });
+
+  test('the backfill does not touch a handset already on v47', () async {
+    // A v47 device's clone is already flagged, and the branch must not run
+    // again — `from < 47` is false. Nothing here should change.
     await database.surveyDao.upsertAll([
-      SurveysCompanion.insert(id: 'survey-1', name: const Value('Survey')),
+      SurveysCompanion.insert(
+        id: 'survey-2_team-1',
+        sourceSurveyId: const Value('survey-2'),
+        teamId: const Value('team-1'),
+      ),
     ], const {});
-    // `isNull`/`isNotNull` are ambiguous here — drift exports its own.
-    expect(await database.surveyDao.getById('survey-1'), isA<SurveyRow>());
 
-    await runUpgrade();
+    await runUpgrade(from: 47);
 
-    expect(await database.surveyDao.getById('survey-1'), equals(null));
+    expect(
+      (await database.surveyDao.getById('survey-2_team-1'))?.needsSync,
+      isFalse,
+      reason:
+          'the id shape alone is not authorship — on v47 the flag is '
+          'authoritative, and a row without it was not adopted here',
+    );
+  });
+
+  test('the surveys indexes are rebuilt on a preserved table', () async {
+    await installSurveyShapeBeforeV35();
+
+    await runUpgrade(from: 34);
+
+    final indexes = await database
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type = 'index' "
+          "AND tbl_name IN ('surveys', 'survey_questions')",
+        )
+        .get();
+    expect(
+      indexes.map((row) => row.read<String>('name')),
+      containsAll(<String>[
+        'surveys_created_date',
+        'surveys_course_id',
+        'survey_questions_survey',
+      ]),
+      reason:
+          'createAll emits a bare CREATE INDEX, so course_id has to exist '
+          'by the time it runs',
+    );
+  });
+
+  test('a table added after the running version is created complete', () async {
+    // The `_addColumnIfMissing` calls that precede `createAll` have to tolerate
+    // a table SQLite does not have yet — an upgrade from a version predating
+    // it. `createAll` then builds it with every column, so the steps no-op.
+    await database.customStatement('SELECT 1');
+    await database.customStatement('DROP TABLE surveys');
+
+    await runUpgrade(from: 34);
+
+    expect(
+      await columnsOf('surveys'),
+      containsAll(database.surveys.$columns.map((column) => column.name)),
+    );
   });
 
   test(

--- a/flutter/test/data/local/migration_test.dart
+++ b/flutter/test/data/local/migration_test.dart
@@ -1251,11 +1251,17 @@ void main() {
   ///
   /// Checked against the live table before the literals are installed, the way
   /// [recreateTeamTasksWithoutV46Columns] checks its own hand-written shape.
-  /// There is no v34 schema artefact to read, so a *renamed or removed*
-  /// `Surveys` column would otherwise slip past the `containsAll` assertions
-  /// below — those catch an addition, not a rename. Exact equality here means a
-  /// new column fails at the fixture, before the outcome assertion, which is
-  /// the earliest and clearest place to be told a step is owed.
+  /// There is no v34 schema artefact to read, so this is the only thing keeping
+  /// the literals honest.
+  ///
+  /// Exact equality, so a new column fails **at the fixture** rather than at
+  /// the outcome — the earliest and clearest place to be told a step is owed.
+  /// (A rename would red the `containsAll` assertions anyway, since the new
+  /// name is absent after the upgrade; a removal would not, but an extra column
+  /// on an upgraded table is harmless, because drift maps by name. So the value
+  /// here is the early, specific failure, not catching a case the outcome
+  /// assertions miss — an earlier revision of this comment claimed the latter
+  /// and was wrong on both halves.)
   const frozenSurveyColumns = {
     'id',
     '_rev',
@@ -1275,10 +1281,40 @@ void main() {
   };
   const migratedSurveyColumns = {'course_id', 'step_id', 'needs_sync'};
 
+  Future<String> liveDdl(String table) async {
+    final row = await database
+        .customSelect(
+          "SELECT sql FROM sqlite_master WHERE type = 'table' "
+          "AND name = '$table'",
+        )
+        .getSingle();
+    return row.read<String>('sql');
+  }
+
   Future<Set<String>> columnsOf(String table) async {
     final rows = await database.customSelect('PRAGMA table_info($table)').get();
     return rows.map((row) => row.read<String>('name')).toSet();
   }
+
+  /// The adoption marker `SurveysRepository.adoptSurvey` writes beside every
+  /// clone, via `createSurveyAdoptionSubmission`: `parentId` is the **source**
+  /// survey's id and `teamId` the team. The v47 backfill requires it, because
+  /// the clone id shape alone is not authorship — a publicly shared clone is
+  /// served back under the same id (see `app_database.dart`'s backfill, and
+  /// `survey_clone_survives_schema_bump_test.dart`, which drives that path
+  /// through the production `saveSurveyFromPublicApi` rather than a literal).
+  ///
+  /// Written by hand here because this file has no repository harness. The
+  /// production-driven version of the positive case lives in that other file;
+  /// what this fixture is for is the **negative** set.
+  Future<void> insertAdoptionMarker({
+    required String sourceId,
+    required String teamId,
+  }) => database.customStatement(
+    'INSERT INTO submissions (id, parent_id, team_id, type, status) '
+    "VALUES ('${sourceId}_${teamId}_adoption', '$sourceId', '$teamId', "
+    "'survey', '')",
+  );
 
   /// Replaces the freshly-created tables with a frozen historical shape, the
   /// way an on-device upgrade would find them. Dropping a table drops its
@@ -1291,6 +1327,25 @@ void main() {
       await columnsOf('surveys'),
       frozenSurveyColumns.union(migratedSurveyColumns),
       reason: 'the frozen literals below have drifted from the live table',
+    );
+    // The name set is not enough: a column whose *type* changed keeps its name,
+    // no `_addColumnIfMissing` step can ALTER a type, and every other
+    // assertion in this file would stay green while an upgraded device carried
+    // the old type and a fresh one the new. So compare the DDL text drift
+    // actually emits, which is what these literals claim to be.
+    expect(
+      await liveDdl('surveys'),
+      surveysDdlBeforeV47.replaceFirst(
+        ', PRIMARY KEY ("id"))',
+        ', "needs_sync" INTEGER NOT NULL DEFAULT 0 '
+            'CHECK ("needs_sync" IN (0, 1)), PRIMARY KEY ("id"))',
+      ),
+      reason: 'the frozen surveys DDL no longer matches what drift creates',
+    );
+    expect(
+      await liveDdl('survey_questions'),
+      surveyQuestionsDdlFrozen,
+      reason: 'the frozen survey_questions DDL no longer matches drift',
     );
     await database.customStatement('DROP TABLE surveys');
     await database.customStatement('DROP TABLE survey_questions');
@@ -1309,6 +1364,7 @@ void main() {
       "VALUES ('survey-1_team-1', 'Water needs - Team One', "
       "'survey-1', 'team-1')",
     );
+    await insertAdoptionMarker(sourceId: 'survey-1', teamId: 'team-1');
     await database.customStatement(
       "INSERT INTO survey_questions (id, survey_id, header, position) "
       "VALUES ('survey-1_team-1:q1', 'survey-1_team-1', 'How was it?', 0)",
@@ -1382,6 +1438,10 @@ void main() {
       "('survey-3_team-1', 'Published clone on a step', NULL, 'survey-3', "
       "'team-1', 'course-1:0', 'course-1')",
     );
+    // Only the first row gets a marker — this device adopted that one and
+    // nothing else. Its absence is what excludes every other row that happens
+    // to share the id shape.
+    await insertAdoptionMarker(sourceId: 'survey-1', teamId: 'team-1');
   }
 
   test(

--- a/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
+++ b/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
@@ -1,0 +1,182 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The upgrade-path half of `adopted_survey_survives_sync_test.dart`.
+///
+/// Phase 138 stopped `SurveyDao.deleteNotIn` destroying an adopted team survey
+/// clone on the next sync. It left the same loss reachable by an *upgrade*:
+/// `surveys` and `survey_questions` were not in
+/// [AppDatabase.localAuthorityTables] while `submissions`,
+/// `submission_answers` and `submission_questions` all are — so a schema bump
+/// on a handset that had adopted but not yet published dropped the clone and
+/// its questions and **kept** the members' answer sheets.
+///
+/// Nothing here fabricates a join, for the reason the sync-path test gives: the
+/// source survey comes out of `SurveyMapper.fromCourseDoc` reading a course
+/// document shaped like the server's, and the clone is produced by the
+/// production `adoptSurvey`.
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository submissions;
+  late SurveysRepository surveys;
+  late MockPlanetApi api;
+
+  const courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'Clean water',
+    'steps': [
+      {
+        'stepTitle': 'First',
+        'survey': {
+          '_id': 'survey-1',
+          'type': 'surveys',
+          'name': 'Water needs',
+          'teamShareAllowed': true,
+          'sourcePlanet': 'nation',
+          'questions': [
+            {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+          ],
+        },
+      },
+    ],
+  };
+
+  const cloneId = 'survey-1_team-1';
+
+  setUp(() async {
+    database = AppDatabase(NativeDatabase.memory());
+    api = MockPlanetApi();
+    submissions = SubmissionsRepository(
+      api,
+      database.submissionDao,
+      database.submitPhotosDao,
+      database.surveyDao,
+      database.examDao,
+      teamDao: database.teamDao,
+    );
+    surveys = SurveysRepository(
+      api,
+      database.surveyDao,
+      database.examDao,
+      submissions,
+    );
+
+    final parsed = CourseMapper.fromDoc(courseDoc)!;
+    await database.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      courseDoc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await database.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+    await surveys.adoptSurvey(
+      surveyId: 'survey-1',
+      userId: 'user-1',
+      userName: 'Ada',
+      teamId: 'team-1',
+      isTeam: true,
+      teamName: 'Team One',
+    );
+  });
+  tearDown(() => database.close());
+
+  /// The real bump a v47 handset is one release away from.
+  Future<void> runUpgrade({int from = 47}) async {
+    final migrator = database.createMigrator();
+    await database.migration.onUpgrade(migrator, from, database.schemaVersion);
+  }
+
+  test('an adopted, unpublished clone survives a schema bump', () async {
+    expect(await database.surveyDao.getById(cloneId), isNotNull);
+    expect(await database.surveyDao.questionsFor(cloneId), isNotEmpty);
+
+    await runUpgrade();
+
+    expect(
+      await database.surveyDao.getById(cloneId),
+      isNotNull,
+      reason: 'the clone exists nowhere but this handset until it publishes',
+    );
+    expect(
+      await database.surveyDao.questionsFor(cloneId),
+      isNotEmpty,
+      reason: 'a survey with no questions cannot be answered or reviewed',
+    );
+    expect(
+      (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+      contains(cloneId),
+      reason: 'needsSync must survive too, or the clone never publishes',
+    );
+  });
+
+  test(
+    "a member's answer sheet does not outlive the survey it answers",
+    () async {
+      await submissions.createBulkSurveySubmissions(cloneId, const [
+        'member-1',
+      ]);
+      final sheet = await database.submissionDao.latestPendingByUserAndParent(
+        'member-1',
+        '$cloneId@course-1',
+      );
+      expect(sheet, isNotNull, reason: 'Send writes the sheet under the clone');
+
+      await runUpgrade();
+
+      // `submissions` is preserved, so the sheet is still here. The defect was
+      // the asymmetry: it outlived its own survey.
+      expect(
+        await database.submissionDao.latestPendingByUserAndParent(
+          'member-1',
+          '$cloneId@course-1',
+        ),
+        isNotNull,
+      );
+      expect(
+        await database.surveyDao.getById(sheet!.parentId!.split('@').first),
+        isNotNull,
+        reason: 'an answer sheet whose survey is gone cannot be reviewed',
+      );
+    },
+  );
+
+  test(
+    'a published survey is kept by the bump and evicted by the walk',
+    () async {
+      // The `teams`/`meetups` precedent: preserve the whole table and let the
+      // next `deleteNotIn` evict the stale cache half. A published clone is a
+      // cache row again — `markUploaded` clears `needsSync` — so the walk that
+      // stops naming it is reporting a deletion this prune should honour.
+      await database.surveyDao.markUploaded(cloneId, '1-abc');
+
+      await runUpgrade();
+
+      expect(
+        await database.surveyDao.getById(cloneId),
+        isNotNull,
+        reason: 'the bump no longer decides which rows are stale',
+      );
+
+      await database.surveyDao.deleteNotIn(['survey-1']);
+
+      expect(
+        await database.surveyDao.getById(cloneId),
+        equals(null),
+        reason: 'the walk, not the migration, evicts a row the server dropped',
+      );
+      expect(await database.surveyDao.questionsFor(cloneId), isEmpty);
+    },
+  );
+}

--- a/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
+++ b/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
@@ -1,12 +1,20 @@
 import 'package:drift/native.dart';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/data/local/course_mapper.dart';
 import 'package:myplanet/data/local/survey_mapper.dart';
+import 'package:myplanet/repository/adopted_surveys_uploader.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/repository/submissions_repository.dart';
 import 'package:myplanet/repository/surveys_repository.dart';
+
+import '../../repository/device_identity_fixture.dart';
 
 class MockPlanetApi extends Mock implements PlanetApi {}
 
@@ -28,7 +36,14 @@ void main() {
   late AppDatabase database;
   late SubmissionsRepository submissions;
   late SurveysRepository surveys;
+  late OutboxRepository outbox;
+  late AdoptedSurveysUploader uploader;
   late MockPlanetApi api;
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
 
   const courseDoc = {
     '_id': 'course-1',
@@ -68,6 +83,13 @@ void main() {
       database.surveyDao,
       database.examDao,
       submissions,
+    );
+    outbox = OutboxRepository(database.outboxDao);
+    uploader = AdoptedSurveysUploader(
+      api,
+      database.surveyDao,
+      outbox,
+      testDeviceIdentity,
     );
 
     final parsed = CourseMapper.fromDoc(courseDoc)!;
@@ -148,6 +170,103 @@ void main() {
         await database.surveyDao.getById(sheet!.parentId!.split('@').first),
         isNotNull,
         reason: 'an answer sheet whose survey is gone cannot be reviewed',
+      );
+    },
+  );
+
+  /// The one row the v47 backfill flags that this device did **not** author,
+  /// and why it is accepted rather than predicated away.
+  ///
+  /// The backfill identifies its own work by the port's deterministic clone id
+  /// (`'<sourceSurveyId>_<teamId>'`, which Kotlin's `UUID.randomUUID()` cannot
+  /// collide with). A row can satisfy that *and* `_rev IS NULL` *and*
+  /// `step_id IS NULL` without being local work, through one route:
+  ///
+  ///  1. another handset at v47+ publishes the clone, so the document exists;
+  ///  2. it is attached to a course step on Planet, and this handset's courses
+  ///     walk writes the row back — `SurveyMapper._build` assigns `rev`
+  ///     unconditionally and a course sub-object carries no `_rev`, so the
+  ///     authoritative revision is clobbered to NULL (the two-writer conflict
+  ///     Phase 138 recorded and did not fix);
+  ///  3. the course document stops naming it, and
+  ///     `releaseStepJoinsForCourse` nulls `stepId` **and** `courseId`;
+  ///  4. *then* this handset upgrades off its pre-v47 build.
+  ///
+  /// **`rev` is the only column that records "the server has this", and it is
+  /// exactly the column those two writers disagree about** — so there is no
+  /// local discriminator left to add. Narrowing on `courseId` would miss a
+  /// genuine clone of a course-attached survey (`adoptSurvey` copies
+  /// `courseId`), and requiring the adoption-marker submission would miss a
+  /// clone adopted with no `userId`.
+  ///
+  /// So it is left, because the cost is bounded and self-clearing: the POST
+  /// takes a 409, and Phase 138's `_adoptExistingDocument` GETs the winning
+  /// document, records its rev and clears the flag. One POST and one GET,
+  /// once — after which the row rejoins the prune. Pinned as a **pair** rather
+  /// than asserted, because each half passing alone is the shape this project
+  /// keeps getting wrong.
+  test(
+    'a flagged row the server already has is resolved by the 409 arm',
+    () async {
+      // Step 3's outcome, written straight into the table: the shape a pre-v47
+      // database actually holds when it reaches step 4.
+      await database.customStatement('DELETE FROM surveys');
+      await database.customStatement(
+        'INSERT INTO surveys (id, name, _rev, source_survey_id, team_id, '
+        'step_id, course_id, needs_sync) VALUES '
+        "('survey-3_team-9', 'Other handset clone', NULL, 'survey-3', "
+        "'team-9', NULL, NULL, 0)",
+      );
+
+      await runUpgrade(from: 46);
+
+      expect(
+        (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+        ['survey-3_team-9'],
+        reason: 'the misfire is real; what follows is why it is accepted',
+      );
+
+      // Drain it. The document exists, so the POST conflicts.
+      expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+      final operation = (await outbox.due()).single;
+      when(
+        () => api.postJsonObject(
+          operation.endpoint,
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const NetworkError<Map<String, dynamic>>(409, 'Document conflict'),
+      );
+      when(
+        () => api.getJsonObject(
+          '${operation.endpoint}/survey-3_team-9',
+          authHeader: 'Basic x',
+        ),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': 'survey-3_team-9',
+          '_rev': '4-winner',
+        }),
+      );
+
+      expect(
+        await uploader.handler(
+          operation,
+          jsonDecode(operation.payload) as Map<String, dynamic>,
+          'Basic x',
+        ),
+        isA<NetworkSuccess<Map<String, dynamic>>>(),
+      );
+
+      final row = (await database.surveyDao.getById('survey-3_team-9'))!;
+      expect(row.rev, '4-winner');
+      expect(row.needsSync, isFalse, reason: 'the flag must not persist');
+      expect(
+        await database.surveyDao.pendingAdoptedSurveys(),
+        isEmpty,
+        reason: 'one POST and one GET, once — not one per sync forever',
       );
     },
   );

--- a/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
+++ b/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/native.dart';
 import 'dart:convert';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/config/server_config.dart';
@@ -174,42 +175,178 @@ void main() {
     },
   );
 
-  /// The one row the v47 backfill flags that this device did **not** author,
-  /// and why it is accepted rather than predicated away.
+  /// A survey another planet shared publicly must never be flagged, and this
+  /// is the row that made the first cut of the backfill unsafe.
   ///
-  /// The backfill identifies its own work by the port's deterministic clone id
-  /// (`'<sourceSurveyId>_<teamId>'`, which Kotlin's `UUID.randomUUID()` cannot
-  /// collide with). A row can satisfy that *and* `_rev IS NULL` *and*
-  /// `step_id IS NULL` without being local work, through one route:
+  /// A public survey link is `/survey/<teamId>/<surveyId>` and the `surveyId`
+  /// in it *is* a team's adopted clone — so the document
+  /// `saveSurveyFromPublicApi` stores carries the clone's own id,
+  /// `sourceSurveyId` and `teamId` (`AdoptedSurveysUploader.documentFor` ->
+  /// `SubmissionsRepository.surveyParentDocument`, which emits `_rev` only
+  /// `if (survey.rev != null)`). Whether the row ends up with a NULL `rev`
+  /// therefore depends on what a *remote* Planet chooses to send back, which
+  /// this repository cannot check — and that is the argument on its own: a
+  /// predicate whose safety rests on a server including a field is not safe.
   ///
-  ///  1. another handset at v47+ publishes the clone, so the document exists;
-  ///  2. it is attached to a course step on Planet, and this handset's courses
-  ///     walk writes the row back — `SurveyMapper._build` assigns `rev`
-  ///     unconditionally and a course sub-object carries no `_rev`, so the
-  ///     authoritative revision is clobbered to NULL (the two-writer conflict
-  ///     Phase 138 recorded and did not fix);
-  ///  3. the course document stops naming it, and
-  ///     `releaseStepJoinsForCourse` nulls `stepId` **and** `courseId`;
-  ///  4. *then* this handset upgrades off its pre-v47 build.
+  /// The harm was not the bounded, self-clearing kind either. The document
+  /// lives on the **link's origin** planet, while
+  /// `AdoptedSurveysUploader.endpointFor` POSTs to the **configured** server,
+  /// which has no document under that id — so the POST *succeeds*, and a
+  /// survey this device never authored is created in the user's own `exams`
+  /// database under their credentials, stamped with this handset's origin
+  /// fields. That is the leak `Surveys.needsSync` was introduced to close,
+  /// reopened for one upgrade by the migration that installs the column.
   ///
-  /// **`rev` is the only column that records "the server has this", and it is
-  /// exactly the column those two writers disagree about** — so there is no
-  /// local discriminator left to add. Narrowing on `courseId` would miss a
-  /// genuine clone of a course-attached survey (`adoptSurvey` copies
-  /// `courseId`), and requiring the adoption-marker submission would miss a
-  /// clone adopted with no `userId`.
+  /// Closed by requiring the **adoption marker** `adoptSurvey` writes
+  /// alongside the clone (`createSurveyAdoptionSubmission`: `parentId` is the
+  /// *source* id, `teamId` the team). It is positive evidence of an action
+  /// *this device took*, in a preserved table, which is what the v45 health
+  /// repair's `EXISTS` conjunct is too — and unlike `rev` it has one writer.
   ///
-  /// So it is left, because the cost is bounded and self-clearing: the POST
-  /// takes a 409, and Phase 138's `_adoptExistingDocument` GETs the winning
-  /// document, records its rev and clears the flag. One POST and one GET,
-  /// once — after which the row rejoins the prune. Pinned as a **pair** rather
-  /// than asserted, because each half passing alone is the shape this project
-  /// keeps getting wrong.
+  /// The document is not hand-written: it goes through the production
+  /// `saveSurveyFromPublicApi`, because the first cut's negative fixtures were
+  /// hand-written `INSERT`s and that is precisely why they missed this.
+  test('a publicly shared clone from another planet is never flagged', () async {
+    final saved = await surveys.saveSurveyFromPublicApi({
+      '_id': 'survey-7_team-7',
+      'type': 'surveys',
+      'name': 'Borehole survey - Team Seven',
+      // Absent, as `surveyParentDocument` emits it only for a non-null rev and
+      // as `Surveys.rev`'s own doc-comment says every public-API survey is.
+      'sourceSurveyId': 'survey-7',
+      'teamId': 'team-7',
+      'questions': [
+        {'id': 'q1', 'title': 'Is the pump working?', 'type': 'input'},
+      ],
+    });
+    expect(saved, isNotNull);
+    expect(saved!.rev, equals(null), reason: 'the premise of the leak');
+    expect(saved.needsSync, isFalse);
+    expect(saved.stepId, equals(null));
+
+    // And the harder one: another team's public clone of the **same source
+    // survey this device did adopt**. A marker for `survey-1` exists (from
+    // `setUp`), so matching the marker on `parentId` alone would flag this —
+    // two teams adopting one shared survey is the ordinary case, not a corner.
+    // It is the `teamId` half of the marker match that excludes it.
+    final otherTeam = await surveys.saveSurveyFromPublicApi({
+      '_id': 'survey-1_team-5',
+      'type': 'surveys',
+      'name': 'Water needs - Team Five',
+      'sourceSurveyId': 'survey-1',
+      'teamId': 'team-5',
+      'questions': [
+        {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+      ],
+    });
+    expect(otherTeam, isNotNull);
+
+    await runUpgrade(from: 46);
+
+    expect(
+      (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+      isNot(contains('survey-7_team-7')),
+      reason:
+          "this handset never adopted for team-7, so there is no marker "
+          'and no claim to publish the document',
+    );
+    expect(
+      (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+      isNot(contains('survey-1_team-5')),
+      reason: 'the marker is for team-1; team-5 adopted on its own handset',
+    );
+    // The genuine clone from `setUp`, which does have a marker, is untouched.
+    expect(
+      (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+      contains(cloneId),
+    );
+  });
+
+  /// `Surveys.needsSync` is preserved across a re-pull by **omission**, and
+  /// nothing pinned that until now.
+  ///
+  /// Neither `SurveyMapper` writer mentions the column, so
+  /// `insertOnConflictUpdate` writes only the columns the companion carries and
+  /// leaves the stored flag alone. That is the whole mechanism — there is no
+  /// `existing…` parameter here, so the static guard in
+  /// `mapper_preserves_local_columns_test.dart` cannot see it, and the 409
+  /// tests do not re-pull.
+  ///
+  /// It matters more now that `surveys` is preserved: if a later round
+  /// "completes" the mapper with `needsSync: Value(false)` — the natural thing
+  /// to do when filling in a companion — an unpublished clone would drop out of
+  /// `pendingAdoptedSurveys` on the next walk that names its id and never
+  /// publish. Same shape as Phase 56's credentials, Phase 74's reactions and
+  /// Phase 98's read flag: a sync-in writing over a column the server knows
+  /// nothing about.
+  ///
+  /// The document here is the one that reaches this handset in the two-leader
+  /// case `_adoptExistingDocument` exists for: another leader adopted the same
+  /// source for the same team and published first, so the walk delivers a
+  /// document under the port's deterministic clone id while this device's own
+  /// row is still pending.
+  test('a re-pull under the clone id leaves needsSync alone', () async {
+    final before = (await database.surveyDao.getById(cloneId))!;
+    expect(before.needsSync, isTrue, reason: 'adoptSurvey sets the flag');
+
+    final mapped = SurveyMapper.fromDoc({
+      '_id': cloneId,
+      '_rev': '1-otherleader',
+      'type': 'surveys',
+      'name': 'Water needs - Team One',
+      'teamId': 'team-1',
+      'sourceSurveyId': 'survey-1',
+      'questions': [
+        {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+      ],
+    })!;
+    await database.surveyDao.upsertAll(
+      [mapped.survey],
+      {mapped.survey.id.value: mapped.questions},
+    );
+
+    final after = (await database.surveyDao.getById(cloneId))!;
+    expect(
+      after.rev,
+      '1-otherleader',
+      reason: 'the walk is authoritative for the columns it does carry',
+    );
+    expect(
+      after.needsSync,
+      isTrue,
+      reason:
+          'and must not touch the one it does not — the row stays this '
+          "device's to reconcile, which the 409 arm then does",
+    );
+    expect(
+      (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+      contains(cloneId),
+    );
+  });
+
+  /// The other route to a row that looks like local work, and it is closed by
+  /// the same conjunct as the public-API one.
+  ///
+  /// A clone another handset published, which Planet then attached to a course
+  /// step, arrives with the clone's own id and `sourceSurveyId` and with `rev`
+  /// **NULL** — `SurveyMapper._build` assigns `rev` unconditionally and a
+  /// course document's embedded survey is a sub-object carrying no `_rev` of
+  /// its own (the two-writer conflict Phase 138 recorded and did not fix).
+  /// Once the course stops naming it, `releaseStepJoinsForCourse` nulls
+  /// `stepId` **and** `courseId`. Every conjunct but the marker then holds.
+  ///
+  /// Which is the point worth keeping: `rev` cannot carry this weight, because
+  /// it is the one column two sync walks disagree about the ownership of. The
+  /// adoption marker can, because it has exactly one writer.
+  ///
+  /// And where the marker *is* present, flagging is right rather than wrong:
+  /// both leaders genuinely adopted, the port's deterministic id makes them
+  /// converge on one document by design, and the 409 arm reconciles them —
+  /// which the second half of this test drives, so the mitigation is pinned
+  /// alongside the exclusion rather than assumed.
   test(
-    'a flagged row the server already has is resolved by the 409 arm',
+    'a step-released clone is flagged only if this device adopted it',
     () async {
-      // Step 3's outcome, written straight into the table: the shape a pre-v47
-      // database actually holds when it reaches step 4.
       await database.customStatement('DELETE FROM surveys');
       await database.customStatement(
         'INSERT INTO surveys (id, name, _rev, source_survey_id, team_id, '
@@ -221,12 +358,49 @@ void main() {
       await runUpgrade(from: 46);
 
       expect(
-        (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
-        ['survey-3_team-9'],
-        reason: 'the misfire is real; what follows is why it is accepted',
+        await database.surveyDao.pendingAdoptedSurveys(),
+        isEmpty,
+        reason: 'no marker for team-9: this handset never adopted survey-3',
       );
 
-      // Drain it. The document exists, so the POST conflicts.
+      // Now the marker a real local adoption leaves — written by the
+      // production `adoptSurvey`, not by hand. This is the convergence case
+      // exactly: the source survey is on the device and the other handset's
+      // clone already sits under the deterministic id, so `adoptedTeamSurvey`
+      // finds it and mints no second clone — but the marker is still written,
+      // because that half is gated only on the user.
+      await database.surveyDao.upsertAll([
+        SurveysCompanion.insert(
+          id: 'survey-3',
+          name: const Value('Borehole survey'),
+          teamShareAllowed: const Value(true),
+        ),
+      ], const {});
+      await surveys.adoptSurvey(
+        surveyId: 'survey-3',
+        userId: 'user-1',
+        userName: 'Ada',
+        teamId: 'team-9',
+        isTeam: true,
+        teamName: 'Team Nine',
+      );
+      expect(
+        (await database.surveyDao.getById('survey-3_team-9'))!.needsSync,
+        isFalse,
+        reason:
+            'no second clone was minted, so the flag is still the pulled '
+            "row's — which is what makes the backfill the thing under test",
+      );
+
+      await runUpgrade(from: 46);
+
+      expect(
+        (await database.surveyDao.pendingAdoptedSurveys()).map((row) => row.id),
+        contains('survey-3_team-9'),
+        reason: 'with the marker it is this device\'s to reconcile',
+      );
+
+      // And reconciling it is a 409, because the other handset published first.
       expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
       final operation = (await outbox.due()).single;
       when(
@@ -262,7 +436,7 @@ void main() {
 
       final row = (await database.surveyDao.getById('survey-3_team-9'))!;
       expect(row.rev, '4-winner');
-      expect(row.needsSync, isFalse, reason: 'the flag must not persist');
+      expect(row.needsSync, isFalse);
       expect(
         await database.surveyDao.pendingAdoptedSurveys(),
         isEmpty,


### PR DESCRIPTION
**Lane B of the Phase 143 four-lane round. Draft, open for the integrator's comments — this is the only inbound channel this session has.**

## The hole

Phase 138 stopped `SurveyDao.deleteNotIn` destroying an adopted team survey clone on the next sync, but `surveys` and `survey_questions` are still not in `localAuthorityTables` while `submissions`, `submission_answers` and `submission_questions` all are. So a schema bump on a handset that has adopted but not yet published drops the clone and its questions and **keeps** the members' answer sheets — the same orphaning Phase 138 removed from the sync path, reachable by an upgrade instead. v47, shipped last round, is such a bump.

## Scope

- `flutter/lib/data/local/app_database.dart`
- `flutter/lib/data/local/tables.dart`
- migration/preservation tests
- `flutter/PHASE_143_NOTES.md`

Deliverable is not two lines in a set: both tables' columns audited against the upgrade path with the `_addColumnIfMissing` steps preservation now requires, a migration test that **can fail** (mutation-tested), and a stated decision on handsets already upgraded to v47.

Files owned by Lanes A/C/D are untouched; anything needing them is recorded in the notes' *Reported, not fixed* section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191jzF181CB2utXNauXpZ46

---
_Generated by [Claude Code](https://claude.ai/code/session_0191jzF181CB2utXNauXpZ46)_