### PR TITLE
Phase 146: ingest a course step's embedded resources into my_library

### DIFF
--- a/flutter/PHASE_146_NOTES.md
+++ b/flutter/PHASE_146_NOTES.md
@@ -125,24 +125,23 @@ stamp matches no live step and merely dangles. **The port's exposure is a false
 join where Kotlin's is accretion**, which is the difference between a wrong
 answer and a harmless one — so this needed fixing rather than documenting.
 
-`MyLibraryDao.releaseStepJoinsForCourse` is the direct analogue of
-`ExamDao.releaseStepJoinsForCourse`, whose own doc comment already explains this
-hazard for its table. Three details are not copied blindly:
+**The fix is not the one the exam and survey tables use, and the second audit is
+why.** Those DAOs carry a `releaseStepJoinsForCourse` that clears the joins a
+course's document no longer claims, and this phase shipped that shape first. It
+does not hold here, for two reasons the audit surfaced: `course_steps` has a
+second writer (`ShelfSyncRepository._pullShelfCourses`) that discards the
+resources, and — the reason the narrow version is wrong even in the courses
+walk — clearing only *vanished* step ids misses the actual hazard, because a
+deleted step's id does not vanish, it is inherited by the step that shifted up.
 
-* It runs for **every** course on the page, not only those that still have
-  resources — otherwise removing a course's last resource never clears the join.
-  (Mutation 6 pins this.)
-* Its keep set is the **union across the whole document**, so a resource
-  appearing in two steps is not un-stamped by the release that follows the
-  upsert that just wrote it.
-* It nulls `courseId` alongside `stepId`. For the exam and survey tables that
-  reads as symmetry; here it is the only correct choice, because
-  `getCourseResources` and `getByCourseId` read `courseId` on its own, so a
-  stale one would keep over-filling the course download dialog. (Mutation 5.)
-
-And it is a partial-column update, never `toCompanion` — `my_library` rows carry
-`userId`, `resourceOffline`, `downloadedRev` and `resourceLocalAddress` that a
-whole-row write would clobber.
+So `CourseDao.upsertAll` releases **every** stamp for each course it writes, and
+the courses walk re-stamps immediately after. The invariant is *only a writer
+that has the step's resources may leave a stamp standing*. It is a
+partial-column update, never `toCompanion` — `my_library` rows carry `userId`,
+`resourceOffline`, `downloadedRev` and `resourceLocalAddress` that a whole-row
+write would clobber — and it nulls `courseId` alongside `stepId`, because
+`getCourseResources` reads `courseId` on its own and a stale one would keep
+over-filling the course download dialog.
 
 ## The preservation mechanism, and why it is thinner than Kotlin's
 
@@ -226,16 +225,16 @@ so a failure in one shelf's flush discards another shelf's queued items.
 
 | file | change |
 |---|---|
-| `lib/data/local/tables.dart` | `MyLibraryTable` += `stepId`, `courseId` |
-| `lib/data/local/app_database.dart` | `schemaVersion` 48; `MyLibraryDao` += `getByStepId`, `getByCourseId`, `getCourseResources`, `releaseStepJoinsForCourse`; `deleteNotIn` eligibility guards; `CourseDao` += `existingResources`, `upsertCourseResources` |
+| `lib/data/local/tables.dart` | `MyLibraryTable` += `stepId`, `courseId`, and a `course_id` index |
+| `lib/data/local/app_database.dart` | `schemaVersion` 48; `MyLibraryDao` += `getByStepId`, `getCourseResources`; `deleteNotIn` eligibility guards; `CourseDao` += `existingResources`, `upsertCourseResources`, and the whole-course stamp release in `upsertAll` |
 | `lib/data/local/course_mapper.dart` | `CourseResourceDoc`, `ParsedCourse.resources`, `_parseStepResources` |
-| `lib/data/local/my_library_mapper.dart` | `stepId`/`courseId` params, `_stampOrAbsent` |
+| `lib/data/local/my_library_mapper.dart` | `stepId`/`courseId` params, `_stampOrAbsent`, and the attachment-address clobber fix |
 | `lib/repository/courses_repository.dart` | `_ingestCourseResources`, wired into the page loop |
 | `lib/repository/resources_repository.dart` | `getAllStepResources`, `getCourseResources` |
-| `test/repository/course_step_resources_test.dart` | new, 12 tests |
+| `test/repository/course_step_resources_test.dart` | new, 17 tests |
 | `test/repository/resource_prune_eligibility_test.dart` | new, 3 tests |
 | `test/data/local/course_mapper_test.dart` | +5 tests |
-| `test/data/local/my_library_mapper_test.dart` | +3 tests |
+| `test/data/local/my_library_mapper_test.dart` | +4 tests, one existing test's expectation moved |
 | `test/data/local/migration_test.dart` | +3 tests, frozen v47 `my_library` DDL |
 | `test/repository/resources_repository_test.dart` | `row()` fixture emits a `_rev` |
 
@@ -261,11 +260,13 @@ Every fix reverted, every test replayed.
 | # | mutation | reds |
 |---|---|---|
 | 1 | `_stampOrAbsent` returns `Value(null)` instead of `Value.absent()` | 3 tests, across 2 files — including the resources-re-pull round trip |
-| 2 | drop the `releaseStepJoinsForCourse` call | 2 tests |
+| 2 | drop the whole-course stamp release in `CourseDao.upsertAll` | 3 tests |
 | 3 | stop passing `existingUserIds` to the ingestion mapper call | 2 tests — the mechanical guard *and* the behavioural one |
 | 4 | revert the `deleteNotIn` eligibility guards | 3 tests |
-| 5 | release nulls `stepId` only, leaving a stale `courseId` | 2 tests |
-| 6 | seed the keep set only for courses that still have resources | 1 test |
+| 5 | release only the stamps whose step id has vanished | 1 test — **this was the first fix, and the test rejected it** |
+| 11 | `getCourseResources` drops `resourceLocalAddress IS NOT NULL` | 1 test — **survived until the audit; fixture added** |
+| 12 | `getCourseResources` drops the `isOffline` conjunct | 2 tests — **same** |
+| 13 | attachment addresses written unconditionally again | 2 tests |
 | 7 | drop the blank/`_design` resource-id filter | 2 tests — **after a fixture was added; see below** |
 | 8 | add `my_library` to `localAuthorityTables` | 5 tests |
 | 9 | remove the ingestion call from the walk (the original defect) | 4+ tests |
@@ -284,6 +285,103 @@ mutation red at both levels.
 **Mutation 10 was a non-red by accident**, the different and worse kind: a
 migration test that reads as coverage while being blind to whether the migration
 runs. Fixed rather than recorded.
