### PR TITLE
fix(flutter): outbox permanent-refusal policy (Phase 148, Lane C)

### DIFF
--- a/flutter/PHASE_148_NOTES.md
+++ b/flutter/PHASE_148_NOTES.md
@@ -1,0 +1,19 @@
+# Phase 148 — the outbox's permanent-refusal policy (Lane C)
+
+Two jobs, both policy calls that three consecutive rounds reported and could
+not take:
+
+1. A health examination whose upload answers `id` without `rev` is abandoned on
+   its first attempt and then re-POSTs forever
+   (`PHASE_142_NOTES.md` *Reported, not fixed* item 6, and the `1004e90`
+   amendment it points at).
+2. A permanent refusal accretes one dead outbox row and one doomed POST per
+   sync, unbounded, across all twenty uploaders
+   (`PHASE_138_NOTES.md` *Reported, not fixed* → "The abandoned-row accretion
+   Phase 134 reported now has a twentieth instance").
+
+*In progress — this file is written as the lane goes.*
+
+## Reported, not fixed
+
+*(to be filled in)*

--- a/flutter/PHASE_148_NOTES.md
+++ b/flutter/PHASE_148_NOTES.md
@@ -223,6 +223,9 @@ touched, and `voices_uploader.dart` was not opened for edit.**
 
 ## Tests
 
+Gate green: `dart format` clean, `flutter analyze` clean, **2648 tests pass**
+(2631 before — the three files below go 19 → 27, 14 → 21 and 7 → 9).
+
 Every claim was mutation-tested: the fix reverted, the suite run, the named
 test confirmed failing, the fix restored. Where a mutation survived, the
 fixture was strengthened rather than the clause deleted.

--- a/flutter/PHASE_148_NOTES.md
+++ b/flutter/PHASE_148_NOTES.md
@@ -86,23 +86,36 @@ instead of repeating it.
 
 Two things make the fix worth having anyway.
 
-**The class is reachable elsewhere.** `chat_uploader.dart:69-87` posts to
-Planet's chat API, not to CouchDB, and branches on an application-level
-`data['status'] != 'Success'`. A 200 carrying `{"status":"error", …}` is an
-ordinary answer from that API, and until now it abandoned the row on its first
-attempt and re-POSTed on every subsequent chat write. That is the same branch,
-in production.
+**The class is reachable elsewhere, though not for the reason first written
+here.** `chat_uploader.dart:69-87` branches on an application-level
+`data['status'] != 'Success'` and on `data['couchdb']['id']` — the shape
+Planet's chat service answers with. An earlier revision of this section said
+the uploader posts to that service. It does not:
+`ChatUploader.endpointFor` is `credentialFreeDbUrl(config)/chat`, a **CouchDB**
+database path, while Kotlin's chat POST goes to `UrlUtils.hostUrl` —
+`<scheme>://<host>:5000/` or `<scheme>://<host>/ml/`
+(`UrlUtils.kt:102-106`, `ChatApiService.kt:54-57`) — a different service
+altogether. CouchDB answers `{ok, id, rev}`, which has no `status`, so *every*
+outbox chat upload takes that null-code branch. The branch is therefore
+reachable in production; what it reveals is a pre-existing endpoint defect,
+recorded under *Reported, not fixed*. Under this policy such a chat is POSTed
+once instead of on every subsequent chat write — better, and still broken.
 
 **The loop Job 1 describes is reachable without any unusual response at all.**
-The health document's `_id` *is* the patient's user id
-(`health_repository.dart:846`), so every examination after the first is an
-update needing the current `_rev`. Anything that leaves the local `rev` stale —
-Planet's web UI editing the record, a second handset filing for the same
-patient — yields a 409 on the first attempt. And `cacheDocuments` skips a
-locally dirty row (`health_repository.dart:771`), so the health sync-in is
-structurally unable to refresh that `rev`: the loop could not self-heal. That
-is stronger than the notes claimed, and it is why the same fix had to cover
-plain 4xx rejections and not only the null-code branch.
+An earlier revision of this section had the mechanism wrong, in a way worth
+recording because it is the kind of claim the next round would build on.
+Examinations do **not** share a document: `createExamination` defaults `userId`
+to the row's own generated id (`health_repository.dart:96-99`) and
+`health_provider.dart:468-471` passes none, so each examination is its own
+CouchDB document and cannot conflict with a previous one. What *is* keyed on
+the patient is the **profile** row — `saveHealthProfileBlob` writes
+`id = patientId, userId = user.couchId` (`:273-315`) — and it is re-saved on
+every examination save. So a 409 on the first attempt is reachable there, and
+on a legacy row whose `userId` was set to the patient. Either way
+`cacheDocuments` skips a locally dirty row (`health_repository.dart:772`), so
+the health sync-in is structurally unable to refresh that `rev` and the loop
+cannot self-heal. That is why the fix had to cover plain 4xx rejections and not
+only the null-code branch.
 
 **What the port cannot copy from Kotlin here.** Kotlin gates on `has("id")`,
 tolerates a null rev, and clears `isUpdated` while leaving `_rev` alone
@@ -119,9 +132,11 @@ Phase 138 said the accretion fires "once per *sync*". It is right for four
 upload types and wrong as a general statement. Of twenty-six types:
 
 * **per sync** (`dashboard_sync_provider.syncAll` and `background_entrypoint`):
-  `submissions`, `news` (voices), `adoptedSurvey`, plus the four `activities`
-  types via `recordSyncActivity`, and `searchActivity` when the sync moved
-  anything.
+  `submissions`, `news` (voices), `adoptedSurvey`, the four `activities` types
+  via `recordSyncActivity`, and `searchActivity` when the sync moved anything.
+  The four `activities` types are *also* swept from every resource open,
+  download and course visit (`activities_provider.dart:84`, `:107`,
+  `:131-134`), so their real cadence is closer to `teamLog`'s.
 * **per user write**: `health`, `personal`, `feedback`, `rating`,
   `achievement`, `chat`, `meetup`, `teamTask`, `courseProgress`,
   `submitPhoto`, `user`.
@@ -133,7 +148,10 @@ upload types and wrong as a general statement. Of twenty-six types:
   `teams_uploader.dart:15-19` documents as freezing the row at its local
   version.
 
-So twenty-two of twenty-six re-offered for ever. The cadence differs; the
+So **twenty** of twenty-six re-offered for ever — the three lists above sum
+to 20, and 26 minus the 6 bounded ones agrees. (An earlier revision of this
+file said twenty-two, from neither count. A number that is not the sum of the
+rows above it is a number nobody added up.) The cadence differs; the
 unboundedness did not.
 
 ---
@@ -211,20 +229,27 @@ path is special.
   `markUploaded(id, null)` is not the answer here).
 * `queuePending(retryRefused:)` for the banner's Retry button.
 
+**`flutter/lib/repository/personals_uploader.dart`** — a deterministic
+`uploadedAt`, added by the second audit pass. This is the one other
+`*_uploader.dart` touched, and it is touched because the policy requires it:
+without it the memo is inert for that type (see above).
+
 **Outside the lane's own set, and named because the brief asks:**
 `flutter/lib/providers/health_provider.dart` (thread `retryRefused`; correct a
-dartdoc that described the accretion as intended behaviour) and
+dartdoc that described the accretion as intended behaviour),
 `flutter/lib/ui/health/my_health_screen.dart` (pass `retryRefused: true`;
-correct the comment that said `enqueue` writes a fresh pending row). Both were
-required: without them the memo silently turns Retry into a no-op, and that
-button sits next to a count of stranded records. Neither file is any other
-lane's this round. **No `*_uploader.dart` other than `health_uploader.dart` was
-touched, and `voices_uploader.dart` was not opened for edit.**
+correct the comment that said `enqueue` writes a fresh pending row), and
+`flutter/lib/repository/personals_repository.dart` (one dartdoc, which claimed
+`serialize` "remains deterministic" — it did not). The first two were required:
+without them the memo silently turns Retry into a no-op, and that button sits
+next to a count of stranded records. None of the three is any other lane's this
+round. **`voices_uploader.dart` was not opened for edit**, and no uploader
+other than `health` and `personals` was touched at all.
 
 ## Tests
 
-Gate green: `dart format` clean, `flutter analyze` clean, **2648 tests pass**
-(2631 before — the three files below go 19 → 27, 14 → 21 and 7 → 9).
+Gate green: `dart format` clean, `flutter analyze` clean, **2658 tests pass**
+(2631 before).
 
 Every claim was mutation-tested: the fix reverted, the suite run, the named
 test confirmed failing, the fix restored. Where a mutation survived, the
@@ -262,6 +287,17 @@ fixture was strengthened rather than the clause deleted.
   `a 409 rejects the request the payload made`, with the misreading it carried
   written out at the test.
 
+**`test/repository/personals_uploader_test.dart`** (12, was 10) — added by the
+second audit pass, and both fail on the pre-fix code
+* `the payload a sweep builds is stable across sweeps` — the invariant the
+  whole policy rests on, pinned for the uploader that broke it.
+* `a refused note is POSTed once, however many sweeps run` — the consequence,
+  end to end.
+
+**`test/ui/health/my_health_screen_test.dart`** (22, unchanged count)
+* `the caution offers a retry that re-queues the record` — rewritten so it
+  *can* fail: the abandoned row now carries the request production builds.
+
 **`test/repository/health_legacy_conflict_test.dart`** (9, was 7)
 * `a record refused ten times leaves one row and one POST` — replaces
   `a record refused twice is one stranded record, not two`, which asserted
@@ -274,7 +310,8 @@ fixture was strengthened rather than the clause deleted.
 * `the clinician tapping Retry does override the memo` — a sweep does not
   re-ask, `retryRefused: true` does.
 
-Nine mutations, each reverted one at a time with the suite run in between:
+Thirteen mutations in total, each reverted one at a time with the suite run in
+between. The first nine, before the second audit pass:
 `enqueue` back to `findOpen` (11 failures), the drainer back to
 `(code ?? 0) < 500` (2), the `noUsableResponse` sentinel dropped (4),
 `sameRequest` ignoring the endpoint (1), `rearm` made a no-op (1), the
@@ -294,6 +331,12 @@ pinned by six tests. A reader who deletes `indeterminate` and folds it into
 `rejected` will not break the suite; they will break the reasoning, and the
 notes and the dartdoc are what stand in the way.
 
+The four added by the second audit pass: the personals `uploadedAt`
+(2 failures), the claimed-row guard in `_soleRowFor` (1, after the fixture was
+corrected — see above), the second sentinel (1), the `_soleRowFor` open-row
+preference (1), the `rearm` guard (2), and `retryRefused: true` removed from
+`my_health_screen.dart` (1).
+
 One mutation is worth recording because it survived at first. Reverting
 `_soleRowFor` to `findOpen` left `an unusable 2xx response is not asked again
 either` **passing**, because the first cut of that test counted outbox rows
@@ -301,6 +344,54 @@ rather than sends and the drainer's `due()` never re-offers an abandoned row —
 the accretion is one row *and one POST per sweep*, and only the POST count
 distinguishes the two policies. The test now counts sends. Same reason the
 health tests count `couch.postCount`.
+
+---
+
+## What the second audit pass changed
+
+The mandatory pass over this lane's own finished, already-green code found
+seven defects and seven wrong claims in this file. Four of the defects were
+fixed here; the pattern held for a fifth consecutive round — **an audit of the
+ground truth does not audit the implementation.**
+
+**The worst of them defeated the whole policy for one uploader, and it was the
+worst possible uploader to lose.** `PersonalsUploader.queuePending` built its
+payload with `PersonalsRepository.serialize(row)`, whose `uploadDate` defaults
+to `DateTime.now()`. The memo compares the request being enqueued against the
+one already recorded, so a payload that is not a pure function of the local row
+never matches: for `personals` the memo was inert and a refused note was POSTed
+on every sweep exactly as before. And `personals` is an **append** with a
+server-minted id — the class where the duplicate this policy exists to prevent
+cannot be detected afterwards, and where the handler's own comment says so.
+Fixed by passing the note's creation date, which is the honest value: Kotlin's
+`Date().time` is the moment of the POST, which a durable queue cannot know at
+enqueue time. **A payload that is not a pure function of its row silently
+disables the memo**, so `personals_uploader_test.dart` now pins the property
+directly, and it is the first thing to check when adding an uploader.
+
+Also fixed: `_soleRowFor`'s surplus-row `deleteById` could drop a row a drain
+had claimed (it is the one delete in `OutboxDao` that is not status-scoped, and
+the others are scoped for exactly that reason); `markFailed` stored one
+sentinel for both terminal reasons, so `rejected` read back as `indeterminate`
+and the 409-recovery follow-up below would have found the distinction already
+collapsed — there are two sentinels now; and the drainer's "a null code means
+the send succeeded" comment is a universal that three handlers falsify by
+returning one *before making any request*.
+
+**And the widget test that looked like it covered the Retry override could not
+fail.** `my_health_screen_test.dart`'s helper seeded the abandoned row with
+`payload: '{}'` while the production sweep serializes a real document, so
+`sameRequest` was false either way and the test passed with or without
+`retryRefused: true`. It now seeds
+`jsonEncode(HealthRepository.serialize(row))`, and removing the flag fails it.
+The same trap in miniature appeared in this phase's *own* new test for the
+claimed-surplus-row guard: it seeded the claimed row as the *older* of the two,
+and `_soleRowFor` keeps the first open row in `createdAt` order, so the guard
+was never reached and the mutation survived. **The fixture was the reason, not
+the clause** — the ages are swapped now and it fails as it should.
+
+Three of the audit's findings were argued and **not** taken; they are stated as
+trades under *Reported, not fixed* rather than silently accepted.
 
 ---
 
@@ -331,9 +422,11 @@ Each names the file, the change, and why it was not made here.
    `app_database.dart:1035` (`rev == null ? const Value.absent() : Value(rev)`).
    **Lane A's file this round.** Phase 142 item 7 reported the dead-code
    sibling `HealthRepository.markUploadedBatch`, which has the same bug and
-   still has zero callers.
+   still has zero callers. (The `rev == null ? const Value.absent() :
+   Value(rev)` pattern is at `app_database.dart:1198` and `:2066`; an earlier
+   revision of this file cited `:1035`, which is inside `UserDao.search`.)
 3. **`HealthRepository.cacheDocuments` skips a locally dirty row**
-   (`health_repository.dart:771`, `if (current?.isUpdated == true) continue;`),
+   (`health_repository.dart:772`, `if (current?.isUpdated == true) continue;`),
    and nothing else writes `health_examinations.rev`. So the one self-healing
    route this phase relies on — a pull supplies the revision, the payload
    changes, the memo re-arms — is **structurally unavailable for health**,
@@ -378,5 +471,54 @@ Each names the file, the change, and why it was not made here.
    permanently-set `isUpdated` freezing the row at its local version and
    exempting it from stale-row cleanup for good. The memo does not help there
    because nothing re-offers the row in the first place. Worth its own look.