+
+## What the second audit changed
+
+Aimed at the finished, already-green code. **Seventh consecutive round in which
+it found something**, and this time the top finding was a data loss the phase
+itself created.
+
+### The courses walk was nulling the download pointer on every sync
+
+`MyLibraryMapper.fromDoc` wrote `resourceRemoteAddress` and
+`resourceLocalAddress` **unconditionally**, as `Value(attachment?.…)`. Kotlin
+writes them only inside `if (params.doc.has("_attachments"))` and only for an
+attachment key with no `/` (`MyLibrary.kt:243`, `:260-262`), so an absent
+`_attachments`, an empty one, or one whose keys are all nested leaves the stored
+values alone.
+
+Latent since the resources walk landed, because that walk always sees the full
+document. **This phase made it live**: the courses walk is now a second writer
+of the same rows from a *thinner* document, and `resources` (area 0) runs before
+`courses` (area 1), so the clobber was the state left after every sync. The
+shape that triggers it is one myPlanet itself uploads —
+`MyLibrary.serializeResource` builds `_attachments` from
+`resourceLocalAddress?.let{…}`, so a device that has not downloaded the file
+emits `"_attachments": {}`.
+
+Result: the row claimed `resourceOffline` with no path to the file, the resource
+detail screen took its no-file branch, and **the phase's own new reader**
+`getCourseResources(courseId, isOffline: true)` returned nothing. Fixed by
+returning `Value.absent()` when the document carries no usable attachment —
+the same mechanism the stamp itself relies on. A second, smaller correction came
+with it: an unusable `couchDbUrl` now drops only the *remote* address, where it
+used to discard the attachment name too, losing the filename over a bad server
+URL that Kotlin keeps (`MyLibrary.kt:262` assigns it unconditionally).
+
+### The stale-join fix was the wrong shape, and its own test proved it
+
+Phase 146 shipped `MyLibraryDao.releaseStepJoinsForCourse`, mirroring the exam
+and survey DAOs: clear the stamps a course's document no longer claims. The
+audit pointed out that `ShelfSyncRepository._pullShelfCourses` is a **second
+writer of `course_steps`** — it shrinks the step list through
+`CourseDao.upsertAll` and discards the parsed resources — so on a shelf-only
+sync (the sync centre's per-tile retry) nothing releases anything.
+
+The first fix attempt was to release, inside `upsertAll`, the stamps whose step
+id no longer exists. **The test written for it failed, and the failure was the
+point:** deleting step A does not make `c1:0` disappear, it hands `c1:0` to
+step B. `res-1` still named a live step id, so the narrow release left the false
+join exactly where it was.
+
+So the rule changed to the one the situation actually implies: **only a writer
+that has the step's resources may leave a stamp standing.** `CourseDao.upsertAll`
+now releases *every* stamp for each course it writes, and the courses walk
+re-stamps immediately afterwards. A shelf-only sync therefore yields an empty
+inline resource list until the next courses walk, which is a cost worth paying
+to make a wrong list unreachable.
+
+That made `releaseStepJoinsForCourse` and its keep-set plumbing redundant —
+every case it covered is covered by "cleared, then not re-stamped" — so both are
+deleted rather than kept as a second mechanism nothing can pin. The phase's
+diff is smaller than it was before the audit.
+
+### Two predicates nothing pinned
+
+The audit mutated `getCourseResources`' two new conjuncts and **all 158 tests
+passed either way**: the reader would have been `WHERE course_id = ?` and the
+suite would not have noticed. The one test calling it only ever asked
+`isOffline: false` and never seeded a downloaded row, so the split that is the
+entire reason Kotlin has two methods was unexercised. Three tests now cover the
+offline list, the online list, and a resource with no attachment at all; both
+mutations red.
+
+### A claim of parity that was not parity
+
+`resource_prune_eligibility_test.dart` said the empty-walk branch was a port of
+Kotlin's `deleteAllStalePublic`. That function is **unreachable in Kotlin**: its
+only caller is the `else` of `removeDeletedResources`' `if
+(validCurrentIds.isNotEmpty())`, and `removeDeletedResources` itself runs only
+when `validNewIds.isNotEmpty()` (`SyncManager.kt:416`). So when the `resources`
+database reports zero documents Kotlin deletes **nothing**, while the port
+deletes every public synced row. The guards this phase added narrow that from
+the whole table to the synced-and-public part; they do not make it parity. The
+claim is corrected in both the test and the DAO doc, and the remaining
+divergence is reported below rather than relabelled.
+
+### Smaller corrections
+
+* An index on `my_library.course_id`. The stale-join release runs once per
+  course per page — up to 50 unindexed scans of the table per page, where Kotlin
+  has no release step at all. The comment justifying "not indexed" as parity
+  with Kotlin's `@Entity` list was citing the wrong thing, and is rewritten.
+* `MyLibraryDao.getByCourseId` had no caller anywhere, tests included. Deleted.
+* `deleteNotIn`'s doc claimed `saveLocalResource` writes "a UUID id and no
+  `resourceId`". It writes `resourceId: Value(id)`. No port writer makes the two
+  differ; the conclusion was safer than its stated reason, which is now correct.
+* `_parseStepResources`' doc said `insertMyLibrary` "returns a row only for an
+  empty document" — the opposite of the argument it supports. It bails out only
+  on an empty document.
 
 ## Reported, not fixed
 
@@ -313,11 +411,20 @@ runs. Fixed rather than recorded.
    was verified: `DashboardSyncArea` is ordered with `shelf` last, deliberately,
    and `syncAll` iterates declaration order. **One hole:**
    `DashboardSyncNotifier.retry(DashboardSyncArea.shelf)` — the sync centre's
-   per-tile retry button — runs the shelf pull with no courses walk, so a course
-   newly added to the shelf keeps its steps and gains no resource stamps until
-   the next full sync. Nothing is lost or corrupted (the shelf's own `my_library`
-   writes leave both columns absent); it is staleness. Fix is one line in that
-   file, in the shape of this phase's `_ingestCourseResources`.
+   per-tile retry button — runs the shelf pull with no courses walk.
+
+   **The first draft of this item said "nothing is lost or corrupted … it is
+   staleness", and the second audit showed that was wrong.** That path rewrites
+   `course_steps` through `CourseDao.upsertAll`, so a step deletion shifts the
+   positional ids while nothing revalidates the stamps: a deleted step's
+   resource would surface under the live step that inherited its id, and the
+   auto-download would fetch it. The corruption half is closed here, in this
+   lane's own file — `upsertAll` releases every stamp for the courses it writes,
+   so that path now leaves none standing rather than leaving wrong ones. What
+   remains is genuinely staleness: after a shelf-only retry the inline resource
+   list is empty until the next courses walk. Closing that is one call in
+   `shelf_sync_repository.dart`, in the shape of this phase's
+   `_ingestCourseResources`.
 3. **The port has no `reconcileHtmlResourceOffline`, anywhere.** Kotlin calls it
    from the course-resource drain (`CoursesRepositoryImpl.kt:852-861`) *and* from
    both `resources`-walk sites via `reconcileHtmlLibraries` (`:660`, `:703`). It
@@ -335,7 +442,36 @@ runs. Fixed rather than recorded.
    `serializeTeamDocument` carries no `courses` array), so this is latent — but
    whoever ports team-document upload inherits a correctness dependency on the
    stamp, and should read the release-joins reasoning above first.
-5. **`ResourcesRepository.getAllStepResources` and `getCourseResources` have no
+5. **`take_course_screen.dart:687-697` now says something false, and it is
+   aimed at the next lane.** Its comment reads *"The port cannot render either
+   of those yet, and the blocker is the data, not the widget … `my_library` has
+   no `stepId` column and `MyLibraryMapper` writes no `courseId` … Restoring a
+   tap target means porting that walk first."* All four claims were true when
+   Phase 145 wrote them and were made false by this commit. It is the comment
+   Lane D will read when deciding whether the inline resource list is buildable,
+   and it tells them it is not. Lane D's file, so reported rather than changed —
+   but it should not survive the round.
+6. **The empty-walk prune is a divergence, not parity, and the guards only
+   narrow it.** When the `resources` database reports zero documents (a
+   re-provisioned satellite, or any 200 whose body lacks `total_rows`, since
+   `JsonUtils.getInt` returns 0), Kotlin deletes nothing at all —
+   `deleteAllStalePublic` is unreachable, see above — while the port deletes
+   every public synced row. Closing it means not pruning on an empty walk, which
+   changes an existing intentional behaviour and its test, so it is a decision
+   for a round that can weigh it rather than a fix smuggled into this one.
+7. **`MyLibraryDao.getOfflineResourcesForCourses(courseIds)` has no port
+   counterpart.** Its predicate is `resourceOffline = 0` despite the name, and
+   it is what `CoursesFragment.kt:190` feeds the courses-list bulk download
+   from. This phase ported the singular `getCourseResources` and not the plural
+   one, so the reader the live Kotlin download button uses is still missing.
+8. **`isLocalOnlyPrivate` has no port counterpart** (`MyLibrary.kt:224`, `:285`).
+   Kotlin refuses to let a pull flip a locally-authored private team resource
+   (no `_rev`, `isPrivate`, `privateFor` set) back to public;
+   `MyLibraryMapper.fromDoc` writes `isPrivate` unconditionally. It now
+   interacts with this phase: the new prune guards keep such a row alive, and a
+   walk that flips it to `is_private = 0` makes it prunable on the next
+   resources sync.
+9. **`ResourcesRepository.getAllStepResources` and `getCourseResources` have no
    caller in `lib/` yet**, by design: the three screens that would call them are
    Lane D's files this round. The *writer* is on a live production path
    (`CoursesRepository.sync` ← `courseSyncProvider` ← `syncAll` and
@@ -344,7 +480,7 @@ runs. Fixed rather than recorded.
    left for a reachability audit to rediscover — and if the UI phase does not
    land, these two methods are the thing to delete rather than to keep as
    substrate.
-6. **The markdown image pre-download gap is untouched and neither easier nor
+10. **The markdown image pre-download gap is untouched and neither easier nor
    harder.** `CoursesRepositoryImpl:670,684` calls `DownloadUtils.extractLinks`
    on course and step descriptions and the port wires nothing
    (`PHASE_142_NOTES.md` item 1). This phase touched the same loop in
@@ -353,7 +489,7 @@ runs. Fixed rather than recorded.
    wants its own round. The one thing that changed in its favour: `ParsedCourse`
    now has a precedent for carrying non-row parse output back to the repository,
    which is the shape an extracted-links list would take.
-7. **Phase 145's items 1 and 3–11 are unchanged**, except that item 2 is this
+11. **Phase 145's items 1 and 3–11 are unchanged**, except that item 2 is this
    phase and item 3's premise (`course_detail_screen.dart:204` shows a number the
    port cannot substantiate) is now half-resolved: the port *can* substantiate
    it, and `course_step_resources_test.dart` pins the count against the rows

--- a/flutter/PHASE_146_NOTES.md
+++ b/flutter/PHASE_146_NOTES.md
@@ -1,0 +1,7 @@
+# Phase 146 — ingesting a course step's resources (work in progress)
+
+Lane A of a four-lane round. Brief: Phase 145 *Reported, not fixed* item 2 —
+the port never ingests a course step's embedded resource documents, so
+`noOfResources` counts rows `my_library` does not hold.
+
+Notes are written as the work proceeds; see *Reported, not fixed* at the end.

--- a/flutter/PHASE_146_NOTES.md
+++ b/flutter/PHASE_146_NOTES.md
@@ -1,7 +1,361 @@
-# Phase 146 — ingesting a course step's resources (work in progress)
+# Phase 146 — the port never ingested a course step's resources
 
-Lane A of a four-lane round. Brief: Phase 145 *Reported, not fixed* item 2 —
-the port never ingests a course step's embedded resource documents, so
-`noOfResources` counts rows `my_library` does not hold.
+Lane A of a four-lane round. One job, from Phase 145's *Reported, not fixed*
+item 2 — the eighth consecutive round briefed from the previous round's list:
 
-Notes are written as the work proceeds; see *Reported, not fixed* at the end.
+> Kotlin's courses walk buffers each embedded resource document
+> (`queueCourseResources`, `CoursesRepositoryImpl.kt:792-798`) and drains it
+> into `my_library` stamped with `courseId` and `stepId`
+> (`flushPendingCourseResources`, `:819-863`). `CourseMapper._parseSteps` keeps
+> only the length. So the port holds a count of resources it never stored.
+
+This is the *Reachability* class: not a widget that renders wrong, but a table
+that is never written, so three readers — the inline per-step resource list,
+the course-level download button, and the step's auto-download and next-step
+prefetch — have nowhere to read from. `course_detail_screen.dart:204` renders
+`resourcesInStep(step.noOfResources)`, a number the port could not
+substantiate.
+
+## Method
+
+1. Read the Kotlin by hand: `buildCoursePayload`, `queueCourseResources`,
+   `flushPendingCourseResources`, `MyLibrary.insertMyLibrary`, both
+   `resources`-walk call sites, `MyLibraryDao`'s queries, and **both** drain
+   call sites (`TransactionSyncManager.kt:302` and
+   `CoursesRepositoryImpl.kt:508`).
+2. A `parity-auditor` pass at `effort: max` on **twelve lettered claims**,
+   before touching Dart. It confirmed seven, corrected two, and **refuted one
+   outright** — the refuted one was a data-loss bug sitting in my own file set
+   that the phase would otherwise have shipped a stamp into. See below.
+3. Implement, each defect demonstrated failing first.
+4. Mutation-test every fix — ten mutations, one of which survived and turned
+   out to be a missing fixture row rather than a redundant conjunct.
+5. A second `parity-auditor` pass at `effort: max` aimed at the finished,
+   already-green code.
+
+## What the ground-truth audit changed
+
+### The refutation: `deleteNotIn` was never the port of Kotlin's prune
+
+I asked the auditor to confirm, as claim L, that an ingested course resource
+survives the `resources` walk's `deleteNotIn` because it is a document of the
+`resources` database and therefore in that walk's keep set. It refuted the
+premise the question rested on.
+
+Kotlin's prune is **not** "delete what the walk did not list".
+`MyLibraryDao.deleteStalePublicNotIn` (`MyLibraryDao.kt:170-175`) is
+
+```sql
+DELETE FROM my_library
+WHERE _rev IS NOT NULL AND _rev != '' AND isPrivate = 0
+  AND resourceId NOT IN (:currentResourceIds)
+```
+
+and its empty-list twin `deleteAllStalePublic` (`:177-178`) carries the same two
+guards. The port's `MyLibraryDao.deleteNotIn` had **no predicate at all**. Three
+row classes were being destroyed on every resources sync:
+
+* **A resource the user created offline.** `saveLocalResource` writes a row with
+  no `rev`, no CouchDB document and no outbox entry — nothing can give it back —
+  and the first resources sync deleted it, along with the pointer to the file
+  they picked.
+* **Every private team resource**, which the public walk never lists and so
+  could never keep.
+* **A course step's resource whose embedded sub-object carries no `_rev`.**
+
+The third is why this belongs in *this* phase rather than a later one: it is the
+difference between the stamp being durable and being a one-sync artefact. The
+courses walk would write the join and the next resources walk would delete the
+row underneath it. Fixed, demonstrated failing first, and pinned by
+`resource_prune_eligibility_test.dart`.
+
+**Two writers of one table disagreeing about what "stale" means** is a new
+member of a familiar family. The catalogued shape is a sync-in rewriting a
+locally-authored *column* (Phases 56, 74, 98); this is a sync-in **deleting the
+row**, and the same question exposes it — *can this walk vouch for what it is
+about to overwrite?* A walk over `resources` cannot vouch for a row that has
+never been to the server.
+
+### The correction: a malformed element does not cost one document, it costs the walk
+
+I had claimed Kotlin's per-document `try`/`catch` in `upsertRoomCoursesFromSync`
+swallows the `IllegalStateException` that `.asJsonObject` throws on a non-object
+element in a step's `resources` array. It does — **only when `continueOnError`
+is true**, and the parameter defaults to `false` (`:619`). Of the two callers:
+
+* `batchInsertMyCourses:506` passes `true` — the **shelf** path. One document is
+  dropped; the rest of the batch is written; the drain still runs.
+* `bulkInsertFromSync:610-612` passes nothing — the **sync walk**. The exception
+  propagates to `TransactionSyncManager.kt:335`, which returns `0`. **The entire
+  courses table walk aborts at that page**, nothing on it is written, and the
+  drain at `:302` never runs for it.
+
+So the port filters, rather than reproducing this. It also filters a blank or
+whitespace `_id` and a `_design` id — neither of which `queueCourseResources`
+filters, though `batchInsertResources` filters both before writing the very same
+table (`ResourcesRepositoryImpl.kt:668-671`). Kotlin's unfiltered behaviour is a
+latent corruption, not a quirk worth preserving: `insertMyLibrary` returns a row
+for any non-empty document, so an `_id`-less resource writes `id = ""`, the
+primary key collides, and every such resource in a batch collapses into one row
+carrying the last one's title and the last one's step.
+
+Recorded as a deviation in `CourseMapper._parseStepResources`' doc comment,
+because "the port is stricter than the Kotlin" is exactly the kind of thing a
+later parity audit flags as a defect if nobody wrote down that it was chosen.
+
+## The stale-join hazard, and why it is worse in the port than in Kotlin
+
+The brief flagged Phase 136's warning that the port's step ids are positional
+(`CourseMapper.stepIdFor`, `'<courseId>:<index>'`) and asked what the ingestion
+assumes about a reorder. Working it through, with the auditor:
+
+**A pure reorder is safe.** Swap steps A and B and both are re-stamped in the
+same pass, because every surviving step is written every sync.
+
+**Deletion is not.** Course `c1` with steps `[A, B]`, A holding `r1` and B
+holding `r2`. First sync: `r1.stepId = 'c1:0'`, `r2.stepId = 'c1:1'`. The author
+deletes A. The next sync writes one step, `'c1:0'` = B, and stamps
+`r2.stepId = 'c1:0'` — but **nothing revisits `r1`**, which still says `'c1:0'`.
+`getByStepId('c1:0')` now returns both. A resource belonging to a deleted step
+would appear under the step that took its slot, and the auto-download would
+fetch it.
+
+Kotlin cannot reach this: its step ids hash the step's own JSON, so a stale
+stamp matches no live step and merely dangles. **The port's exposure is a false
+join where Kotlin's is accretion**, which is the difference between a wrong
+answer and a harmless one — so this needed fixing rather than documenting.
+
+`MyLibraryDao.releaseStepJoinsForCourse` is the direct analogue of
+`ExamDao.releaseStepJoinsForCourse`, whose own doc comment already explains this
+hazard for its table. Three details are not copied blindly:
+
+* It runs for **every** course on the page, not only those that still have
+  resources — otherwise removing a course's last resource never clears the join.
+  (Mutation 6 pins this.)
+* Its keep set is the **union across the whole document**, so a resource
+  appearing in two steps is not un-stamped by the release that follows the
+  upsert that just wrote it.
+* It nulls `courseId` alongside `stepId`. For the exam and survey tables that
+  reads as symmetry; here it is the only correct choice, because
+  `getCourseResources` and `getByCourseId` read `courseId` on its own, so a
+  stale one would keep over-filling the course download dialog. (Mutation 5.)
+
+And it is a partial-column update, never `toCompanion` — `my_library` rows carry
+`userId`, `resourceOffline`, `downloadedRev` and `resourceLocalAddress` that a
+whole-row write would clobber.
+
+## The preservation mechanism, and why it is thinner than Kotlin's
+
+The brief's first constraint: write `stepId`/`courseId` only when non-blank, so
+the plain resources walk cannot clear the course link on a re-pull.
+
+Kotlin has **two independent guards** and the port has one. `insertMyLibrary`
+skips each assignment when the value is blank (`MyLibrary.kt:231-236`) *and*
+both `resources`-walk call sites hand it the stored entity to mutate
+(`ResourcesRepositoryImpl.kt:641`, `:685`), so the link survives even if the
+guard were removed. The port's single guard is `Value.absent()`, which works
+because drift builds its `ON CONFLICT DO UPDATE SET` clause from the companion's
+**present** columns alone — `toColumns(true)` at
+`drift-2.34.4/lib/src/runtime/query_builder/statements/insert.dart:392`, emitted
+at `:410-417`. Verified in the pub cache rather than from memory, because the
+whole design rests on it.
+
+That makes `Value.absent()` load-bearing rather than tidy. A `Value(null)` there
+restores the defect, and so would routing any `my_library` write through a
+whole-row `toCompanion(true)`. Mutation 1 reds three tests.
+
+The ingestion also passes all six `existing*` merge lists.
+`MyLibraryMapper.fromDoc` writes `userId: Value(existingUserIds)`
+unconditionally, so a new caller that omitted them would retract shelf
+membership — the Phase 116 defect, in a new writer.
+`mapper_preserves_local_columns_test.dart` catches that mechanically, and
+mutation 3 confirms it reds *and* that the behavioural test reds beside it. No
+`shelfId` is passed, matching Kotlin: the drain sends no `userId` at all, so
+`setUserId` returns early (`MyLibrary.kt:123-130`) and course ingestion never
+*adds* membership either. A course-only resource therefore lands on nobody's
+shelf and in the public catalog, which is right — a step's resource is not a
+shelf item.
+
+## The schema bump
+
+**Allocated `schemaVersion` 48, and taken.** Do not reuse it.
+
+`my_library` is **not** in `localAuthorityTables` — confirmed by reading the
+set, as the brief asked, because Phase 143 had just changed it. So the upgrade's
+drop loop deletes the table and `createAll` rebuilds it carrying both columns:
+**no hand-written `_addColumnIfMissing` step is needed**, and the table has no
+`@TableIndex`, so it never enters the pre-`createAll` reconciliation block
+either. (Kotlin indexes only `_rev`, `titleNormal` and `resourceId` —
+`MyLibrary.kt:32` — so not indexing `stepId` is parity as well as convenience.)
+
+The migration test **can fail**, which took two goes. The frozen v47 DDL was
+dumped from `sqlite_master` *before* the columns were added, not retyped, and is
+guarded against drift the way the surveys literal is. Adding `my_library` to the
+preserved set reds five tests. But the first cut had a hole: leaving
+`schemaVersion` at 47 while adding the columns changed **nothing**, because
+these tests call `migration.onUpgrade` directly and drift's version machinery is
+what actually decides whether it runs at all. An explicit
+`expect(database.schemaVersion, greaterThanOrEqualTo(48))` closes it. That is
+Phase 122's *"make the v46 migration test able to fail"* recurring in a new
+disguise: the test exercised the migration correctly and was blind to whether
+the migration would ever be invoked.
+
+## Where the write happens, and the constructor that was not changed
+
+`CoursesRepository` holds no `MyLibraryDao`, and adding one means editing
+`app_providers.dart` — outside this lane's file set. The tempting alternative,
+an *optional* named parameter, is exactly how a ported feature ends up green and
+dead, which is the failure class this whole phase is about. So the write goes
+through `CourseDao` (in `app_database.dart`, which this lane owns), which
+reaches the sibling accessor on the same `AppDatabase`. `CourseDao` already owns
+the courses walk's write, including its stale-step cleanup, so the courses
+walk's third table is a consistent place for it.
+
+The port writes per page from inside `CoursesRepository.sync`, which is the
+analogue of `TransactionSyncManager.kt:302` — Kotlin's *in-walk* drain, not a
+single flush at the end. That ordering is the point: a step's resources are
+readable before the sync finishes.
+
+Collapsing Kotlin's buffer into a return value also removes two ways it
+misbehaves, both found by the ground-truth pass: a throw mid-page leaves items
+queued under a `courseId` whose row was discarded, and the shelf path runs up to
+six coroutines (`Semaphore(6)`) against the one shared `pendingCourseResources`,
+so a failure in one shelf's flush discards another shelf's queued items.
+
+## Files touched
+
+| file | change |
+|---|---|
+| `lib/data/local/tables.dart` | `MyLibraryTable` += `stepId`, `courseId` |
+| `lib/data/local/app_database.dart` | `schemaVersion` 48; `MyLibraryDao` += `getByStepId`, `getByCourseId`, `getCourseResources`, `releaseStepJoinsForCourse`; `deleteNotIn` eligibility guards; `CourseDao` += `existingResources`, `upsertCourseResources` |
+| `lib/data/local/course_mapper.dart` | `CourseResourceDoc`, `ParsedCourse.resources`, `_parseStepResources` |
+| `lib/data/local/my_library_mapper.dart` | `stepId`/`courseId` params, `_stampOrAbsent` |
+| `lib/repository/courses_repository.dart` | `_ingestCourseResources`, wired into the page loop |
+| `lib/repository/resources_repository.dart` | `getAllStepResources`, `getCourseResources` |
+| `test/repository/course_step_resources_test.dart` | new, 12 tests |
+| `test/repository/resource_prune_eligibility_test.dart` | new, 3 tests |
+| `test/data/local/course_mapper_test.dart` | +5 tests |
+| `test/data/local/my_library_mapper_test.dart` | +3 tests |
+| `test/data/local/migration_test.dart` | +3 tests, frozen v47 `my_library` DDL |
+| `test/repository/resources_repository_test.dart` | `row()` fixture emits a `_rev` |
+
+**No ARB key is added and no locale file is touched**, so there is no derivation
+hand-off for the integrator.
+
+### The fixture change is a finding in its own right
+
+Three existing tests in `resources_repository_test.dart` failed when the prune
+gained its guards, and the reflex — that the change must be wrong — was wrong.
+The `row()` fixture built "server documents" with **no `_rev`**, which a real
+`_all_docs?include_docs=true` response always carries. So those three tests were
+asserting that the walk prunes rows the walk can never produce, and they would
+have kept passing over the data-loss bug indefinitely. The fixture now emits a
+`_rev` and the tests exercise what they claim. *A fixture that fabricates a join
+is not evidence* generalises: neither is one that omits the field the predicate
+turns on.
+
+## Mutation testing
+
+Every fix reverted, every test replayed.
+
+| # | mutation | reds |
+|---|---|---|
+| 1 | `_stampOrAbsent` returns `Value(null)` instead of `Value.absent()` | 3 tests, across 2 files — including the resources-re-pull round trip |
+| 2 | drop the `releaseStepJoinsForCourse` call | 2 tests |
+| 3 | stop passing `existingUserIds` to the ingestion mapper call | 2 tests — the mechanical guard *and* the behavioural one |
+| 4 | revert the `deleteNotIn` eligibility guards | 3 tests |
+| 5 | release nulls `stepId` only, leaving a stale `courseId` | 2 tests |
+| 6 | seed the keep set only for courses that still have resources | 1 test |
+| 7 | drop the blank/`_design` resource-id filter | 2 tests — **after a fixture was added; see below** |
+| 8 | add `my_library` to `localAuthorityTables` | 5 tests |
+| 9 | remove the ingestion call from the walk (the original defect) | 4+ tests |
+| 10 | leave `schemaVersion` at 47 | **nothing, until the test was fixed**; 1 test now |
+
+**Mutation 7 survived at the repository level on the first pass, and the answer
+was a missing fixture row rather than a redundant conjunct** — exactly what
+Phase 143 predicted for a surviving mutation. The repository-level test stayed
+green because `MyLibraryMapper.fromDoc` independently rejects a blank or
+`_design` id, so the courses-walk filter looked redundant for *row writes*. It
+is not: the mapper's check is `isEmpty`, so a whitespace-only `_id` sails
+through it and writes a junk row, and only the courses walk's `trim()` filter
+stops it. Adding that one element to the malformed-array fixture makes the
+mutation red at both levels.
+
+**Mutation 10 was a non-red by accident**, the different and worse kind: a
+migration test that reads as coverage while being blind to whether the migration
+runs. Fixed rather than recorded.
+
+## Reported, not fixed
+
+1. **The v48 bump destroys resources the user created offline, and resets
+   `resourceOffline` on every downloaded resource.** Found by the ground-truth
+   pass, and it outranks everything else here. `my_library` is treated as a pure
+   CouchDB cache and is not one, twice over:
+   `ResourcesRepository.saveLocalResource` writes a row that exists nowhere else
+   (no `rev`, no document, no outbox row), and the port never re-derives
+   `resourceOffline` on sync-in the way Kotlin does (`insertMyLibrary` sets it
+   from `FileUtils.checkFileExist` on every pull, `MyLibrary.kt:263-267`; the
+   port's only writers are download completion and the viewer's stale-flag
+   repair). So after any bump the bytes are on disk and the table says otherwise,
+   and an offline-created resource is gone.
+   **This is pre-existing — every prior bump shipped it — but this phase is the
+   bump that ships it next.** The fix is to add `my_library` to
+   `localAuthorityTables` with a hand-written `_addColumnIfMissing` pair, which
+   is a decision about eviction semantics for the whole table and deliberately
+   larger than this lane; the auditor's own recommendation was to bump and
+   report. Note the two halves interact: fixing `deleteNotIn` (done here) is what
+   makes preserving the table safe, because the prune now spares exactly the rows
+   preservation is for.
+2. **`ShelfSyncRepository._pullShelfCourses` does not ingest course resources**,
+   and it is outside this lane's file set. It already skips the embedded exams
+   and surveys on the stated grounds that "the `courses` walk runs earlier in the
+   same pass over the same documents and owns those tables", and that rationale
+   was verified: `DashboardSyncArea` is ordered with `shelf` last, deliberately,
+   and `syncAll` iterates declaration order. **One hole:**
+   `DashboardSyncNotifier.retry(DashboardSyncArea.shelf)` — the sync centre's
+   per-tile retry button — runs the shelf pull with no courses walk, so a course
+   newly added to the shelf keeps its steps and gains no resource stamps until
+   the next full sync. Nothing is lost or corrupted (the shelf's own `my_library`
+   writes leave both columns absent); it is staleness. Fix is one line in that
+   file, in the shape of this phase's `_ingestCourseResources`.
+3. **The port has no `reconcileHtmlResourceOffline`, anywhere.** Kotlin calls it
+   from the course-resource drain (`CoursesRepositoryImpl.kt:852-861`) *and* from
+   both `resources`-walk sites via `reconcileHtmlLibraries` (`:660`, `:703`). It
+   repairs an HTML resource that a previous install unpacked to disk but whose
+   `resourceOffline`/`resourceLocalAddress` were never recorded. Omitting it from
+   the ingestion introduces nothing — it leaves an existing port-wide gap where
+   it is — but it is now a gap in two walks rather than one, and it is the
+   natural companion to item 1's `checkFileExist` half.
+4. **`my_library.stepId` is a Kotlin *upload* input, not only a display one.**
+   `TeamsRepositoryImpl.getTeamsForUpload:90-110` groups `getByCourseIds` by
+   `courseId` then `stepId` and hands the map to `MyTeam.serialize` →
+   `MyCourse.serialize:133`, which rebuilds each step's `resources` array from
+   it. So in Kotlin a wrong stamp uploads the wrong resources under the wrong
+   step. The port has no counterpart today (`teams_repository.dart`'s
+   `serializeTeamDocument` carries no `courses` array), so this is latent — but
+   whoever ports team-document upload inherits a correctness dependency on the
+   stamp, and should read the release-joins reasoning above first.
+5. **`ResourcesRepository.getAllStepResources` and `getCourseResources` have no
+   caller in `lib/` yet**, by design: the three screens that would call them are
+   Lane D's files this round. The *writer* is on a live production path
+   (`CoursesRepository.sync` ← `courseSyncProvider` ← `syncAll` and
+   `background_entrypoint`), so the table is genuinely populated on a real
+   device; the readers are the API the UI phase needs. Named here rather than
+   left for a reachability audit to rediscover — and if the UI phase does not
+   land, these two methods are the thing to delete rather than to keep as
+   substrate.
+6. **The markdown image pre-download gap is untouched and neither easier nor
+   harder.** `CoursesRepositoryImpl:670,684` calls `DownloadUtils.extractLinks`
+   on course and step descriptions and the port wires nothing
+   (`PHASE_142_NOTES.md` item 1). This phase touched the same loop in
+   `CourseMapper._parseSteps` and deliberately did not widen into it; the slice
+   still spans `voices_repository.dart` and `teams_repository.dart` and still
+   wants its own round. The one thing that changed in its favour: `ParsedCourse`
+   now has a precedent for carrying non-row parse output back to the repository,
+   which is the shape an extracted-links list would take.
+7. **Phase 145's items 1 and 3–11 are unchanged**, except that item 2 is this
+   phase and item 3's premise (`course_detail_screen.dart:204` shows a number the
+   port cannot substantiate) is now half-resolved: the port *can* substantiate
+   it, and `course_step_resources_test.dart` pins the count against the rows
+   held. Whether that slot should show the resource count or Kotlin's
+   `test_size` question count remains Lane D's display decision.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1436,9 +1436,8 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   /// **Only rows the server has actually seen are eligible**, which this had
   /// never implemented. Kotlin's prune is not "delete what the walk did not
   /// list": `deleteStalePublicNotIn` is `WHERE _rev IS NOT NULL AND _rev != ''
-  /// AND isPrivate = 0 AND resourceId NOT IN (...)`, and its empty-list twin
-  /// `deleteAllStalePublic` carries the same two guards
-  /// (`MyLibraryDao.kt:170-178`). Without them the port deleted:
+  /// AND isPrivate = 0 AND resourceId NOT IN (...)`
+  /// (`MyLibraryDao.kt:171-175`). Without those guards the port deleted:
   ///
   /// * **a resource the user created offline.** [saveLocalResource] writes a
   ///   row with no `rev`, no CouchDB document and no outbox entry, so nothing
@@ -1452,14 +1451,30 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   ///   ingest the row and the next resources walk would delete it, making the
   ///   join a one-sync artefact.
   ///
-  /// Matching on `id` rather than Kotlin's `resourceId` is kept: the two are
-  /// equal for every synced row ([MyLibraryMapper.fromDoc] writes the document
-  /// id into both), and the one writer that makes them differ
-  /// ([saveLocalResource], a UUID id and no `resourceId`) is now spared by the
-  /// `rev` guard anyway.
+  /// Matching on `id` rather than Kotlin's `resourceId` is kept, but not for
+  /// the reason first given here — no port writer makes the two differ at all
+  /// ([saveLocalResource] sets `resourceId` to its own generated `id`). The
+  /// column choice is therefore immaterial for every row the port can produce,
+  /// and `id` is the primary key. Where they *could* differ the port is
+  /// strictly the more aggressive of the two: Kotlin's `resourceId NOT IN (…)`
+  /// spares a row whose `resourceId` is NULL, and a primary key never is.
+  /// **The empty-list branch is not a port of anything Kotlin runs**, and
+  /// calling it one (as this comment first did) invited the next reader to stop
+  /// questioning it. Kotlin's `deleteAllStalePublic` (`MyLibraryDao.kt:177-178`)
+  /// carries the same two guards but is **unreachable**: its only caller is the
+  /// `else` of `removeDeletedResources`' `if (validCurrentIds.isNotEmpty())`
+  /// (`ResourcesRepositoryImpl.kt:537-544`), and `removeDeletedResources` is
+  /// itself called only when `validNewIds.isNotEmpty()` (`SyncManager.kt:416`).
+  /// So when the `resources` database reports zero documents Kotlin deletes
+  /// nothing, while the port deletes every public synced row — a re-provisioned
+  /// satellite, or any 200 whose body lacks `total_rows`, empties the library.
+  /// The guards narrow that from the whole table to the synced-and-public part;
+  /// closing it entirely means not pruning on an empty walk at all, which is a
+  /// behaviour change beyond the phase that found it. Recorded as a divergence,
+  /// not dressed up as parity.
   Future<int> deleteNotIn(List<String> keepIds) async {
-    // `isPrivate = 0 AND (_rev IS NOT NULL AND _rev != '')` — the eligibility
-    // half of both Kotlin statements, shared by the empty-list branch.
+    // `isPrivate = 0 AND (_rev IS NOT NULL AND _rev != '')` — Kotlin's
+    // eligibility half, applied to both branches.
     Expression<bool> prunable(MyLibraryTable r) =>
         r.isPrivate.equals(false) & r.rev.isNotNull() & r.rev.equals('').not();
 
@@ -1496,10 +1511,6 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   Future<List<MyLibraryRow>> getByStepId(String stepId) =>
       (select(myLibraryTable)..where((r) => r.stepId.equals(stepId))).get();
 
-  /// Port of `MyLibraryDao.getByCourseId`.
-  Future<List<MyLibraryRow>> getByCourseId(String courseId) =>
-      (select(myLibraryTable)..where((r) => r.courseId.equals(courseId))).get();
-
   /// Port of `MyLibraryDao.getCourseResources(courseId, isOffline)` — the
   /// course-level download button's two lists
   /// (`CoursesRepositoryImpl.getCourseOnlineResources` / `…OfflineResources`).
@@ -1519,51 +1530,6 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
                 r.resourceLocalAddress.isNotNull(),
           ))
           .get();
-
-  /// Detaches every resource of [courseId] that [keepIds] does not name.
-  ///
-  /// The direct analogue of [ExamDao.releaseStepJoinsForCourse], and needed for
-  /// the same reason with a sharper edge. The port's step id is positional
-  /// (`CourseMapper.stepIdFor`, `'$courseId:$index'`), so **deleting** a step
-  /// shifts every later step's id down one. A resource belonging to the removed
-  /// step is never re-stamped, so it keeps an id that now names a *different,
-  /// live* step: `getByStepId` returns it, the inline list shows it and the
-  /// auto-download fetches it. Kotlin cannot reach that — its step ids hash the
-  /// step's own JSON, so a stale stamp matches no live step and merely dangles.
-  /// A pure reorder is safe in the port either way, because every surviving
-  /// step is re-stamped in the same pass; it is shortening that corrupts.
-  ///
-  /// `courseId` is nulled together with `stepId`, which for this table is the
-  /// only correct choice rather than symmetry with the exam DAO:
-  /// [getCourseResources] and [getByCourseId] read `courseId` on its own, so a
-  /// stale one left behind would keep over-filling the course download dialog.
-  ///
-  /// A partial-column update, never `toCompanion` — `my_library` rows carry
-  /// `userId`, `resourceOffline`, `downloadedRev` and `resourceLocalAddress`
-  /// that a whole-row write would clobber with sync-time values.
-  Future<void> releaseStepJoinsForCourse(
-    String courseId,
-    Set<String> keepIds,
-  ) async {
-    final stale =
-        await (selectOnly(myLibraryTable)
-              ..addColumns([myLibraryTable.id])
-              ..where(
-                myLibraryTable.courseId.equals(courseId) &
-                    myLibraryTable.stepId.isNotNull(),
-              ))
-            .map((row) => row.read(myLibraryTable.id)!)
-            .get();
-    final drop = stale.where((id) => !keepIds.contains(id)).toList();
-    for (final chunk in _chunked(drop, _sqliteVariableChunk)) {
-      await (update(myLibraryTable)..where((r) => r.id.isIn(chunk))).write(
-        const MyLibraryTableCompanion(
-          stepId: Value(null),
-          courseId: Value(null),
-        ),
-      );
-    }
-  }
 
   /// Gets a single resource by its local id.
   Future<MyLibraryRow?> getById(String id) =>
@@ -1652,7 +1618,7 @@ Iterable<List<T>> _chunked<T>(List<T> items, int size) sync* {
 }
 
 /// Port of `data/room/dao/MyCourseDao.kt` and `CourseStepDao.kt`.
-@DriftAccessor(tables: [Courses, CourseSteps])
+@DriftAccessor(tables: [Courses, CourseSteps, MyLibraryTable])
 class CourseDao extends DatabaseAccessor<AppDatabase> with _$CourseDaoMixin {
   CourseDao(super.db);
 
@@ -1689,6 +1655,33 @@ class CourseDao extends DatabaseAccessor<AppDatabase> with _$CourseDaoMixin {
           statement.where((s) => s.id.isNotIn(kept.toList()));
         }
         await statement.go();
+
+        // Every `my_library` stamp for this course is released here, and the
+        // courses walk re-writes the current ones immediately afterwards
+        // ([upsertCourseResources]).
+        //
+        // Clearing *all* of them rather than only those whose step id has
+        // vanished is the whole point, and the narrower version was tried
+        // first and was wrong: step ids are positional, so deleting a step
+        // hands its id to whichever step shifted up, and a resource left
+        // pointing at that id is not dangling — it is attached to the wrong
+        // live step, which `getByStepId` will happily return.
+        //
+        // The rule this encodes is that **only a writer that has the step's
+        // resources may leave a stamp standing**. The courses walk has them;
+        // `ShelfSyncRepository._pullShelfCourses` writes the same rows through
+        // this method and discards them, so after a shelf-only sync (the sync
+        // centre's per-tile retry) the stamps are simply absent until the next
+        // courses walk. An empty inline resource list is a cost worth paying
+        // to make a wrong one unreachable.
+        await (update(
+          myLibraryTable,
+        )..where((r) => r.courseId.equals(courseId))).write(
+          const MyLibraryTableCompanion(
+            stepId: Value(null),
+            courseId: Value(null),
+          ),
+        );
       }
     });
   }