-9. **Phase 142's items 1, 3, 4, 5, 7–10 and Phase 138's other items are still
+9. **`ChatUploader` posts to the wrong service, and the port's live chat path
+   does too.** `endpointFor` is `credentialFreeDbUrl(config)/chat` — CouchDB —
+   while the handler branches on `data['status'] == 'Success'` and
+   `data['couchdb']['id']`, the shape Planet's chat service returns. Kotlin
+   sends chat to `UrlUtils.hostUrl`, `<scheme>://<host>:5000/` or
+   `<scheme>://<host>/ml/` (`UrlUtils.kt:102-106`,
+   `ChatApiService.kt:54-57`), a different host and port. CouchDB answers
+   `{ok, id, rev}` with no `status`, so every outbox chat upload takes the
+   "not Success" branch. The same wrong base is on the live path at
+   `chat_repository.dart:354`. **Severity: high** — this is chat write-back not
+   working, not a policy question — but it is a chat slice, not an outbox one,
+   and fixing it needs the Planet chat API's real contract rather than a guess.
+   Found by the second audit pass while checking a claim this file made about
+   chat, which is the second time this round that checking my own citation
+   found something bigger than the citation.
+10. **Three handlers return a null code before sending anything**, so the
+   drainer reads them as `indeterminate` ("the write may already have landed")
+   when nothing was sent: `user_uploader.dart:126` and `:143-147`,
+   `achievements_uploader.dart:63`. The effect is the same today — terminal
+   either way — and the first is genuinely terminal, since the local row is
+   gone. But `'User document carries no _rev; cannot update'` is about the
+   *server's* current state and a later attempt could succeed, and `user` has
+   no payload-changing recovery route (`UserMapper.toDoc` emits no `_rev`;
+   the handler fetches it at send time), so a profile edit can now sit
+   abandoned where it used to be re-attempted. The clean fix is for those
+   handlers to say what they mean with `OutboxRepository.notSent` or a
+   retryable code rather than let the drainer guess — three one-line uploader
+   edits, which is per-uploader special-casing this lane deliberately avoided.
+   Reachability is low (a `_users` GET always carries `_rev`).
+11. **403-as-transient and 404-as-transient are trades, not certainties.**
+   CouchDB has a second 403 — `validate_doc_update` answering
+   `{forbidden: …}` — which is a permanent property of the document's bytes;
+   and `public_survey`'s endpoint is a Planet REST route
+   (`surveys_repository.dart:633-638`), where a 404 means the team or survey
+   does not exist. Both are read as transient here. The reasoning is at the
+   constant and worth repeating: reading them as terminal strands a write with
+   nothing able to re-arm it, because neither repair changes the request, while
+   reading them as transient costs wasted requests and leaves the row bounded
+   at one. Wasted requests are the cheaper mistake. If Planet is ever confirmed
+   to ship `validate_doc_update` on a database the port writes to, revisit —
+   and note that would want a *recovery* arm, not a reclassification.
+12. **A pre-Phase-148 abandoned row with a null `httpCode` gets one more
+   attempt on upgrade.** The old drainer stored `NULL` for a handler's verdict
+   on a 2xx, which is indistinguishable from a transport failure, so
+   `classifyStatus` reads it as transient and re-arms it once. It self-heals
+   immediately — the next failure writes the sentinel — and `outbox` is
+   preserved, so these rows do arrive on upgraded installs. Pinned by a test
+   rather than fixed, because the alternative is treating every legacy
+   null-code row as terminal, which would strand transport failures.
+13. **Phase 142's items 1, 3, 4, 5, 7–10 and Phase 138's other items are still
    open**; none is in this lane's set.

--- a/flutter/PHASE_148_NOTES.md
+++ b/flutter/PHASE_148_NOTES.md
@@ -1,19 +1,379 @@
 # Phase 148 — the outbox's permanent-refusal policy (Lane C)
 
-Two jobs, both policy calls that three consecutive rounds reported and could
-not take:
+Two jobs, both reported by three consecutive rounds and left because they are
+policy calls rather than repairs:
 
 1. A health examination whose upload answers `id` without `rev` is abandoned on
-   its first attempt and then re-POSTs forever
+   its first attempt and then re-POSTs for ever
    (`PHASE_142_NOTES.md` *Reported, not fixed* item 6, and the `1004e90`
    amendment it points at).
 2. A permanent refusal accretes one dead outbox row and one doomed POST per