@@ -1715,27 +1708,18 @@ class CourseDao extends DatabaseAccessor<AppDatabase> with _$CourseDaoMixin {
   /// minus the buffer: the port parses and writes in one page loop, so the rows
   /// arrive built.
   ///
-  /// [keptByCourse] is, per course on the page, the resource ids its document
-  /// still claims across **all** its steps — a union, so the release below
-  /// cannot un-stamp a row the upsert just wrote. Every course on the page is
-  /// passed, including those whose steps now carry no resources at all, or
-  /// removing a course's last resource would never clear the old join.
-  ///
-  /// One transaction, so a course's steps and its resources become visible
-  /// together.
+  /// No release step of its own. [upsertAll] has already cleared every stamp
+  /// belonging to the courses on this page, so writing the current rows here is
+  /// the whole of the update: a resource the document no longer claims is
+  /// simply one that is not re-stamped. A resource appearing in two steps of
+  /// one course keeps the **last** step, because there is one row per resource
+  /// id and the later companion wins the upsert — which is what Kotlin's
+  /// `REPLACE` over the twice-mutated entity does.
   Future<void> upsertCourseResources(
     List<MyLibraryTableCompanion> resourceRows,
-    Map<String, Set<String>> keptByCourse,
   ) async {
-    if (resourceRows.isEmpty && keptByCourse.isEmpty) return;
-    await transaction(() async {
-      if (resourceRows.isNotEmpty) {
-        await _library.upsertAll(resourceRows);
-      }
-      for (final entry in keptByCourse.entries) {
-        await _library.releaseStepJoinsForCourse(entry.key, entry.value);
-      }
-    });
+    if (resourceRows.isEmpty) return;
+    await _library.upsertAll(resourceRows);
   }
 
   Future<CourseRow?> getById(String courseId) =>

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -109,7 +109,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 47;
+  int get schemaVersion => 48;
 
   /// Tables holding local intent the server cannot give back.
   ///
@@ -567,6 +567,16 @@ class AppDatabase extends _$AppDatabase {
         await _addColumnIfMissing(m, teamTasks, teamTasks.sync);
         await _addColumnIfMissing(m, teamTasks, teamTasks.link);
       }
+
+      // v48 adds `my_library.step_id` / `.course_id` for the course-step
+      // resource ingestion. **No step is needed here, and that is a fact about
+      // the table rather than an oversight**: `my_library` is not in
+      // [_localAuthorityTables], so the drop loop above deleted it and
+      // `createAll` has just rebuilt it carrying both columns. It also has no
+      // `@TableIndex`, so it never enters the pre-`createAll` reconciliation
+      // block. `migration_test.dart` pins this against a frozen v47 shape —
+      // adding `my_library` to the preserved set without a hand-written
+      // [_addColumnIfMissing] pair reds it.
     },
   );
 
@@ -1422,17 +1432,51 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   /// binding every kept id into one `NOT IN`: SQLite caps bound variables at
   /// `SQLITE_MAX_VARIABLE_NUMBER` (999 on older builds), and a library easily
   /// exceeds that, which would fail the whole sync.
+  ///
+  /// **Only rows the server has actually seen are eligible**, which this had
+  /// never implemented. Kotlin's prune is not "delete what the walk did not
+  /// list": `deleteStalePublicNotIn` is `WHERE _rev IS NOT NULL AND _rev != ''
+  /// AND isPrivate = 0 AND resourceId NOT IN (...)`, and its empty-list twin
+  /// `deleteAllStalePublic` carries the same two guards
+  /// (`MyLibraryDao.kt:170-178`). Without them the port deleted:
+  ///
+  /// * **a resource the user created offline.** [saveLocalResource] writes a
+  ///   row with no `rev`, no CouchDB document and no outbox entry, so nothing
+  ///   could give it back — and the very first resources sync removed it,
+  ///   along with the pointer to the file they picked.
+  /// * **a private team resource**, which the public `resources` walk never
+  ///   lists and so could never keep.
+  /// * **a course step's resource whose embedded sub-object carries no
+  ///   `_rev`.** That one is why the guard is load-bearing for the course
+  ///   stamp above rather than only adjacent to it: the courses walk would
+  ///   ingest the row and the next resources walk would delete it, making the
+  ///   join a one-sync artefact.
+  ///
+  /// Matching on `id` rather than Kotlin's `resourceId` is kept: the two are
+  /// equal for every synced row ([MyLibraryMapper.fromDoc] writes the document
+  /// id into both), and the one writer that makes them differ
+  /// ([saveLocalResource], a UUID id and no `resourceId`) is now spared by the
+  /// `rev` guard anyway.
   Future<int> deleteNotIn(List<String> keepIds) async {
-    if (keepIds.isEmpty) return delete(myLibraryTable).go();
+    // `isPrivate = 0 AND (_rev IS NOT NULL AND _rev != '')` — the eligibility
+    // half of both Kotlin statements, shared by the empty-list branch.
+    Expression<bool> prunable(MyLibraryTable r) =>
+        r.isPrivate.equals(false) & r.rev.isNotNull() & r.rev.equals('').not();
+
+    if (keepIds.isEmpty) {
+      return (delete(myLibraryTable)..where(prunable)).go();
+    }
 
     return transaction(() async {
-      final localIds =
-          await (selectOnly(myLibraryTable)..addColumns([myLibraryTable.id]))
-              .map((row) => row.read(myLibraryTable.id)!)
-              .get();
+      final query = selectOnly(myLibraryTable)
+        ..addColumns([myLibraryTable.id])
+        ..where(prunable(myLibraryTable));
+      final eligibleIds = await query
+          .map((row) => row.read(myLibraryTable.id)!)
+          .get();
 
       final keep = keepIds.toSet();
-      final stale = localIds.where((id) => !keep.contains(id)).toList();
+      final stale = eligibleIds.where((id) => !keep.contains(id)).toList();
 
       var deleted = 0;
       for (final chunk in _chunked(stale, _sqliteVariableChunk)) {
@@ -1442,6 +1486,83 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
       }
       return deleted;
     });
+  }
+
+  /// Port of `MyLibraryDao.getByStepId` — a course step's embedded resources.
+  ///
+  /// Feeds `CourseStepFragment.setupInlineResources` / `autoDownloadResources`
+  /// / `prefetchNextStepResources` through
+  /// `ResourcesRepositoryImpl.getAllStepResources`.
+  Future<List<MyLibraryRow>> getByStepId(String stepId) =>
+      (select(myLibraryTable)..where((r) => r.stepId.equals(stepId))).get();
+
+  /// Port of `MyLibraryDao.getByCourseId`.
+  Future<List<MyLibraryRow>> getByCourseId(String courseId) =>
+      (select(myLibraryTable)..where((r) => r.courseId.equals(courseId))).get();
+
+  /// Port of `MyLibraryDao.getCourseResources(courseId, isOffline)` — the
+  /// course-level download button's two lists
+  /// (`CoursesRepositoryImpl.getCourseOnlineResources` / `…OfflineResources`).
+  ///
+  /// `resourceLocalAddress IS NOT NULL` is the Kotlin's, and it is not a test
+  /// for a file on disk: the column holds the CouchDB attachment *name*,
+  /// written on every sync. It says "this resource has an attachment to
+  /// download at all".
+  Future<List<MyLibraryRow>> getCourseResources(
+    String courseId, {
+    required bool isOffline,
+  }) =>
+      (select(myLibraryTable)..where(
+            (r) =>
+                r.courseId.equals(courseId) &
+                r.resourceOffline.equals(isOffline) &
+                r.resourceLocalAddress.isNotNull(),
+          ))
+          .get();
+
+  /// Detaches every resource of [courseId] that [keepIds] does not name.
+  ///
+  /// The direct analogue of [ExamDao.releaseStepJoinsForCourse], and needed for
+  /// the same reason with a sharper edge. The port's step id is positional
+  /// (`CourseMapper.stepIdFor`, `'$courseId:$index'`), so **deleting** a step
+  /// shifts every later step's id down one. A resource belonging to the removed
+  /// step is never re-stamped, so it keeps an id that now names a *different,
+  /// live* step: `getByStepId` returns it, the inline list shows it and the
+  /// auto-download fetches it. Kotlin cannot reach that — its step ids hash the
+  /// step's own JSON, so a stale stamp matches no live step and merely dangles.
+  /// A pure reorder is safe in the port either way, because every surviving
+  /// step is re-stamped in the same pass; it is shortening that corrupts.
+  ///
+  /// `courseId` is nulled together with `stepId`, which for this table is the
+  /// only correct choice rather than symmetry with the exam DAO:
+  /// [getCourseResources] and [getByCourseId] read `courseId` on its own, so a
+  /// stale one left behind would keep over-filling the course download dialog.
+  ///
+  /// A partial-column update, never `toCompanion` — `my_library` rows carry
+  /// `userId`, `resourceOffline`, `downloadedRev` and `resourceLocalAddress`
+  /// that a whole-row write would clobber with sync-time values.
+  Future<void> releaseStepJoinsForCourse(
+    String courseId,
+    Set<String> keepIds,
+  ) async {
+    final stale =
+        await (selectOnly(myLibraryTable)
+              ..addColumns([myLibraryTable.id])
+              ..where(
+                myLibraryTable.courseId.equals(courseId) &
+                    myLibraryTable.stepId.isNotNull(),
+              ))
+            .map((row) => row.read(myLibraryTable.id)!)
+            .get();
+    final drop = stale.where((id) => !keepIds.contains(id)).toList();
+    for (final chunk in _chunked(drop, _sqliteVariableChunk)) {
+      await (update(myLibraryTable)..where((r) => r.id.isIn(chunk))).write(
+        const MyLibraryTableCompanion(
+          stepId: Value(null),
+          courseId: Value(null),
+        ),
+      );
+    }
   }
 
   /// Gets a single resource by its local id.
@@ -1568,6 +1689,51 @@ class CourseDao extends DatabaseAccessor<AppDatabase> with _$CourseDaoMixin {
           statement.where((s) => s.id.isNotIn(kept.toList()));
         }
         await statement.go();
+      }
+    });
+  }
+
+  /// The courses walk's third table.
+  ///
+  /// A course document carries its steps' resources inline, and Kotlin's walk
+  /// writes them into `my_library` from inside the same batch
+  /// (`TransactionSyncManager.kt:302`). The port reaches that table through the
+  /// sibling accessor rather than giving [CoursesRepository] a second DAO,
+  /// because its constructor is built in `app_providers.dart`: an added
+  /// parameter there is a file this lane does not own, and an *optional* one
+  /// that production never passes is how a ported feature ends up green and
+  /// dead.
+  MyLibraryDao get _library => attachedDatabase.myLibraryDao;
+
+  /// The `my_library` rows these ids already have, so the caller can hand
+  /// [MyLibraryMapper.fromDoc] the columns the server does not own — the shelf
+  /// membership above all. See `mapper_preserves_local_columns_test.dart`.
+  Future<List<MyLibraryRow>> existingResources(List<String> ids) =>
+      _library.getByIds(ids);
+
+  /// Port of `flushPendingCourseResources` (`CoursesRepositoryImpl.kt:819-863`)
+  /// minus the buffer: the port parses and writes in one page loop, so the rows
+  /// arrive built.
+  ///
+  /// [keptByCourse] is, per course on the page, the resource ids its document
+  /// still claims across **all** its steps — a union, so the release below
+  /// cannot un-stamp a row the upsert just wrote. Every course on the page is
+  /// passed, including those whose steps now carry no resources at all, or
+  /// removing a course's last resource would never clear the old join.
+  ///
+  /// One transaction, so a course's steps and its resources become visible
+  /// together.
+  Future<void> upsertCourseResources(
+    List<MyLibraryTableCompanion> resourceRows,
+    Map<String, Set<String>> keptByCourse,
+  ) async {
+    if (resourceRows.isEmpty && keptByCourse.isEmpty) return;
+    await transaction(() async {
+      if (resourceRows.isNotEmpty) {
+        await _library.upsertAll(resourceRows);
+      }
+      for (final entry in keptByCourse.entries) {
+        await _library.releaseStepJoinsForCourse(entry.key, entry.value);
       }
     });
   }