-   sync, unbounded, across all twenty uploaders
-   (`PHASE_138_NOTES.md` *Reported, not fixed* → "The abandoned-row accretion
-   Phase 134 reported now has a twentieth instance").
+   sweep, unbounded, across twenty-odd uploaders
+   (`PHASE_138_NOTES.md` → "The abandoned-row accretion Phase 134 reported now
+   has a twentieth instance").
 
-*In progress — this file is written as the lane goes.*
+**They are one defect, and the honest answer was to unify them.** Job 1 is not
+a health bug; it is the *only* class of refusal where re-sending can create a
+second document, reached through a branch fourteen uploaders share. Job 2 is
+the same loop reached through a status code. Both are fixed by one rule at the
+repository layer, with **no uploader edited**.
+
+---
+
+## The policy, stated plainly
+
+> **An `outbox` item owns exactly one row, for ever. A terminal row is a memo:
+> the request it holds has been answered, and nothing re-asks the identical
+> question unattended. What re-arms it is a *changed request* — a different
+> payload, endpoint or verb — or a person explicitly asking for a retry.**
+
+Concretely:
+
+| What happened | Class | Row | Re-armed by an identical sweep? |
+|---|---|---|---|
+| 5xx, 0, transport failure, handler threw | `transient` | retried under the backoff; abandoned after `maxAttempts` | **yes** — nothing about it was a verdict on the request |
+| 401, 403, 408, 429 | `transient` | as above | **yes** — about the caller or the moment, not the bytes |
+| any other 4xx (400, 404, 409, 412, …) | `rejected` | abandoned on the first attempt | **no** |
+| a handler's own verdict on a **2xx** (`NetworkError(null, …)`) | `indeterminate` | abandoned on the first attempt | **no** |
+| a payload that will not parse | `rejected` | abandoned; never even sent | no (and no POST either way) |
+
+And the invariant that makes it bounded: **one row per `(uploadType, itemId)`**.
+`enqueue` reuses the item's row whatever its status instead of minting a new
+one, and collapses any surplus an older build left behind — which matters,
+because `outbox` is a preserved table and those rows survive every schema bump.
+
+### Why `indeterminate` is not retried, against the auditor's own suggestion
+
+The ground-truth `parity-auditor` pass argued a handler's "unusable response"
+verdict "should be retryable at most". I disagree, from that same report's
+paragraph (a): eleven uploaders are **appends** with server-assigned ids, so a
+duplicate created by a retry is undetectable afterwards — nothing on the device
+knows the id the server minted. A `NetworkError(null, …)` follows a **2xx**:
+the transport says the write landed. Retrying it is the one move that can file
+a second copy of a document that is already there. Where a retry would be safe
+(a deterministic `_id`, so a re-POST merely 409s) the *right* answer is not a
+retry but the 409-recovery arm — see *Reported, not fixed* item 1. So: not
+re-sent, and the diagnostic kept.
+
+### Why not `cleanup()`
+
+Phase 138 offered two options: "bound `cleanup()` and give it a caller, or
+clear an item's abandoned rows on re-enqueue and lose the diagnostic". Both
+lose something. Reusing the row is a third: the table is bounded by the number
+of distinct refused items rather than by time, and the diagnostic
+`OutboxDao.abandoned` reads is exactly the row that is being reused, so nothing
+is lost. `cleanup()` still has no caller, deliberately — deleting an abandoned
+row is deleting the only record the port keeps of a write the server refused,
+which is what Phase 107 added `abandoned()` to stop.
+
+---
+
+## What each job actually was
+
+### Job 1 — and a correction to the claim it was filed under
+
+Phase 142's amendment said `id` without `rev` "is what CouchDB returns for
+`?batch=ok`". **Neither this port nor the Kotlin app sends `batch=ok`
+anywhere** — `grep -rn "batch=ok" flutter/lib app/src/main/java` is empty. And
+`PlanetApi._request` checks the status *before* converting the body
+(`planet_api.dart:249-253`), so a CouchDB error body can never reach a
+handler's success branch, and a 2xx that will not decode becomes a
+`NetworkException` (retryable) rather than this. The only route in is a 2xx
+that decodes to a JSON object without a usable `rev` — which for CouchDB means
+`batch=ok`, which is not sent. So **the health branch is defensive, and the
+route the notes named does not exist**; the comment at the code now says so
+instead of repeating it.
+
+Two things make the fix worth having anyway.
+
+**The class is reachable elsewhere.** `chat_uploader.dart:69-87` posts to
+Planet's chat API, not to CouchDB, and branches on an application-level
+`data['status'] != 'Success'`. A 200 carrying `{"status":"error", …}` is an
+ordinary answer from that API, and until now it abandoned the row on its first
+attempt and re-POSTed on every subsequent chat write. That is the same branch,
+in production.
+
+**The loop Job 1 describes is reachable without any unusual response at all.**
+The health document's `_id` *is* the patient's user id
+(`health_repository.dart:846`), so every examination after the first is an
+update needing the current `_rev`. Anything that leaves the local `rev` stale —
+Planet's web UI editing the record, a second handset filing for the same
+patient — yields a 409 on the first attempt. And `cacheDocuments` skips a
+locally dirty row (`health_repository.dart:771`), so the health sync-in is
+structurally unable to refresh that `rev`: the loop could not self-heal. That
+is stronger than the notes claimed, and it is why the same fix had to cover
+plain 4xx rejections and not only the null-code branch.
+
+**What the port cannot copy from Kotlin here.** Kotlin gates on `has("id")`,
+tolerates a null rev, and clears `isUpdated` while leaving `_rev` alone
+(`HealthRepositoryImpl.kt:103-131`, `HealthExaminationDao.kt:36-46` — the
+partition `1004e90` added). The port's `HealthExaminationDao.markUploaded`
+writes `rev: Value(rev)`, so passing the null we have would **erase** the
+revision — the pre-`1004e90` bug exactly. `app_database.dart` is Lane A's file
+this round, so the port keeps the row dirty and lets the memo stop the
+re-POST. Reported below.
+
+### Job 2 — and a correction to "one POST per sync"
+
+Phase 138 said the accretion fires "once per *sync*". It is right for four
+upload types and wrong as a general statement. Of twenty-six types:
+
+* **per sync** (`dashboard_sync_provider.syncAll` and `background_entrypoint`):
+  `submissions`, `news` (voices), `adoptedSurvey`, plus the four `activities`
+  types via `recordSyncActivity`, and `searchActivity` when the sync moved
+  anything.
+* **per user write**: `health`, `personal`, `feedback`, `rating`,
+  `achievement`, `chat`, `meetup`, `teamTask`, `courseProgress`,
+  `submitPhoto`, `user`.
+* **per screen mount**: `teamLog` — every mount of the team detail screen,
+  a far higher rate than a sync.
+* **bounded already** (one-shot enqueue, never swept): the five `teams*` types
+  and `public_survey`. The *row* is bounded there; the local `isUpdated` is
+  still left permanently set, which
+  `teams_uploader.dart:15-19` documents as freezing the row at its local
+  version.
+
+So twenty-two of twenty-six re-offered for ever. The cadence differs; the
+unboundedness did not.
+
+---
+
+## Kotlin, and how much of it is safe to cite
+
+Phase 144's three findings were re-verified and all three hold, so none of that
+retry path was ported. Two further readings mattered more:
+
+**Kotlin's queue never abandons an *item*, only an operation.**
+`RetryQueue.queueFailedOperation` returns early on `!error.retryable`
+(`RetryQueue.kt:36-39`) — "non-retryable" means *do not queue*, not *do not
+retry*. `UploadCoordinator` passes only succeeded items to `persistUploaded`,
+so a refused item's local flag is untouched and the next sweep re-offers it.
+The port's outbox made that verdict terminal, and that single difference is the
+origin of every symptom in Job 2. The memo is the port's structural equivalent
+of Kotlin's early return: applied at re-enqueue instead of at admission,
+because the port has a row where Kotlin has none.
+
+**The port's own citation of `UploadCoordinator` on 409 was a misreading, and a
+test name pinned it.** `outbox_drainer.dart` said *"`UploadCoordinator` treats
+`code >= 500` as retryable and everything else — 409 conflict, 400, 401 — as
+permanent."* `UploadCoordinator.kt:169-204` intercepts a 409 **before** that
+rule, GETs the document, adopts its `_rev` and reports **success**;
+`retryable = false` appears only when the recovery GET itself fails. The test
+`'a 409 conflict is permanent, matching UploadCoordinator'` has been renamed
+and now says what it actually pins. `adopted_surveys_uploader.dart:219-242` is
+the one place the port has that recovery arm.
+
+**Kotlin's 401 rule and the port's are the same rule reached differently.**
+Kotlin's `retryable = response.code() >= 500` (`UploadCoordinator.kt:211`)
+makes a 401 non-retryable — and then Kotlin's sweep re-reads the live table and
+re-posts anyway. The port's sweep re-*enqueues*, so reaching the same outcome
+needs 401 classified transient here. `outbox_drainer.dart`'s `onlyTypes`
+workaround existed because a 401 abandoned deliverable writes; it stays, but as
+belt-and-braces rather than the only defence. This is the shape Phase 103
+recorded: a workaround on one path is evidence the rule is wrong, not that the
+path is special.
+
+---
+
+## The changes
+
+**`flutter/lib/repository/outbox_repository.dart`**
+* New `OutboxRefusal { transient, rejected, indeterminate }` — three reasons,
+  two behaviours, so the policy can be *stated* rather than inferred from an
+  int comparison.
+* `OutboxRepository.classifyStatus(int?)`, the single reading of a status code,
+  used by the drainer when it fails and by `enqueue` when it decides whether to
+  re-ask. `retryableStatuses = {401, 403, 404, 408, 429}` — 404 belongs there
+  because a 404 on a CouchDB *write* is the database being absent, never the
+  document, and like a bad credential it is repaired on the server without the
+  request changing. What stays terminal (400, 409, 413, 415, 422) is about the
+  bytes, and each of those has a local repair that *does* change them. That is
+  what keeps the memo from stranding a write whose cause was fixed elsewhere.
+* `noUsableResponse = -1`, recorded in `outbox.httpCode` for a terminal refusal
+  that carries no status of its own. Without it a handler's verdict on a 2xx
+  and a transport failure both stored `NULL` and the two need opposite
+  treatment. No schema change: the column is already `integer().nullable()`.
+* `enqueue` looks up the item's row whatever its status, via the existing
+  `OutboxDao.forItem`, instead of `findOpen`; `_soleRowFor` collapses surplus
+  rows from older builds.
+* `markFailed` takes `refusal:` in place of `permanent:`.
+* New `rearm(uploadType, itemId)` — the deliberate override of the memo.
+
+**`flutter/lib/repository/outbox_drainer.dart`**
+* `permanent = (code ?? 0) < 500` replaced by the classifier, with `code == null`
+  read as `indeterminate`. That reading is load-bearing and it is a *reading*:
+  `PlanetApi` builds a `NetworkError` only from a response it received and
+  substitutes `0` for a missing status, so every transport-authored error
+  carries an int and a null can only have come from a handler.
+
+**`flutter/lib/repository/health_uploader.dart`**
+* The `no rev` comment corrected (no `batch=ok`; what Kotlin does; why
+  `markUploaded(id, null)` is not the answer here).
+* `queuePending(retryRefused:)` for the banner's Retry button.
+
+**Outside the lane's own set, and named because the brief asks:**
+`flutter/lib/providers/health_provider.dart` (thread `retryRefused`; correct a
+dartdoc that described the accretion as intended behaviour) and
+`flutter/lib/ui/health/my_health_screen.dart` (pass `retryRefused: true`;
+correct the comment that said `enqueue` writes a fresh pending row). Both were
+required: without them the memo silently turns Retry into a no-op, and that
+button sits next to a count of stranded records. Neither file is any other
+lane's this round. **No `*_uploader.dart` other than `health_uploader.dart` was
+touched, and `voices_uploader.dart` was not opened for edit.**
+
+## Tests
+
+Every claim was mutation-tested: the fix reverted, the suite run, the named
+test confirmed failing, the fix restored. Where a mutation survived, the
+fixture was strengthened rather than the clause deleted.
+
+**`test/repository/outbox_repository_test.dart`** (27, was 19)
+* `a rejected item is not re-armed by the identical request` — the rewrite of
+  `an abandoned item does not block a fresh enqueue`, whose assertion
+  (`expect(second, isNot(first))`) *was* the accretion, written down as
+  intended behaviour.
+* `a changed request re-arms the same row`, `a reconfigured endpoint re-arms a
+  rejected row` — the two recovery routes.
+* `an exhausted transient failure is re-armed unchanged` — the half that must
+  not regress: bounding rows must not bound retries.
+* `a rejection without a status is still terminal`, `a transport failure keeps
+  a null status and stays retryable` — the pair `noUsableResponse` exists to
+  separate. Reverting the sentinel makes the first fail.
+* `surplus rows an older build left are collapsed to one` — the retroactive
+  repair, seeded with four hand-written abandoned rows.
+* `classifyStatus splits the caller from the request`.
+
+**`test/repository/outbox_drainer_test.dart`** (21, was 14)
+* `a rejected request is asked once, however many sweeps run` — **five** sweeps,
+  because one repeat is not a demonstration of unboundedness. Asserts one POST
+  and one row.
+* `an unusable 2xx response is not asked again either` — Job 1's class, five
+  sweeps, one send.
+* `a transient failure keeps being offered across sweeps` — three sweeps, three
+  sends, one row.
+* `a 401 is retried`, `403, 408 and 429 are retried for the same reason`.
+* `a handler's verdict on a 2xx body is not a server refusal` — pins the null
+  code → `indeterminate` → `noUsableResponse` chain.
+* `a rejected row is re-armed by an edited payload`.
+* `a 409 conflict is permanent, matching UploadCoordinator` renamed to
+  `a 409 rejects the request the payload made`, with the misreading it carried
+  written out at the test.
+
+**`test/repository/health_legacy_conflict_test.dart`** (9, was 7)
+* `a record refused ten times leaves one row and one POST` — replaces
+  `a record refused twice is one stranded record, not two`, which asserted
+  `abandoned.length == 2`. Ten sweeps against a fake CouchDB that enforces
+  `_id` uniqueness, counting real POSTs.
+* `an accepted response with no revision is never re-sent` — Job 1 end to end:
+  the fake answers `{id}` with no `rev`, the document *is* on the server, five
+  sweeps produce one POST, the row carries `noUsableResponse`, and the local
+  `rev` is untouched.
+* `the clinician tapping Retry does override the memo` — a sweep does not
+  re-ask, `retryRefused: true` does.
+
+Nine mutations, each reverted one at a time with the suite run in between:
+`enqueue` back to `findOpen` (11 failures), the drainer back to
+`(code ?? 0) < 500` (2), the `noUsableResponse` sentinel dropped (4),
+`sameRequest` ignoring the endpoint (1), `rearm` made a no-op (1), the
+surplus-row collapse removed (1), 404 out of `retryableStatuses` (1), the memo
+widened to every terminal row (2), and `markFailed` ignoring the terminal
+refusal (15). Every one failed the test it should.
+
+**One thing deliberately has no behavioural pin, and it is worth saying so.**
+Reverting the drainer's `code == null → indeterminate` to
+`code == null → rejected` fails *nothing*, because the two classes share a
+behaviour: both are terminal and both store `noUsableResponse`. The enum has
+three values because there are three *reasons* and the distinction changes what
+a future reader should do — `rejected` is repaired by editing the request,
+`indeterminate` must never be re-sent because the write may already have
+landed. Only `transient` is separated by behaviour, and that separation is
+pinned by six tests. A reader who deletes `indeterminate` and folds it into
+`rejected` will not break the suite; they will break the reasoning, and the
+notes and the dartdoc are what stand in the way.
+
+One mutation is worth recording because it survived at first. Reverting
+`_soleRowFor` to `findOpen` left `an unusable 2xx response is not asked again
+either` **passing**, because the first cut of that test counted outbox rows
+rather than sends and the drainer's `due()` never re-offers an abandoned row —
+the accretion is one row *and one POST per sweep*, and only the POST count
+distinguishes the two policies. The test now counts sends. Same reason the
+health tests count `couch.postCount`.
+
+---
 
 ## Reported, not fixed
 
-*(to be filled in)*
+Each names the file, the change, and why it was not made here.
+
+1. **Take a 409 out of the failure path entirely — the port has the arm, for
+   one uploader.** `UploadCoordinator.kt:169-204` answers a 409 by GETting the
+   document, adopting its `_rev` and reporting **success**;
+   `adopted_surveys_uploader.dart:219-242` is a working port of exactly that,
+   and its own comment describes the accretion this phase fixed. Six uploaders
+   send a deterministic `_id` and could adopt it directly — `health` (`_id` is
+   the patient's user id), `teams`, `achievements`, `user` (which already
+   read-then-writes its `_rev`), `feedback`, and `adopted_surveys` (done);
+   five more (`course_progress`, `ratings`, `submissions`, `events`, `voices`)
+   could once `couchId` is set. This phase makes a 409 *safe* — one row, one
+   POST, recoverable by a pull that changes the payload — but recovery is
+   strictly better than safety, and it is per-uploader work with a new GET on
+   each. Severity: medium. It is the single highest-value follow-up here.
+2. **`HealthExaminationDao.markUploaded(id, null)` erases a stored `_rev`.**
+   `app_database.dart:3812-3819` writes `rev: Value(rev)`. Kotlin repaired the
+   identical defect in `1004e90` by partitioning null-rev ids into
+   `SET isUpdated = 0 WHERE _id IN (:ids)`, with a test
+   (`markUploaded_rowsWithoutRev_clearsIsUpdatedAndPreservesExistingRev`). The
+   port cannot align its health handler with Kotlin's `has("id")` gate until
+   that DAO is fixed; the correct pattern is one table over at
+   `app_database.dart:1035` (`rev == null ? const Value.absent() : Value(rev)`).
+   **Lane A's file this round.** Phase 142 item 7 reported the dead-code
+   sibling `HealthRepository.markUploadedBatch`, which has the same bug and
+   still has zero callers.
+3. **`HealthRepository.cacheDocuments` skips a locally dirty row**
+   (`health_repository.dart:771`, `if (current?.isUpdated == true) continue;`),
+   and nothing else writes `health_examinations.rev`. So the one self-healing
+   route this phase relies on — a pull supplies the revision, the payload
+   changes, the memo re-arms — is **structurally unavailable for health**,
+   which is why the banner's Retry had to be wired instead. Every other
+   uploader whose sync-in writes `rev` unconditionally does get that route.
+   Fixing it means merging the server's `_rev` into a dirty row without
+   touching its edited fields; that is a repository change with a real
+   conflict-resolution question inside it, not a one-liner. Severity: medium.
+4. **`chat_uploader.dart` conflates two different failures under one null
+   code.** `:69-87` returns `NetworkError(null, …)` both when the API answers
+   200 with `{"status":"error"}` (a **rejection**: the message was not stored)
+   and when a successful answer carries no `couchdb.id` (**indeterminate**).
+   Under this policy both are terminal and not re-sent, so behaviour is
+   identical today and nothing is broken — but chat is the one uploader where
+   this branch is reachable in production, and if that API's error is ever
+   *transient* (a rate limit answered as 200) the message is now stranded where
+   it used to be retried on every chat write. The fix is for that handler to
+   return a status code it believes, not for the drainer to guess. I did not
+   change it because I have no way to verify what the chat API's `status`
+   values mean. Severity: low-medium.
+5. **`pendingUploadCountProvider` (`app_providers.dart:686-688`) has zero
+   readers**, in `lib` *and* `test`, and its dartdoc says "for the UI to
+   surface". The only user-facing signal the outbox has is the health banner,
+   for one of twenty-six upload types. Kotlin has a settings-screen queue
+   snapshot and a clear (`SettingsViewModel.kt:52,60`). A general "writes
+   waiting / writes refused" surface is worth a slice; the memo makes it more
+   useful, since an abandoned row now means something durable rather than
+   "the last of N attempts".
+6. **`OutboxRepository.cancel` leaves a terminal row behind.** It is
+   `deletePending`, deliberately status-scoped so a cancel cannot race a drain
+   — but a subject that no longer exists should not keep a memo, and on a type
+   whose ids are reused a stale memo would suppress a genuinely new write.
+   Nothing in the port reuses ids today, which is why it was left. One line if
+   someone decides the diagnostic for a deleted subject is worthless.
+7. **`teams_uploader.dart:9` has `import 'dart:developer';` below the relative
+   imports**, against the project's ordering. `flutter analyze` does not flag
+   it. Cosmetic; not touched because the file needed no change for this policy
+   and "one file, one owner" is cheap to honour.
+8. **The five `teams*` types and `public_survey` are bounded by having no
+   sweep, not by anything this phase did**, and their *local* state is still
+   left wrong on a refusal — `teams_uploader.dart:15-19` documents a
+   permanently-set `isUpdated` freezing the row at its local version and
+   exempting it from stale-row cleanup for good. The memo does not help there
+   because nothing re-offers the row in the first place. Worth its own look.
+9. **Phase 142's items 1, 3, 4, 5, 7–10 and Phase 138's other items are still
+   open**; none is in this lane's set.

--- a/flutter/lib/providers/health_provider.dart
+++ b/flutter/lib/providers/health_provider.dart
@@ -161,7 +161,11 @@ class HealthQueue {
 
   final Ref _ref;
 
-  Future<int> queuePending() async {
+  /// [retryRefused] is the clinician tapping *Retry* on the stranded-records
+  /// banner rather than the app sweeping. Only that overrides the memo
+  /// `OutboxRepository.enqueue` keeps against an already-refused request; see
+  /// [HealthUploader.queuePending].
+  Future<int> queuePending({bool retryRefused = false}) async {
     final config = _ref.read(serverConfigProvider);
     if (config == null) return 0;
     // `await`ed rather than read with `valueOrNull`: nothing on the
@@ -172,7 +176,11 @@ class HealthQueue {
     final session = await _ref.read(sessionProvider.future);
     return _ref
         .read(healthUploaderProvider)
-        .queuePending(config: config, userId: session?.id);
+        .queuePending(
+          config: config,
+          userId: session?.id,
+          retryRefused: retryRefused,
+        );
   }
 }
 
@@ -180,18 +188,21 @@ final healthQueueProvider = Provider<HealthQueue>(HealthQueue.new);
 
 /// How many health records the server has refused for good.
 ///
-/// [OutboxDrainer] treats any `code < 500` as permanent, so a 409 — the
-/// conflict a legacy row's `_id` collision produces — abandons the operation on
-/// its first attempt. The row is kept rather than deleted, and until now that
-/// keeping *was* the whole of the observability: nothing selected an abandoned
-/// row, nothing counted one, and no screen said a word. A reading a clinician
-/// took stayed on the handset while the app behaved as though it had been
-/// filed.
+/// A 409 — the conflict a legacy row's `_id` collision produces, and the one a
+/// stale `_rev` produces on any patient whose document another device has
+/// touched — is a rejection of the request as sent, so the operation is
+/// abandoned on its first attempt. The row is kept rather than deleted, and
+/// until Phase 107 that keeping *was* the whole of the observability: nothing
+/// selected an abandoned row, nothing counted one, and no screen said a word.
+/// A reading a clinician took stayed on the handset while the app behaved as
+/// though it had been filed.
 ///
-/// Counted by distinct `itemId`, not by row: [OutboxRepository.enqueue] only
-/// looks for an *open* operation, so a record refused again on every save
-/// leaves one abandoned row per attempt. What the clinician needs to know is
-/// how many records are stranded, not how many times the app has tried.
+/// Counted by distinct `itemId` rather than by row. Since Phase 148 an item
+/// owns exactly one outbox row, so the two agree on a current install — but
+/// `outbox` is preserved across schema bumps, so a device that accreted a row
+/// per sweep under the old policy still carries them until its next enqueue
+/// collapses them. What the clinician needs to know is how many records are
+/// stranded, not how many times the app has tried.
 ///
 /// A [FutureProvider] rather than a stream: the count only moves when a drain
 /// finishes, and holding a live drift query open for the life of the screen

--- a/flutter/lib/repository/health_uploader.dart
+++ b/flutter/lib/repository/health_uploader.dart
@@ -32,12 +32,20 @@ class HealthUploader {
   static String endpointFor(ServerConfig config) =>
       '${UrlUtils.credentialFreeDbUrl(config)}/health';
 
+  /// [retryRefused] overrides the memo [OutboxRepository.enqueue] keeps against
+  /// a request the server has already refused. The sweeps this method serves —
+  /// a saved examination, a background pass — must not override it, which is
+  /// the whole of Phase 148's fix. `MyHealthScreen`'s **Retry** must: it is
+  /// offered next to a count of stranded records, and a button that provably
+  /// does nothing is worse than one extra POST.
   Future<int> queuePending({
     required ServerConfig config,
     String? userId,
+    bool retryRefused = false,
   }) async {
     final rows = await _repository.getUpdated();
     for (final row in rows) {
+      if (retryRefused) await _outbox.rearm(type, row.id);
       await _outbox.enqueue(
         uploadType: type,
         itemId: row.id,
@@ -61,6 +69,36 @@ class HealthUploader {
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final rev = data['rev'];
       if (rev is! String) {
+        // Defensive, and deliberately kept. `PlanetApi` reaches this branch
+        // only on a 2xx whose body decoded to a JSON object
+        // (`planet_api.dart:249-253` checks the status *before* converting,
+        // and a 2xx that will not decode becomes a `NetworkException`), and
+        // CouchDB answers a create with `id` and no `rev` only for a
+        // `?batch=ok` POST — which nothing in this port or in the Kotlin app
+        // sends. So this is not a shape the server produces here; what it
+        // catches is an intermediary that reshapes a 2xx body. Phase 148
+        // audited that and says so rather than repeating the earlier claim
+        // that `batch=ok` was the route.
+        //
+        // Kotlin gates on `has("id")` instead and tolerates a null rev
+        // (`HealthRepositoryImpl.kt:103-131`), clearing `isUpdated` without
+        // touching `_rev` (`HealthExaminationDao.kt:36-46`, which is what
+        // `1004e90` added). The port cannot copy that half: its
+        // `markUploaded` writes `rev: Value(rev)`, so passing the null we have
+        // would erase the revision the row already holds — the pre-`1004e90`
+        // defect exactly, and `app_database.dart` is not this lane's file.
+        //
+        // What *is* fixed here is the classification. A null code is how
+        // [OutboxDrainer] recognises a handler's own verdict, and it reads it
+        // as [OutboxRefusal.indeterminate]: the transport said the write
+        // landed, so re-sending risks a second copy of a record that is
+        // already filed. The row is abandoned once and never re-sent under the
+        // same payload. Before Phase 148 the same return abandoned the row on
+        // its first attempt *and* let the next sweep mint a fresh one,
+        // re-POSTing the unchanged `_rev` into a 409 for the life of the
+        // install. The record stays `isUpdated` and `OutboxDao.abandoned`
+        // keeps reporting it as stranded, which is the honest answer: the app
+        // does not know whether it arrived.
         return const NetworkError<Map<String, dynamic>>(
           null,
           'Upload response carried no rev',
@@ -71,10 +109,12 @@ class HealthUploader {
       // `isUpdated` is what stops it being queued a second time.
       await _dao.markUploaded(row.itemId, rev);
       // And the record is no longer stranded, so the refusals that said it was
-      // must go with it. An abandoned row is never reused and nothing sweeps
-      // them, so leaving them would have `MyHealthScreen` warn about a record
-      // that is on the server — for the life of the install, with no action to
-      // offer. This is the only event that makes an old refusal untrue.
+      // must go with it. Since Phase 148 an item owns a single outbox row that
+      // `markCompleted` has just deleted, so this is belt-and-braces for the
+      // pile an older build left behind — `outbox` is preserved across schema
+      // bumps, so those rows outlive the upgrade. Without it `MyHealthScreen`
+      // would warn about a record that is on the server, with no action to
+      // offer. Delivery is the only event that makes an old refusal untrue.
       await _outbox.clearAbandoned(type, row.itemId);
     }
     return result;

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -168,10 +168,20 @@ class OutboxDrainer {
         // builds a `NetworkError` only from a response it actually received,
         // and substitutes `0` for a missing status
         // (`planet_api.dart:249-252`), so every transport-authored error
-        // carries an int. A handler-authored one therefore means: the send
+        // carries an int. A handler-authored one usually means: the send
         // succeeded and the response was not something the handler could use.
         // The write may already be on the server, which is why that is
         // [OutboxRefusal.indeterminate] rather than a failure to deliver.
+        //
+        // *Usually*, not always — and the exception is worth knowing before
+        // relying on this. Three handlers return a null code **before making
+        // any request**: `user_uploader.dart:126` and `:143-147`, and
+        // `achievements_uploader.dart:63`. For those the write certainly did
+        // not land, so `indeterminate` overstates what is known; the effect is
+        // the same either way (terminal, not re-sent) and the first of them is
+        // genuinely terminal — the local row is gone — but a handler that has
+        // sent nothing should say so with [OutboxRepository.notSent] rather
+        // than let this branch guess. See `PHASE_148_NOTES.md`.
         //
         // The previous rule was `permanent = (code ?? 0) < 500`, a port of
         // `UploadCoordinator.kt:211`. It mapped null to 0 to "permanent" and

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -14,8 +14,10 @@ enum OutboxOutcome {
   /// Transient — it will be retried after the backoff.
   retryScheduled,
 
-  /// Permanent, or attempts exhausted. The row is kept as `abandoned` so the
-  /// failure is inspectable rather than silently discarded.
+  /// Terminal, or attempts exhausted. The row is kept as `abandoned` so the
+  /// failure is inspectable rather than silently discarded — and, since the
+  /// row is also the memo [OutboxRepository.enqueue] reads, so that an
+  /// identical request is not asked a second time.
   abandoned,
 }
 
@@ -69,9 +71,13 @@ class OutboxDrainer {
   /// [onlyTypes] restricts the pass to those `uploadType`s. It exists for one
   /// case: a public-survey respondent has no server configuration, so there is
   /// no credential for the rest of the queue and posting it unauthenticated
-  /// would earn a 401 — which the retry rule classifies as *permanent* and would
-  /// abandon writes that are perfectly deliverable later. Draining only the
-  /// credential-free type leaves those rows untouched.
+  /// would earn a 401 on writes that are perfectly deliverable later. Draining
+  /// only the credential-free type leaves those rows untouched.
+  ///
+  /// A 401 is [OutboxRefusal.transient] now, so this is no longer the only
+  /// thing standing between an unauthenticated pass and a queue of abandoned
+  /// rows — it still spends attempts from those rows' ladders, which is reason
+  /// enough to keep it.
   Future<List<OutboxOutcome>> drain({
     String? authHeader,
     Set<String>? onlyTypes,
@@ -127,7 +133,7 @@ class OutboxDrainer {
       await _outbox.markFailed(
         row.id,
         errorMessage: 'Malformed payload',
-        permanent: true,
+        refusal: OutboxRefusal.rejected,
       );
       return OutboxOutcome.abandoned;
     }
@@ -158,14 +164,28 @@ class OutboxDrainer {
         return OutboxOutcome.completed;
 
       case NetworkError<Map<String, dynamic>>(:final code, :final message):
-        // `UploadCoordinator` treats `code >= 500` as retryable and everything
-        // else — 409 conflict, 400, 401 — as permanent.
-        final permanent = (code ?? 0) < 500;
+        // A **null** code can only have come from a handler. `PlanetApi`
+        // builds a `NetworkError` only from a response it actually received,
+        // and substitutes `0` for a missing status
+        // (`planet_api.dart:249-252`), so every transport-authored error
+        // carries an int. A handler-authored one therefore means: the send
+        // succeeded and the response was not something the handler could use.
+        // The write may already be on the server, which is why that is
+        // [OutboxRefusal.indeterminate] rather than a failure to deliver.
+        //
+        // The previous rule was `permanent = (code ?? 0) < 500`, a port of
+        // `UploadCoordinator.kt:211`. It mapped null to 0 to "permanent" and
+        // abandoned such a row on its first attempt, and — because
+        // `enqueue` used to mint a fresh row per sweep — re-POSTed it forever
+        // after. See [OutboxRefusal] and `PHASE_148_NOTES.md`.
+        final refusal = code == null
+            ? OutboxRefusal.indeterminate
+            : OutboxRepository.classifyStatus(code);
         final abandoned = await _outbox.markFailed(
           row.id,
           errorMessage: message,
           httpCode: code,
-          permanent: permanent,
+          refusal: refusal,
         );
         return abandoned
             ? OutboxOutcome.abandoned

--- a/flutter/lib/repository/outbox_repository.dart
+++ b/flutter/lib/repository/outbox_repository.dart
@@ -62,12 +62,29 @@ class OutboxRepository {
   /// `RetryOperation.DEFAULT_MAX_ATTEMPTS`.
   static const int defaultMaxAttempts = 5;
 
-  /// Recorded in `outbox.httpCode` when an attempt ended terminally without an
-  /// HTTP status of its own — a handler's verdict on a 2xx body, or a payload
-  /// that will not parse. Negative, so it cannot collide with a status code,
-  /// and distinct from `null`, which keeps its existing meaning: *no response
-  /// arrived*, which says nothing about the request and stays retryable.
+  /// Recorded in `outbox.httpCode` when the transport reported success and the
+  /// handler could not use what came back. Negative, so it cannot collide with
+  /// a status code, and distinct from `null`, which keeps its existing
+  /// meaning: *no response arrived*, which says nothing about the request and
+  /// stays retryable.
+  ///
+  /// `PlanetApi` builds every `NetworkError` as `NetworkError(status, …)` with
+  /// `status = response.statusCode ?? 0` (`planet_api.dart:202`, `:251`), so
+  /// no build past or present can have written a negative code by another
+  /// route.
   static const int noUsableResponse = -1;
+
+  /// Recorded in `outbox.httpCode` when the operation was refused terminally
+  /// **without ever reaching the server** — today only a payload that will not
+  /// parse.
+  ///
+  /// Distinct from [noUsableResponse] rather than folded into it, even though
+  /// the two behave identically here: `PHASE_148_NOTES.md`'s own
+  /// highest-value follow-up is a 409-recovery arm, and that needs to tell
+  /// "the server considered this and refused" from "the write may already have
+  /// landed". A sentinel that collapses the two would have taken the
+  /// distinction away before anything could use it.
+  static const int notSent = -2;
 
   /// The statuses that say something about the caller, the moment or the
   /// server's configuration rather than about the request. Retried, and
@@ -75,13 +92,28 @@ class OutboxRepository {
   ///
   /// 401 and 403 are a credential or a role, 408 and 429 are the moment, and
   /// 404 on a CouchDB *write* is the database not being there — a document
-  /// that does not exist is what a POST or a PUT is for, so a 404 can only be
-  /// about the endpoint. Every one of those is fixed on the server or in the
-  /// app's configuration, and none of those fixes changes the request; if they
-  /// were terminal, [enqueue]'s memo would have nothing to re-arm them with.
-  /// What remains terminal — 400, 409, 413, 415, 422 — is about the bytes, and
-  /// each has a local repair that *does* change them: an edit, or a pull that
-  /// supplies the revision the conflict was about.
+  /// that does not exist is what a POST or a PUT is for. Every one of those is
+  /// fixed on the server or in the app's configuration, and none of those
+  /// fixes changes the request; if they were terminal, [enqueue]'s memo would
+  /// have nothing to re-arm them with. What remains terminal — 400, 409, 413,
+  /// 415, 422 — is about the bytes, and each has a local repair that *does*
+  /// change them: an edit, or a pull that supplies the revision the conflict
+  /// was about.
+  ///
+  /// **Two of those readings are a trade, not a certainty, and the trade is
+  /// deliberate.** CouchDB has a second 403: a `validate_doc_update` function
+  /// answering `{forbidden: …}`, which is a permanent property of the
+  /// document's bytes. And one endpoint the outbox carries is not CouchDB at
+  /// all — `public_survey`'s
+  /// `<host>/api/public/surveys/<team>/<survey>/submissions`
+  /// (`surveys_repository.dart:633-638`), where a 404 means the team or the
+  /// survey does not exist. Reading either as transient costs wasted requests;
+  /// reading it as terminal costs a stranded write with nothing able to re-arm
+  /// it, because neither repair changes the request. Wasted requests are the
+  /// cheaper mistake — the row stays bounded at one either way — so both stay
+  /// here. Note what that does *not* concede: a transient failure being
+  /// retried across sweeps is the policy working, not the accretion returning.
+  /// The accretion was unbounded *rows*.
   ///
   /// **This is a deliberate deviation from Kotlin**, whose one rule is
   /// `retryable = response.code() >= 500` (`UploadCoordinator.kt:211`). Under
@@ -101,6 +133,7 @@ class OutboxRepository {
   static OutboxRefusal classifyStatus(int? httpCode) {
     if (httpCode == null) return OutboxRefusal.transient;
     if (httpCode == noUsableResponse) return OutboxRefusal.indeterminate;
+    if (httpCode == notSent) return OutboxRefusal.rejected;
     if (httpCode == 0 || httpCode >= 500) return OutboxRefusal.transient;
     if (retryableStatuses.contains(httpCode)) return OutboxRefusal.transient;
     return OutboxRefusal.rejected;
@@ -274,7 +307,17 @@ class OutboxRepository {
       orElse: () => rows.last,
     );
     for (final row in rows) {
-      if (row.id != keep.id) await _dao.deleteById(row.id);
+      if (row.id == keep.id) continue;
+      // `deleteById` is the one delete in `OutboxDao` that is not
+      // status-scoped, and `deletePending`'s doc comment says why the others
+      // are: a drain interleaves at every `await`, so a row can be claimed
+      // between the read above and this delete and would then be dropped with
+      // its request on the wire. A surplus row is only ever reachable through
+      // a simultaneous-insert race between the UI and headless isolates, so
+      // this is narrow — and skipping it costs one extra row until the next
+      // enqueue, which is exactly what this method is for.
+      if (row.status == OutboxDao.statusInProgress) continue;
+      await _dao.deleteById(row.id);
     }
     return keep;
   }
@@ -382,10 +425,10 @@ class OutboxRepository {
   /// point the operation is already queued.
   ///
   /// A terminal refusal is recorded so that [enqueue] can read it back later:
-  /// that is what [noUsableResponse] is for. Without it a handler's verdict on
-  /// a 2xx body and a transport failure would both store a null `httpCode`,
-  /// and the two want opposite treatment — the first must never be sent again,
-  /// the second must be.
+  /// that is what [noUsableResponse] and [notSent] are for. Without them a
+  /// handler's verdict on a 2xx body and a transport failure would both store
+  /// a null `httpCode`, and the two want opposite treatment — the first must
+  /// never be sent again, the second must be.
   Future<bool> markFailed(
     String id, {
     String? errorMessage,
@@ -410,11 +453,19 @@ class OutboxRepository {
         lastAttemptAt: Value(nowMs),
         nextAttemptAt: Value(nowMs + backoffFor(attempts).inMilliseconds),
         errorMessage: Value(errorMessage),
-        httpCode: Value(httpCode ?? (terminal ? noUsableResponse : null)),
+        httpCode: Value(httpCode ?? _sentinelFor(refusal)),
       ),
     );
     return abandoned;
   }
+
+  /// The code stored for a terminal refusal that carries no HTTP status of its
+  /// own. `null` for a transient one, which keeps its existing meaning.
+  static int? _sentinelFor(OutboxRefusal refusal) => switch (refusal) {
+    OutboxRefusal.transient => null,
+    OutboxRefusal.rejected => notSent,
+    OutboxRefusal.indeterminate => noUsableResponse,
+  };
 
   /// Port of `recoverStuckOperations`, for the startup path.
   Future<int> recoverStuck() => _dao.recoverStuck(

--- a/flutter/lib/repository/outbox_repository.dart
+++ b/flutter/lib/repository/outbox_repository.dart
@@ -5,6 +5,38 @@ import 'package:drift/drift.dart';
 
 import '../data/local/app_database.dart';
 
+/// Why a drain attempt failed, and therefore what a later enqueue of the *same
+/// request* is entitled to do about it.
+///
+/// The port's outbox admits every write and classifies at drain time; Kotlin's
+/// `RetryQueue.queueFailedOperation` does the opposite and refuses to queue a
+/// non-retryable error at all (`RetryQueue.kt:36-39`). Because a refused write
+/// therefore leaves no row in Kotlin, Kotlin needs no policy for one. This
+/// enum is that policy — the port's structural equivalent of that early
+/// return, applied at re-enqueue instead of at admission.
+enum OutboxRefusal {
+  /// The failure was about the transport, the moment, or the caller — not the
+  /// bytes. 5xx, a timeout, a rate limit, a missing or rejected credential, a
+  /// handler that threw. Retried under the backoff, and a later sweep may
+  /// re-arm it: the same request could well succeed once the environment
+  /// changes.
+  transient,
+
+  /// The server considered this exact request and refused it — a 400, a 413, a
+  /// 409 against a stale `_rev`. Resending the same bytes cannot succeed, so
+  /// nothing but a *changed* request re-arms it. (A 404 is deliberately not
+  /// here; see [OutboxRepository.retryableStatuses].)
+  rejected,
+
+  /// The transport reported success and the handler could not use what came
+  /// back — a 2xx whose body carries no usable `rev`/`id`. The write may
+  /// already be on the server, which makes this the one class where resending
+  /// is worse than not: it risks a second copy of a document that is already
+  /// filed. Terminal for the same reason as [rejected], for a different
+  /// reason.
+  indeterminate,
+}
+
 /// Port of `services/retry/RetryQueue.kt` and the `RetryOperation` companion.
 ///
 /// This is the durable half of the Kotlin write-back path. `RetryQueue` owns
@@ -28,6 +60,50 @@ class OutboxRepository {
 
   /// `RetryOperation.DEFAULT_MAX_ATTEMPTS`.
   static const int defaultMaxAttempts = 5;
+
+  /// Recorded in `outbox.httpCode` when an attempt ended terminally without an
+  /// HTTP status of its own — a handler's verdict on a 2xx body, or a payload
+  /// that will not parse. Negative, so it cannot collide with a status code,
+  /// and distinct from `null`, which keeps its existing meaning: *no response
+  /// arrived*, which says nothing about the request and stays retryable.
+  static const int noUsableResponse = -1;
+
+  /// The statuses that say something about the caller, the moment or the
+  /// server's configuration rather than about the request. Retried, and
+  /// re-armed by a later sweep.
+  ///
+  /// 401 and 403 are a credential or a role, 408 and 429 are the moment, and
+  /// 404 on a CouchDB *write* is the database not being there — a document
+  /// that does not exist is what a POST or a PUT is for, so a 404 can only be
+  /// about the endpoint. Every one of those is fixed on the server or in the
+  /// app's configuration, and none of those fixes changes the request; if they
+  /// were terminal, [enqueue]'s memo would have nothing to re-arm them with.
+  /// What remains terminal — 400, 409, 413, 415, 422 — is about the bytes, and
+  /// each has a local repair that *does* change them: an edit, or a pull that
+  /// supplies the revision the conflict was about.
+  ///
+  /// **This is a deliberate deviation from Kotlin**, whose one rule is
+  /// `retryable = response.code() >= 500` (`UploadCoordinator.kt:211`). Under
+  /// that rule a 401 is non-retryable, so `RetryQueue` drops it — and the
+  /// write is re-attempted anyway, because Kotlin's sweep re-reads the live
+  /// table on every sync. The port's sweep re-*enqueues*, so reaching the same
+  /// outcome needs the status classified as retryable here instead. The
+  /// drainer's `onlyTypes` guard, which exists because a 401 used to abandon
+  /// deliverable writes, is now belt-and-braces rather than the only defence.
+  static const Set<int> retryableStatuses = {401, 403, 404, 408, 429};
+
+  /// The verdict [enqueue] reaches from the code a previous drain recorded.
+  ///
+  /// It has to agree with the drainer's own reading, so both go through here.
+  /// `null` is *no status recorded* — a transport failure, or a row that has
+  /// never been attempted.
+  static OutboxRefusal classifyStatus(int? httpCode) {
+    if (httpCode == null) return OutboxRefusal.transient;
+    if (httpCode == noUsableResponse) return OutboxRefusal.indeterminate;
+    if (httpCode == 0 || httpCode >= 500) return OutboxRefusal.transient;
+    if (retryableStatuses.contains(httpCode)) return OutboxRefusal.transient;
+    return OutboxRefusal.rejected;
+  }
 
   /// A worker gets ten minutes on Android. Twice that window avoids stealing
   /// a live claim when a foreground drain overlaps a headless isolate, while
@@ -53,11 +129,26 @@ class OutboxRepository {
     return Duration(milliseconds: min(scaled, maxDelay.inMilliseconds));
   }
 
-  /// Queues a write, or records another failed attempt against the one already
-  /// queued for this item.
+  /// Queues a write against the single row this `(uploadType, itemId)` owns.
   ///
   /// Kotlin's `queueFailedOperation` keys on `(itemId, uploadType)` for the
   /// same reason: retrying a submission must not enqueue a second copy of it.
+  /// The port holds the stronger invariant — **at most one `outbox` row per
+  /// `(uploadType, itemId)`, whatever its status** — because unlike Kotlin it
+  /// keeps a refused operation rather than declining to queue it.
+  ///
+  /// Before this, `findOpen` was the lookup, and it deliberately ignores an
+  /// `abandoned` row so a fresh enqueue is never blocked by one. The
+  /// consequence was that every sweep after a permanent refusal minted a
+  /// *new* row and made one more doomed POST, for the life of an install, in
+  /// a table that survives schema bumps. See `PHASE_148_NOTES.md`.
+  ///
+  /// What re-arms a terminal row is a **changed request** — a different
+  /// payload, endpoint or verb. That is the whole recovery story, and it is
+  /// enough: a user edit changes the payload, a pull that supplies the
+  /// revision a 409 was about changes the payload, a reconfigured server
+  /// changes the endpoint. What does *not* re-arm one is asking the server the
+  /// identical question a second time.
   Future<String> enqueue({
     required String uploadType,
     required String itemId,
@@ -67,33 +158,70 @@ class OutboxRepository {
     String? userId,
     int maxAttempts = defaultMaxAttempts,
   }) async {
-    final existing = await _dao.findOpen(uploadType, itemId);
+    final encoded = jsonEncode(payload);
+    final existing = await _soleRowFor(uploadType, itemId);
+
     if (existing != null) {
-      // Refresh the payload rather than keeping the first one: the row may have
-      // been edited between the failure and this call.
+      // Refresh the request rather than keeping the first one: the row may
+      // have been edited between the failure and this call.
       final base = OutboxEntriesCompanion(
-        payload: Value(jsonEncode(payload)),
+        payload: Value(encoded),
         endpoint: Value(endpoint),
         httpMethod: Value(httpMethod),
       );
-      // A drain may already have claimed this row and read the *old* payload.
-      // Putting it back to `pending` is what stops `markCompleted` deleting it
-      // when that in-flight send succeeds, so the edit still goes out on the
-      // next pass instead of vanishing with the row.
-      //
-      // `nextAttemptAt` is only made due on that transition. Resetting it for a
-      // row that is merely backing off would defeat the backoff outright —
-      // `queuePending` re-enqueues every pending item after each user write, so
-      // a failing operation would be retried on every keystroke-driven save.
-      await _dao.patch(
-        existing.id,
-        existing.status == OutboxDao.statusInProgress
-            ? base.copyWith(
-                status: const Value(OutboxDao.statusPending),
-                nextAttemptAt: Value(_now().millisecondsSinceEpoch),
-              )
-            : base,
-      );
+
+      switch (existing.status) {
+        // A drain may already have claimed this row and read the *old*
+        // payload. Putting it back to `pending` is what stops `markCompleted`
+        // deleting it when that in-flight send succeeds, so the edit still
+        // goes out on the next pass instead of vanishing with the row.
+        case OutboxDao.statusInProgress:
+          await _dao.patch(
+            existing.id,
+            base.copyWith(
+              status: const Value(OutboxDao.statusPending),
+              nextAttemptAt: Value(_now().millisecondsSinceEpoch),
+            ),
+          );
+
+        // Merely backing off. `nextAttemptAt` is deliberately left alone:
+        // `queuePending` re-enqueues every pending item after each user write,
+        // so making the row due here would retry a failing server on every
+        // keystroke-driven save and defeat the backoff outright.
+        case OutboxDao.statusPending:
+          await _dao.patch(existing.id, base);
+
+        // Terminal — abandoned, or the `completed` status nothing writes.
+        default:
+          final sameRequest =
+              existing.payload == encoded &&
+              existing.endpoint == endpoint &&
+              existing.httpMethod == httpMethod;
+          if (sameRequest &&
+              classifyStatus(existing.httpCode) != OutboxRefusal.transient) {
+            // The memo. The server has already answered this exact question,
+            // or answered in a way that leaves the write's fate unknown;
+            // asking again cannot help and may file a second copy. The row
+            // stays where `OutboxDao.abandoned` can still read it, which is
+            // what the health screen's caution banner counts.
+            return existing.id;
+          }
+          await _dao.patch(
+            existing.id,
+            base.copyWith(
+              status: const Value(OutboxDao.statusPending),
+              // A fresh ladder: the previous attempts were spent on a request
+              // that is no longer the one being made, or on a failure that was
+              // never about the request.
+              attemptCount: const Value(0),
+              nextAttemptAt: Value(_now().millisecondsSinceEpoch),
+              errorMessage: const Value(null),
+              httpCode: const Value(null),
+              maxAttempts: Value(maxAttempts),
+              userId: Value(userId),
+            ),
+          );
+      }
       return existing.id;
     }
 
@@ -104,7 +232,7 @@ class OutboxRepository {
         id: id,
         uploadType: uploadType,
         itemId: itemId,
-        payload: jsonEncode(payload),
+        payload: encoded,
         endpoint: endpoint,
         httpMethod: Value(httpMethod),
         status: const Value(OutboxDao.statusPending),
@@ -117,6 +245,37 @@ class OutboxRepository {
       ),
     );
     return id;
+  }
+
+  /// The one row this item owns, collapsing any surplus an older build left.
+  ///
+  /// An install upgrading into this policy can already carry a pile of
+  /// abandoned rows for a single item — one per sweep since the first refusal
+  /// — and `outbox` is preserved across schema bumps, so they do not go away
+  /// on their own. Keeping the newest and dropping the rest bounds the table
+  /// retroactively without losing the diagnostic: what a clinician needs is
+  /// *which record is stranded and why*, and the newest row carries the most
+  /// recent answer to both.
+  ///
+  /// An open row always wins over a terminal one, whatever their ages: it is
+  /// the live operation, and there can be at most one because every path here
+  /// goes through this method.
+  Future<OutboxRow?> _soleRowFor(String uploadType, String itemId) async {
+    final rows = await _dao.forItem(uploadType, itemId);
+    if (rows.isEmpty) return null;
+    if (rows.length == 1) return rows.single;
+
+    final keep = rows.firstWhere(
+      (row) =>
+          row.status == OutboxDao.statusPending ||
+          row.status == OutboxDao.statusInProgress,
+      // `forItem` orders by `createdAt` ascending.
+      orElse: () => rows.last,
+    );
+    for (final row in rows) {
+      if (row.id != keep.id) await _dao.deleteById(row.id);
+    }
+    return keep;
   }
 
   Future<List<OutboxRow>> due() => _dao.due(_now().millisecondsSinceEpoch);
@@ -168,32 +327,77 @@ class OutboxRepository {
   /// succeeded carried the superseded body.
   Future<void> markCompleted(String id) => _dao.deleteIfInProgress(id);
 
+  /// Puts a terminal row back on the wire even though nothing about the
+  /// request has changed — the deliberate override of [enqueue]'s memo.
+  ///
+  /// The memo is right for a sweep, which is the app guessing that something
+  /// might have changed. It is wrong for a person tapping *Retry* on a screen
+  /// that has just told them a record is stranded: they may know something the
+  /// device does not (an administrator fixed the server, another handset's
+  /// conflicting edit was withdrawn), and refusing to ask would leave them
+  /// with a warning and no action. One extra POST is the right price for an
+  /// explicit instruction; it is only the *unattended* repetition that had to
+  /// stop.
+  ///
+  /// A no-op when the item has no terminal row. Returns whether anything was
+  /// re-armed.
+  Future<bool> rearm(String uploadType, String itemId) async {
+    final row = await _soleRowFor(uploadType, itemId);
+    if (row == null) return false;
+    if (row.status == OutboxDao.statusPending ||
+        row.status == OutboxDao.statusInProgress) {
+      return false;
+    }
+    final nowMs = _now().millisecondsSinceEpoch;
+    await _dao.patch(
+      row.id,
+      OutboxEntriesCompanion(
+        status: const Value(OutboxDao.statusPending),
+        attemptCount: const Value(0),
+        nextAttemptAt: Value(nowMs),
+        errorMessage: const Value(null),
+        httpCode: const Value(null),
+      ),
+    );
+    return true;
+  }
+
   /// Forgets the permanent failures recorded against one item.
   ///
-  /// Called when a later attempt succeeds: [enqueue] never reuses an abandoned
-  /// row and [cleanup] has no caller, so the record of a refusal outlives the
-  /// refusal itself unless something withdraws it.
+  /// Called when a later attempt succeeds. [enqueue] now reuses the item's one
+  /// row rather than minting another, so on a current install `markCompleted`
+  /// has already removed it; this clears the pile an older build left behind,
+  /// which `outbox` being a preserved table would otherwise carry across every
+  /// future upgrade. [cleanup] still has no caller — see `PHASE_148_NOTES.md`
+  /// for why deleting the diagnostic wholesale is not the answer.
   Future<int> clearAbandoned(String uploadType, String itemId) =>
       _dao.clearAbandonedFor(uploadType, itemId);
 
   /// Records a failed attempt and schedules the next one.
   ///
-  /// Returns `true` if the operation was abandoned — attempts exhausted, or the
-  /// failure was permanent. `RetryQueue` refuses to queue a non-retryable error
-  /// at all; the equivalent here is [permanent], since by this point the
-  /// operation is already queued.
+  /// Returns `true` if the operation was abandoned — attempts exhausted, or
+  /// [refusal] was terminal. `RetryQueue` refuses to queue a non-retryable
+  /// error at all; the equivalent here is the terminal [refusal], since by this
+  /// point the operation is already queued.
+  ///
+  /// A terminal refusal is recorded so that [enqueue] can read it back later:
+  /// that is what [noUsableResponse] is for. Without it a handler's verdict on
+  /// a 2xx body and a transport failure would both store a null `httpCode`,
+  /// and the two want opposite treatment — the first must never be sent again,
+  /// the second must be.
   Future<bool> markFailed(
     String id, {
     String? errorMessage,
     int? httpCode,
-    bool permanent = false,
+    OutboxRefusal refusal = OutboxRefusal.transient,
   }) async {
     final row = await _dao.getById(id);
     if (row == null) return false;
 
     final attempts = row.attemptCount + 1;
     final nowMs = _now().millisecondsSinceEpoch;
-    final abandoned = permanent || attempts >= row.maxAttempts;
+    final terminal = refusal != OutboxRefusal.transient;
+    final abandoned = terminal || attempts >= row.maxAttempts;
 
     await _dao.patch(
       id,
@@ -205,7 +409,7 @@ class OutboxRepository {
         lastAttemptAt: Value(nowMs),
         nextAttemptAt: Value(nowMs + backoffFor(attempts).inMilliseconds),
         errorMessage: Value(errorMessage),
-        httpCode: Value(httpCode),
+        httpCode: Value(httpCode ?? (terminal ? noUsableResponse : null)),
       ),
     );
     return abandoned;

--- a/flutter/lib/repository/outbox_repository.dart
+++ b/flutter/lib/repository/outbox_repository.dart
@@ -32,8 +32,9 @@ enum OutboxRefusal {
   /// back — a 2xx whose body carries no usable `rev`/`id`. The write may
   /// already be on the server, which makes this the one class where resending
   /// is worse than not: it risks a second copy of a document that is already
-  /// filed. Terminal for the same reason as [rejected], for a different
-  /// reason.
+  /// filed. Terminal to the same effect as [rejected], for the opposite
+  /// reason: [rejected] is certain the write did not land, this one is not
+  /// certain it did not.
   indeterminate,
 }
 

--- a/flutter/lib/repository/personals_repository.dart
+++ b/flutter/lib/repository/personals_repository.dart
@@ -90,7 +90,12 @@ class PersonalsRepository {
   /// Port of `Personal.serialize`.
   ///
   /// Device telemetry is deliberately added by [PersonalsUploader], where the
-  /// platform seam is available; this pure row serializer remains deterministic.
+  /// platform seam is available.
+  ///
+  /// **This is only deterministic if [uploadedAt] is passed.** The
+  /// `DateTime.now()` default made the same row serialize differently on every
+  /// call, which defeats `OutboxRepository.enqueue`'s memo — see the call site
+  /// in [PersonalsUploader.queuePending] for why that mattered enough to fix.
   static Map<String, dynamic> serialize(
     PersonalRow row, {
     DateTime? uploadedAt,

--- a/flutter/lib/repository/personals_uploader.dart
+++ b/flutter/lib/repository/personals_uploader.dart
@@ -62,7 +62,25 @@ class PersonalsUploader {
         itemId: row.id,
         endpoint: endpoint,
         payload: {
-          ...PersonalsRepository.serialize(row),
+          // `uploadedAt` is passed, and passed *deterministically*, because
+          // `serialize`'s default is `DateTime.now()` — and this payload is
+          // re-serialized on every sweep, not once at send time as Kotlin's is
+          // (`Personal.serialize:39`). A drifting field makes the payload
+          // differ from the one already recorded against this note, so
+          // `OutboxRepository.enqueue`'s memo can never match and a note the
+          // server refused is POSTed again on every sweep. That is the
+          // duplicate this handler's own "carried no id/rev" branch exists to
+          // prevent, so of all twenty uploaders this was the worst one to
+          // leave volatile.
+          //
+          // The note's creation date is the honest value here. Kotlin's
+          // `Date().time` is the moment of the POST, which this app cannot
+          // know at enqueue time — the drain may be days later — so a captured
+          // `now` would be neither creation nor delivery.
+          ...PersonalsRepository.serialize(
+            row,
+            uploadedAt: DateTime.fromMillisecondsSinceEpoch(row.date),
+          ),
           ...identity!.documentFields,
         },
         userId: userId,

--- a/flutter/lib/ui/health/my_health_screen.dart
+++ b/flutter/lib/ui/health/my_health_screen.dart
@@ -443,8 +443,10 @@ class _RejectedUploadsBanner extends ConsumerWidget {
             // sync (`UploadToShelfService.uploadHealth`, run from
             // `AutoSyncWorker`); the port re-queues only from the examination
             // form's own save, so a stranded record has no other way back onto
-            // the wire. `enqueue` ignores the abandoned row and writes a fresh
-            // pending one, so this is a real retry rather than a nudge.
+            // the wire. Since Phase 148 an identical request is not re-sent by
+            // a sweep, so this passes `retryRefused: true` — an explicit
+            // instruction from someone looking at the banner is the one thing
+            // entitled to override that. Still a real retry, not a nudge.
             TextButton(onPressed: () => _retry(ref), child: Text(l10n.retry)),
           ],
         ),
@@ -453,7 +455,7 @@ class _RejectedUploadsBanner extends ConsumerWidget {
   }
 
   Future<void> _retry(WidgetRef ref) async {
-    await ref.read(healthQueueProvider).queuePending();
+    await ref.read(healthQueueProvider).queuePending(retryRefused: true);
     final config = ref.read(serverConfigProvider);
     if (config != null) {
       await ref

--- a/flutter/test/repository/health_legacy_conflict_test.dart
+++ b/flutter/test/repository/health_legacy_conflict_test.dart
@@ -151,19 +151,108 @@ void main() {
     expect(abandoned.single.httpCode, 409);
   });
 
-  test('a record refused twice is one stranded record, not two', () async {
-    // `enqueue` only looks for an *open* operation, so an abandoned row never
-    // blocks a fresh one — a save re-queues the same doomed record and earns a
-    // second abandoned row. Counting rows would tell the clinician the wrong
-    // number and keep growing.
+  test('a record refused ten times leaves one row and one POST', () async {
+    // The accretion. `enqueue` used to look only for an *open* operation, so
+    // an abandoned row never blocked a fresh one and every sweep minted
+    // another dead row and made another doomed POST — in `outbox`, a table
+    // schema bumps preserve. Ten sweeps rather than two, because one repeat is
+    // not a demonstration of unboundedness.
+    final legacyId = await seedLegacyPair();
+
+    // `seedLegacyPair` leaves two dirty rows — the patient's profile and the
+    // examination that collides with it — so the first sweep legitimately
+    // POSTs twice. What must not grow is everything after it.
+    await queueAndDrain();
+    final afterFirstSweep = couch.postCount;
+    expect(afterFirstSweep, 2);
+
+    for (var sweep = 0; sweep < 9; sweep++) {
+      await queueAndDrain();
+    }
+
+    expect(
+      couch.postCount,
+      afterFirstSweep,
+      reason: 'the server was asked the identical question exactly once',
+    );
+    final rows = await database.outboxDao.forItem(
+      HealthUploader.type,
+      legacyId,
+    );
+    expect(rows, hasLength(1));
+    expect(rows.single.status, OutboxDao.statusAbandoned);
+    expect(rows.single.httpCode, 409, reason: 'still diagnosable');
+
+    final abandoned = await database.outboxDao.abandoned(HealthUploader.type);
+    expect(abandoned.map((row) => row.itemId), [legacyId]);
+  });
+
+  test('the clinician tapping Retry does override the memo', () async {
+    // `MyHealthScreen`'s banner counts stranded records and offers Retry next
+    // to the count. A sweep must not re-ask; a person who has just been told
+    // something is wrong must be able to.
     final legacyId = await seedLegacyPair();
 
     await queueAndDrain();
+    final afterFirstSweep = couch.postCount;
     await queueAndDrain();
+    expect(couch.postCount, afterFirstSweep, reason: 'a sweep does not re-ask');
 
-    final abandoned = await database.outboxDao.abandoned(HealthUploader.type);
-    expect(abandoned.length, 2);
-    expect(abandoned.map((row) => row.itemId).toSet(), {legacyId});
+    await uploader.queuePending(
+      config: config,
+      userId: patientId,
+      retryRefused: true,
+    );
+    await drainer.drain(authHeader: 'auth');
+
+    expect(couch.postCount, afterFirstSweep + 1);
+    // Still refused, so still one row and still reported.
+    final rows = await database.outboxDao.forItem(
+      HealthUploader.type,
+      legacyId,
+    );
+    expect(rows, hasLength(1));
+    expect(rows.single.status, OutboxDao.statusAbandoned);
+  });
+
+  test('an accepted response with no revision is never re-sent', () async {
+    // Job 1. The transport called the send a success, so the examination may
+    // be on the server; asking again could file it twice. The row is abandoned
+    // once, with a code that says no HTTP status was the reason, and no sweep
+    // re-arms it.
+    final legacyId = await seedLegacyPair();
+    // The v45 repair first, so the examination owns its own document id and
+    // the response shape is the only thing under test — otherwise it collides
+    // with the profile and earns a 409 instead.
+    await database.customStatement('SELECT 1');
+    await database.migration.onUpgrade(database.createMigrator(), 44, 45);
+    couch.omitRevOnPost = true;
+
+    await queueAndDrain();
+    final afterFirstSweep = couch.postCount;
+
+    for (var sweep = 0; sweep < 4; sweep++) {
+      await queueAndDrain();
+    }
+
+    expect(couch.postCount, afterFirstSweep);
+    expect(
+      couch.documents.containsKey(legacyId),
+      isTrue,
+      reason: 'the server did accept it — that is what makes re-sending unsafe',
+    );
+    final rows = await database.outboxDao.forItem(
+      HealthUploader.type,
+      legacyId,
+    );
+    expect(rows, hasLength(1));
+    expect(rows.single.status, OutboxDao.statusAbandoned);
+    expect(rows.single.httpCode, OutboxRepository.noUsableResponse);
+    expect(rows.single.errorMessage, 'Upload response carried no rev');
+
+    // And the revision the row already held is untouched: `markUploaded` is
+    // not called with a null, which would erase it.
+    expect((await repository.getById(legacyId))!.isUpdated, isTrue);
   });
 
   test('a delivered record stops being reported as stranded', () async {
@@ -267,11 +356,21 @@ class _FakeCouchDb extends Mock implements PlanetApi {
   final Map<String, Map<String, dynamic>> documents = {};
   var _rev = 0;
 
+  /// Every POST that reached this fake, so a test can assert that a refused
+  /// request was not asked a second time.
+  var postCount = 0;
+
+  /// Answers an accepted write with `id` and no `rev` — the shape
+  /// `HealthUploader`'s handler refuses to interpret.
+  var omitRevOnPost = false;
+
   NetworkResult<Map<String, dynamic>> _post(Map<String, dynamic> body) {
+    postCount++;
     final id = body['_id'] as String?;
     if (id == null) {
       final minted = 'minted-${documents.length}';
       documents[minted] = {...body};
+      if (omitRevOnPost) return NetworkSuccess({'id': minted});
       return NetworkSuccess({'id': minted, 'rev': '1-${++_rev}'});
     }
     final existing = documents[id];
@@ -280,6 +379,7 @@ class _FakeCouchDb extends Mock implements PlanetApi {
     }
     final rev = '${++_rev}-x';
     documents[id] = {...body, '_rev': rev};
+    if (omitRevOnPost) return NetworkSuccess({'id': id});
     return NetworkSuccess({'id': id, 'rev': rev});
   }
 }

--- a/flutter/test/repository/outbox_drainer_test.dart
+++ b/flutter/test/repository/outbox_drainer_test.dart
@@ -77,7 +77,15 @@ void main() {
     expect(await outbox.due(), hasLength(1));
   });
 
-  test('a 409 conflict is permanent, matching UploadCoordinator', () async {
+  test('a 409 rejects the request the payload made', () async {
+    // Renamed from "a 409 conflict is permanent, matching UploadCoordinator",
+    // which misread the Kotlin: `UploadCoordinator.kt:169-204` intercepts a
+    // 409 *before* its `code >= 500` rule, GETs the document, adopts its
+    // `_rev` and reports success. `retryable = false` appears only when that
+    // recovery GET itself fails. The port has that arm for exactly one
+    // uploader (`adopted_surveys_uploader.dart:219-242`); everywhere else a
+    // 409 lands here. What this test pins is the narrower true thing: the
+    // request as sent has been refused, so nothing re-sends it unchanged.
     final id = await enqueue();
     stubSend(const NetworkError<Map<String, dynamic>>(409, 'conflict'));
 
@@ -90,10 +98,189 @@ void main() {
     expect(row?.httpCode, 409);
   });
 
-  test('a 400 is permanent — only 5xx is retryable', () async {
+  test('a 400 is a rejection of the request', () async {
     await enqueue();
     stubSend(const NetworkError<Map<String, dynamic>>(400, 'bad request'));
     expect(await drainer().drain(), [OutboxOutcome.abandoned]);
+  });
+
+  test('a 401 is retried — it is about the caller, not the request', () async {
+    // Kotlin's one rule is `retryable = response.code() >= 500`
+    // (`UploadCoordinator.kt:211`), which makes a 401 non-retryable — but
+    // `RetryQueue` then declines to queue it at all and Kotlin's sweep
+    // re-reads the live table on the next sync, so the write *is* re-attempted
+    // there. The port's sweep re-enqueues rather than re-posts, so reaching
+    // the same outcome needs 401 classified as transient here.
+    await enqueue();
+    stubSend(const NetworkError<Map<String, dynamic>>(401, 'unauthorized'));
+
+    expect(await drainer().drain(), [OutboxOutcome.retryScheduled]);
+    clock = clock.add(const Duration(minutes: 1));
+    expect(await outbox.due(), hasLength(1));
+  });
+
+  test('403, 408 and 429 are retried for the same reason', () async {
+    for (final code in [403, 408, 429]) {
+      await outbox.enqueue(
+        uploadType: 'personals',
+        itemId: 'note-$code',
+        endpoint: endpoint,
+        payload: const {'title': 'A note'},
+      );
+      stubSend(NetworkError<Map<String, dynamic>>(code, 'refused'));
+      // Rows queued by an earlier turn of this loop are due again, so the
+      // assertion is on the kind of every outcome rather than on the count.
+      expect(
+        await drainer().drain(),
+        everyElement(OutboxOutcome.retryScheduled),
+        reason: '$code',
+      );
+      clock = clock.add(const Duration(minutes: 1));
+    }
+    for (final code in [403, 408, 429]) {
+      final rows = await database.outboxDao.forItem('personals', 'note-$code');
+      expect(rows.single.status, OutboxDao.statusPending, reason: '$code');
+    }
+  });
+
+  test("a handler's verdict on a 2xx body is not a server refusal", () async {
+    // `PlanetApi` only builds a `NetworkError` from a response it received
+    // and substitutes 0 for a missing status, so a *null* code can only have
+    // come from a handler: the send succeeded and the body was unusable. The
+    // write may already be on the server, so it is recorded terminally —
+    // never re-sent under the same payload — but with a code that says no
+    // HTTP status was the reason.
+    final id = await enqueue();
+
+    final outcomes = await drainer(
+      handlers: {
+        'personals': (row, payload, authHeader) async =>
+            const NetworkError<Map<String, dynamic>>(null, 'no rev'),
+      },
+    ).drain();
+
+    expect(outcomes, [OutboxOutcome.abandoned]);
+    final row = await database.outboxDao.getById(id);
+    expect(row?.status, OutboxDao.statusAbandoned);
+    expect(row?.httpCode, OutboxRepository.noUsableResponse);
+    expect(
+      OutboxRepository.classifyStatus(row?.httpCode),
+      OutboxRefusal.indeterminate,
+    );
+  });
+
+  test('a rejected request is asked once, however many sweeps run', () async {
+    // The accretion Phase 134 reported and Phase 138 sharpened. One sweep is
+    // not evidence — the row and the POST used to be minted afresh on *every*
+    // sweep, so the demonstration has to be several. The cadence differs per
+    // upload type (per sync for submissions and voices, per user write for
+    // health, per team-detail mount for `teamLog`); what they share is that
+    // nothing about it is bounded.
+    stubSend(const NetworkError<Map<String, dynamic>>(409, 'conflict'));
+
+    for (var sync = 0; sync < 5; sync++) {
+      // What `queuePending` does on every sweep: re-offer every locally dirty
+      // record, whose serialization has not changed because nothing has
+      // successfully uploaded it.
+      await enqueue();
+      await drainer().drain();
+      clock = clock.add(const Duration(hours: 1));
+    }
+
+    verify(
+      () => api.sendJsonObject(
+        any(),
+        body: any(named: 'body'),
+        method: any(named: 'method'),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).called(1);
+    expect(
+      await database.outboxDao.forItem('personals', 'note-1'),
+      hasLength(1),
+      reason: 'one row for the item, not one per sweep',
+    );
+    expect(
+      await database.outboxDao.abandoned('personals'),
+      hasLength(1),
+      reason: 'still diagnosable, just not repeated',
+    );
+  });
+
+  test('an unusable 2xx response is not asked again either', () async {
+    // Job 1: the same unboundedness, reached through a handler's own verdict
+    // rather than through a status code — and the case where re-asking risks
+    // a *second* copy of a document that is already filed.
+    var sends = 0;
+
+    for (var sync = 0; sync < 5; sync++) {
+      await enqueue();
+      await drainer(
+        handlers: {
+          'personals': (row, payload, authHeader) async {
+            sends++;
+            return const NetworkError<Map<String, dynamic>>(null, 'no rev');
+          },
+        },
+      ).drain();
+      clock = clock.add(const Duration(hours: 1));
+    }
+
+    expect(sends, 1);
+    expect(
+      await database.outboxDao.forItem('personals', 'note-1'),
+      hasLength(1),
+    );
+  });
+
+  test('a transient failure keeps being offered across sweeps', () async {
+    // The other half of the policy: bounding the *rows* must not bound the
+    // *retries* of a write that is still deliverable. A server that is down
+    // for a week is not a verdict on the record — and Kotlin agrees, since
+    // `RetryQueue` never abandons an *item*, only an operation: a refused
+    // item's local flag is untouched (`UploadCoordinator.kt:63-68, 241-257`)
+    // and the next sweep re-offers it.
+    stubSend(const NetworkError<Map<String, dynamic>>(503, 'unavailable'));
+
+    for (var sync = 0; sync < 3; sync++) {
+      await enqueue();
+      await drainer().drain();
+      clock = clock.add(const Duration(hours: 1));
+    }
+
+    expect(
+      await database.outboxDao.forItem('personals', 'note-1'),
+      hasLength(1),
+      reason: 'one row, still',
+    );
+    verify(
+      () => api.sendJsonObject(
+        any(),
+        body: any(named: 'body'),
+        method: any(named: 'method'),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).called(3);
+  });
+
+  test('a rejected row is re-armed by an edited payload', () async {
+    stubSend(const NetworkError<Map<String, dynamic>>(409, 'conflict'));
+    await enqueue();
+    await drainer().drain();
+    clock = clock.add(const Duration(hours: 1));
+
+    // The pull that follows a sync hands the row the revision the 409 was
+    // about, so the next serialization differs.
+    await outbox.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: endpoint,
+      payload: const {'title': 'A note', '_rev': '2-b'},
+    );
+    stubSend(const NetworkSuccess<Map<String, dynamic>>({'ok': true}));
+
+    expect(await drainer().drain(), [OutboxOutcome.completed]);
+    expect(await database.outboxDao.forItem('personals', 'note-1'), isEmpty);
   });
 
   test('a transport failure is always retryable', () async {

--- a/flutter/test/repository/outbox_drainer_test.dart
+++ b/flutter/test/repository/outbox_drainer_test.dart
@@ -453,9 +453,11 @@ void main() {
 
   test('onlyTypes leaves every other type untouched', () async {
     // The public-survey case: a respondent with no server configuration has no
-    // credential, and posting the rest of the queue unauthenticated would earn a
-    // 401 — which the retry rule calls *permanent* and would abandon writes that
-    // are perfectly deliverable once the app is configured.
+    // credential, and posting the rest of the queue unauthenticated would earn
+    // a 401 on writes that are perfectly deliverable once the app is
+    // configured. Since Phase 148 a 401 is transient, so this no longer
+    // abandons them — it still spends attempts off their ladders, which is
+    // reason enough to keep the scoping.
     await enqueue(itemId: 'note-1');
     await outbox.enqueue(
       uploadType: 'public_survey',

--- a/flutter/test/repository/outbox_repository_test.dart
+++ b/flutter/test/repository/outbox_repository_test.dart
@@ -169,7 +169,11 @@ void main() {
     );
 
     expect(
-      await repository.markFailed(id, httpCode: 409, permanent: true),
+      await repository.markFailed(
+        id,
+        httpCode: 409,
+        refusal: OutboxRefusal.rejected,
+      ),
       isTrue,
     );
     clock = clock.add(const Duration(days: 1));
@@ -288,14 +292,23 @@ void main() {
     expect(await repository.due(), hasLength(1));
   });
 
-  test('an abandoned item does not block a fresh enqueue', () async {
+  test('a rejected item is not re-armed by the identical request', () async {
+    // This used to read "an abandoned item does not block a fresh enqueue",
+    // and it asserted `second` was a *different* row. That is the accretion:
+    // `queuePending` runs every sync, so one 409 became one more dead row and
+    // one more doomed POST per sync, for ever, in a table that survives schema
+    // bumps.
     final first = await repository.enqueue(
       uploadType: 'personals',
       itemId: 'note-1',
       endpoint: 'e',
       payload: const {},
     );
-    await repository.markFailed(first, permanent: true);
+    await repository.markFailed(
+      first,
+      httpCode: 409,
+      refusal: OutboxRefusal.rejected,
+    );
 
     final second = await repository.enqueue(
       uploadType: 'personals',
@@ -303,8 +316,196 @@ void main() {
       endpoint: 'e',
       payload: const {},
     );
-    expect(second, isNot(first));
+    expect(second, first, reason: 'one row per (uploadType, itemId)');
+    expect(await repository.due(), isEmpty, reason: 'nothing left to ask');
+    expect(
+      await database.outboxDao.forItem('personals', 'note-1'),
+      hasLength(1),
+    );
+  });
+
+  test('a changed request re-arms the same row', () async {
+    final first = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {'body': 'first'},
+    );
+    await repository.markFailed(
+      first,
+      httpCode: 409,
+      refusal: OutboxRefusal.rejected,
+    );
+
+    // The user edited the note; a 409 against a stale `_rev` says nothing
+    // about a body the server has not seen.
+    final second = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {'body': 'edited'},
+    );
+
+    expect(second, first);
+    final due = await repository.due();
+    expect(due, hasLength(1));
+    expect(due.single.attemptCount, 0, reason: 'a fresh ladder');
+    expect(due.single.httpCode, isNull);
+    expect(due.single.errorMessage, isNull);
+  });
+
+  test('a reconfigured endpoint re-arms a rejected row', () async {
+    // The outbox freezes `endpoint` at enqueue time, so moving the app to the
+    // clone URL changes the request even when the body is byte-identical.
+    final first = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'https://primary.example/db',
+      payload: const {},
+    );
+    await repository.markFailed(
+      first,
+      httpCode: 400,
+      refusal: OutboxRefusal.rejected,
+    );
+
+    await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'https://clone.example/db',
+      payload: const {},
+    );
     expect(await repository.due(), hasLength(1));
+  });
+
+  test('an exhausted transient failure is re-armed unchanged', () async {
+    // Nothing about a 503 or a dropped connection is a verdict on the
+    // request, so a later sweep is entitled to ask again — which is how a
+    // record queued during a server outage eventually lands.
+    final id = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+      maxAttempts: 1,
+    );
+    expect(
+      await repository.markFailed(id, httpCode: 503, errorMessage: 'down'),
+      isTrue,
+    );
+    expect(await repository.due(), isEmpty);
+
+    final second = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+    expect(second, id);
+    expect(await repository.due(), hasLength(1));
+  });
+
+  test('a rejection without a status is still terminal', () async {
+    // `markFailed` records [OutboxRepository.noUsableResponse] for a terminal
+    // refusal that carries no HTTP status of its own — a handler's verdict on
+    // a 2xx body, or a payload that will not parse. Storing plain `null` would
+    // make it indistinguishable from a transport failure, which must be
+    // retried.
+    final id = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+    await repository.markFailed(
+      id,
+      errorMessage: 'no rev',
+      refusal: OutboxRefusal.indeterminate,
+    );
+    expect(
+      (await database.outboxDao.getById(id))?.httpCode,
+      OutboxRepository.noUsableResponse,
+    );
+
+    await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+    expect(await repository.due(), isEmpty);
+  });
+
+  test('a transport failure keeps a null status and stays retryable', () async {
+    final id = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+      maxAttempts: 1,
+    );
+    await repository.markFailed(id, errorMessage: 'connection reset');
+    expect((await database.outboxDao.getById(id))?.httpCode, isNull);
+
+    await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+    expect(await repository.due(), hasLength(1));
+  });
+
+  test('surplus rows an older build left are collapsed to one', () async {
+    // An install upgrading into this policy carries one abandoned row per
+    // sweep since its first refusal, and `outbox` survives schema bumps.
+    for (var i = 0; i < 4; i++) {
+      await database.outboxDao.upsert(
+        OutboxEntriesCompanion.insert(
+          id: 'legacy-$i',
+          uploadType: 'personals',
+          itemId: 'note-1',
+          payload: '{}',
+          endpoint: 'e',
+          status: const Value(OutboxDao.statusAbandoned),
+          httpCode: const Value(409),
+          createdAt: 1000 + i,
+        ),
+      );
+    }
+
+    await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+
+    final rows = await database.outboxDao.forItem('personals', 'note-1');
+    expect(rows, hasLength(1));
+    expect(rows.single.id, 'legacy-3', reason: 'the newest answer is kept');
+    expect(rows.single.status, OutboxDao.statusAbandoned);
+  });
+
+  test('classifyStatus splits the caller from the request', () {
+    for (final code in [null, 0, 500, 503, 401, 403, 404, 408, 429]) {
+      expect(
+        OutboxRepository.classifyStatus(code),
+        OutboxRefusal.transient,
+        reason: '$code',
+      );
+    }
+    for (final code in [400, 409, 412, 413, 415, 422]) {
+      expect(
+        OutboxRepository.classifyStatus(code),
+        OutboxRefusal.rejected,
+        reason: '$code',
+      );
+    }
+    expect(
+      OutboxRepository.classifyStatus(OutboxRepository.noUsableResponse),
+      OutboxRefusal.indeterminate,
+    );
   });
 
   test('watchPendingCount tracks the queue', () async {
@@ -328,7 +529,11 @@ void main() {
       endpoint: 'e',
       payload: const {},
     );
-    await repository.markFailed(abandoned, permanent: true);
+    await repository.markFailed(
+      abandoned,
+      httpCode: 409,
+      refusal: OutboxRefusal.rejected,
+    );
     await repository.enqueue(
       uploadType: 'personals',
       itemId: 'note-2',

--- a/flutter/test/repository/outbox_repository_test.dart
+++ b/flutter/test/repository/outbox_repository_test.dart
@@ -487,6 +487,232 @@ void main() {
     expect(rows.single.status, OutboxDao.statusAbandoned);
   });
 
+  group('rearm', () {
+    Future<String> queue() => repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+
+    test('is a no-op for an item with no row', () async {
+      expect(await repository.rearm('personals', 'note-1'), isFalse);
+    });
+
+    test('leaves a backing-off row alone, backoff included', () async {
+      final id = await queue();
+      await repository.markFailed(id, httpCode: 503, errorMessage: 'down');
+      final backedOff = (await database.outboxDao.getById(id))!.nextAttemptAt;
+
+      expect(await repository.rearm('personals', 'note-1'), isFalse);
+
+      final row = (await database.outboxDao.getById(id))!;
+      expect(
+        row.nextAttemptAt,
+        backedOff,
+        reason: 'Retry is not a backoff bypass',
+      );
+      expect(row.status, OutboxDao.statusPending);
+    });
+
+    test('leaves a claimed row alone', () async {
+      final id = await queue();
+      await repository.markInProgress(id);
+
+      expect(await repository.rearm('personals', 'note-1'), isFalse);
+      expect(
+        (await database.outboxDao.getById(id))?.status,
+        OutboxDao.statusInProgress,
+        reason: 'its request may already be on the wire',
+      );
+    });
+
+    test('puts a terminal row back with a clean slate', () async {
+      final id = await queue();
+      await repository.markFailed(
+        id,
+        httpCode: 409,
+        errorMessage: 'conflict',
+        refusal: OutboxRefusal.rejected,
+      );
+      clock = clock.add(const Duration(hours: 1));
+
+      expect(await repository.rearm('personals', 'note-1'), isTrue);
+
+      final row = (await database.outboxDao.getById(id))!;
+      expect(row.status, OutboxDao.statusPending);
+      expect(row.attemptCount, 0);
+      expect(row.httpCode, isNull);
+      expect(row.errorMessage, isNull);
+      expect(await repository.due(), hasLength(1));
+    });
+  });
+
+  test('an open row wins over a terminal one, whatever their ages', () async {
+    // `_soleRowFor`'s stated rule, which the surplus-collapse test above does
+    // not exercise: it seeds abandoned rows only, so `orElse` handles the
+    // whole thing and the `firstWhere` predicate is never reached.
+    for (var i = 0; i < 3; i++) {
+      await database.outboxDao.upsert(
+        OutboxEntriesCompanion.insert(
+          id: 'legacy-$i',
+          uploadType: 'personals',
+          itemId: 'note-1',
+          payload: '{}',
+          endpoint: 'e',
+          status: const Value(OutboxDao.statusAbandoned),
+          httpCode: const Value(409),
+          createdAt: 5000 + i,
+        ),
+      );
+    }
+    // Older than every abandoned row, and still the one that must survive.
+    await database.outboxDao.upsert(
+      OutboxEntriesCompanion.insert(
+        id: 'live',
+        uploadType: 'personals',
+        itemId: 'note-1',
+        payload: '{}',
+        endpoint: 'e',
+        status: const Value(OutboxDao.statusPending),
+        createdAt: 1,
+      ),
+    );
+
+    final id = await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+
+    expect(id, 'live');
+    expect(
+      await database.outboxDao.forItem('personals', 'note-1'),
+      hasLength(1),
+    );
+  });
+
+  test(
+    'a claimed surplus row is never deleted out from under a drain',
+    () async {
+      // `deleteById` is the one delete in `OutboxDao` that is not status-scoped,
+      // and the others are scoped precisely so a row cannot be dropped with its
+      // request on the wire.
+      //
+      // The ages matter, and a first cut of this test had them the wrong way
+      // round: the row kept is the *first* open one in `createdAt` order, so a
+      // claimed row is only ever surplus when it is the younger of the two.
+      // With the older row claimed, the guard is never reached and removing it
+      // changes nothing — the mutation survived, and the fixture was the
+      // reason, not the clause.
+      await database.outboxDao.upsert(
+        OutboxEntriesCompanion.insert(
+          id: 'older-pending',
+          uploadType: 'personals',
+          itemId: 'note-1',
+          payload: '{}',
+          endpoint: 'e',
+          status: const Value(OutboxDao.statusPending),
+          createdAt: 2,
+        ),
+      );
+      await database.outboxDao.upsert(
+        OutboxEntriesCompanion.insert(
+          id: 'in-flight',
+          uploadType: 'personals',
+          itemId: 'note-1',
+          payload: '{}',
+          endpoint: 'e',
+          status: const Value(OutboxDao.statusInProgress),
+          createdAt: 9,
+        ),
+      );
+
+      await repository.enqueue(
+        uploadType: 'personals',
+        itemId: 'note-1',
+        endpoint: 'e',
+        payload: const {},
+      );
+
+      expect(
+        await database.outboxDao.getById('in-flight'),
+        isNotNull,
+        reason: 'the drainer still needs it to record the outcome against',
+      );
+    },
+  );
+
+  test('a pre-Phase-148 refusal with no status is retried once', () async {
+    // What the old drainer stored for a handler's verdict on a 2xx: a null
+    // `httpCode`, indistinguishable from a transport failure. `outbox` is
+    // preserved across schema bumps, so these rows arrive on an upgraded
+    // install and this is what happens to them — one more attempt, after
+    // which the new sentinel makes them terminal for good.
+    await database.outboxDao.upsert(
+      OutboxEntriesCompanion.insert(
+        id: 'legacy',
+        uploadType: 'personals',
+        itemId: 'note-1',
+        payload: '{}',
+        endpoint: 'e',
+        status: const Value(OutboxDao.statusAbandoned),
+        errorMessage: const Value('Upload response carried no rev'),
+        createdAt: 1,
+      ),
+    );
+
+    await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+    expect(await repository.due(), hasLength(1));
+
+    await repository.markFailed(
+      'legacy',
+      errorMessage: 'Upload response carried no rev',
+      refusal: OutboxRefusal.indeterminate,
+    );
+    await repository.enqueue(
+      uploadType: 'personals',
+      itemId: 'note-1',
+      endpoint: 'e',
+      payload: const {},
+    );
+    expect(await repository.due(), isEmpty, reason: 'terminal from here on');
+  });
+
+  test('a terminal refusal keeps its reason across the round trip', () async {
+    // `rejected` and `indeterminate` behave identically today, so nothing else
+    // would notice them collapsing — and the notes' own highest-value
+    // follow-up, a 409-recovery arm, is exactly what needs to tell them apart.
+    Future<int?> codeAfter(OutboxRefusal refusal) async {
+      final id = await repository.enqueue(
+        uploadType: 'personals',
+        itemId: 'note-$refusal',
+        endpoint: 'e',
+        payload: const {},
+      );
+      await repository.markFailed(id, refusal: refusal);
+      return (await database.outboxDao.getById(id))?.httpCode;
+    }
+
+    expect(
+      OutboxRepository.classifyStatus(
+        await codeAfter(OutboxRefusal.indeterminate),
+      ),
+      OutboxRefusal.indeterminate,
+    );
+    expect(
+      OutboxRepository.classifyStatus(await codeAfter(OutboxRefusal.rejected)),
+      OutboxRefusal.rejected,
+    );
+    expect(await codeAfter(OutboxRefusal.transient), isNull);
+  });
+
   test('classifyStatus splits the caller from the request', () {
     for (final code in [null, 0, 500, 503, 401, 403, 404, 408, 429]) {
       expect(
@@ -505,6 +731,10 @@ void main() {
     expect(
       OutboxRepository.classifyStatus(OutboxRepository.noUsableResponse),
       OutboxRefusal.indeterminate,
+    );
+    expect(
+      OutboxRepository.classifyStatus(OutboxRepository.notSent),
+      OutboxRefusal.rejected,
     );
   });
 

--- a/flutter/test/repository/personals_uploader_test.dart
+++ b/flutter/test/repository/personals_uploader_test.dart
@@ -120,6 +120,53 @@ void main() {
     expect(await outbox.due(), hasLength(2));
   });
 
+  test('the payload a sweep builds is stable across sweeps', () async {
+    // `OutboxRepository.enqueue`'s memo compares the request it is being
+    // handed against the one already recorded for this item, so a payload that
+    // is not a pure function of the local row defeats it silently: the memo
+    // never matches, and a note the server refused is POSTed again on every
+    // sweep. `PersonalsRepository.serialize` defaults `uploadDate` to
+    // `DateTime.now()`, so this was live until Phase 148 — and personals is
+    // the worst place for it, because a personal note is an append with a
+    // server-minted id and a duplicate cannot be detected afterwards.
+    await personals.create(userId: 'user-1', userName: 'ada', title: 'One');
+
+    await uploader.queuePending(config: config, userId: 'user-1');
+    final first = (await outbox.due()).single.payload;
+
+    // Wall-clock time moves between sweeps; nothing about the note does.
+    clock = clock.add(const Duration(hours: 3));
+    await uploader.queuePending(config: config, userId: 'user-1');
+
+    expect((await outbox.due()).single.payload, first);
+  });
+
+  test('a refused note is POSTed once, however many sweeps run', () async {
+    // The consequence of the test above, end to end. Five sweeps against a
+    // server that refuses the request must produce one POST — before Phase 148
+    // this produced five, each one a candidate duplicate document.
+    await personals.create(userId: 'user-1', userName: 'ada', title: 'One');
+    stubPost(const NetworkError<Map<String, dynamic>>(400, 'bad request'));
+
+    for (var sweep = 0; sweep < 5; sweep++) {
+      await uploader.queuePending(config: config, userId: 'user-1');
+      await drainer().drain();
+      clock = clock.add(const Duration(hours: 1));
+    }
+
+    verify(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).called(1);
+    expect(
+      await database.outboxDao.forItem(PersonalsUploader.type, 'note-0'),
+      hasLength(1),
+    );
+  });
+
   test('the endpoint carries no credentials', () {
     expect(
       PersonalsUploader.endpointFor(config),

--- a/flutter/test/ui/health/my_health_screen_test.dart
+++ b/flutter/test/ui/health/my_health_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/repository/health_repository.dart';
+import 'package:myplanet/repository/health_uploader.dart';
 import 'package:myplanet/repository/outbox_drainer.dart';
 import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/ui/components/profile_avatar.dart';
@@ -52,13 +53,15 @@ class _UnreachableApi extends Mock implements PlanetApi {
   }) async => const NetworkException(SocketException('offline'));
 }
 
+const testConfig = ServerConfig(
+  serverUrl: 'https://planet.example',
+  couchDbUrl: 'https://satellite:1234@planet.example:443',
+  pin: '1234',
+);
+
 class _TestServerConfigNotifier extends ServerConfigNotifier {
   @override
-  ServerConfig? build() => const ServerConfig(
-    serverUrl: 'https://planet.example',
-    couchDbUrl: 'https://satellite:1234@planet.example:443',
-    pin: '1234',
-  );
+  ServerConfig? build() => testConfig;
 }
 
 void main() {
@@ -614,14 +617,19 @@ void main() {
     // collides with another document is abandoned on its first attempt. Nothing
     // read that state before — the reading stayed on the handset while the
     // screen listed it as recorded.
-    Future<void> abandon(AppDatabase db, String itemId) async {
+    Future<void> abandon(
+      AppDatabase db,
+      String itemId, {
+      String payload = '{}',
+      String id = '',
+    }) async {
       await db.outboxDao.upsert(
         OutboxEntriesCompanion.insert(
-          id: 'op-$itemId',
+          id: id.isEmpty ? 'op-$itemId' : id,
           uploadType: 'health',
           itemId: itemId,
-          payload: '{}',
-          endpoint: 'https://planet.example/db/health',
+          payload: payload,
+          endpoint: HealthUploader.endpointFor(testConfig),
           createdAt: 1000,
           status: const Value('abandoned'),
           httpCode: const Value(409),
@@ -705,7 +713,18 @@ void main() {
           isUpdated: const Value(true),
         ),
       );
-      await abandon(db, 'health-1');
+      // Seeded with the request `HealthUploader.queuePending` actually
+      // builds, not a `'{}'` placeholder. That is the whole point of this
+      // test since Phase 148: `OutboxRepository.enqueue` suppresses a re-send
+      // only when the request is byte-identical to the refused one, so a
+      // fixture that cannot match makes the assertion pass with or without
+      // `retryRefused: true` — coverage that cannot fail.
+      final examRow = (await db.healthExaminationDao.getById('health-1'))!;
+      await abandon(
+        db,
+        'health-1',
+        payload: jsonEncode(HealthRepository.serialize(examRow)),
+      );
       await pumpScreen(
         tester,
         session: user,
@@ -732,12 +751,17 @@ void main() {
       await tester.tap(find.widgetWithText(TextButton, 'Retry'));
       await tester.pumpAndSettle();
 
-      // A fresh operation alongside the abandoned one, because `enqueue`
-      // ignores an abandoned row rather than reusing it — which is what makes
-      // the retry a real re-attempt.
+      // The item's one row is back on the wire. A sweep would have left it
+      // abandoned — the request has not changed — so this passes only because
+      // the button asks for the memo to be overridden.
       final open = await db.outboxDao.findOpen('health', 'health-1');
       expect(open, isNotNull);
       expect(open!.status, OutboxDao.statusPending);
+      expect(
+        await db.outboxDao.forItem('health', 'health-1'),
+        hasLength(1),
+        reason: 'one row per item, re-armed rather than duplicated',
+      );
     });
 
     testWidgets('the count is of records, not of attempts', (tester) async {
@@ -753,7 +777,7 @@ void main() {
           uploadType: 'health',
           itemId: 'health-1',
           payload: '{}',
-          endpoint: 'https://planet.example/db/health',
+          endpoint: HealthUploader.endpointFor(testConfig),
           createdAt: 2000,
           status: const Value('abandoned'),
           httpCode: const Value(409),


### PR DESCRIPTION
Lane C of the Phase 148 parallel round. Full reasoning in `flutter/PHASE_148_NOTES.md`.

## The two jobs turned out to be one

- `PHASE_142_NOTES.md` item 6 — a health examination whose upload answers `id` without `rev` is abandoned, then re-POSTs for ever.
- `PHASE_138_NOTES.md` — a permanent refusal accretes one dead outbox row and one doomed POST per sweep, unbounded.

Job 1 is not a health bug. It is the one class of refusal where re-sending can create a *second* document, reached through a branch fourteen uploaders share. Job 2 is the same loop reached through a status code. One rule at the repository layer fixes both.

## The policy

> **An outbox item owns exactly one row, for ever. A terminal row is a memo: nothing re-asks the identical request unattended. What re-arms it is a *changed request* — a different payload, endpoint or verb — or a person explicitly retrying.**

| What happened | Class | Re-armed by an identical sweep? |
|---|---|---|
| 5xx, 0, transport failure, handler threw | `transient` | yes |
| 401, 403, 404, 408, 429 | `transient` | yes — about the caller, the moment, or the server's configuration |
| any other 4xx (400, 409, 413, 415, 422) | `rejected` | no |
| a handler's verdict on a **2xx** (`NetworkError(null, …)`) | `indeterminate` | no — the write may already have landed |

`enqueue` reuses the item's row whatever its status instead of minting a new one, and collapses surplus rows an older build accreted — `outbox` is preserved across schema bumps, so those rows outlive the upgrade. No schema change: the sentinels go in the existing nullable `httpCode` column.

## Corrections to the briefs this lane was given

- **`?batch=ok` is not sent** by this port or the Kotlin app, so the route Phase 142 named for `id`-without-`rev` does not exist. The same loop is reachable through an ordinary first-attempt 409, and `cacheDocuments` skips a dirty row so it could never self-heal.
- **"one doomed POST per sync"** holds for some upload types and not others — twenty of twenty-six re-offered for ever, at cadences from per-sync to per-*screen-mount*.
- **The port's `UploadCoordinator` 409 citation was a misreading**, pinned in a test name — Kotlin GETs the doc and adopts its `_rev`, reporting success. Renamed, with the misreading written out at the test.

## What the second audit pass caught

It found four defects in this lane's own green code, and the worst one defeated the policy entirely for `personals`: its payload carried a `DateTime.now()`, so the memo could never match and a refused note was POSTed on every sweep as before — in the one uploader class where the resulting duplicate is undetectable. Also fixed: an unscoped delete that could drop a claimed row, one sentinel doing the work of two, and an over-claiming comment.

**And the widget test covering the Retry override could not fail** — it seeded a placeholder payload, so the memo never applied. It now seeds the request production builds, and removing the flag fails it.

## Files

Owned: `outbox_repository.dart`, `outbox_drainer.dart`, `health_uploader.dart` and their tests, plus `personals_uploader.dart` (required — the policy is inert for that type without it). **`voices_uploader.dart` was not opened for edit**; no other uploader was touched. `app_database.dart` and `tables.dart` untouched.

Outside the listed set, named in the notes: `providers/health_provider.dart`, `ui/health/my_health_screen.dart` (without them the memo silently turns the stranded-records **Retry** button into a no-op) and one dartdoc in `personals_repository.dart`. None is another lane's file this round.

## Verification

Format and analyze clean; **2658 tests pass** (2631 before). Thirteen mutations, each reverted one at a time — every one failed the test it should, and the one that survived was fixed by correcting the fixture, not by deleting the clause. Two `parity-auditor` passes at `effort: max`, one on the ground truth before implementing and one on the finished code.

## Reported, not fixed

Thirteen items in the notes. The two worth flagging here: a **409-recovery arm** is the highest-value follow-up (Kotlin has it, and `adopted_surveys_uploader.dart` is a working port of it for one uploader), and **`ChatUploader` posts to CouchDB while parsing Planet's chat-service response shape**, so every outbox chat upload fails — high severity, but a chat slice rather than an outbox one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Hi9eYJgjQhysB8Xhx9RkU