--- a/flutter/lib/data/local/course_mapper.dart
+++ b/flutter/lib/data/local/course_mapper.dart
@@ -166,8 +166,9 @@ class CourseMapper {
   ///   walk does not** (`:619` defaults to false). So one malformed element
   ///   aborts the whole `courses` table walk at that page, writing nothing and
   ///   skipping the drain.
-  /// * A blank or whitespace-only `_id` is skipped. `insertMyLibrary` returns a row only for an
-  ///   empty document (`MyLibrary.kt:220`), so Kotlin writes `id = ""` — and
+  /// * A blank or whitespace-only `_id` is skipped. `insertMyLibrary` bails out
+  ///   only on an *empty* document (`MyLibrary.kt:220`), so one with fields but
+  ///   no `_id` still yields a row and Kotlin writes `id = ""` — and
   ///   because the primary key collides, every `_id`-less resource in a batch
   ///   collapses into one row under `REPLACE`, leaving a phantom carrying the
   ///   last one's title and the last one's step.

--- a/flutter/lib/data/local/course_mapper.dart
+++ b/flutter/lib/data/local/course_mapper.dart
@@ -9,10 +9,42 @@ import 'app_database.dart';
 /// Port of `CoursesRepositoryImpl.ParsedCourseSyncPayload`, minus the exam and
 /// question halves — those arrive with the `ui/exam` package.
 class ParsedCourse {
-  const ParsedCourse({required this.course, required this.steps});
+  const ParsedCourse({
+    required this.course,
+    required this.steps,
+    this.resources = const [],
+  });
 
   final CoursesCompanion course;
   final List<CourseStepsCompanion> steps;
+
+  /// The resource documents embedded in the steps, in document order.
+  final List<CourseResourceDoc> resources;
+}
+
+/// One resource document embedded in a course step, with the join it belongs
+/// to. Port of `CoursesRepositoryImpl.PendingCourseResource`.
+///
+/// Kotlin buffers these on the repository and drains the buffer separately
+/// (`queueCourseResources` → `flushPendingCourseResources`), because its parse
+/// and its write are in different methods. The port parses and writes in one
+/// page loop, so the buffer collapses into a return value — which also removes
+/// the two ways Kotlin's buffer misbehaves: a throw mid-page leaves items
+/// queued under a `courseId` whose row was discarded, and the shelf path runs
+/// up to six coroutines against the one shared list.
+class CourseResourceDoc {
+  const CourseResourceDoc({
+    required this.doc,
+    required this.courseId,
+    required this.stepId,
+  });
+
+  final Map<String, dynamic> doc;
+  final String courseId;
+  final String stepId;
+
+  /// The resource's CouchDB id — the `my_library` primary key it lands under.
+  String get resourceId => JsonUtils.getString('_id', doc);
 }
 
 /// Port of the course-parsing half of `repository/CoursesRepositoryImpl.kt`
@@ -32,9 +64,11 @@ class CourseMapper {
     if (courseId.isEmpty || courseId.startsWith('_design')) return null;
 
     final title = JsonUtils.getString('courseTitle', doc);
-    final steps = _parseSteps(doc, courseId);
+    final resources = <CourseResourceDoc>[];
+    final steps = _parseSteps(doc, courseId, resources);
 
     return ParsedCourse(
+      resources: resources,
       course: CoursesCompanion(
         id: Value(courseId),
         couchId: Value(courseId),
@@ -90,6 +124,7 @@ class CourseMapper {
   static List<CourseStepsCompanion> _parseSteps(
     Map<String, dynamic> doc,
     String courseId,
+    List<CourseResourceDoc> collectedResources,
   ) {
     final rawSteps = doc['steps'];
     if (rawSteps is! List) return const [];
@@ -100,6 +135,9 @@ class CourseMapper {
       if (step is! Map<String, dynamic>) continue;
 
       final resources = step['resources'];
+      collectedResources.addAll(
+        _parseStepResources(resources, courseId, stepIdFor(courseId, i)),
+      );
       steps.add(
         CourseStepsCompanion(
           id: Value(stepIdFor(courseId, i)),
@@ -112,6 +150,47 @@ class CourseMapper {
       );
     }
     return steps;
+  }
+
+  /// Port of `queueCourseResources` (`CoursesRepositoryImpl.kt:792-798`).
+  ///
+  /// **Three deviations, all of them refusals to reproduce a latent
+  /// corruption**, because Kotlin filters nothing here — unlike
+  /// `batchInsertResources`, which filters both blank ids and `_design` docs
+  /// (`ResourcesRepositoryImpl.kt:668-671`) before writing the same table:
+  ///
+  /// * A non-object element is skipped. Kotlin calls `.asJsonObject` on it,
+  ///   which throws `IllegalStateException`, and the enclosing catch
+  ///   (`CoursesRepositoryImpl.kt:637-646`) only swallows it when
+  ///   `continueOnError` is true — which the shelf path passes and **the sync
+  ///   walk does not** (`:619` defaults to false). So one malformed element
+  ///   aborts the whole `courses` table walk at that page, writing nothing and
+  ///   skipping the drain.
+  /// * A blank or whitespace-only `_id` is skipped. `insertMyLibrary` returns a row only for an
+  ///   empty document (`MyLibrary.kt:220`), so Kotlin writes `id = ""` — and
+  ///   because the primary key collides, every `_id`-less resource in a batch
+  ///   collapses into one row under `REPLACE`, leaving a phantom carrying the
+  ///   last one's title and the last one's step.
+  /// * A `_design` id is skipped, as the `resources` walk already does.
+  static List<CourseResourceDoc> _parseStepResources(
+    Object? resources,
+    String courseId,
+    String stepId,
+  ) {
+    if (resources is! List) return const [];
+
+    final parsed = <CourseResourceDoc>[];
+    for (final resource in resources) {
+      if (resource is! Map<String, dynamic>) continue;
+      final resourceId = JsonUtils.getString('_id', resource);
+      if (resourceId.trim().isEmpty || resourceId.startsWith('_design')) {
+        continue;
+      }
+      parsed.add(
+        CourseResourceDoc(doc: resource, courseId: courseId, stepId: stepId),
+      );
+    }
+    return parsed;
   }
 
   /// Local step id: `<courseId>:<position>`.

--- a/flutter/lib/data/local/my_library_mapper.dart
+++ b/flutter/lib/data/local/my_library_mapper.dart
@@ -47,6 +47,8 @@ class MyLibraryMapper {
     List<String> existingTag = const [],
     List<String> existingLanguages = const [],
     String? shelfId,
+    String? stepId,
+    String? courseId,
   }) {
     if (doc.isEmpty) return null;
 
@@ -121,8 +123,32 @@ class MyLibraryMapper {
       ),
       isPrivate: Value(isPrivate),
       privateFor: _privateFor(doc, isPrivate),
+      stepId: _stampOrAbsent(stepId),
+      courseId: _stampOrAbsent(courseId),
     );
   }
+
+  /// Port of the two non-blank guards in `insertMyLibrary`
+  /// (`MyLibrary.kt:231-236`).
+  ///
+  /// The `resources` walk passes neither, and it must not clear a link the
+  /// courses walk wrote — one column, two writers. Kotlin gets that from the
+  /// guard *and* from being handed the stored entity to mutate; the port has
+  /// only the guard, because drift's `insertAllOnConflictUpdate` builds its
+  /// `SET` clause from the companion's **present** columns alone
+  /// (`toColumns(true)`), so an absent one is not written on insert or on
+  /// conflict. That makes [Value.absent] load-bearing rather than tidy: a
+  /// `Value(null)` here, or routing a `my_library` write through a whole-row
+  /// `toCompanion(true)`, silently restores the defect.
+  ///
+  /// Blank is folded into absent, not written as `''`, because
+  /// `isNullOrBlank()` is what the Kotlin tests — and `WHERE stepId = ''`
+  /// matches nothing, so an empty stamp is a link that reads as broken rather
+  /// than as unset.
+  static Value<String?> _stampOrAbsent(String? value) =>
+      value == null || value.trim().isEmpty
+      ? const Value<String?>.absent()
+      : Value(value);
 
   /// Port of `MyLibrary.kt:292-299`.
   ///

--- a/flutter/lib/data/local/my_library_mapper.dart
+++ b/flutter/lib/data/local/my_library_mapper.dart
@@ -90,8 +90,14 @@ class MyLibraryMapper {
       resourceType: Value(JsonUtils.getStringOrNull('resourceType', doc)),
       medium: Value(JsonUtils.getStringOrNull('medium', doc)),
       timesRated: Value(JsonUtils.getInt('timesRated', doc)),
-      resourceRemoteAddress: Value(attachment?.remoteAddress),
-      resourceLocalAddress: Value(attachment?.localAddress),
+      // Absent, not `Value(null)`, when the document carries no usable
+      // attachment — see [_primaryAttachment].
+      resourceRemoteAddress: attachment == null
+          ? const Value<String?>.absent()
+          : Value(attachment.remoteAddress),
+      resourceLocalAddress: attachment == null
+          ? const Value<String?>.absent()
+          : Value(attachment.localAddress),
       userId: Value(mergeUserIds(existingUserIds, shelfId)),
       resourceFor: Value(
         _mergedList(
@@ -202,14 +208,34 @@ class MyLibraryMapper {
   /// The Kotlin walks `_attachments` and treats the first key without a `/` as
   /// the resource's own file, deriving the download URL from it.
   ///
+  /// Returning `null` means **"this document says nothing about an
+  /// attachment"**, and the caller must then leave both address columns alone
+  /// rather than writing null over them. That is what the Kotlin does, though
+  /// it never had to say so: the two assignments sit inside
+  /// `if (params.doc.has("_attachments"))` and inside `if (key.indexOf("/") <
+  /// 0)` (`MyLibrary.kt:243`, `:260-262`), so an absent `_attachments`, an
+  /// empty one, or one whose keys are all nested simply never reaches them.
+  ///
+  /// Writing `Value(null)` here instead was a live data loss the moment the
+  /// courses walk became a second writer of these rows. A course document
+  /// embeds a *thinner* copy of each resource, and `MyLibrary.serializeResource`
+  /// builds its `_attachments` from `resourceLocalAddress?.let{…}` — so a device
+  /// that has not downloaded the file uploads `"_attachments": {}`, and pulling
+  /// that back erased the download pointer the `resources` walk had written,
+  /// on every sync, leaving the row claiming `resourceOffline` with no path to
+  /// the file.
+  ///
   /// **Deviation from the Kotlin**, twice over:
   /// * The userinfo is stripped before the URL is stored. `couchDbUrl` carries
   ///   `satellite:<pin>@`, and the Kotlin writes that straight into
   ///   `resourceRemoteAddress` — putting the PIN in a database row for every
   ///   resource, from where it reaches anything that reads, exports or logs the
   ///   row. Credentials are attached at request time instead.
-  /// * An empty `couchDbUrl` yields `null` rather than the Kotlin's
-  ///   `http:///resources/...`, which is not a usable URL.
+  /// * An unusable `couchDbUrl` drops the *remote* address rather than storing
+  ///   the Kotlin's `http:///resources/...`, which is not a usable URL. The
+  ///   local address is still recorded, because it is the attachment name and
+  ///   does not depend on the base — the earlier version discarded both and so
+  ///   lost the filename over a bad server URL.
   static _Attachment? _primaryAttachment(
     Map<String, dynamic> doc,
     String resourceId,
@@ -219,16 +245,16 @@ class MyLibraryMapper {
     if (attachments == null) return null;
 
     final base = credentialFreeBase(couchDbUrl);
-    if (base == null) return null;
 
     for (final key in attachments.keys) {
       if (key.contains('/')) continue;
       return _Attachment(
         // Encoded to match UrlUtils.resourceUrl — both build the same download
         // path, and server-supplied filenames can contain spaces, '#' or '?'.
-        remoteAddress:
-            '$base/resources'
-            '/${Uri.encodeComponent(resourceId)}/${Uri.encodeComponent(key)}',
+        remoteAddress: base == null
+            ? null
+            : '$base/resources'
+                  '/${Uri.encodeComponent(resourceId)}/${Uri.encodeComponent(key)}',
         localAddress: key,
       );
     }
@@ -253,7 +279,9 @@ class MyLibraryMapper {
 class _Attachment {
   const _Attachment({required this.remoteAddress, required this.localAddress});
 
-  final String remoteAddress;
+  /// Null when `couchDbUrl` is unusable — the attachment exists, but no
+  /// download URL can be built for it.
+  final String? remoteAddress;
   final String localAddress;
 }
 

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -82,6 +82,7 @@ class Users extends Table {
 
 /// Port of `model/MyLibrary.kt` (`@Entity(tableName = "my_library")`).
 @DataClassName('MyLibraryRow')
+@TableIndex(name: 'my_library_course_id', columns: {#courseId})
 class MyLibraryTable extends Table {
   @override
   String get tableName => 'my_library';
@@ -160,10 +161,20 @@ class MyLibraryTable extends Table {
   /// cannot clear the link. Two writers, one column; see
   /// `mapper_preserves_local_columns_test.dart`.
   ///
-  /// Nullable with no default, and deliberately **not** indexed: Kotlin's
-  /// `@Entity` indexes only `_rev`, `titleNormal` and `resourceId`
-  /// (`MyLibrary.kt:32`), and an index here would drag `my_library` into the
-  /// migration's pre-`createAll` reconciliation block for no read it needs.
+  /// Both nullable with no default. `courseId` is indexed and `stepId` is not,
+  /// which is **not** a copy of Kotlin's `@Entity` list — that indexes only
+  /// `_rev`, `titleNormal` and `resourceId` (`MyLibrary.kt:32`), and citing it
+  /// here would be citing the wrong thing, because Kotlin never issues the
+  /// query the index is for. The port's courses walk releases stale step joins
+  /// once per course per page (up to 50), and Kotlin has no release step at
+  /// all; unindexed, that is fifty full scans of `my_library` per page, most
+  /// matching nothing. `stepId` needs none: it is read one step at a time from
+  /// a screen, not in a loop over a sync page.
+  ///
+  /// Safe to index because `my_library` is a cache: the upgrade drops it and
+  /// `createAll` rebuilds table and index together, so it never enters the
+  /// pre-`createAll` reconciliation block that exists for *preserved* tables
+  /// whose indexes name columns they may not have yet.
   TextColumn get stepId => text().nullable()();
   TextColumn get courseId => text().nullable()();
 

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -147,6 +147,26 @@ class MyLibraryTable extends Table {
   BoolColumn get isPrivate => boolean().withDefault(const Constant(false))();
   TextColumn get privateFor => text().nullable()();
 
+  /// The course step this resource is embedded in, and that step's course.
+  ///
+  /// Port of `MyLibrary.stepId` / `.courseId`, written by the courses walk from
+  /// a step's embedded `resources` array (`CoursesRepositoryImpl
+  /// .queueCourseResources:792-798` → `flushPendingCourseResources:819-863`).
+  /// The `resources` walk knows nothing about courses and must leave both
+  /// alone: `MyLibrary.insertMyLibrary` assigns each only when non-blank
+  /// (`MyLibrary.kt:231-236`), and [MyLibraryMapper.fromDoc] does the same by
+  /// leaving them [Value.absent] — which drift excludes from both the INSERT
+  /// column list and the `ON CONFLICT DO UPDATE SET` clause, so a re-pull
+  /// cannot clear the link. Two writers, one column; see
+  /// `mapper_preserves_local_columns_test.dart`.
+  ///
+  /// Nullable with no default, and deliberately **not** indexed: Kotlin's
+  /// `@Entity` indexes only `_rev`, `titleNormal` and `resourceId`
+  /// (`MyLibrary.kt:32`), and an index here would drag `my_library` into the
+  /// migration's pre-`createAll` reconciliation block for no read it needs.
+  TextColumn get stepId => text().nullable()();
+  TextColumn get courseId => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }

--- a/flutter/lib/repository/courses_repository.dart
+++ b/flutter/lib/repository/courses_repository.dart
@@ -8,6 +8,7 @@ import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 import '../data/local/course_mapper.dart';
 import '../data/local/exam_mapper.dart';
+import '../data/local/my_library_mapper.dart';
 import '../data/local/survey_mapper.dart';
 import 'shelf_repository.dart';
 
@@ -186,6 +187,11 @@ class CoursesRepository {
 
       final courseRows = <CoursesCompanion>[];
       final stepRows = <CourseStepsCompanion>[];
+      // The resource documents embedded in this page's course steps, and per
+      // course the union of the ids its steps still claim — the keep set the
+      // stale-join release runs against.
+      final parsedResources = <CourseResourceDoc>[];
+      final resourceIdsByCourse = <String, Set<String>>{};
       final examRows = <ExamsCompanion>[];
       final examQuestionRows = <String, List<ExamQuestionsCompanion>>{};
       final surveyRows = <SurveysCompanion>[];
@@ -227,6 +233,14 @@ class CoursesRepository {
         stepRows.addAll(parsed.steps);
         savedIds.add(parsed.course.id.value);
 
+        parsedResources.addAll(parsed.resources);
+        // Seeded for every course, not only those that still carry resources,
+        // so a course whose last resource was removed still gets its old join
+        // released below.
+        resourceIdsByCourse
+            .putIfAbsent(courseId, () => <String>{})
+            .addAll(parsed.resources.map((r) => r.resourceId));
+
         // A question map entry is written only when the embedded object
         // actually carried questions. `ExamDao.upsertAll` deletes an exam's
         // questions before reinserting the entry's list, so passing an empty
@@ -263,6 +277,14 @@ class CoursesRepository {
       if (courseRows.isNotEmpty) {
         await _dao.upsertAll(courseRows, stepRows);
       }
+      // Kotlin drains its buffered course resources here, per batch, from
+      // inside the walk itself (`TransactionSyncManager.kt:302`) — not once at
+      // the end — so a step's resources are readable before the sync finishes.
+      await _ingestCourseResources(
+        config: config,
+        parsedResources: parsedResources,
+        resourceIdsByCourse: resourceIdsByCourse,
+      );
       // Written after the courses, so a step row always exists by the time an
       // exam claims to belong to it. Neither table is pruned here: the `exams`
       // database walk owns their `deleteNotIn`, and a course test is a document
@@ -303,5 +325,66 @@ class CoursesRepository {
     }
 
     return SyncComplete(savedIds.length);
+  }
+
+  /// Writes one page's embedded step resources into `my_library`, stamped with
+  /// the step and course they came from.
+  ///
+  /// Port of `flushPendingCourseResources` (`CoursesRepositoryImpl.kt:819-863`).
+  /// The stamp is what makes a step's resources readable at all —
+  /// `MyLibraryDao.getByStepId` and `getCourseResources` are the Kotlin
+  /// readers, and before this the port held the *count* of a step's resources
+  /// and none of the rows.
+  ///
+  /// Two properties are deliberate:
+  ///
+  /// * **The existing row is read first and its six merge lists passed back
+  ///   in.** `my_library.userId` is the shelf, written by the user's own tap as
+  ///   well as by a walk, and `MyLibraryMapper.fromDoc` writes
+  ///   `Value(existingUserIds)` unconditionally — so ingesting a course
+  ///   resource without this would retract a membership, the Phase 116 defect
+  ///   in a new caller. No `shelfId` is passed, matching Kotlin: the drain
+  ///   sends no `userId` at all, so `setUserId` returns early
+  ///   (`MyLibrary.kt:123-130`) and course ingestion never *adds* membership
+  ///   either.
+  /// * **A resource in two steps of one course keeps the last step's stamp.**
+  ///   One row per resource id, so the later companion wins the upsert —
+  ///   exactly what Kotlin's `REPLACE` over the twice-mutated entity does. The
+  ///   keep set is a union across the document precisely so the release step
+  ///   does not then un-stamp it.
+  Future<void> _ingestCourseResources({
+    required ServerConfig config,
+    required List<CourseResourceDoc> parsedResources,
+    required Map<String, Set<String>> resourceIdsByCourse,
+  }) async {
+    if (resourceIdsByCourse.isEmpty) return;
+
+    final existingById = {
+      for (final row in await _dao.existingResources([
+        for (final resource in parsedResources) resource.resourceId,
+      ]))
+        row.id: row,
+    };
+
+    final rows = <MyLibraryTableCompanion>[];
+    for (final resource in parsedResources) {
+      final existing = existingById[resource.resourceId];
+      final companion = MyLibraryMapper.fromDoc(
+        resource.doc,
+        couchDbUrl: config.couchDbUrl,
+        existingUserIds: existing?.userId ?? const [],
+        existingResourceFor: existing?.resourceFor ?? const [],
+        existingSubject: existing?.subject ?? const [],
+        existingLevel: existing?.level ?? const [],
+        existingTag: existing?.tag ?? const [],
+        existingLanguages: existing?.languages ?? const [],
+        stepId: resource.stepId,
+        courseId: resource.courseId,
+      );
+      if (companion == null) continue;
+      rows.add(companion);
+    }
+
+    await _dao.upsertCourseResources(rows, resourceIdsByCourse);
   }
 }

--- a/flutter/lib/repository/courses_repository.dart
+++ b/flutter/lib/repository/courses_repository.dart
@@ -187,11 +187,11 @@ class CoursesRepository {
 
       final courseRows = <CoursesCompanion>[];
       final stepRows = <CourseStepsCompanion>[];
-      // The resource documents embedded in this page's course steps, and per
-      // course the union of the ids its steps still claim — the keep set the
-      // stale-join release runs against.
+      // The resource documents embedded in this page's course steps.
+      // `CourseDao.upsertAll` has already released every stamp these courses
+      // held by the time these are written, so there is no keep set to carry:
+      // what is not re-stamped stays released.
       final parsedResources = <CourseResourceDoc>[];
-      final resourceIdsByCourse = <String, Set<String>>{};
       final examRows = <ExamsCompanion>[];
       final examQuestionRows = <String, List<ExamQuestionsCompanion>>{};
       final surveyRows = <SurveysCompanion>[];
@@ -234,12 +234,6 @@ class CoursesRepository {
         savedIds.add(parsed.course.id.value);
 
         parsedResources.addAll(parsed.resources);
-        // Seeded for every course, not only those that still carry resources,
-        // so a course whose last resource was removed still gets its old join
-        // released below.
-        resourceIdsByCourse
-            .putIfAbsent(courseId, () => <String>{})
-            .addAll(parsed.resources.map((r) => r.resourceId));
 
         // A question map entry is written only when the embedded object
         // actually carried questions. `ExamDao.upsertAll` deletes an exam's
@@ -283,7 +277,6 @@ class CoursesRepository {
       await _ingestCourseResources(
         config: config,
         parsedResources: parsedResources,
-        resourceIdsByCourse: resourceIdsByCourse,
       );
       // Written after the courses, so a step row always exists by the time an
       // exam claims to belong to it. Neither table is pruned here: the `exams`
@@ -347,17 +340,15 @@ class CoursesRepository {
   ///   sends no `userId` at all, so `setUserId` returns early
   ///   (`MyLibrary.kt:123-130`) and course ingestion never *adds* membership
   ///   either.
-  /// * **A resource in two steps of one course keeps the last step's stamp.**
-  ///   One row per resource id, so the later companion wins the upsert —
-  ///   exactly what Kotlin's `REPLACE` over the twice-mutated entity does. The
-  ///   keep set is a union across the document precisely so the release step
-  ///   does not then un-stamp it.
+  /// * **It runs after `CourseDao.upsertAll`, which has released every stamp
+  ///   these courses held.** So this writes the current set and nothing has to
+  ///   compute which old stamps to retire — a resource the document dropped is
+  ///   one this pass does not re-stamp.
   Future<void> _ingestCourseResources({
     required ServerConfig config,
     required List<CourseResourceDoc> parsedResources,
-    required Map<String, Set<String>> resourceIdsByCourse,
   }) async {
-    if (resourceIdsByCourse.isEmpty) return;
+    if (parsedResources.isEmpty) return;
 
     final existingById = {
       for (final row in await _dao.existingResources([
@@ -385,6 +376,6 @@ class CoursesRepository {
       rows.add(companion);
     }
 
-    await _dao.upsertCourseResources(rows, resourceIdsByCourse);
+    await _dao.upsertCourseResources(rows);
   }
 }

--- a/flutter/lib/repository/resources_repository.dart
+++ b/flutter/lib/repository/resources_repository.dart
@@ -62,6 +62,33 @@ class ResourcesRepository {
 
   Future<int> localCount() => _dao.count();
 
+  /// Port of `ResourcesRepositoryImpl.getAllStepResources` (`:208-211`) — the
+  /// resources embedded in one course step, written by the courses walk.
+  ///
+  /// The null guard is the Kotlin's, quirk included: it tests `stepId == null`
+  /// and not `isNullOrBlank`. A blank id would fall through to the query and
+  /// match nothing, since [MyLibraryMapper] folds a blank stamp into "unset".
+  Future<List<MyLibraryRow>> getAllStepResources(String? stepId) async {
+    if (stepId == null) return const [];
+    return _dao.getByStepId(stepId);
+  }
+
+  /// Port of `CoursesRepositoryImpl.getCourseOnlineResources` /
+  /// `getCourseOfflineResources` (`:180-192`) — the two lists behind the
+  /// course-level download button (`BaseContainerFragment.setResourceButton`).
+  ///
+  /// Placed here rather than on [CoursesRepository] because that is where the
+  /// `my_library` DAO lives; the Kotlin split follows its own repository's DAO
+  /// injection, not a domain boundary. The blank guard is the Kotlin's
+  /// `isNullOrEmpty` at `:245`.
+  Future<List<MyLibraryRow>> getCourseResources(
+    String? courseId, {
+    required bool isOffline,
+  }) async {
+    if (courseId == null || courseId.isEmpty) return const [];
+    return _dao.getCourseResources(courseId, isOffline: isOffline);
+  }
+
   /// Port of `ResourcesRepositoryImpl.countLibrariesNeedingUpdate`
   /// (`:213-216`) — how many of the user's shelf resources are missing from
   /// the device or stale on it. Feeds the bell's *"You have N resources not

--- a/flutter/test/data/local/course_mapper_test.dart
+++ b/flutter/test/data/local/course_mapper_test.dart
@@ -188,6 +188,127 @@ void main() {
     });
   });
 
+  group('fromDoc — embedded step resources', () {
+    // Port of `queueCourseResources` (`CoursesRepositoryImpl.kt:792-798`).
+    // The mapper kept `resources.length` and discarded the documents, so
+    // `noOfResources` counted rows `my_library` did not hold.
+    test('collects each step resource stamped with its step and course', () {
+      final parsed = CourseMapper.fromDoc(
+        courseDoc(
+          steps: [
+            {
+              'stepTitle': 'One',
+              'resources': [
+                {'_id': 'r1', 'title': 'First'},
+                {'_id': 'r2', 'title': 'Second'},
+              ],
+            },
+            {
+              'stepTitle': 'Two',
+              'resources': [
+                {'_id': 'r3', 'title': 'Third'},
+              ],
+            },
+          ],
+        ),
+      )!;
+
+      expect(parsed.resources.map((r) => r.resourceId), ['r1', 'r2', 'r3']);
+      expect(parsed.resources.map((r) => r.stepId), [
+        'course-1:0',
+        'course-1:0',
+        'course-1:1',
+      ]);
+      expect(parsed.resources.map((r) => r.courseId), everyElement('course-1'));
+      // The stamp keys on the port's own positional id, not Kotlin's
+      // `Base64(stepElement.toString())`.
+      expect(
+        parsed.resources.first.stepId,
+        CourseMapper.stepIdFor('course-1', 0),
+      );
+    });
+
+    test('the collected count agrees with noOfResources', () {
+      final parsed = CourseMapper.fromDoc(
+        courseDoc(
+          steps: [
+            {
+              'stepTitle': 'One',
+              'resources': [
+                {'_id': 'r1'},
+                {'_id': 'r2'},
+              ],
+            },
+          ],
+        ),
+      )!;
+
+      expect(parsed.resources, hasLength(parsed.steps[0].noOfResources.value));
+    });
+
+    test('a step with no resources contributes none', () {
+      final parsed = CourseMapper.fromDoc(
+        courseDoc(
+          steps: [
+            {'stepTitle': 'One'},
+            {'stepTitle': 'Two', 'resources': <dynamic>[]},
+            {'stepTitle': 'Three', 'resources': 'not a list'},
+          ],
+        ),
+      )!;
+
+      expect(parsed.resources, isEmpty);
+    });
+
+    test('skips elements Kotlin would corrupt or throw on', () {
+      // Kotlin filters nothing here: `.asJsonObject` throws on a primitive
+      // (aborting the whole sync walk, since `continueOnError` is false), and
+      // an `_id`-less object writes `id = ""` where the primary key collides.
+      final parsed = CourseMapper.fromDoc(
+        courseDoc(
+          steps: [
+            {
+              'stepTitle': 'One',
+              'resources': [
+                'a bare string',
+                42,
+                null,
+                {'title': 'no id'},
+                {'_id': '', 'title': 'blank id'},
+                {'_id': '   ', 'title': 'whitespace id'},
+                {'_id': '_design/x'},
+                {'_id': 'r1'},
+              ],
+            },
+          ],
+        ),
+      )!;
+
+      expect(parsed.resources.map((r) => r.resourceId), ['r1']);
+    });
+
+    test('the step count is unaffected by what the filter drops', () {
+      // `noOfResources` is the array length, as Kotlin has it — the filter
+      // governs what is written, not what is counted.
+      final parsed = CourseMapper.fromDoc(
+        courseDoc(
+          steps: [
+            {
+              'stepTitle': 'One',
+              'resources': [
+                'junk',
+                {'_id': 'r1'},
+              ],
+            },
+          ],
+        ),
+      )!;
+
+      expect(parsed.steps[0].noOfResources.value, 2);
+      expect(parsed.resources, hasLength(1));
+    });
+  });
+
   group('mergeUserIds', () {
     test('adds the shelf id without dropping existing members', () {
       expect(

--- a/flutter/test/data/local/migration_test.dart
+++ b/flutter/test/data/local/migration_test.dart
@@ -1629,4 +1629,131 @@ void main() {
       expect(row!.subType, 'join_request');
     },
   );
+
+  /// The `my_library` DDL **frozen at v47**, the shape a device that has never
+  /// run v48 carries. Dumped from `sqlite_master` on the v47 schema, not
+  /// retyped.
+  ///
+  /// v48 adds `step_id` and `course_id` for the course-step resource
+  /// ingestion, and writes **no** hand-written migration step — because
+  /// `my_library` is a CouchDB cache, so the drop loop deletes it and
+  /// `createAll` rebuilds it carrying both columns. That reasoning is a fact
+  /// about [AppDatabase.localAuthorityTables], and it is exactly the kind of
+  /// fact a later phase changes without noticing what depended on it: add
+  /// `my_library` to the preserved set and the drop is skipped, `CREATE TABLE
+  /// IF NOT EXISTS` no-ops over the old shape, and the two columns never
+  /// appear. These tests red when that happens.
+  const myLibraryDdlFrozenAtV47 =
+      'CREATE TABLE "my_library" ("id" TEXT NOT NULL, "_id" TEXT NULL'
+      ', "_rev" TEXT NULL, "user_id" TEXT NOT NULL DEFAULT \'[]\''
+      ', "title" TEXT NULL, "title_normal" TEXT NULL'
+      ', "description" TEXT NULL, "resource_id" TEXT NULL'
+      ', "resource_remote_address" TEXT NULL'
+      ', "resource_local_address" TEXT NULL'
+      ', "resource_offline" INTEGER NOT NULL DEFAULT 0 CHECK ("resource_offline" IN (0, 1))'
+      ', "downloaded_rev" TEXT NULL, "filename" TEXT NULL'
+      ', "average_rating" TEXT NULL, "upload_date" TEXT NULL'
+      ', "year" TEXT NULL, "added_by" TEXT NULL'
+      ', "publisher" TEXT NULL, "link_to_license" TEXT NULL'
+      ', "open_with" TEXT NULL, "open_which_file" TEXT NULL'
+      ', "article_date" TEXT NULL, "kind" TEXT NULL'
+      ', "created_date" INTEGER NOT NULL DEFAULT 0'
+      ', "language" TEXT NULL, "author" TEXT NULL'
+      ', "media_type" TEXT NULL, "resource_type" TEXT NULL'
+      ', "medium" TEXT NULL, "times_rated" INTEGER NOT NULL DEFAULT 0'
+      ', "resource_for" TEXT NOT NULL DEFAULT \'[]\''
+      ', "subject" TEXT NOT NULL DEFAULT \'[]\''
+      ', "level" TEXT NOT NULL DEFAULT \'[]\''
+      ', "tag" TEXT NOT NULL DEFAULT \'[]\''
+      ', "languages" TEXT NOT NULL DEFAULT \'[]\''
+      ', "is_private" INTEGER NOT NULL DEFAULT 0 CHECK ("is_private" IN (0, 1))'
+      ', "private_for" TEXT NULL, PRIMARY KEY ("id"))';
+
+  /// The columns v48 adds on top of the frozen shape.
+  const myLibraryColumnsAddedAtV48 = {'step_id', 'course_id'};
+
+  /// Replaces the freshly-created `my_library` with its v47 shape, the way an
+  /// on-device upgrade would find it.
+  Future<void> installMyLibraryShapeBeforeV48() async {
+    await database.customStatement('SELECT 1');
+    // Same guard the surveys shape carries: a frozen literal that has drifted
+    // from what drift emits would make every assertion below vacuous.
+    expect(
+      await liveDdl('my_library'),
+      _withMyLibraryV48Columns(myLibraryDdlFrozenAtV47),
+      reason: 'the frozen my_library DDL no longer matches what drift creates',
+    );
+    await database.customStatement('DROP TABLE my_library');
+    await database.customStatement(myLibraryDdlFrozenAtV47);
+  }
+
+  test('the resource cache gains the course-step columns on upgrade', () async {
+    // The columns reach a device that already has the app only if the version
+    // actually moves: drift calls `onUpgrade` on a difference, so leaving
+    // `schemaVersion` at 47 while adding columns delivers them to fresh
+    // installs and to nobody else. Asserted here because these tests invoke
+    // `onUpgrade` directly and would otherwise stay green through exactly that
+    // mistake.
+    expect(
+      database.schemaVersion,
+      greaterThanOrEqualTo(48),
+      reason: 'my_library gained step_id/course_id at v48',
+    );
+
+    await installMyLibraryShapeBeforeV48();
+    expect(
+      await columnsOf('my_library'),
+      isNot(containsAll(myLibraryColumnsAddedAtV48)),
+      reason: 'the frozen shape is meant to predate them',
+    );
+
+    await runUpgrade(from: 47);
+
+    expect(
+      await columnsOf('my_library'),
+      containsAll(myLibraryColumnsAddedAtV48),
+    );
+  });
+
+  test('a stamped resource row is writable after the upgrade', () async {
+    // The column existing is not the same as the write path working: a
+    // preserved-but-unaltered table would still be missing them here, and this
+    // is the assertion that says so in the language the ingestion uses.
+    await installMyLibraryShapeBeforeV48();
+    await runUpgrade(from: 47);
+
+    await database.myLibraryDao.upsertAll([
+      MyLibraryTableCompanion.insert(
+        id: 'res-1',
+        title: const Value('Rainfall'),
+        stepId: const Value('course-1:0'),
+        courseId: const Value('course-1'),
+      ),
+    ]);
+
+    final byStep = await database.myLibraryDao.getByStepId('course-1:0');
+    expect(byStep.map((row) => row.id), ['res-1']);
+  });
+
+  test('the cached resource rows themselves are still dropped', () async {
+    // The other half of the claim: `my_library` is *not* preserved, and this
+    // upgrade discards its rows for the next sync to refill. Stated as a test
+    // so that adding it to the preserved set is a deliberate, visible change
+    // rather than something the two assertions above quietly tolerate.
+    await installMyLibraryShapeBeforeV48();
+    await database.customStatement(
+      "INSERT INTO my_library (id, title) VALUES ('res-1', 'Rainfall')",
+    );
+
+    await runUpgrade(from: 47);
+
+    expect(await database.myLibraryDao.getAll(), isEmpty);
+  });
 }
+
+/// The frozen v47 literal with v48's two columns spliced in, for the
+/// drift-drift guard above.
+String _withMyLibraryV48Columns(String frozen) => frozen.replaceFirst(
+  ', PRIMARY KEY ("id"))',
+  ', "step_id" TEXT NULL, "course_id" TEXT NULL, PRIMARY KEY ("id"))',
+);

--- a/flutter/test/data/local/my_library_mapper_test.dart
+++ b/flutter/test/data/local/my_library_mapper_test.dart
@@ -130,7 +130,7 @@ void main() {
       expect(blank!.openWhichFile.value, isNull);
     });
 
-    test('has no attachment address when the CouchDB URL is unknown', () {
+    test('keeps the attachment name when the CouchDB URL is unknown', () {
       final row = MyLibraryMapper.fromDoc({
         '_id': 'res-1',
         'title': 'Doc',
@@ -141,7 +141,34 @@ void main() {
 
       // Better an absent URL than the unusable 'http:///resources/...'.
       expect(row!.resourceRemoteAddress.value, isNull);
-      expect(row.resourceLocalAddress.value, isNull);
+      // But the *local* address is the attachment name and does not depend on
+      // the base URL — Kotlin assigns it unconditionally inside the same loop
+      // (`MyLibrary.kt:262`). Dropping it too, as this once did, lost the
+      // filename over a bad server URL.
+      expect(row.resourceLocalAddress.value, 'main.epub');
+    });
+
+    test('a document with no usable attachment leaves both addresses alone', () {
+      // Not `Value(null)` — see `_primaryAttachment`. A course document embeds
+      // a thinner copy of the resource, and `serializeResource` emits
+      // `"_attachments": {}` for a device that has not downloaded the file, so
+      // writing null here erased the download pointer on every sync.
+      for (final doc in <Map<String, dynamic>>[
+        {'_id': 'res-1', 'title': 'Doc'},
+        {'_id': 'res-1', 'title': 'Doc', '_attachments': <String, dynamic>{}},
+        {
+          '_id': 'res-1',
+          'title': 'Doc',
+          // Every key nested, so Kotlin's `key.indexOf("/") < 0` never matches.
+          '_attachments': {
+            'sudoku/index.html': {'content_type': 'text/html'},
+          },
+        },
+      ]) {
+        final row = MyLibraryMapper.fromDoc(doc, couchDbUrl: couchDbUrl)!;
+        expect(row.resourceRemoteAddress, const Value<String?>.absent());
+        expect(row.resourceLocalAddress, const Value<String?>.absent());
+      }
     });
 
     test('returns null for empty, design and id-less documents', () {

--- a/flutter/test/data/local/my_library_mapper_test.dart
+++ b/flutter/test/data/local/my_library_mapper_test.dart
@@ -276,6 +276,57 @@ void main() {
     });
   });
 
+  group('the course-step stamp', () {
+    // Port of the two non-blank guards in `insertMyLibrary`
+    // (`MyLibrary.kt:231-236`). The courses walk stamps; the resources walk
+    // passes nothing and must not clear what the courses walk wrote.
+    test('a non-blank stamp is written', () {
+      final companion = MyLibraryMapper.fromDoc(
+        {'_id': 'res-1', 'title': 'Doc'},
+        couchDbUrl: couchDbUrl,
+        stepId: 'course-1:0',
+        courseId: 'course-1',
+      )!;
+
+      expect(companion.stepId, const Value('course-1:0'));
+      expect(companion.courseId, const Value('course-1'));
+    });
+
+    test('no stamp leaves both columns absent', () {
+      final companion = MyLibraryMapper.fromDoc({
+        '_id': 'res-1',
+        'title': 'Doc',
+      }, couchDbUrl: couchDbUrl)!;
+
+      expect(
+        companion.stepId,
+        const Value<String?>.absent(),
+        reason: 'a Value(null) here is written, and would clear the link',
+      );
+      expect(companion.courseId, const Value<String?>.absent());
+    });
+
+    test(
+      'a blank stamp is folded into absent, not written as an empty string',
+      () {
+        // `isNullOrBlank()` is what the Kotlin tests, and `WHERE stepId = \'\''
+        // matches nothing — an empty stamp is a link that reads as broken
+        // rather than as unset.
+        for (final blank in ['', '   ']) {
+          final companion = MyLibraryMapper.fromDoc(
+            {'_id': 'res-1', 'title': 'Doc'},
+            couchDbUrl: couchDbUrl,
+            stepId: blank,
+            courseId: blank,
+          )!;
+
+          expect(companion.stepId, const Value<String?>.absent());
+          expect(companion.courseId, const Value<String?>.absent());
+        }
+      },
+    );
+  });
+
   group('credentialFreeBase', () {
     test('strips the satellite credentials', () {
       // The default :443 normalizes away; the non-default case is covered below.

--- a/flutter/test/repository/course_step_resources_test.dart
+++ b/flutter/test/repository/course_step_resources_test.dart
@@ -368,6 +368,76 @@ void main() {
       expect((await db.myLibraryDao.getById('res-1'))!.stepId, isNull);
     });
 
+    test('a second writer of course_steps cannot re-bind a stamp', () async {
+      // `ShelfSyncRepository._pullShelfCourses` writes the same course and
+      // step rows through `CourseDao.upsertAll` and **discards** the parsed
+      // resources, so the courses walk's release never runs for it. Because
+      // step ids are positional, shrinking the step list there would hand
+      // `course-1:0` to the step that shifted up while `res-1` still claimed
+      // it — a deleted step's resource surfacing under a live one. Driven
+      // through the DAO, which is the contract both writers share.
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [resourceDoc('res-1')],
+            },
+            {
+              'stepTitle': 'Deeper',
+              'resources': [resourceDoc('res-2', title: 'Aquifers')],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+      expect((await db.myLibraryDao.getById('res-1'))!.stepId, 'course-1:0');
+
+      // The shelf pull's write: course + the one surviving step, no
+      // resources.
+      final parsed = CourseMapper.fromDoc(
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Deeper',
+              'resources': [resourceDoc('res-2', title: 'Aquifers')],
+            },
+          ],
+        ),
+      )!;
+      await db.courseDao.upsertAll([parsed.course], parsed.steps);
+
+      // Both stamps are released, not re-pointed. A writer that discards
+      // the resources cannot validate any stamp, so it leaves none standing;
+      // the next courses walk re-stamps. An empty inline list beats a wrong
+      // one — and the narrower "clear only stamps whose step vanished" fix
+      // was tried first and failed exactly here, because `res-1` still named
+      // a live step id.
+      expect(await resources.getAllStepResources('course-1:0'), isEmpty);
+      expect((await db.myLibraryDao.getById('res-1'))!.stepId, isNull);
+      expect((await db.myLibraryDao.getById('res-2'))!.stepId, isNull);
+
+      // …and the next full courses walk restores the correct stamp.
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Deeper',
+              'resources': [resourceDoc('res-2', title: 'Aquifers')],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+      expect(
+        (await resources.getAllStepResources('course-1:0')).map((r) => r.id),
+        ['res-2'],
+      );
+    });
+
     test('another course\'s stamp is left alone', () async {
       stubCoursesWalk([
         courseDoc(
@@ -393,6 +463,86 @@ void main() {
 
       expect((await db.myLibraryDao.getById('res-1'))!.courseId, 'course-1');
       expect((await db.myLibraryDao.getById('res-2'))!.courseId, 'course-2');
+    });
+  });
+
+  group('getCourseResources splits on the downloaded flag', () {
+    // Kotlin has two methods over one query for this
+    // (`getCourseOnlineResources` / `getCourseOfflineResources`,
+    // `CoursesRepositoryImpl.kt:180-186`), so both conjuncts are the point of
+    // the reader. Without a downloaded row and a pointer-less row in the
+    // fixture, deleting either conjunct left the whole suite green.
+    setUp(() async {
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [
+                resourceDoc('res-downloaded'),
+                resourceDoc('res-pending', title: 'Aquifers'),
+              ],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+      await db.myLibraryDao.markDownloaded(
+        'res-downloaded',
+        'rainfall.pdf',
+        '1-a',
+      );
+    });
+
+    test('the offline list is the downloaded ones', () async {
+      final offline = await resources.getCourseResources(
+        'course-1',
+        isOffline: true,
+      );
+      expect(offline.map((r) => r.id), ['res-downloaded']);
+    });
+
+    test('the online list is the ones still to fetch', () async {
+      final online = await resources.getCourseResources(
+        'course-1',
+        isOffline: false,
+      );
+      expect(online.map((r) => r.id), ['res-pending']);
+    });
+
+    test('a resource with no attachment is in neither list', () async {
+      // `resourceLocalAddress IS NOT NULL` is Kotlin's third conjunct: it says
+      // "this resource has something to download at all". A document with no
+      // `_attachments` has no such pointer.
+      stubCoursesWalk([
+        courseDoc(
+          'course-2',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [
+                {'_id': 'res-linkless', '_rev': '1-a', 'title': 'A link'},
+              ],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+
+      expect(
+        await resources.getCourseResources('course-2', isOffline: false),
+        isEmpty,
+      );
+      expect(
+        await resources.getCourseResources('course-2', isOffline: true),
+        isEmpty,
+      );
+      // …but it is still a resource of the course, reachable by its step.
+      final byStep = await resources.getAllStepResources(
+        CourseMapper.stepIdFor('course-2', 0),
+      );
+      expect(byStep.map((r) => r.id), ['res-linkless']);
     });
   });
 
@@ -494,6 +644,57 @@ void main() {
         expect(row.stepId, CourseMapper.stepIdFor('course-1', 0));
       },
     );
+
+    test('ingesting a thin course copy keeps the download pointer', () async {
+      // A course document embeds a *thinner* copy of each resource, and
+      // `MyLibrary.serializeResource` builds its `_attachments` from
+      // `resourceLocalAddress?.let{…}` — so a device that has not downloaded
+      // the file uploads `"_attachments": {}`. Pulling that back through the
+      // courses walk used to write null over the pointer the resources walk
+      // had stored, leaving the row claiming `resourceOffline` with no path
+      // to the file and dropping it out of `getCourseResources` entirely.
+      await db.myLibraryDao.upsertAll([
+        MyLibraryTableCompanion.insert(
+          id: 'res-1',
+          rev: const Value('1-a'),
+          resourceLocalAddress: const Value('rainfall.pdf'),
+          resourceRemoteAddress: const Value(
+            'https://planet.example.org/resources/res-1/rainfall.pdf',
+          ),
+          resourceOffline: const Value(true),
+          downloadedRev: const Value('1-a'),
+        ),
+      ]);
+
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [
+                {
+                  '_id': 'res-1',
+                  '_rev': '1-a',
+                  'title': 'Rainfall',
+                  '_attachments': <String, dynamic>{},
+                },
+              ],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+
+      final row = await db.myLibraryDao.getById('res-1');
+      expect(row!.resourceLocalAddress, 'rainfall.pdf');
+      expect(row.resourceRemoteAddress, isNotNull);
+      expect(
+        await resources.getCourseResources('course-1', isOffline: true),
+        hasLength(1),
+        reason: 'the phase\'s own reader must still find it',
+      );
+    });
 
     test('a course-only resource is not put on anybody\'s shelf', () async {
       stubCoursesWalk([

--- a/flutter/test/repository/course_step_resources_test.dart
+++ b/flutter/test/repository/course_step_resources_test.dart
@@ -1,0 +1,516 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/repository/courses_repository.dart';
+import 'package:myplanet/repository/resources_repository.dart';
+
+/// The courses walk's third table.
+///
+/// Kotlin knows a course step's resources because `queueCourseResources`
+/// buffers each embedded resource **document** and
+/// `flushPendingCourseResources` writes it into `my_library` stamped with the
+/// step and course it came from (`CoursesRepositoryImpl.kt:792-798`,
+/// `:819-863`). `CourseMapper._parseSteps` kept `resources.length` and threw
+/// the documents away, so the port held a count of rows it did not have — and
+/// every reader of a step's resources was unreachable, not merely unwritten.
+///
+/// These drive the walk with a document shaped the way the server sends one,
+/// and read back through the DAO predicates the Kotlin readers use. A fixture
+/// that inserts a stamped row directly would prove nothing: the question is
+/// whether the writer can produce values the reader's `WHERE` matches.
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late CoursesRepository repository;
+  late ResourcesRepository resources;
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = CoursesRepository(
+      api,
+      db.courseDao,
+      db.removedLogDao,
+      db.examDao,
+      db.surveyDao,
+    );
+    resources = ResourcesRepository(api, db.myLibraryDao, db.removedLogDao);
+  });
+  tearDown(() => db.close());
+
+  void stubCoursesWalk(List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  /// A resource sub-object shaped the way Planet embeds one in a course step —
+  /// `MyCourse.serialize` rebuilds exactly this from `serializeResource`
+  /// (`MyCourse.kt:135-137`, `MyLibrary.kt:82-84`).
+  Map<String, dynamic> resourceDoc(
+    String id, {
+    String title = 'Rainfall',
+    String rev = '1-a',
+    String mediaType = 'pdf',
+  }) => {
+    '_id': id,
+    '_rev': rev,
+    'title': title,
+    'mediaType': mediaType,
+    '_attachments': {
+      'rainfall.pdf': {'content_type': 'application/pdf', 'length': 10},
+    },
+  };
+
+  Map<String, dynamic> courseDoc(
+    String id, {
+    required List<Map<String, dynamic>> steps,
+  }) => {'_id': id, 'courseTitle': 'Water', 'steps': steps};
+
+  group('ingestion', () {
+    test(
+      'a step resource lands in my_library keyed by its document id',
+      () async {
+        stubCoursesWalk([
+          courseDoc(
+            'course-1',
+            steps: [
+              {
+                'stepTitle': 'Intro',
+                'resources': [resourceDoc('res-1')],
+              },
+            ],
+          ),
+        ]);
+
+        await repository.sync(config: config);
+
+        final row = await db.myLibraryDao.getById('res-1');
+        expect(row, isNotNull);
+        expect(row!.title, 'Rainfall');
+        expect(row.rev, '1-a');
+        // The attachment is resolved the same way the resources walk resolves it,
+        // so the download path works for a course-only resource too.
+        expect(row.resourceLocalAddress, 'rainfall.pdf');
+      },
+    );
+
+    test(
+      'the stamp makes the step reachable through the Kotlin reader',
+      () async {
+        stubCoursesWalk([
+          courseDoc(
+            'course-1',
+            steps: [
+              {
+                'stepTitle': 'Intro',
+                'resources': [resourceDoc('res-1')],
+              },
+              {
+                'stepTitle': 'Deeper',
+                'resources': [resourceDoc('res-2', title: 'Aquifers')],
+              },
+            ],
+          ),
+        ]);
+
+        await repository.sync(config: config);
+
+        // `getAllStepResources` is the port of the call three Kotlin readers
+        // make: the inline list, the auto-download and the next-step prefetch.
+        final stepOne = await resources.getAllStepResources(
+          CourseMapper.stepIdFor('course-1', 0),
+        );
+        final stepTwo = await resources.getAllStepResources(
+          CourseMapper.stepIdFor('course-1', 1),
+        );
+        expect(stepOne.map((r) => r.id), ['res-1']);
+        expect(stepTwo.map((r) => r.id), ['res-2']);
+
+        // And the course-level download button's own predicate.
+        final notDownloaded = await resources.getCourseResources(
+          'course-1',
+          isOffline: false,
+        );
+        expect(notDownloaded.map((r) => r.id).toSet(), {'res-1', 'res-2'});
+      },
+    );
+
+    test('the count on the tile now matches the rows held', () async {
+      // `course_detail_screen` renders `resourcesInStep(step.noOfResources)`.
+      // That number was previously unsubstantiated; pin the two together.
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [
+                resourceDoc('res-1'),
+                resourceDoc('res-2', title: 'Aquifers'),
+              ],
+            },
+          ],
+        ),
+      ]);
+
+      await repository.sync(config: config);
+
+      final step = (await repository.getCourseSteps('course-1')).single;
+      final held = await resources.getAllStepResources(step.id);
+      expect(held, hasLength(step.noOfResources));
+    });
+
+    test('a step with no resources writes none', () async {
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {'stepTitle': 'Intro'},
+          ],
+        ),
+      ]);
+
+      await repository.sync(config: config);
+
+      expect(await db.myLibraryDao.getAll(), isEmpty);
+    });
+
+    test(
+      'a malformed resources array cannot abort the walk or write a phantom',
+      () async {
+        // Kotlin calls `.asJsonObject` on every element and the sync walk's
+        // `continueOnError` is false, so one bad element throws out of the
+        // whole page. And an `_id`-less object writes `id = ""`, where the
+        // primary key collides and the last such resource wins.
+        stubCoursesWalk([
+          courseDoc(
+            'course-1',
+            steps: [
+              {
+                'stepTitle': 'Intro',
+                'resources': [
+                  'not-an-object',
+                  {'title': 'no id at all'},
+                  {'_id': '', 'title': 'blank id'},
+                  // Whitespace is the case `MyLibraryMapper.fromDoc`'s own
+                  // `isEmpty` check does *not* catch, so only the courses
+                  // walk's trim-filter keeps this junk row out of the table.
+                  {'_id': '   ', 'title': 'whitespace id'},
+                  {'_id': '_design/thing', 'title': 'a design doc'},
+                  resourceDoc('res-1'),
+                ],
+              },
+            ],
+          ),
+        ]);
+
+        final result = await repository.sync(config: config);
+
+        expect(result, isA<SyncComplete>());
+        expect(
+          (await db.myLibraryDao.getAll()).map((r) => r.id),
+          ['res-1'],
+          reason: 'the good resource survives and no blank-id row is written',
+        );
+        expect(await repository.getCourseSteps('course-1'), hasLength(1));
+      },
+    );
+
+    test('a resource in two steps of one course keeps the last step', () async {
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [resourceDoc('res-1')],
+            },
+            {
+              'stepTitle': 'Again',
+              'resources': [resourceDoc('res-1')],
+            },
+          ],
+        ),
+      ]);
+
+      await repository.sync(config: config);
+
+      // One row per resource id, so the later companion wins the upsert —
+      // what Kotlin's REPLACE over the twice-mutated entity does. The keep
+      // set is a union across the document, so the release must not undo it.
+      final row = await db.myLibraryDao.getById('res-1');
+      expect(row!.stepId, CourseMapper.stepIdFor('course-1', 1));
+      expect(row.courseId, 'course-1');
+    });
+  });
+
+  group('the stamp is retired when the course stops claiming it', () {
+    test(
+      'deleting a step releases its resource rather than re-binding it',
+      () async {
+        stubCoursesWalk([
+          courseDoc(
+            'course-1',
+            steps: [
+              {
+                'stepTitle': 'Intro',
+                'resources': [resourceDoc('res-1')],
+              },
+              {
+                'stepTitle': 'Deeper',
+                'resources': [resourceDoc('res-2', title: 'Aquifers')],
+              },
+            ],
+          ),
+        ]);
+        await repository.sync(config: config);
+
+        // The author removes step 0. Step ids are positional, so what was
+        // `course-1:1` becomes `course-1:0` — the id `res-1` still carries.
+        stubCoursesWalk([
+          courseDoc(
+            'course-1',
+            steps: [
+              {
+                'stepTitle': 'Deeper',
+                'resources': [resourceDoc('res-2', title: 'Aquifers')],
+              },
+            ],
+          ),
+        ]);
+        await repository.sync(config: config);
+
+        final surviving = await resources.getAllStepResources(
+          CourseMapper.stepIdFor('course-1', 0),
+        );
+        expect(
+          surviving.map((r) => r.id),
+          ['res-2'],
+          reason:
+              'the deleted step\'s resource must not surface under the step '
+              'that took its slot',
+        );
+
+        final released = await db.myLibraryDao.getById('res-1');
+        expect(released!.stepId, isNull);
+        expect(
+          released.courseId,
+          isNull,
+          reason:
+              'getCourseResources reads courseId alone, so a stale one would '
+              'keep over-filling the course download dialog',
+        );
+      },
+    );
+
+    test('removing a course\'s last resource clears the old join', () async {
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [resourceDoc('res-1')],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {'stepTitle': 'Intro'},
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+
+      expect(
+        await resources.getCourseResources('course-1', isOffline: false),
+        isEmpty,
+      );
+      expect((await db.myLibraryDao.getById('res-1'))!.stepId, isNull);
+    });
+
+    test('another course\'s stamp is left alone', () async {
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [resourceDoc('res-1')],
+            },
+          ],
+        ),
+        courseDoc(
+          'course-2',
+          steps: [
+            {
+              'stepTitle': 'Other',
+              'resources': [resourceDoc('res-2', title: 'Aquifers')],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+
+      expect((await db.myLibraryDao.getById('res-1'))!.courseId, 'course-1');
+      expect((await db.myLibraryDao.getById('res-2'))!.courseId, 'course-2');
+    });
+  });
+
+  group('the course link and the shelf survive a resources re-pull', () {
+    test(
+      'the resources walk cannot clear a stamp the courses walk wrote',
+      () async {
+        stubCoursesWalk([
+          courseDoc(
+            'course-1',
+            steps: [
+              {
+                'stepTitle': 'Intro',
+                'resources': [resourceDoc('res-1')],
+              },
+            ],
+          ),
+        ]);
+        await repository.sync(config: config);
+
+        // The user then adds the same resource to their shelf.
+        await db.myLibraryDao.upsertAll([
+          (await db.myLibraryDao.getById(
+            'res-1',
+          ))!.toCompanion(false).copyWith(userId: const Value(['user-1'])),
+        ]);
+
+        // Now the `resources` database walk pulls the same document. It knows
+        // nothing about courses and passes no stamp.
+        when(
+          () => api.getJsonObject(
+            '$dbUrl/resources/_all_docs?limit=0',
+            authHeader: any(named: 'authHeader'),
+          ),
+        ).thenAnswer(
+          (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 1}),
+        );
+        when(
+          () => api.getJsonObject(
+            '$dbUrl/resources/_all_docs?include_docs=true&limit=100&skip=0',
+            authHeader: any(named: 'authHeader'),
+          ),
+        ).thenAnswer(
+          (_) async => NetworkSuccess<Map<String, dynamic>>({
+            'rows': [
+              {'id': 'res-1', 'doc': resourceDoc('res-1', rev: '2-b')},
+            ],
+          }),
+        );
+
+        await resources.sync(config: config);
+
+        final row = await db.myLibraryDao.getById('res-1');
+        expect(row!.rev, '2-b', reason: 'the re-pull still updates the row');
+        expect(
+          row.stepId,
+          CourseMapper.stepIdFor('course-1', 0),
+          reason: 'Value.absent() must not be written over the stamp',
+        );
+        expect(row.courseId, 'course-1');
+        expect(row.userId, [
+          'user-1',
+        ], reason: 'and the shelf the user built is still there');
+      },
+    );
+
+    test(
+      'ingesting a course resource does not retract a shelf membership',
+      () async {
+        await db.myLibraryDao.upsertAll([
+          MyLibraryTableCompanion.insert(
+            id: 'res-1',
+            rev: const Value('1-a'),
+            userId: const Value(['user-1']),
+          ),
+        ]);
+
+        stubCoursesWalk([
+          courseDoc(
+            'course-1',
+            steps: [
+              {
+                'stepTitle': 'Intro',
+                'resources': [resourceDoc('res-1')],
+              },
+            ],
+          ),
+        ]);
+        await repository.sync(config: config);
+
+        final row = await db.myLibraryDao.getById('res-1');
+        expect(
+          row!.userId,
+          ['user-1'],
+          reason:
+              'Kotlin passes no userId to the drain, so setUserId returns '
+              'early and the stored shelf is untouched',
+        );
+        expect(row.stepId, CourseMapper.stepIdFor('course-1', 0));
+      },
+    );
+
+    test('a course-only resource is not put on anybody\'s shelf', () async {
+      stubCoursesWalk([
+        courseDoc(
+          'course-1',
+          steps: [
+            {
+              'stepTitle': 'Intro',
+              'resources': [resourceDoc('res-1')],
+            },
+          ],
+        ),
+      ]);
+      await repository.sync(config: config);
+
+      expect((await db.myLibraryDao.getById('res-1'))!.userId, isEmpty);
+      expect(await db.myLibraryDao.resourcesOnShelf('user-1'), isEmpty);
+    });
+  });
+}

--- a/flutter/test/repository/resource_prune_eligibility_test.dart
+++ b/flutter/test/repository/resource_prune_eligibility_test.dart
@@ -56,8 +56,12 @@ void main() {
   });
 
   test('the empty-walk branch carries the same guards', () async {
-    // `total_rows == 0` calls `deleteNotIn(const [])`, Kotlin's
-    // `deleteAllStalePublic` — which is guarded identically, not a bare wipe.
+    // `total_rows == 0` calls `deleteNotIn(const [])`. Kotlin's counterpart
+    // `deleteAllStalePublic` is guarded identically — but it is also
+    // **unreachable** (`removeDeletedResources` runs only when the id list is
+    // non-empty, `SyncManager.kt:416`), so on an empty walk Kotlin deletes
+    // nothing at all and the port still deletes the synced public rows. The
+    // guards narrow the blast radius; they do not make this branch parity.
     await seed();
 
     await db.myLibraryDao.deleteNotIn(const []);

--- a/flutter/test/repository/resource_prune_eligibility_test.dart
+++ b/flutter/test/repository/resource_prune_eligibility_test.dart
@@ -1,0 +1,86 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+
+/// `MyLibraryDao.deleteNotIn` is the port of Kotlin's `removeDeletedResources`,
+/// and for a long time it was not: Kotlin prunes only rows the server has
+/// actually seen — `WHERE _rev IS NOT NULL AND _rev != '' AND isPrivate = 0`
+/// (`MyLibraryDao.kt:170-178`) — while the port deleted anything the walk had
+/// not listed.
+///
+/// Three rows are destroyed by the unguarded version, and the first is the one
+/// that matters: `ResourcesRepository.saveLocalResource` writes a row with no
+/// `rev`, no CouchDB document and no outbox entry, so nothing can give it back.
+/// The third is why this sits beside the course-resource work rather than in
+/// its own phase — it decides whether a course step's stamp is durable or a
+/// one-sync artefact.
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase.memory());
+  tearDown(() => db.close());
+
+  Future<void> seed() => db.myLibraryDao.upsertAll([
+    // Created offline through the add-resource screen: no rev, ever.
+    MyLibraryTableCompanion.insert(
+      id: 'local-1',
+      title: const Value('My own resource'),
+    ),
+    // A row that reached the server but whose rev came back empty.
+    MyLibraryTableCompanion.insert(id: 'blank-rev-1', rev: const Value('')),
+    // A private team resource the public walk never lists.
+    MyLibraryTableCompanion.insert(
+      id: 'private-1',
+      rev: const Value('1-a'),
+      isPrivate: const Value(true),
+      privateFor: const Value('team-1'),
+    ),
+    // An ordinary synced resource the walk no longer lists.
+    MyLibraryTableCompanion.insert(id: 'stale-1', rev: const Value('1-a')),
+    MyLibraryTableCompanion.insert(id: 'server-1', rev: const Value('1-a')),
+  ]);
+
+  Future<Set<String>> remaining() async =>
+      (await db.myLibraryDao.getAll()).map((r) => r.id).toSet();
+
+  test('the prune removes only public rows the server has seen', () async {
+    await seed();
+
+    final deleted = await db.myLibraryDao.deleteNotIn(['server-1']);
+
+    expect(deleted, 1, reason: 'only stale-1 is eligible');
+    expect(
+      remaining(),
+      completion({'local-1', 'blank-rev-1', 'private-1', 'server-1'}),
+    );
+  });
+
+  test('the empty-walk branch carries the same guards', () async {
+    // `total_rows == 0` calls `deleteNotIn(const [])`, Kotlin's
+    // `deleteAllStalePublic` — which is guarded identically, not a bare wipe.
+    await seed();
+
+    await db.myLibraryDao.deleteNotIn(const []);
+
+    expect(remaining(), completion({'local-1', 'blank-rev-1', 'private-1'}));
+  });
+
+  test('a course resource with no rev of its own is not pruned away', () async {
+    // A step's embedded sub-object is not obliged to carry `_rev`. Kotlin's
+    // `_rev != ''` clause spares it; the port used to delete it on the next
+    // resources sync, taking the freshly written step join with it.
+    await db.myLibraryDao.upsertAll([
+      MyLibraryTableCompanion.insert(
+        id: 'course-res-1',
+        stepId: const Value('course-1:0'),
+        courseId: const Value('course-1'),
+      ),
+    ]);
+
+    await db.myLibraryDao.deleteNotIn(['something-else']);
+
+    final row = await db.myLibraryDao.getById('course-res-1');
+    expect(row, isNotNull);
+    expect(row!.stepId, 'course-1:0');
+  });
+}

--- a/flutter/test/repository/resources_repository_test.dart
+++ b/flutter/test/repository/resources_repository_test.dart
@@ -36,9 +36,18 @@ void main() {
 
   tearDown(() => db.close());
 
-  Map<String, dynamic> row(String id, String title) => {
+  /// A row as `_all_docs?include_docs=true` returns it.
+  ///
+  /// The `_rev` is not decoration. `MyLibraryDao.deleteNotIn` prunes only rows
+  /// the server has actually seen — Kotlin's `deleteStalePublicNotIn` is
+  /// `WHERE _rev IS NOT NULL AND _rev != '' AND isPrivate = 0`
+  /// (`MyLibraryDao.kt:170-178`) — because a row with no revision was authored
+  /// on this device and no walk can vouch for it. A fixture that omits the
+  /// field is not a server document, and the prune tests below would be
+  /// asserting against rows the real walk never produces.
+  Map<String, dynamic> row(String id, String title, {String rev = '1-a'}) => {
     'id': id,
-    'doc': {'_id': id, 'title': title},
+    'doc': {'_id': id, '_rev': rev, 'title': title},
   };
 
   void stubCount(int totalRows) {


### PR DESCRIPTION
Lane A of the Phase 146 four-lane round. **Complete — gate green, ready for the integrator.**

**Brief:** Phase 145 *Reported, not fixed* item 2. Kotlin's courses walk buffers each embedded resource document (`queueCourseResources`, `CoursesRepositoryImpl.kt:792-798`) and drains it into `my_library` stamped with `courseId`/`stepId` (`flushPendingCourseResources`, `:819-863`), while `CourseMapper._parseSteps` kept only `resources.length`. The port held a count of rows it did not have, so the inline per-step resource list, the course-level download button, and step auto-download/prefetch had nowhere to read from.

## What landed

- `MyLibraryTable` gains `stepId`/`courseId` (+ a `course_id` index). **Drift `schemaVersion` 48 is spent** — next round must not reuse it. No hand-written migration step: `my_library` is a cache, so the drop loop deletes it and `createAll` rebuilds it complete.
- `CourseMapper` returns the parsed resource documents; `CoursesRepository.sync` writes them per page, as Kotlin drains per batch *inside* the walk.
- The stamp is written only when non-blank and `Value.absent()` otherwise, so the `resources` walk cannot clear a link it knows nothing about.
- Readers for the UI phase: `ResourcesRepository.getAllStepResources` and `getCourseResources`.

## Three defects found along the way, each demonstrated failing first

1. **`MyLibraryDao.deleteNotIn` was never the port of Kotlin's prune.** Kotlin spares `_rev IS NULL OR _rev = ''` and `isPrivate = 1` (`MyLibraryDao.kt:171-178`); the port deleted anything the walk had not listed — destroying every resource created offline on the first sync, every private team resource, and any course resource whose embedded sub-object lacks a `_rev`, which would have made the new stamp a one-sync artefact.
2. **The courses walk was nulling the resource download pointer on every sync.** `MyLibraryMapper` wrote the attachment addresses unconditionally where Kotlin writes them only inside `if (doc.has("_attachments"))`. Latent until this phase made the courses walk a second writer reading a *thinner* document.
3. **Positional step ids could re-bind a stamp.** Deleting a step hands its id to the step that shifts up. `CourseDao.upsertAll` now releases every stamp for the courses it writes and the walk re-stamps after — *only a writer that has the step's resources may leave a stamp standing*.

## Method

Two `parity-auditor` passes at `effort: max`. The ground-truth pass refuted one of my claims (defect 1); the second pass, on green code, found defect 2 and two predicates nothing pinned. Fourteen mutations replayed. Full reasoning, including a **Reported, not fixed** list of eleven items, is in `flutter/PHASE_146_NOTES.md`.

**For whoever takes the course UI:** `take_course_screen.dart:687-697` still says the port cannot render a step's resources. That was true when Phase 145 wrote it and is false now — see reported item 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9vwUbCFwgj6v3Z1Rhb64R