### PR TITLE
fix(flutter): phase 151 — `""` vs null in the submissions sync-in

### DIFF
--- a/flutter/PHASE_151_NOTES.md
+++ b/flutter/PHASE_151_NOTES.md
@@ -1,4 +1,4 @@
-# Phase 151 — `""` and null are not the same thing, and a learner paid for it
+# Phase 151 — `""` and null are not the same thing
 
 Lane B of a four-lane round. One defect, traced end to end, fixed on one line,
 with the rest of its reach measured and handed on rather than half-closed.
@@ -25,7 +25,12 @@ SELECT COUNT(*) FROM submissions
 ```
 
 `'' != 'pending'` is true, the count is 1, `isStepCompleted` returns true and the
-course step's **Next** button unlocks.
+course step's **Next** button unlocks. The whole chain is
+`SubmissionsRepositoryImpl.isStepCompleted:359-365` →
+`CoursesRepositoryImpl.kt:577` → `TakeCourseViewModel.kt:67` →
+`TakeCourseFragment.changeNextButtonState:317-336`, whose body is gated on the
+MyPlanet Onboarding course id; count 0 means `isNextStepLocked = true` and a
+`please_complete_test` snackbar instead of advancing.
 
 The port stored `getStringOrNull('status', json)`, which is null for a missing
 key *and* for `""` (`json_utils.dart`). `NOT (NULL = 'pending')` is SQL **NULL**,
@@ -68,13 +73,22 @@ Three further arguments, all checked rather than asserted:
 2. **`''` and NULL select identically under every positive equality**, so the
    change can only ever *include* rows Kotlin includes. It cannot strand
    anything, which is the failure mode this project keeps paying for.
-3. **It is self-healing on handsets that have already synced.** `sync()` walks
-   `_all_docs?include_docs=true` in full every run and re-upserts every page
-   (and there is deliberately no `deleteNotIn`), so a row a shipped build stored
-   as NULL is rewritten to `''` by the next ordinary sync. Neither option
-   repairs an existing row *retroactively* — the brief was right to ask — but
-   the writer fix needs no migration to converge, where the reader fix would
-   have to be correct for both states for ever.
+3. **It needs no migration to converge** — but *not* "self-healing on the next
+   sync", which is what my first draft of this said and what the code comment
+   claimed until the audit caught it. `sync()` does walk
+   `_all_docs?include_docs=true` in full every run and re-upsert every page
+   (there is deliberately no `deleteNotIn`), so the repair is free **when it
+   runs**. It has exactly one caller: the refresh icon on the Submissions
+   screen (`submissions_screen.dart:122`). `DashboardSyncArea` has no
+   `submissions` member and `dashboard_sync_provider.dart:276` says so
+   outright, where Kotlin pulls this table on **every** full sync
+   (`SyncManager.kt:209` → `HeavyTableSyncWorker`). So a device that already
+   synced keeps its NULL statuses until the learner opens Submissions and taps
+   refresh. Neither option repairs an existing row retroactively — the brief
+   was right to ask — but the reader fix would have to stay correct for both
+   states for ever, where this one converges as soon as the table is pulled.
+   **I checked that the walk was complete and never checked who calls it.
+   Verifying a mechanism is not verifying that it runs.**
 
 ### The one place the argument could have failed, verified rather than reasoned
 
@@ -90,6 +104,14 @@ argument, so it is **pinned by three tests** rather than left as a paragraph: a
 round-tripped marker is not re-queued, a local marker is still excluded, and a
 genuinely NULL-status local row is still swept (the case that predicate's
 strictness exists for).
+
+Mutating that predicate the other way is the useful part. Rewriting
+`isATeamAdoptionMarker` as `coalesce([status, ''])  == ''` — which is precisely
+the reader-side fix (R) would have applied — makes *a status-less local row is
+still swept* fail: the row is stranded on the handset with no outbox entry.
+So (R) is not merely more call sites than (W); on this column, applied
+uniformly, it would have created a data-loss defect of the class this project
+keeps paying for. That is an experiment, not an argument.
 
 ### What the fix does *not* change
 
@@ -160,7 +182,8 @@ local edit sets `isUpdated` on a synced typeless row.
    `submission_detail_screen.dart:80` and `:91` made `''`-aware with the
    `row.type?.trim().isNotEmpty == true ? … : …` idiom the list screen and now
    the exporter both use. One slice, one owner, three lines.
-2. **`submission_detail_screen.dart:84` is now the odd one out on `status`.**
+2. **Three surfaces now disagree about a status-less submission's label, and
+   `submission_detail_screen.dart:84` is the one left behind.**
    `row.status ?? l10n.pending` does not catch `''`, so a status-less synced
    submission shows a blank status label there while the list and the PDF say
    "Pending". It matches Kotlin, which shows blank too
@@ -177,34 +200,133 @@ local edit sets `isUpdated` on a synced typeless row.
    `teamId.isNull() | teamId.equals('')` and accept both. Moving them is parity
    tidying with no behavioural payload — worth doing in one pass with item 1,
    not worth a phase.
-4. **The port-wide sweep found no second live instance, and that is a
-   measurement rather than an impression.** `getStringOrNull` has **198 call
-   sites**, which is not auditable one by one, so the sweep ran from the
-   *readers* instead — the only predicates that can distinguish `''` from NULL
-   are a negated equality, `LIKE`, `IS NOT`, and a Dart `??` fallback. Every
-   such site in the port is one of: already explicitly null-safe
-   (`teams.status`' four `isNull() | …not()` readers, `health.getUpdated`'s
-   `userId.isNotNull()`, the two `rev.isNotNull() & rev.equals('').not()`
-   pairs); on a **non-nullable** column (`teamTasks.status`, default `'active'`,
-   whose comment already records this exact reasoning; `achievements.id`, a
-   primary key); written by `getString` already (`tags.name`, so `parentTags`'
-   `name IS NOT ''` — which is **true** for NULL — is safe); deliberately
-   matching Kotlin (`offlineActivities.pendingLoginUploads`, where Kotlin's
-   `getUnuploadedLoginActivities` drops null-`userId` rows after the query too);
-   or **latent but unreachable**: `ratings.pendingUploads` and
+4. **`course_progress.userId` is a second live instance, and my first sweep
+   missed it.** Kotlin's `ProgressRepositoryImpl.kt:260` writes
+   `JsonUtils.getString("userId", act)` → `''`; the port's
+   `course_progress_mapper.dart:54` writes `getStringOrNull` → NULL. The reader
+   `CourseProgressDao.getByUserAndCourseIds` (`app_database.dart:4005-4015`)
+   uses `equalsNullable`, drift's spelling of `IS`, matching Kotlin's `IS` — so
+   on a `courses_progress` document that omits `userId`, **Kotlin's
+   `userId IS NULL` finds nothing and the port's finds the row**, attributing
+   its `passed`/`stepNum` to every null-user progress read. Already documented
+   in the port at `app_database.dart:3993-4002`, which names
+   `PHASE_135_NOTES.md` and says the mapper is the side that should move.
+   Verified here against both sources.
+
+   **Why my sweep missed it, because the method matters more than the miss.**
+   I swept from the readers rather than the 198 writers, which was right, but
+   with an incomplete list of distinguishing predicates: negated equality,
+   `LIKE`, `IS NOT`, and a Dart `??`. **`IS NULL` / `equalsNullable` also
+   distinguishes** — it matches NULL and not `''` — and it is a *positive*
+   predicate, so it did not look like a candidate. Anything with a null-safe
+   comparison belongs on that list. `teamId`'s
+   `isNull() | equals('')` disjuncts in item 3 are the same family, already
+   written to accept both.
+5. **Everything else in the reader sweep is clear, and that is a measurement
+   rather than an impression.** With the corrected predicate list, every
+   remaining site that can distinguish `''` from NULL is one of: already
+   explicitly null-safe (`teams.status`' four `isNull() | …not()` readers,
+   `health.getUpdated`'s `userId.isNotNull()`, the `rev.isNotNull() &
+   rev.equals('').not()` pairs, the generic distinct helper); on a
+   **non-nullable** column (`teamTasks.status`, default `'active'`, whose
+   comment already records this exact reasoning; `achievements.id`, a primary
+   key); written by `getString` already (`tags.name`, so `parentTags`'
+   `name IS NOT ''` — **true** for NULL — is safe; `newsEntries.docId`, which
+   matters because it feeds a destructive `deleteNotIn`); deliberately matching
+   Kotlin (`offlineActivities.pendingLoginUploads`, where Kotlin's
+   `getUnuploadedLoginActivities` drops null-`userId` rows after the query
+   too); or **latent but unreachable**: `ratings.pendingUploads` and
    `courseProgress.getPendingUploads` both negate `userId LIKE 'guest%'` on a
-   nullable column, and a NULL there would be silently stranded rather than
-   uploaded — but the rating writer takes a `required String userId` and only
+   nullable column, where a NULL would be silently stranded rather than
+   uploaded — but the rating writer takes a `required String userId`, only
    local writes set `isUpdated`, and the progress query additionally requires
    `couchId IS NULL`, which excludes every synced row. Both are one careless
-   writer away from being real; neither is real today. All of these live in
-   `app_database.dart`, Lane A's file, so all are report-only either way.
-5. **The trap is now documented at the helper**, since that is the layer with
+   writer away from real; neither is real today.
+
+   Two general rules fell out of it. **`_id` and `_rev` can never diverge on
+   this axis** — CouchDB always returns a non-empty `_rev` from
+   `_all_docs?include_docs=true` — so only optional document fields can, which
+   cuts the 198 call sites down sharply. And **sometimes the port's null is
+   better and must not be "fixed" toward Kotlin**: `my_library_mapper.dart:73`
+   reads `year`, and Kotlin's `getString` blanks a JSON *number* (its
+   `isString` test's false branch returns `""`), so a resource with
+   `"year": 2019` shows no year in the Kotlin app and shows `2019` here. The
+   port's `getString` differs from Kotlin's in exactly that case, which the
+   helper's own doc comment described incompletely; same class for any
+   numeric-valued string column.
+6. **A counter-precedent to blanket-(W), worth knowing before the next one.**
+   `surveys.rev`/`exams.rev` carried this same fold and were fixed on the
+   **reader/schema** side instead: Kotlin's `ExamDao.kt:21`
+   (`sourceSurveyId IS NOT NULL AND _rev IS NULL`) names one writer only
+   because its sync writers store `''`, while the port's `getStringOrNull`
+   made `rev` NULL for every course-embedded survey — and Phase 138 found the
+   resulting sweep POSTing another team's private copy under the signed-in
+   user's credentials. The remedy chosen there was a new local-authority
+   column, `Surveys.needsSync`, not a writer change. So (W) is the right call
+   for `status` on the argument above, and it is not automatically the right
+   call for the next column: **ask whether the port needs to distinguish local
+   authorship, and if it does, say so with a column rather than with `''`.**
+7. **`app_database.dart:2946-2954` explains `isATeamAdoptionMarker`'s
+   strictness with a clause this fix makes false**: *"the sync-in stores null
+   for a document that omits the key"*. It no longer does, for `status`. **The
+   predicate should stay** — rows a pre-Phase-151 build stored are still NULL
+   on device, and two of that table's own tests build a status-less row to
+   probe the guest test — but its argument now rests on those two things
+   rather than on the sync-in. Handed over rather than edited: *making an
+   existing statement true* is a stop-and-report carve-out, but
+   `app_database.dart` is **Lane A's named file this round**, and a carve-out
+   is not a licence to edit into a live collision. (The same correction in
+   `submissions_repository.dart` and `surveys_repository.dart` is done — the
+   first is this lane's file, the second is unowned and comment-only.)
+8. **The port does not pull `submissions` in the sync center at all**, which
+   is how item 3's caveat arises and is a bigger gap than the caveat.
+   `DashboardSyncArea` has sixteen members and no `submissions`
+   (`dashboard_sync_provider.dart:30-47`, and `:276` records it), while Kotlin
+   pulls the table on every full sync (`SyncManager.kt:209` →
+   `HeavyTableSyncWorker.ALL_HEAVY_TABLES`). So a submission made on Planet
+   web or another handset reaches this device only when the learner opens the
+   Submissions screen and taps refresh. Pre-existing and already noted in that
+   file; repeated here because this phase's repair depends on it.
+9. **Kotlin's one negated `type` predicate belongs to a feature the port does
+   not have.** `SubmissionDao.kt:32`'s `type != 'survey'` — where `'' !=
+   'survey'` is true, so Kotlin *deletes* a typeless submission and the port
+   would keep it — is reached only from
+   `CoursesRepositoryImpl.deleteCoursesProgress`, when a learner removes a
+   course from their shelf. The port has no counterpart to that method at all.
+   A separate pre-existing gap, and the reason item 1's `type` change stays
+   safe in the meantime.
+10. **The port's `JsonUtils.getString` is not quite Kotlin's.** Kotlin's
+   returns `""` for a non-string primitive (the `isString` test's false
+   branch); the port's does `value.toString()`. The port's behaviour is the
+   better one — see item 5's `year` example — but the helper's doc comment
+   said only "missing/null becomes `''`", which is half the Kotlin. Left as
+   is, deliberately, and now described accurately.
+11. **The trap is now documented at the helper**, since that is the layer with
    198 callers: `getStringOrNull`'s dartdoc states the three-valued-logic
    mechanism, names this defect as the instance that reached a learner, lists
    the three earlier reader-side patches, and says to prefer `getString` on a
    sync-in path unless the column's readers are all positive equalities and
    nothing reads it with a `??` fallback.
+
+## Two process notes, both mine
+
+**A mechanism verified is not a mechanism that runs.** I established that the
+submissions walk is a complete `_all_docs` re-upsert, correctly, and wrote
+"self-healing by the next ordinary sync" into both the code and these notes
+without checking `sync()`'s callers. It has one, behind a refresh icon. The
+audit caught it. This is the same shape as Phase 149's inherited-citation
+mistake and Phase 148's — the sentence looked finished, so nothing re-read it.
+
+**Do not `git checkout <file>` to revert a mutation while the fix is
+uncommitted.** Twice it restored HEAD and silently deleted the change under
+test — once the whole writer fix and its comment, once the exporter
+extraction — and each time the next test run passed for the wrong reason,
+because the mutation *and* the fix were gone together. `git status` caught
+both, which is why `CLAUDE.md` says to read the tree after an audit rather
+than stage it. The fix is to **commit before mutation-testing**, so a revert
+restores the fix instead of erasing it; after that, every mutation behaved.
+Seven mutations (M1–M7) then each failed exactly one test, and the two
+predicate mutations were run against a committed tree deliberately.
 
 ## Method
 

--- a/flutter/PHASE_151_NOTES.md
+++ b/flutter/PHASE_151_NOTES.md
@@ -60,35 +60,64 @@ predicate changed**, which is also why this lane needed nothing from Lane A.
 
 Three further arguments, all checked rather than asserted:
 
-1. **The port has already paid for the reader-side approach three times**, once
-   per phase, each time as a separate defect report: `pendingUploads`' coalesced
-   guest operands, `SubmissionsRepository._repairSurveyParentId`'s
+1. **The port has already paid for the reader-side approach, and the count is
+   smaller than my first draft claimed.** That draft said three times —
+   `pendingUploads`' coalesced operands, `_repairSurveyParentId`'s
    `coalesce([row.status, Constant('')]).equals('').not()`, and
-   `SurveysRepository`'s adoption guard `(row.status ?? '').isEmpty`. The step
-   count is the fourth reader of the same column and nobody remembered it. A
-   rule enforced at one writer is enforced; a rule enforced at N readers is a
-   rule that gets broken again — which is Phase 148's *one rule at the right
-   layer beat twenty special cases*, and Phase 78's `normalizeText`, and Phase
-   95's `ProfileAvatar`.
+   `SurveysRepository`'s `(row.status ?? '').isEmpty`. The implementation audit
+   took two of the three apart and it was right:
+
+   * `pendingUploads`' coalesces are on **`type` and `userId`**, not `status`;
+     its `status` clause is deliberately *not* coalesced.
+   * `_repairSurveyParentId`'s `coalesce` is **behaviourally redundant** —
+     `status.equals('').not()` excludes NULL and `''` identically, because
+     `NOT (NULL = '')` is NULL and a `WHERE` drops it. Verified by mutation:
+     dropping the coalesce passes the suite. Phase 136's actual fix was the
+     *operator* (`isNotValue` → `equals().not()`), not the coalesce. The
+     comment at the site now says so, and says not to cite it as evidence.
+
+   So the unambiguous instance is one: `SurveysRepository`'s Dart-side guard.
+   **The conclusion survives and the evidence was a third of what I claimed**,
+   which is worth the space because the argument is the phase's main one:
+   a rule enforced at one writer is enforced, a rule enforced at N readers
+   gets broken again — Phase 148's *one rule at the right layer beat twenty
+   special cases*, Phase 78's `normalizeText`, Phase 95's `ProfileAvatar`. And
+   the step count really was a reader nobody remembered.
 2. **`''` and NULL select identically under every positive equality**, so the
    change can only ever *include* rows Kotlin includes. It cannot strand
    anything, which is the failure mode this project keeps paying for.
-3. **It needs no migration to converge** — but *not* "self-healing on the next
-   sync", which is what my first draft of this said and what the code comment
-   claimed until the audit caught it. `sync()` does walk
-   `_all_docs?include_docs=true` in full every run and re-upsert every page
-   (there is deliberately no `deleteNotIn`), so the repair is free **when it
-   runs**. It has exactly one caller: the refresh icon on the Submissions
-   screen (`submissions_screen.dart:122`). `DashboardSyncArea` has no
-   `submissions` member and `dashboard_sync_provider.dart:276` says so
-   outright, where Kotlin pulls this table on **every** full sync
-   (`SyncManager.kt:209` → `HeavyTableSyncWorker`). So a device that already
-   synced keeps its NULL statuses until the learner opens Submissions and taps
-   refresh. Neither option repairs an existing row retroactively — the brief
-   was right to ask — but the reader fix would have to stay correct for both
-   states for ever, where this one converges as soon as the table is pulled.
-   **I checked that the walk was complete and never checked who calls it.
-   Verifying a mechanism is not verifying that it runs.**
+3. **It needs no migration to converge.** `sync()` walks
+   `_all_docs?include_docs=true` in full every run and re-upserts every page
+   (there is deliberately no `deleteNotIn`), so a submissions pull rewrites a
+   row a shipped build stored as NULL. Neither option repairs an existing row
+   retroactively — the brief was right to ask — but the reader fix would have
+   to stay correct for both states for ever, where this one converges as soon
+   as the table is pulled.
+
+   **The count of callers went wrong twice before landing here, and it is the
+   most instructive thing in the phase.** My first draft said "self-healing by
+   the next ordinary sync". The ground-truth audit called that false, on the
+   grounds that `sync()` has exactly one caller — the Submissions screen's
+   refresh icon — and I took the correction, wrote it into the code and the
+   notes, and made *"a mechanism verified is not a mechanism that runs"* the
+   phase's headline lesson. The implementation audit then found
+   `background_entrypoint.dart:195-202`: a `BackgroundSyncStep('submissions',
+   …)` inside `syncSteps`, on the periodic auto-sync task, with
+   `PlanetPrefs.autoSyncEnabled` defaulting to **true**
+   (`planet_prefs.dart:441`). Verified by hand. **The table is pulled
+   headlessly, the original claim was substantially right, and the correction
+   over-corrected.**
+
+   What is actually true of the sync center is only what
+   `dashboard_sync_provider.dart:276` says — nothing in the **foreground**
+   pass pulls `submissions` — which is a real gap against Kotlin's
+   `HeavyTableSyncWorker` (`SyncManager.kt:209`) and is a different statement
+   from the one I built on it. **An audit finding is a claim like any other.**
+   The first pass was right that I had not checked who calls `sync`; it was
+   wrong about the answer, and I propagated its answer without doing the check
+   its own finding said I had skipped. Fifth instance of the class this
+   project has now recorded, and the first where the error arrived *through* a
+   correction.
 
 ### The one place the argument could have failed, verified rather than reasoned
 
@@ -153,6 +182,42 @@ Planet-shaped document (owner in the nested `user` object, no top-level
 Both directions are pinned, so the fix cannot be mistaken for "count
 everything": a `pending` status still locks the step.
 
+## The defect this phase caused, and the guard it disarmed
+
+**The most valuable thing the implementation audit found is a defect the fix
+created in the test suite, on a line the same commit annotated to say it
+had not.**
+
+`_repairSurveyParentId`'s status test exists because Phase 136 shipped
+`row.status.isNotValue('')`, which emits SQL `IS NOT`; `NULL IS NOT ''` is
+**true**, so the guard rewrote an adoption marker into the gate key and, in
+that test's own words, *"the learner's Finish sailed past a survey they had
+never answered."* The only fixture reaching that branch was one document whose
+explicit `'status': ''` the old sync-in folded to NULL.
+
+After the writer fix that document stores `''`, and `'' IS NOT ''` is **false**
+— so the bug became invisible. Reverting `_repairSurveyParentId` to the
+Phase-136 form left all 40 tests in the three relevant files green.
+Demonstrated, not reasoned. And my edit to that test's expectation carried the
+comment *"The assertion below is unaffected either way"*, which was true of
+that assertion and false of the test's purpose; the same commit wrote the
+justification *"which is why the `coalesce` stays: rows a pre-Phase-151 build
+stored as NULL are still on devices"* and removed the coverage for exactly
+that population.
+
+Fixed by building the legacy row as a companion — **the sync-in can no longer
+produce it** — and asserting the repair leaves it alone. Reverting the guard
+now fails. `submissions` is a preserved table, so those rows are real, not
+hypothetical.
+
+**The general lesson, which is new here:** when a writer fix changes what a
+column holds, every test whose *fixture* went through that writer may have
+moved off the branch it was written to cover — silently, while staying green.
+Changing an expectation from `isNull` to `''` is the visible half; the
+invisible half is that no fixture reaches the old branch any more. **After a
+writer change, re-run the mutation that the affected guards were written
+against, not just the phase's own tests.**
+
 ## `type`, and why it is reported rather than fixed
 
 The inherited report says *"the same divergence exists on `type`"*. In the
@@ -199,11 +264,29 @@ local edit sets `isUpdated` on a synced typeless row.
    divergence with no reader that can see it.** Swept: `sender`, `source` and
    `parentCode` on `submissions` are read by **no predicate anywhere** in the
    port (and Kotlin's uploader supplies `source`/`parentCode` from arguments,
-   not from the row); `teamId`'s null-distinguishing readers,
-   `pendingSurveySubmissions` and the team-scoped pair, are already written
-   `teamId.isNull() | teamId.equals('')` and accept both. Moving them is parity
-   tidying with no behavioural payload — worth doing in one pass with item 1,
-   not worth a phase.
+   not from the row). Moving them is parity tidying with no behavioural
+   payload — worth doing in one pass with item 1, not worth a phase.
+
+   **`teamId` needs a sharper statement than "no payload", though.** The
+   *writer* change really is inert, because `byUserWithoutTeam`
+   (`app_database.dart:2688-2694`) and `pendingSurveySubmissions` are written
+   `teamId.isNull() | teamId.equals('')` and accept both. But that disjunct is
+   itself a divergence in the other direction: Kotlin's
+   `getByUserIdWithoutTeam`, `getUniquePendingSurveyCandidates` and
+   `deletePendingSurveyOrphans` are plain `teamId IS NULL`
+   (`SubmissionDao.kt:14`, `:20`, `:39`) while Kotlin's sync-in stores `''`, so
+   **Kotlin's own readers match no synced team-less submission at all** and the
+   port's match every one. A Kotlin bug the port does not reproduce, and
+   `SurveysRepository.findExistingAdoption`'s non-team path sits downstream of
+   it. **Anyone who "tidies up" the `equals('')` disjunct after item 1 lands
+   will break `byUserWithoutTeam` for every pulled row.**
+
+   And **`parentId` belongs on this list**, which presented itself as
+   complete and was not: `submissions_repository.dart`'s `parentId` is
+   `getStringOrNull` where Kotlin's `:661` is `getString`, and Kotlin *does*
+   have a distinguishing reader for it (`SubmissionDao.kt:40`,
+   `parentId IS NOT NULL`). Latent in the port — no port predicate
+   distinguishes it — but it is the same divergence.
 4. **`course_progress.userId` is a second live instance, and my first sweep
    missed it.** Kotlin's `ProgressRepositoryImpl.kt:260` writes
    `JsonUtils.getString("userId", act)` → `''`; the port's
@@ -247,10 +330,16 @@ local edit sets `isUpdated` on a synced typeless row.
    `couchId IS NULL`, which excludes every synced row. Both are one careless
    writer away from real; neither is real today.
 
-   Two general rules fell out of it. **`_id` and `_rev` can never diverge on
-   this axis** — CouchDB always returns a non-empty `_rev` from
-   `_all_docs?include_docs=true` — so only optional document fields can, which
-   cuts the 198 call sites down sharply. And **sometimes the port's null is
+   One general rule fell out of it, and one claim that looked like a rule and
+   was false. **`_id` and `_rev` cannot diverge on this axis *for a top-level
+   document*** — CouchDB always returns a non-empty `_rev` from
+   `_all_docs?include_docs=true`. My first draft stated that unqualified, as
+   something that "cuts the 198 call sites down sharply", and the
+   implementation audit refuted it with the phase's own material: not every
+   mapper input is a top-level document. `survey_mapper.dart:145` and
+   `exam_mapper.dart:247` read `_rev` from a survey or exam **embedded in a
+   course document**, which has none — and item 6 below describes exactly that
+   as the Phase-138 defect, two paragraphs from where I wrote the rule. And **sometimes the port's null is
    better and must not be "fixed" toward Kotlin**: `my_library_mapper.dart:73`
    reads `year`, and Kotlin's `getString` blanks a JSON *number* (its
    `isString` test's false branch returns `""`), so a resource with
@@ -305,7 +394,20 @@ local edit sets `isUpdated` on a synced typeless row.
    better one — see item 5's `year` example — but the helper's doc comment
    said only "missing/null becomes `''`", which is half the Kotlin. Left as
    is, deliberately, and now described accurately.
-11. **The trap is now documented at the helper**, since that is the layer with
+11. **`app_database.dart:2907-2911` carries the same falsified claim** as item
+   7's range — *"`json_utils.dart:19-22` turns the empty string back into null
+   on a re-pull"* — and is additionally stale against its own code, since it
+   justifies a `coalesce` that `isATeamAdoptionMarker` does not use. Two
+   ranges in Lane A's file, one hand-over. Its `json_utils.dart:19-22`
+   citation is also now off by ~37 lines, because this phase's own doc
+   comments moved `getStringOrNull`'s body; the same stale citation is fixed
+   in the two test files and in this lane's own new one.
+12. **`submissionStatusLabel` trims and `submissions_screen.dart:248` does
+   not**, so a status of `'  graded  '` renders trimmed in the PDF and padded
+   in the list. The trim is deliberate (a PDF table cell has no layout that
+   absorbs leading whitespace) and now pinned by a test; the screen's line is
+   outside this lane's set. One line if anyone wants them identical.
+13. **The trap is now documented at the helper**, since that is the layer with
    198 callers: `getStringOrNull`'s dartdoc states the three-valued-logic
    mechanism, names this defect as the instance that reached a learner, lists
    the three earlier reader-side patches, and says to prefer `getString` on a
@@ -314,12 +416,16 @@ local edit sets `isUpdated` on a synced typeless row.
 
 ## Two process notes, both mine
 
-**A mechanism verified is not a mechanism that runs.** I established that the
-submissions walk is a complete `_all_docs` re-upsert, correctly, and wrote
-"self-healing by the next ordinary sync" into both the code and these notes
-without checking `sync()`'s callers. It has one, behind a refresh icon. The
-audit caught it. This is the same shape as Phase 149's inherited-citation
-mistake and Phase 148's — the sentence looked finished, so nothing re-read it.
+**An audit finding is a claim like any other.** The ground-truth pass told me
+my "self-healing by the next ordinary sync" was false because `sync()` has one
+caller. I took it, wrote it into the code and these notes, and made it the
+phase's headline lesson — without running the check its own finding said I had
+skipped. It has two callers, one of them headless and on by default, so the
+original claim was substantially right and the correction was the error that
+shipped. Phase 149 recorded that *a supplied replacement sentence is a claim,
+not a patch*; this is the same failure with an audit as the supplier, which is
+worse, because an audit finding arrives pre-labelled as verified. **Open the
+citation even when the correction comes from something whose job was checking.**
 
 **Do not `git checkout <file>` to revert a mutation while the fix is
 uncommitted.** Twice it restored HEAD and silently deleted the change under

--- a/flutter/PHASE_151_NOTES.md
+++ b/flutter/PHASE_151_NOTES.md
@@ -1,0 +1,10 @@
+# Phase 151 — `""` and null are not the same thing
+
+Lane B of a four-lane round. Brief: `PHASE_149_NOTES.md` § *Reported, not fixed*
+item 1 — a status-less Planet submission unlocks a course step in Kotlin and
+locks it in the port, because Kotlin's `JsonUtils.getString` stores `""` where
+the port's `getStringOrNull` stores null, and `NOT (NULL = 'pending')` is NULL.
+
+**Status: in progress.** This file is written as the phase goes; see the final
+revision for what landed and § *Reported, not fixed* for the reach of the
+divergence that this lane did not close.

--- a/flutter/PHASE_151_NOTES.md
+++ b/flutter/PHASE_151_NOTES.md
@@ -1,10 +1,218 @@
-# Phase 151 — `""` and null are not the same thing
+# Phase 151 — `""` and null are not the same thing, and a learner paid for it
 
-Lane B of a four-lane round. Brief: `PHASE_149_NOTES.md` § *Reported, not fixed*
-item 1 — a status-less Planet submission unlocks a course step in Kotlin and
-locks it in the port, because Kotlin's `JsonUtils.getString` stores `""` where
-the port's `getStringOrNull` stores null, and `NOT (NULL = 'pending')` is NULL.
+Lane B of a four-lane round. One defect, traced end to end, fixed on one line,
+with the rest of its reach measured and handed on rather than half-closed.
 
-**Status: in progress.** This file is written as the phase goes; see the final
-revision for what landed and § *Reported, not fixed* for the reach of the
-divergence that this lane did not close.
+Brief: `PHASE_149_NOTES.md` § *Reported, not fixed* item 1, described by its
+author as *"the biggest live item on this list."* It was right, and it was right
+for the reason it gave.
+
+## The defect
+
+Kotlin's submissions sync-in stores `JsonUtils.getString("status", submission)`
+(`SubmissionsRepositoryImpl.kt:659`, `:679`). Kotlin's `getString` returns `""`
+for a key the document does not carry — and for an explicit JSON `null`, and for
+a non-string primitive, since the `isString` test's false branch also returns
+`""` (`JsonUtils.kt:65-68`). So a Planet submission with no `status` is stored
+as `""`.
+
+`SubmissionDao.countCompletedByUserAndExamId` (`SubmissionDao.kt:24`) is
+
+```sql
+SELECT COUNT(*) FROM submissions
+ WHERE userId IS :userId AND parentId LIKE '%' || :examId || '%'
+   AND status != 'pending'
+```
+
+`'' != 'pending'` is true, the count is 1, `isStepCompleted` returns true and the
+course step's **Next** button unlocks.
+
+The port stored `getStringOrNull('status', json)`, which is null for a missing
+key *and* for `""` (`json_utils.dart`). `NOT (NULL = 'pending')` is SQL **NULL**,
+not true, and `WHERE NULL` drops the row. The count was 0 and **the step stayed
+locked for a learner Kotlin lets straight through.**
+
+Not hypothetical, and not a fixture artefact: the only thing needed to reach it
+is a submission document that omits `status`, which is the shape Planet sends
+whenever nothing has set one.
+
+## Which side moved, and why
+
+Two candidates. The brief said to argue it rather than default to the
+reader-side fix, so:
+
+**The reader was never wrong.** `countCompletedByUserAndExamId` is a faithful
+port of Kotlin's query, its three-valued NULL behaviour included — Kotlin's own
+reader also excludes a NULL status, and `app_database.dart` already says so in
+as many words at the query. Coalescing there would have made the port's *reader*
+diverge from Kotlin's in order to compensate for the port's *writer* diverging
+from Kotlin's. Two wrongs, and the second one permanent: every future reader of
+the column would inherit the obligation to remember.
+
+**The writer had drifted, alone, on one line.** So one line moved:
+`getStringOrNull` → `getString` for `status` in `upsertDocuments`. **No DAO
+predicate changed**, which is also why this lane needed nothing from Lane A.
+
+Three further arguments, all checked rather than asserted:
+
+1. **The port has already paid for the reader-side approach three times**, once
+   per phase, each time as a separate defect report: `pendingUploads`' coalesced
+   guest operands, `SubmissionsRepository._repairSurveyParentId`'s
+   `coalesce([row.status, Constant('')]).equals('').not()`, and
+   `SurveysRepository`'s adoption guard `(row.status ?? '').isEmpty`. The step
+   count is the fourth reader of the same column and nobody remembered it. A
+   rule enforced at one writer is enforced; a rule enforced at N readers is a
+   rule that gets broken again — which is Phase 148's *one rule at the right
+   layer beat twenty special cases*, and Phase 78's `normalizeText`, and Phase
+   95's `ProfileAvatar`.
+2. **`''` and NULL select identically under every positive equality**, so the
+   change can only ever *include* rows Kotlin includes. It cannot strand
+   anything, which is the failure mode this project keeps paying for.
+3. **It is self-healing on handsets that have already synced.** `sync()` walks
+   `_all_docs?include_docs=true` in full every run and re-upserts every page
+   (and there is deliberately no `deleteNotIn`), so a row a shipped build stored
+   as NULL is rewritten to `''` by the next ordinary sync. Neither option
+   repairs an existing row *retroactively* — the brief was right to ask — but
+   the writer fix needs no migration to converge, where the reader fix would
+   have to be correct for both states for ever.
+
+### The one place the argument could have failed, verified rather than reasoned
+
+`pendingUploads`' `isATeamAdoptionMarker` is deliberately
+`status IS NOT NULL AND status = ''`, and its comment argues for that strictness
+on the grounds that a **round-tripped marker reads back as NULL**. After this
+change it reads back as `''`, so the marker test now *matches* a pulled row.
+
+It still does not select one, because `upsertDocuments` hard-codes
+`isUpdated: false` and the sweep requires `isUpdated = true`, so a pulled row
+never reaches the marker test at all. That is the load-bearing step in the whole
+argument, so it is **pinned by three tests** rather than left as a paragraph: a
+round-tripped marker is not re-queued, a local marker is still excluded, and a
+genuinely NULL-status local row is still swept (the case that predicate's
+strictness exists for).
+
+### What the fix does *not* change
+
+`serialize` is untouched and became *more* faithful for free. Kotlin's
+`serializeSubmission` writes `submission.status ?: "pending"`
+(`SubmissionsRepositoryImpl.kt:840`) — an Elvis, so it fires on null and **not**
+on `""`. The port's `row.status ?? 'pending'` is the same expression, so a
+status-less document that Kotlin pulls and re-sends carries `""` back, and now
+the port does too. Before this phase it substituted `pending` and told Planet
+something the document never said.
+
+`submissions_exporter.dart` needed one line to stay where it was. `row.status ??
+'Pending'` stopped covering the status-less case the moment the column held `''`
+instead of null, and both states mean *the server told us nothing*, so both now
+take the fallback. That is the idiom `submissions_screen.dart`'s tile subtitle
+already uses, so a submission does not read "Pending" in the list and blank in
+its own PDF. Kotlin prints the bare column here and therefore shows blank
+(`SubmissionsRepositoryExporter.kt:77`); keeping the port's label is a
+deliberate nicety and this phase's job was the step lock, not a change of copy.
+
+## The test that can see this axis
+
+`test/repository/submission_empty_vs_null_status_test.dart`, 11 tests. Six
+failed on the pre-fix code, the headline one with `Expected: <1> Actual: <0>`.
+
+The existing coverage could not see it **by construction**, which is the point
+worth keeping. `step_next_lock_test`'s type-less document sets
+`'status': 'complete'` — it exercises the `type` axis and holds the status axis
+at a value that passes either way. Every other sync-in test hands
+`upsertDocuments` a document that carries a status. A test for this axis has to
+*omit the key*, which is what the server does, so the fixture here is a whole
+Planet-shaped document (owner in the nested `user` object, no top-level
+`userId`, a `_rev` because it came back from CouchDB) with one key absent.
+
+Both directions are pinned, so the fix cannot be mistaken for "count
+everything": a `pending` status still locks the step.
+
+## `type`, and why it is reported rather than fixed
+
+The inherited report says *"the same divergence exists on `type`"*. In the
+column, it does. **At every reader, it is invisible**, and the reason matters
+for whoever picks it up:
+
+* Every port predicate on `submissions.type` is a **positive equality** —
+  `getExamSubmissionsByUser`'s `type = 'exam'`, `getSurveySubmissionsByUser`'s
+  `type = 'survey'`, `countByUserParentAndType` — and `'' = 'exam'` and
+  `NULL = 'exam'` both fail to select. Moving the writer buys no behavioural
+  parity at all.
+* What it *would* buy is two blank labels.
+  `submission_detail_screen.dart:80` falls back
+  `submissionDisplayTitle(row) ?? row.type ?? l10n.submission` and `:91` renders
+  `row.type ?? '—'`; neither fallback catches `''`, so a typeless submission
+  would lose its title and its type row. That file is on **no lane's set** this
+  round, and half a pair across two lanes is worse than a clean hand-over.
+
+So `type` stays null this round, and the *decision* is pinned rather than the
+divergence: one test asserts it is still null with the reason, another asserts
+no positive predicate distinguishes — which is the guard that trips if a later
+phase adds a negated type predicate without moving the writer with it. A third
+pins the narrow consequence that remains: `serialize` still sends
+`type: 'survey'` where Kotlin echoes the `""` it received, reachable only once a
+local edit sets `isUpdated` on a synced typeless row.
+
+## Reported, not fixed
+
+1. **`type` in the submissions sync-in**, as above. The complete change is
+   `submissions_repository.dart`'s `type:` line to `JsonUtils.getString`, plus
+   `submission_detail_screen.dart:80` and `:91` made `''`-aware with the
+   `row.type?.trim().isNotEmpty == true ? … : …` idiom the list screen and now
+   the exporter both use. One slice, one owner, three lines.
+2. **`submission_detail_screen.dart:84` is now the odd one out on `status`.**
+   `row.status ?? l10n.pending` does not catch `''`, so a status-less synced
+   submission shows a blank status label there while the list and the PDF say
+   "Pending". It matches Kotlin, which shows blank too
+   (`SubmissionsRepositoryImpl.kt:310`'s `?: "Unknown"` fires on null only), so
+   this is a port-internal inconsistency rather than a parity gap — but it is
+   one *this phase introduced* and it is one line to close, in a file this lane
+   does not own.
+3. **`sender`, `source`, `parentCode` and `teamId` carry the same writer-side
+   divergence with no reader that can see it.** Swept: `sender`, `source` and
+   `parentCode` on `submissions` are read by **no predicate anywhere** in the
+   port (and Kotlin's uploader supplies `source`/`parentCode` from arguments,
+   not from the row); `teamId`'s null-distinguishing readers,
+   `pendingSurveySubmissions` and the team-scoped pair, are already written
+   `teamId.isNull() | teamId.equals('')` and accept both. Moving them is parity
+   tidying with no behavioural payload — worth doing in one pass with item 1,
+   not worth a phase.
+4. **The port-wide sweep found no second live instance, and that is a
+   measurement rather than an impression.** `getStringOrNull` has **198 call
+   sites**, which is not auditable one by one, so the sweep ran from the
+   *readers* instead — the only predicates that can distinguish `''` from NULL
+   are a negated equality, `LIKE`, `IS NOT`, and a Dart `??` fallback. Every
+   such site in the port is one of: already explicitly null-safe
+   (`teams.status`' four `isNull() | …not()` readers, `health.getUpdated`'s
+   `userId.isNotNull()`, the two `rev.isNotNull() & rev.equals('').not()`
+   pairs); on a **non-nullable** column (`teamTasks.status`, default `'active'`,
+   whose comment already records this exact reasoning; `achievements.id`, a
+   primary key); written by `getString` already (`tags.name`, so `parentTags`'
+   `name IS NOT ''` — which is **true** for NULL — is safe); deliberately
+   matching Kotlin (`offlineActivities.pendingLoginUploads`, where Kotlin's
+   `getUnuploadedLoginActivities` drops null-`userId` rows after the query too);
+   or **latent but unreachable**: `ratings.pendingUploads` and
+   `courseProgress.getPendingUploads` both negate `userId LIKE 'guest%'` on a
+   nullable column, and a NULL there would be silently stranded rather than
+   uploaded — but the rating writer takes a `required String userId` and only
+   local writes set `isUpdated`, and the progress query additionally requires
+   `couchId IS NULL`, which excludes every synced row. Both are one careless
+   writer away from being real; neither is real today. All of these live in
+   `app_database.dart`, Lane A's file, so all are report-only either way.
+5. **The trap is now documented at the helper**, since that is the layer with
+   198 callers: `getStringOrNull`'s dartdoc states the three-valued-logic
+   mechanism, names this defect as the instance that reached a learner, lists
+   the three earlier reader-side patches, and says to prefer `getString` on a
+   sync-in path unless the column's readers are all positive equalities and
+   nothing reads it with a `??` fallback.
+
+## Method
+
+Ground-truth `parity-auditor` pass at `effort: max` on the Kotlin **before**
+implementing, plus an independent hand reading of the same Kotlin (JsonUtils,
+the sync-in, `SubmissionDao`, `Submission`'s nullability, `serializeSubmission`,
+the exporter and the three UI status readers) — the two agreed on the finding
+the phase turned on, which is the argument for doing both. Then: failing test
+first, implement, mutation-test every pin, second `parity-auditor` pass at
+`effort: max` on the finished green code, `git status` read after each audit
+pass.

--- a/flutter/PHASE_151_NOTES.md
+++ b/flutter/PHASE_151_NOTES.md
@@ -134,8 +134,12 @@ deliberate nicety and this phase's job was the step lock, not a change of copy.
 
 ## The test that can see this axis
 
-`test/repository/submission_empty_vs_null_status_test.dart`, 11 tests. Six
-failed on the pre-fix code, the headline one with `Expected: <1> Actual: <0>`.
+`test/repository/submission_empty_vs_null_status_test.dart`, 11 tests.
+Reverting the writer (M1) fails **five** of them, the headline one with
+`Expected: <1> Actual: <0>`. The other six are controls, and each is pinned by
+its own mutation — the figure is five rather than the six an earlier draft of
+this said, because two of the original failures were `type` assertions since
+rewritten to pin the deferral instead.
 
 The existing coverage could not see it **by construction**, which is the point
 worth keeping. `step_next_lock_test`'s type-less document sets

--- a/flutter/lib/core/utils/json_utils.dart
+++ b/flutter/lib/core/utils/json_utils.dart
@@ -9,18 +9,32 @@ import 'dart:convert';
 class JsonUtils {
   const JsonUtils._();
 
-  /// Port of `JsonUtils.getString` — missing key, explicit JSON `null`, and a
-  /// non-primitive all become `''`, as Kotlin's does (`JsonUtils.kt:65-68`).
+  /// Port of `JsonUtils.getString`. A missing key and an explicit JSON `null`
+  /// become `''`, as Kotlin's do (`JsonUtils.kt:65-68`).
   ///
-  /// **One deliberate divergence.** Kotlin's map overload also returns `''`
-  /// for a non-string *primitive*, because its lambda is
-  /// `if (el.isJsonPrimitive && el.asJsonPrimitive.isString) el.asString else ""`
-  /// — so `{"year": 2019}` reads as `''` there and `'2019'` here. The port's
-  /// value is the useful one, and the Kotlin app really does drop the year on
-  /// a resource whose `year` is a JSON number (`MyLibrary.kt:274`). Kotlin's
-  /// sibling `getString(array, index)` overload omits that test, which is what
-  /// shows the map overload's is intentional rather than an oversight. Do not
-  /// "correct" this toward Kotlin.
+  /// **Everything else diverges, in two ways, and only one of them is
+  /// benign.** Kotlin's map overload is
+  /// `if (el.isJsonPrimitive && el.asJsonPrimitive.isString) el.asString else ""`,
+  /// so it returns `''` for *anything* that is not a string primitive. This
+  /// returns `value.toString()`:
+  ///
+  /// * **A non-string primitive** — `{"year": 2019}` is `''` in Kotlin and
+  ///   `'2019'` here. The port's value is the useful one; the Kotlin app
+  ///   really does drop the year on a resource whose `year` is a JSON number
+  ///   (`MyLibrary.kt:274`). Do not "correct" this toward Kotlin.
+  /// * **A Map or List** — `{"parent": {...}}` is `''` in Kotlin and
+  ///   `'{_id: exam-1, name: Week 1 quiz}'` here, which is Dart's
+  ///   `Map.toString()` and **is not JSON**, so `jsonDecode` throws on it
+  ///   wherever it is read back. That has already cost this project a defect,
+  ///   recorded at [SubmissionsRepository.upsertDocuments]: the sync-in stored
+  ///   that literal for `user`/`parent` until it was changed to `jsonEncode`.
+  ///   **Never pass this an object or array key** — use [getObject] and encode
+  ///   it, or `jsonEncode` the value yourself.
+  ///
+  /// An earlier revision of this comment claimed a non-primitive becomes `''`
+  /// "as Kotlin's does" and named the primitive case as the only divergence.
+  /// Both halves were wrong, in the doc comment added to stop the next of 198
+  /// callers being misled.
   static String getString(String key, Map<String, dynamic>? json) {
     final value = json?[key];
     if (value == null) return '';

--- a/flutter/lib/core/utils/json_utils.dart
+++ b/flutter/lib/core/utils/json_utils.dart
@@ -9,7 +9,18 @@ import 'dart:convert';
 class JsonUtils {
   const JsonUtils._();
 
-  /// Port of `JsonUtils.getString` — missing/null becomes `''`.
+  /// Port of `JsonUtils.getString` — missing key, explicit JSON `null`, and a
+  /// non-primitive all become `''`, as Kotlin's does (`JsonUtils.kt:65-68`).
+  ///
+  /// **One deliberate divergence.** Kotlin's map overload also returns `''`
+  /// for a non-string *primitive*, because its lambda is
+  /// `if (el.isJsonPrimitive && el.asJsonPrimitive.isString) el.asString else ""`
+  /// — so `{"year": 2019}` reads as `''` there and `'2019'` here. The port's
+  /// value is the useful one, and the Kotlin app really does drop the year on
+  /// a resource whose `year` is a JSON number (`MyLibrary.kt:274`). Kotlin's
+  /// sibling `getString(array, index)` overload omits that test, which is what
+  /// shows the map overload's is intentional rather than an oversight. Do not
+  /// "correct" this toward Kotlin.
   static String getString(String key, Map<String, dynamic>? json) {
     final value = json?[key];
     if (value == null) return '';

--- a/flutter/lib/core/utils/json_utils.dart
+++ b/flutter/lib/core/utils/json_utils.dart
@@ -16,6 +16,32 @@ class JsonUtils {
     return value is String ? value : value.toString();
   }
 
+  /// [getString]'s result, with the empty string folded to null.
+  ///
+  /// **This helper has no Kotlin counterpart, and folding `''` to null is not
+  /// a free convenience — it changes what SQL does with the column.** Kotlin's
+  /// sync-in stores `getString`, so a key the server omits is `''` there and
+  /// null here, and the two are only interchangeable under a *positive*
+  /// predicate: `'' = 'x'` and `NULL = 'x'` both fail to select. Under a
+  /// negated one they diverge, because SQL is three-valued —
+  /// `NOT (NULL = 'x')` is NULL, and `WHERE NULL` drops the row. `LIKE`, `IS
+  /// NOT` (`NULL IS NOT ''` is **true**) and a Dart `?? fallback` all
+  /// distinguish them too.
+  ///
+  /// That is not hypothetical. Phase 151 traced one instance end to end: the
+  /// submissions sync-in stored a missing `status` as null, and
+  /// `SubmissionDao.countCompletedByUserAndExamId`'s `status != 'pending'`
+  /// therefore counted 0 where Kotlin counts 1 — **a course step stayed locked
+  /// for a learner Kotlin lets through.** Three earlier phases had already
+  /// paid for the same fold one reader at a time
+  /// (`SubmissionDao.pendingUploads`' coalesced operands,
+  /// `SubmissionsRepository._repairSurveyParentId`, `SurveysRepository`'s
+  /// adoption guard), each found as a separate defect.
+  ///
+  /// So: on a **sync-in or mapper** path, prefer [getString] and store what
+  /// Kotlin stores, unless the column's readers are all positive equalities
+  /// *and* nothing reads it with a `??` fallback. Reach for this helper where
+  /// null genuinely means absent to the code that reads it back.
   static String? getStringOrNull(String key, Map<String, dynamic>? json) {
     final value = getString(key, json);
     return value.isEmpty ? null : value;

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -574,14 +574,16 @@ final stepNextLockProvider = FutureProvider.autoDispose
 /// The NULL-`status` case is unchanged, and the *predicate* was already right:
 /// `NOT (status = 'pending')` is NULL for a NULL status and `WHERE NULL`
 /// excludes the row, which is what the explicit `status != null` test did in
-/// Dart. **The outcome still diverges, one layer down, and this swap does not
-/// touch it**: Kotlin's sync-in stores `JsonUtils.getString('status', …)`,
-/// which is `""` for a missing key, and `'' != 'pending'` counts; the port's
-/// `upsertDocuments` stores `getStringOrNull`, which is null for a missing key
-/// *and* for `""`, and does not. So a Planet submission carrying no `status`
-/// unlocks the step in Kotlin and locks it here. That is a `""`-vs-null
-/// decision every submission reader shares — see `PHASE_149_NOTES.md`,
-/// *Reported, not fixed* item 1.
+/// Dart — and which is Kotlin's behaviour too, so the predicate is right.
+///
+/// **The outcome used to diverge one layer down, and Phase 151 closed it.**
+/// Kotlin's sync-in stores `JsonUtils.getString('status', …)`, which is `""`
+/// for a missing key, and `'' != 'pending'` counts; the port's
+/// `upsertDocuments` stored `getStringOrNull`, which is null for a missing key
+/// *and* for `""`, so a Planet submission carrying no `status` unlocked the
+/// step in Kotlin and locked it here. The writer now stores Kotlin's `''` and
+/// this reader is unchanged, because only one side had drifted. Pinned by
+/// `test/repository/submission_empty_vs_null_status_test.dart`.
 ///
 /// Which *row* is interrogated stays this function's own judgement, above —
 /// the query takes an id, not a step.

--- a/flutter/lib/repository/submissions_exporter.dart
+++ b/flutter/lib/repository/submissions_exporter.dart
@@ -107,7 +107,21 @@ class SubmissionsExporter {
   pw.Widget _metadata(SubmissionRow row) => pw.Table(
     columnWidths: const {0: pw.FixedColumnWidth(90)},
     children: [
-      _metadataRow('Status', row.status ?? 'Pending'),
+      // `?? 'Pending'` alone stopped covering this the moment the sync-in
+      // began storing Kotlin's `''` for a status-less document instead of
+      // null (`submissions_repository.dart`, `upsertDocuments`). Both states
+      // mean "the server told us nothing", so both take the fallback — which
+      // is the idiom `submissions_screen.dart`'s tile subtitle already uses
+      // (`row.status?.trim().isNotEmpty == true ? … : l10n.pending`), so a
+      // submission no longer reads "Pending" in the list and blank in its own
+      // PDF. Kotlin prints the bare column here (`"Status: ${submission
+      // .status}"`, `SubmissionsRepositoryExporter.kt:77`) and so shows blank;
+      // keeping the port's label is a deliberate nicety, not a parity gap, and
+      // this phase's job was the step lock rather than a change of copy.
+      _metadataRow(
+        'Status',
+        row.status?.trim().isNotEmpty == true ? row.status! : 'Pending',
+      ),
       // `getNormalizedSubmitterName` (`SubmissionsRepositoryImpl.kt:316-323`)
       // — the `name` inside the JSON, never the JSON.
       _metadataRow(

--- a/flutter/lib/repository/submissions_exporter.dart
+++ b/flutter/lib/repository/submissions_exporter.dart
@@ -14,6 +14,34 @@ import 'submissions_repository.dart';
 
 /// Dart port of `SubmissionsRepositoryExporter` using the cross-platform PDF
 /// package rather than Android's `PdfDocument` and `Canvas` APIs.
+/// The report's Status row.
+///
+/// A **top-level function rather than an inline `??`** for the reason Phase
+/// 99's `reportExportDateSuffix` is one: the drawn cell is unreachable from a
+/// test. The PDF's *metadata* survives in the bytes as plain text — which is
+/// what `submissions_exporter_test` asserts the title through, and why that
+/// test can genuinely fail — but content streams are compressed, so
+/// `String.fromCharCodes(bytes).contains('Pending')` is false however the cell
+/// is drawn. Verified rather than assumed. Extracting it is the difference
+/// between a pinned behaviour and a comment.
+///
+/// `row.status ?? 'Pending'` alone stopped covering the empty case the moment
+/// the sync-in began storing Kotlin's `''` for a status-less document instead
+/// of null (`SubmissionsRepository.upsertDocuments`). Both states mean *the
+/// server told us nothing*, so both take the fallback — the idiom
+/// `submissions_screen.dart`'s tile subtitle already uses
+/// (`row.status?.trim().isNotEmpty == true ? … : l10n.pending`), so a
+/// submission does not read "Pending" in the list and blank in its own PDF.
+///
+/// Kotlin prints the bare column here (`"Status: ${submission.status}"`,
+/// `SubmissionsRepositoryExporter.kt:77`) and therefore shows blank. Keeping
+/// the port's label is a deliberate nicety rather than a parity gap: Phase
+/// 151's job was the step lock, not a change of copy. English literals match
+/// the rest of this file, which draws a PDF with no `BuildContext` to localise
+/// against.
+String submissionStatusLabel(SubmissionRow row) =>
+    row.status?.trim().isNotEmpty == true ? row.status!.trim() : 'Pending';
+
 class SubmissionsExporter {
   const SubmissionsExporter(this._repository);
 
@@ -107,21 +135,7 @@ class SubmissionsExporter {
   pw.Widget _metadata(SubmissionRow row) => pw.Table(
     columnWidths: const {0: pw.FixedColumnWidth(90)},
     children: [
-      // `?? 'Pending'` alone stopped covering this the moment the sync-in
-      // began storing Kotlin's `''` for a status-less document instead of
-      // null (`submissions_repository.dart`, `upsertDocuments`). Both states
-      // mean "the server told us nothing", so both take the fallback — which
-      // is the idiom `submissions_screen.dart`'s tile subtitle already uses
-      // (`row.status?.trim().isNotEmpty == true ? … : l10n.pending`), so a
-      // submission no longer reads "Pending" in the list and blank in its own
-      // PDF. Kotlin prints the bare column here (`"Status: ${submission
-      // .status}"`, `SubmissionsRepositoryExporter.kt:77`) and so shows blank;
-      // keeping the port's label is a deliberate nicety, not a parity gap, and
-      // this phase's job was the step lock rather than a change of copy.
-      _metadataRow(
-        'Status',
-        row.status?.trim().isNotEmpty == true ? row.status! : 'Pending',
-      ),
+      _metadataRow('Status', submissionStatusLabel(row)),
       // `getNormalizedSubmitterName` (`SubmissionsRepositoryImpl.kt:316-323`)
       // — the `name` inside the JSON, never the JSON.
       _metadataRow(

--- a/flutter/lib/repository/submissions_exporter.dart
+++ b/flutter/lib/repository/submissions_exporter.dart
@@ -12,8 +12,6 @@ import '../data/local/app_database.dart';
 import '../data/local/converters.dart';
 import 'submissions_repository.dart';
 
-/// Dart port of `SubmissionsRepositoryExporter` using the cross-platform PDF
-/// package rather than Android's `PdfDocument` and `Canvas` APIs.
 /// The report's Status row.
 ///
 /// A **top-level function rather than an inline `??`** for the reason Phase
@@ -33,6 +31,13 @@ import 'submissions_repository.dart';
 /// (`row.status?.trim().isNotEmpty == true ? … : l10n.pending`), so a
 /// submission does not read "Pending" in the list and blank in its own PDF.
 ///
+/// The returned value is **trimmed**, which the screen's version is not: it
+/// renders `row.status!` with the padding intact. A deliberate difference
+/// rather than a copy of the idiom — a PDF table cell has no layout that
+/// absorbs leading whitespace — and pinned by a test, because an unpinned
+/// `.trim()` is how the two surfaces drift apart again. The screen's line is
+/// outside this lane's set; see `PHASE_151_NOTES.md`.
+///
 /// Kotlin prints the bare column here (`"Status: ${submission.status}"`,
 /// `SubmissionsRepositoryExporter.kt:77`) and therefore shows blank. Keeping
 /// the port's label is a deliberate nicety rather than a parity gap: Phase
@@ -42,6 +47,8 @@ import 'submissions_repository.dart';
 String submissionStatusLabel(SubmissionRow row) =>
     row.status?.trim().isNotEmpty == true ? row.status!.trim() : 'Pending';
 
+/// Dart port of `SubmissionsRepositoryExporter` using the cross-platform PDF
+/// package rather than Android's `PdfDocument` and `Canvas` APIs.
 class SubmissionsExporter {
   const SubmissionsExporter(this._repository);
 

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -1759,7 +1759,40 @@ class SubmissionsRepository {
           startTime: Value(JsonUtils.getLong('startTime', json)),
           lastUpdateTime: Value(JsonUtils.getLong('lastUpdateTime', json)),
           grade: Value(JsonUtils.getLong('grade', json)),
-          status: Value(JsonUtils.getStringOrNull('status', json)),
+          // **`getString`, not `getStringOrNull`, and the difference locked a
+          // course step.** Kotlin stores
+          // `JsonUtils.getString("status", submission)`
+          // (`SubmissionsRepositoryImpl.kt:659`, `:679`), which is `""` for a
+          // key the document does not carry (`JsonUtils.kt:65-68`). The port
+          // stored `getStringOrNull`, which is null for a missing key *and*
+          // for `""` (`json_utils.dart`).
+          //
+          // `SubmissionDao.countCompletedByUserAndExamId`'s
+          // `status != 'pending'` (`SubmissionDao.kt:24`) is then the whole
+          // defect: `NOT (NULL = 'pending')` is SQL NULL and `WHERE NULL`
+          // drops the row, so a Planet submission with no `status` counted 0
+          // and `isStepCompleted` held the step shut — for a learner Kotlin,
+          // storing `""`, lets straight through.
+          //
+          // The reader was never wrong. `countCompletedByUserAndExamId` is a
+          // faithful port of that query, its NULL behaviour included, and
+          // Kotlin's own reader excludes a NULL status too. Coalescing there
+          // would have made the port's *reader* diverge from Kotlin's in order
+          // to compensate for the port's *writer* diverging from Kotlin's.
+          // Only one side had drifted, so only one side moved — which is also
+          // why no DAO predicate changed.
+          //
+          // Self-healing on already-synced handsets: [sync] walks
+          // `_all_docs?include_docs=true` in full every run and re-upserts
+          // every page, so a row a shipped build stored as NULL is rewritten
+          // to `''` by the next ordinary sync. Nothing has to migrate it.
+          //
+          // `type`, `sender`, `source`, `parentCode` and `teamId` carry the
+          // same divergence and are deliberately left alone this round —
+          // `PHASE_151_NOTES.md` § *Reported, not fixed* has the reach of each
+          // and why `type`'s fix needs two lines in `submission_detail_screen`
+          // that this lane does not own.
+          status: Value(JsonUtils.getString('status', json)),
           uploaded: Value(rev.isNotEmpty),
           sender: Value(JsonUtils.getStringOrNull('sender', json)),
           source: Value(JsonUtils.getStringOrNull('source', json)),

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -815,8 +815,17 @@ class SubmissionsRepository {
   /// build stored as NULL are still on devices, and only a submissions pull
   /// rewrites them.
   ///
-  /// `coalesce` on the status is the same idiom, for the same reason, as
-  /// `SubmissionDao.pendingUploads`' coalesced guest operands.
+  /// **The `coalesce` is redundant, and saying so is the point.** The fix
+  /// Phase 136 needed was the *operator*: `status IS NOT ''` is true for NULL,
+  /// `NOT (status = '')` is NULL for NULL and a `WHERE` drops it. So
+  /// `row.status.equals('').not()` selects exactly what the coalesced form
+  /// selects — verified by mutation, which passes the suite. It is kept
+  /// because it states "a null status is an empty one" in the expression
+  /// rather than leaving it to three-valued logic, but it is **not** the same
+  /// idiom as `SubmissionDao.pendingUploads`' coalesced guest operands: there
+  /// the coalesce stops NULL poisoning a *negated conjunction* and is
+  /// load-bearing. Do not cite this one as evidence that the reader side
+  /// needed patching.
   Future<int> _repairSurveyParentId(SurveyRow survey) async {
     final target = examParentId(examId: survey.id, courseId: survey.courseId);
     // A survey with no `courseId` of its own keys to the bare id already.
@@ -1267,8 +1276,10 @@ class SubmissionsRepository {
     return {
       if (row.couchId != null && row.couchId!.isNotEmpty) '_id': row.couchId,
       if (row.rev != null && row.rev!.isNotEmpty) '_rev': row.rev,
-      // Kotlin's own defaults, `serializeSubmission:827-832`: Planet reads
+      // Kotlin's own defaults, `serializeSubmission:834-835`: Planet reads
       // these unconditionally, so a null would arrive as a missing field.
+      // (`:827-832` are the conditional `_id`/`_rev` guards, which is what an
+      // earlier revision of this comment cited.)
       'parentId': row.parentId ?? '',
       'type': row.type ?? 'survey',
       // Straight after `type`, where both Kotlin serializers add it
@@ -1787,21 +1798,27 @@ class SubmissionsRepository {
           // Only one side had drifted, so only one side moved — which is also
           // why no DAO predicate changed.
           //
-          // Rows a shipped build already stored as NULL are **not** repaired
-          // by this, and the first draft of this comment said they were "by
-          // the next ordinary sync". They are not. [sync] does walk
-          // `_all_docs?include_docs=true` in full every run and re-upsert
-          // every page — so no migration is needed and the repair is free
-          // *when it runs* — but it has exactly one caller in the port, the
-          // refresh icon on the Submissions screen
-          // (`submissions_screen.dart:122`). `DashboardSyncArea` has no
-          // `submissions` member and `dashboard_sync_provider.dart:276` says
-          // so outright, where Kotlin pulls this table on every full sync
-          // (`SyncManager.kt:209` → `HeavyTableSyncWorker`'s
-          // `ALL_HEAVY_TABLES`). So an existing NULL survives until the
-          // learner opens Submissions and taps refresh. That the port does
-          // not pull `submissions` in the sync center is a separate gap,
-          // recorded where it lives.
+          // Rows a shipped build already stored as NULL need no migration:
+          // [sync] walks `_all_docs?include_docs=true` in full every run and
+          // re-upserts every page, so a submissions pull rewrites them.
+          //
+          // **Two callers, and this comment got the count wrong twice before
+          // landing on it.** The first draft said "the next ordinary sync";
+          // the ground-truth audit called that false on the grounds of a
+          // single caller (the Submissions screen's refresh icon,
+          // `submissions_screen.dart:122`) and the correction was taken; the
+          // implementation audit then found
+          // `background_entrypoint.dart:195-202`, a `BackgroundSyncStep`
+          // inside `syncSteps` that calls this repository's `sync` on the
+          // periodic auto-sync task — and `PlanetPrefs.autoSyncEnabled`
+          // defaults to **true** (`planet_prefs.dart:441`). So the table is
+          // pulled headlessly, without the learner visiting any screen, and
+          // the original claim was substantially right. What is true of
+          // `DashboardSyncArea` is only what
+          // `dashboard_sync_provider.dart:276` actually says — nothing in the
+          // **foreground** pass pulls `submissions` — which is a real gap
+          // against Kotlin's `HeavyTableSyncWorker` (`SyncManager.kt:209`)
+          // and is not the same statement.
           //
           // `type`, `sender`, `source`, `parentCode` and `teamId` carry the
           // same divergence and are deliberately left alone this round —

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -799,16 +799,21 @@ class SubmissionsRepository {
   /// (`expression.dart:118-120` → `:148-154`), and `NULL IS NOT ''` is **true**
   /// — so the first cut of this admitted exactly the rows it existed to skip.
   ///
-  /// A marker reaches null status by an ordinary route, not a corner case.
+  /// A marker reaches an empty status by an ordinary route, not a corner case.
   /// [createSurveyAdoptionSubmission] writes `status: ''` **and**
   /// `isUpdated: true`, so the generic `pendingUploads` sweep uploads it;
-  /// [serialize] sends `'status': ''`; and [upsertDocuments] reads it back
-  /// through `JsonUtils.getStringOrNull`, which maps the empty string to null
-  /// (`json_utils.dart:19-22`). Every marker that has round-tripped — and
-  /// every marker a Kotlin handset in the same deployment published, since
-  /// Kotlin writes them bare on purpose — arrives with `status = NULL`. In a
-  /// real mixed fleet that is the repair's *most likely* match, where a bare-id
-  /// answer sheet can only come from a pre-Phase-125 build.
+  /// [serialize] sends `'status': ''`; and [upsertDocuments] stores that back
+  /// verbatim. In a real mixed fleet that is the repair's *most likely* match,
+  /// where a bare-id answer sheet can only come from a pre-Phase-125 build —
+  /// and a marker a Kotlin handset in the same deployment published arrives
+  /// the same way, since Kotlin writes them bare on purpose.
+  ///
+  /// **A round-tripped marker used to arrive with `status = NULL`**, because
+  /// the sync-in folded `''` to null through `getStringOrNull`. Phase 151
+  /// removed that fold for this column, so both states now mean the same
+  /// thing here — which is why the `coalesce` stays: rows a pre-Phase-151
+  /// build stored as NULL are still on devices, and only a submissions pull
+  /// rewrites them.
   ///
   /// `coalesce` on the status is the same idiom, for the same reason, as
   /// `SubmissionDao.pendingUploads`' coalesced guest operands.
@@ -1782,10 +1787,21 @@ class SubmissionsRepository {
           // Only one side had drifted, so only one side moved — which is also
           // why no DAO predicate changed.
           //
-          // Self-healing on already-synced handsets: [sync] walks
-          // `_all_docs?include_docs=true` in full every run and re-upserts
-          // every page, so a row a shipped build stored as NULL is rewritten
-          // to `''` by the next ordinary sync. Nothing has to migrate it.
+          // Rows a shipped build already stored as NULL are **not** repaired
+          // by this, and the first draft of this comment said they were "by
+          // the next ordinary sync". They are not. [sync] does walk
+          // `_all_docs?include_docs=true` in full every run and re-upsert
+          // every page — so no migration is needed and the repair is free
+          // *when it runs* — but it has exactly one caller in the port, the
+          // refresh icon on the Submissions screen
+          // (`submissions_screen.dart:122`). `DashboardSyncArea` has no
+          // `submissions` member and `dashboard_sync_provider.dart:276` says
+          // so outright, where Kotlin pulls this table on every full sync
+          // (`SyncManager.kt:209` → `HeavyTableSyncWorker`'s
+          // `ALL_HEAVY_TABLES`). So an existing NULL survives until the
+          // learner opens Submissions and taps refresh. That the port does
+          // not pull `submissions` in the sync center is a separate gap,
+          // recorded where it lives.
           //
           // `type`, `sender`, `source`, `parentCode` and `teamId` carry the
           // same divergence and are deliberately left alone this round —

--- a/flutter/lib/repository/surveys_repository.dart
+++ b/flutter/lib/repository/surveys_repository.dart
@@ -195,12 +195,13 @@ class SurveysRepository {
         ? await _submissions.submissionsForTeam(teamId)
         : await _submissions.submissionsForUserWithoutTeam(userId);
     // `it.status.orEmpty().isEmpty()` (`SurveysRepositoryImpl.kt:206`) — a
-    // **null** status counts as empty, and null is the normal state for a
-    // marker that has round-tripped: [SubmissionsRepository.serialize] sends
-    // `'status': ''` and `upsertDocuments` reads the empty string back as null
-    // (`json_utils.dart:19-22`). `row.status == ''` missed those and rewrote
-    // the marker on every adopt tap, re-queueing it for upload. Same shape as
-    // the `coalesce(status, '')` that `_repairSurveyParentId` needs.
+    // **null** status counts as empty, so both states have to match here.
+    // A round-tripped marker was null until Phase 151, which stopped the
+    // sync-in folding Kotlin's `''` to null for this column; it is `''` now,
+    // and rows a pre-Phase-151 build stored are still null on device. Reading
+    // `row.status == ''` missed the null ones and rewrote the marker on every
+    // adopt tap, re-queueing it for upload. Same shape as the
+    // `coalesce(status, '')` that `_repairSurveyParentId` needs.
     final exists = candidates.any(
       (row) =>
           row.userId == userId &&

--- a/flutter/test/repository/adopted_team_survey_course_key_test.dart
+++ b/flutter/test/repository/adopted_team_survey_course_key_test.dart
@@ -352,11 +352,15 @@ void main() {
   test('re-adopting does not rewrite a round-tripped marker', () async {
     // Kotlin's guard is `it.status.orEmpty().isEmpty()`
     // (`SurveysRepositoryImpl.kt:206`), which matches a null status and an
-    // empty one alike. `row.status == ''` misses the null — and null is the
-    // *normal* state for a marker that has synced, because [serialize] sends
-    // `'status': ''` and `upsertDocuments` reads the empty string back as null
-    // (`json_utils.dart:19-22`). The same shape `_repairSurveyParentId` needed
-    // `coalesce(status, '')` for.
+    // empty one alike. `row.status == ''` misses the null.
+    //
+    // Null was the *normal* state for a synced marker until Phase 151, because
+    // [serialize] sends `'status': ''` and `upsertDocuments` folded the empty
+    // string back to null. The writer now stores `''` verbatim, so null is the
+    // **legacy** state — rows a pre-Phase-151 build stored, on a preserved
+    // table, until a submissions pull rewrites them. That is why this test
+    // forces the null below rather than relying on the pull to produce one,
+    // and why the guard still has to match both.
     await adopt();
     final marker = (await database.submissionDao.getSurveySubmissionsByUser(
       'leader-1',

--- a/flutter/test/repository/mandatory_survey_round_trip_test.dart
+++ b/flutter/test/repository/mandatory_survey_round_trip_test.dart
@@ -336,7 +336,15 @@ void main() {
       },
     ]);
     final synced = await submissions.getById('adopt-doc-1');
-    expect(synced!.status, isNull, reason: 'the pull nulls an empty status');
+    // Phase 151 moved this: the pull used to fold `''` to null and now stores
+    // Kotlin's `''` verbatim. The assertion below is unaffected either way,
+    // which is the point of `_repairSurveyParentId`'s
+    // `coalesce(status, '') != ''` — it skipped the NULL and skips the `''`.
+    expect(
+      synced!.status,
+      '',
+      reason: 'the pull stores the empty status Kotlin stores',
+    );
 
     expect(
       await submissions.hasUnfinishedSurveys(

--- a/flutter/test/repository/mandatory_survey_round_trip_test.dart
+++ b/flutter/test/repository/mandatory_survey_round_trip_test.dart
@@ -304,12 +304,13 @@ void main() {
     //
     // An adoption marker is `status = ''` on the device that wrote it, and
     // `createSurveyAdoptionSubmission` also sets `isUpdated: true` — so the
-    // generic `pendingUploads` sweep uploads it. `serialize` sends
-    // `'status': ''`, and the pull reads it back through
-    // `JsonUtils.getStringOrNull`, which maps the empty string to **null**
-    // (`json_utils.dart:19-22`). So every marker that has round-tripped, and
-    // every marker a Kotlin handset in the same deployment published, carries
-    // `status = NULL` rather than `''`.
+    // generic `pendingUploads` sweep uploads it, and `serialize` sends
+    // `'status': ''`. **Until Phase 151 the pull folded that back to null**
+    // through `JsonUtils.getStringOrNull`, so a round-tripped marker — and
+    // every marker a Kotlin handset in the same deployment published —
+    // carried `status = NULL`. It is `''` now, and NULL is the *legacy*
+    // state rather than the normal one. Both are built below, because only
+    // the NULL one shows the bug.
     //
     // The guard was `row.status.isNotValue('')`, and drift's `isNotValue`
     // emits SQL `IS NOT`, not `!=` (`expression.dart:118-120` -> `:148-154`).
@@ -317,14 +318,21 @@ void main() {
     // existed to skip: the marker was rewritten to `survey-1@course-1`, the
     // status-blind count accepted it, and the learner's Finish sailed past a
     // survey they had never answered. Kotlin's own predicate is
-    // `it.status.orEmpty().isEmpty()` (`SurveysRepositoryImpl.kt:203-207`) —
-    // negating that needs `coalesce(status, '') != ''`, which is the idiom
-    // `pendingUploads` already uses for the same reason.
+    // `it.status.orEmpty().isEmpty()` (`SurveysRepositoryImpl.kt:203-207`).
     //
-    // In a real deployment this is the repair's *most likely* match, not a
-    // corner case: a bare-id answer sheet can only come from a pre-Phase-125
-    // port build, while a bare-id adoption marker is written on purpose by
-    // every Kotlin handset there is.
+    // **Both status states have to be built here, and Phase 151 is why.**
+    // Until then the sync-in folded `''` to null, so this one document
+    // exercised the NULL branch — the only branch the `isNotValue` bug is
+    // visible on, since `'' IS NOT ''` is false. After the writer fix a pulled
+    // marker is `''`, and with only this document the buggy predicate passes
+    // the suite: demonstrated by reverting the guard, which left all 40 tests
+    // in these three files green. So the legacy row is built below as a
+    // companion, because **the sync-in can no longer produce it** — and it is
+    // not hypothetical, since `submissions` is a preserved table
+    // (`app_database.dart`'s `_localAuthorityTables`), so rows a pre-Phase-151
+    // build stored as NULL survive on device until a submissions pull
+    // rewrites them. That is exactly the population
+    // `_repairSurveyParentId`'s `coalesce` is documented to exist for.
     await submissions.upsertDocuments([
       {
         '_id': 'adopt-doc-1',
@@ -335,6 +343,25 @@ void main() {
         'user': {'_id': 'org.couchdb.user:ada'},
       },
     ]);
+    // The pre-Phase-151 shape of the very same marker, still on any device
+    // that has not pulled submissions since.
+    await database.submissionDao.upsertAll([
+      SubmissionsCompanion.insert(
+        id: 'adopt-legacy-1',
+        couchId: const Value('adopt-legacy-1'),
+        rev: const Value('1-a'),
+        parentId: const Value('survey-1'),
+        type: const Value('survey'),
+        userId: const Value('org.couchdb.user:ada'),
+        uploaded: const Value(true),
+      ),
+    ]);
+    expect(
+      (await submissions.getById('adopt-legacy-1'))?.status,
+      isNull,
+      reason: 'the legacy row is only evidence while its status is NULL',
+    );
+
     final synced = await submissions.getById('adopt-doc-1');
     // Phase 151 moved this: the pull used to fold `''` to null and now stores
     // Kotlin's `''` verbatim. The assertion below is unaffected either way,
@@ -358,6 +385,13 @@ void main() {
       (await submissions.getById('adopt-doc-1'))!.parentId,
       'survey-1',
       reason: '`findExistingAdoption` looks this up by the bare id',
+    );
+    expect(
+      (await submissions.getById('adopt-legacy-1'))!.parentId,
+      'survey-1',
+      reason:
+          'a NULL status is an empty one too; this is the row the '
+          '`isNotValue` bug rewrote',
     );
   });
 

--- a/flutter/test/repository/submission_empty_vs_null_status_test.dart
+++ b/flutter/test/repository/submission_empty_vs_null_status_test.dart
@@ -158,7 +158,7 @@ void main() {
         isNull,
         reason:
             'deferred deliberately; Kotlin stores "" here '
-            '(SubmissionsRepositoryImpl.kt:671)',
+            '(SubmissionsRepositoryImpl.kt:673)',
       );
     });
 

--- a/flutter/test/repository/submission_empty_vs_null_status_test.dart
+++ b/flutter/test/repository/submission_empty_vs_null_status_test.dart
@@ -1,0 +1,312 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+
+/// `""` and null are not the same thing, and the difference reached a learner.
+///
+/// Kotlin's sync-in stores `JsonUtils.getString("status", submission)`
+/// (`SubmissionsRepositoryImpl.kt:659`, `:679`) and Kotlin's `getString`
+/// returns `""` for a key the document does not carry (`JsonUtils.kt:65-68`).
+/// So a Planet submission with no `status` is stored as `""`,
+/// `SubmissionDao.countCompletedByUserAndExamId`'s `status != 'pending'`
+/// (`SubmissionDao.kt:24`) is satisfied, the count is 1, and
+/// `isStepCompleted` releases the course step.
+///
+/// The port stored `getStringOrNull`, which is null for a missing key **and**
+/// for `""` (`json_utils.dart:19-22`). `NOT (status = 'pending')` is SQL NULL
+/// for a NULL status and `WHERE NULL` drops the row, so the count was 0 and
+/// **the step stayed locked for a learner Kotlin lets through.**
+///
+/// The reader was never the defect: it is a faithful port of Kotlin's query,
+/// NULL behaviour included. Only the writer diverged, which is why the fix is
+/// on the writer and no DAO predicate changes.
+///
+/// The `type` column carries the same writer-side divergence and is
+/// deliberately left alone; the group below pins why that is currently
+/// invisible and what a follow-up needs.
+///
+/// **Why the existing coverage could not see this.** `step_next_lock_test`'s
+/// type-less document sets `'status': 'complete'`, so it exercises the `type`
+/// axis and holds the status axis fixed at a value that passes either way; and
+/// every other sync-in test hands `upsertDocuments` a document that carries a
+/// status. A test for this axis has to omit the key, the way the server does.
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository repository;
+
+  setUp(() {
+    database = AppDatabase.memory();
+    repository = SubmissionsRepository(
+      MockPlanetApi(),
+      database.submissionDao,
+      database.submitPhotosDao,
+      database.surveyDao,
+      database.examDao,
+      teamDao: database.teamDao,
+    );
+  });
+  tearDown(() => database.close());
+
+  /// A submission document shaped the way Planet sends one: the owner in the
+  /// nested `user` object with no top-level `userId`, a `_rev` because it came
+  /// back from CouchDB, and a `parentId` minted the way the app mints it.
+  ///
+  /// Whatever [extra] carries is merged last, so a test can add a key or —
+  /// which is the whole point here — leave one out.
+  Map<String, dynamic> planetDocument({
+    String id = 'sub-1',
+    Map<String, dynamic> extra = const {},
+  }) => {
+    '_id': id,
+    '_rev': '1-abc',
+    'parentId': SubmissionsRepository.examParentId(
+      examId: 'exam-1',
+      courseId: 'course-1',
+    ),
+    'user': {'_id': 'user-1', 'name': 'ada'},
+    'startTime': 1700000000000,
+    'lastUpdateTime': 1700000001000,
+    'grade': 0,
+    'answers': const <Map<String, dynamic>>[],
+    'parent': const {'_id': 'exam-1', 'name': 'Week 1 quiz'},
+    ...extra,
+  };
+
+  group('a Planet submission that omits `status`', () {
+    test('releases the course step, as Kotlin does', () async {
+      await repository.upsertDocuments([planetDocument()]);
+
+      // The reader is Kotlin's own query, unchanged by this phase. What
+      // changed is what the writer put in the column for it to read.
+      expect(
+        await database.submissionDao.countCompletedByUserAndExamId(
+          'user-1',
+          'exam-1',
+        ),
+        1,
+        reason:
+            'Kotlin stores "" and counts the row; a NULL status is dropped by '
+            'NOT (status = \'pending\') and locks the step',
+      );
+    });
+
+    test('is stored as the empty string, not null', () async {
+      await repository.upsertDocuments([planetDocument()]);
+
+      expect((await database.submissionDao.getById('sub-1'))?.status, '');
+    });
+
+    test('an explicit empty `status` is stored the same way', () async {
+      // Kotlin's `getString` cannot tell these two documents apart, so the
+      // port must not either: `""` and a missing key both arrive as `""`.
+      await repository.upsertDocuments([
+        planetDocument(extra: const {'status': ''}),
+      ]);
+
+      expect((await database.submissionDao.getById('sub-1'))?.status, '');
+      expect(
+        await database.submissionDao.countCompletedByUserAndExamId(
+          'user-1',
+          'exam-1',
+        ),
+        1,
+      );
+    });
+
+    test('a `pending` status still locks the step', () async {
+      // The other side of the predicate, so the fix cannot be mistaken for
+      // "count everything".
+      await repository.upsertDocuments([
+        planetDocument(extra: const {'status': 'pending'}),
+      ]);
+
+      expect(
+        await database.submissionDao.countCompletedByUserAndExamId(
+          'user-1',
+          'exam-1',
+        ),
+        0,
+      );
+    });
+  });
+
+  group('a Planet submission that omits `type`', () {
+    // **The `type` half of the inherited report is real in the column and,
+    // today, invisible at every reader — so it is deliberately not changed
+    // here, and these tests pin that decision rather than the divergence.**
+    //
+    // Every port predicate on `submissions.type` is a *positive* equality
+    // (`type.equals('exam')`, `.equals('survey')`, `countByUserParentAndType`),
+    // and `'' = 'exam'` and `NULL = 'exam'` both fail to select, so switching
+    // the writer would buy no behavioural parity at all. What it would buy is
+    // two blank labels: `submission_detail_screen.dart:80` falls back
+    // `submissionDisplayTitle(row) ?? row.type ?? l10n.submission` and `:91`
+    // renders `row.type ?? '—'`, and neither fallback catches `''`. That file
+    // is on no lane's set this round, and half a pair across two lanes is
+    // worse than a clean hand-over — see `PHASE_151_NOTES.md`
+    // § *Reported, not fixed*.
+    test('is still stored as null', () async {
+      await repository.upsertDocuments([planetDocument()]);
+
+      expect(
+        (await database.submissionDao.getById('sub-1'))?.type,
+        isNull,
+        reason:
+            'deferred deliberately; Kotlin stores "" here '
+            '(SubmissionsRepositoryImpl.kt:671)',
+      );
+    });
+
+    test('is matched by no positive `type` predicate either way', () async {
+      // The invariant that makes the deferral safe, and the guard that trips
+      // if a later phase adds a *negated* type predicate without moving the
+      // writer with it.
+      await repository.upsertDocuments([planetDocument()]);
+
+      expect(
+        await database.submissionDao.getExamSubmissionsByUser('user-1'),
+        isEmpty,
+      );
+      expect(
+        await database.submissionDao.getSurveySubmissionsByUser('user-1'),
+        isEmpty,
+      );
+      expect(
+        await database.submissionDao.countByUserParentAndType(
+          'user-1',
+          SubmissionsRepository.examParentId(
+            examId: 'exam-1',
+            courseId: 'course-1',
+          ),
+          'survey',
+        ),
+        0,
+      );
+
+      // The positive control, so the three `isEmpty`/`0` assertions above are
+      // evidence about the type-less row rather than about a query that never
+      // returns anything.
+      await repository.upsertDocuments([
+        planetDocument(id: 'sub-typed', extra: const {'type': 'exam'}),
+      ]);
+      expect(
+        (await database.submissionDao.getExamSubmissionsByUser(
+          'user-1',
+        )).map((row) => row.id),
+        ['sub-typed'],
+      );
+    });
+  });
+
+  group('re-serializing a pulled row', () {
+    test('sends the empty status and type Kotlin sends', () async {
+      // `serializeSubmission`'s `submission.status ?: "pending"` and
+      // `submission.type ?: "survey"` (`SubmissionsRepositoryImpl.kt:835`,
+      // `:840`) do **not** catch `""` — Kotlin's Elvis fires on null only. So
+      // a status-less document Kotlin pulled and re-sent carries `""` back,
+      // where the port used to substitute `pending`/`survey` and tell Planet
+      // something the document never said.
+      await repository.upsertDocuments([planetDocument()]);
+      final row = (await database.submissionDao.getById('sub-1'))!;
+
+      final payload = await repository.serialize(row);
+
+      expect(payload['status'], '');
+      // The deferred half, pinned as it stands: `type` is still null in the
+      // column, so the port's own `?? 'survey'` fires and tells Planet
+      // `survey` where Kotlin echoes the `""` the document arrived with. A
+      // narrow divergence — a synced row only re-uploads once a local edit
+      // sets `isUpdated` — and it moves the day the writer does.
+      expect(payload['type'], 'survey');
+    });
+
+    test('still defaults a genuinely null status, as Kotlin does', () async {
+      // A row with no status at all is not something the sync-in can now
+      // produce, but a local writer or an older build's row can be in that
+      // state, and Kotlin's `?:` covers exactly it.
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'local-1',
+          userId: const Value('user-1'),
+          isUpdated: const Value(true),
+        ),
+      ]);
+      final row = (await database.submissionDao.getById('local-1'))!;
+
+      final payload = await repository.serialize(row);
+
+      expect(payload['status'], 'pending');
+      expect(payload['type'], 'survey');
+    });
+  });
+
+  group('the team-survey adoption marker survives the writer change', () {
+    test(
+      'a round-tripped marker reads back as `""` and is not re-queued',
+      () async {
+        // `pendingUploads`' `isATeamAdoptionMarker` is deliberately
+        // `status IS NOT NULL AND status = ''` (`app_database.dart`), written
+        // strict on the argument that a *round-tripped* marker reads back as
+        // NULL. After this phase it reads back as `''` instead, so the marker
+        // test now matches a pulled row — and must still not select it, because
+        // `upsertDocuments` hard-codes `isUpdated: false` and the sweep wants
+        // `isUpdated = true`. That is the load-bearing step in the argument for
+        // fixing the writer rather than the readers, so it is pinned rather
+        // than reasoned about.
+        await repository.upsertDocuments([
+          planetDocument(id: 'marker-1', extra: const {'status': ''}),
+        ]);
+        final marker = (await database.submissionDao.getById('marker-1'))!;
+
+        expect(marker.status, '');
+        expect(marker.isUpdated, isFalse);
+        expect(
+          (await database.submissionDao.pendingUploads()).map((row) => row.id),
+          isNot(contains('marker-1')),
+        );
+      },
+    );
+
+    test('a local marker awaiting upload is still excluded', () async {
+      // The row the strict marker test exists for: authored locally by
+      // `createSurveyAdoptionSubmission` with the literal empty string and
+      // `isUpdated: true`.
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'marker-local',
+          userId: const Value('user-1'),
+          status: const Value(''),
+          isUpdated: const Value(true),
+        ),
+      ]);
+
+      expect(
+        (await database.submissionDao.pendingUploads()).map((row) => row.id),
+        isNot(contains('marker-local')),
+      );
+    });
+
+    test('a status-less local row is still swept for upload', () async {
+      // The other half of that predicate's strictness, and the reason it was
+      // not written as a `coalesce`: a row with a genuinely NULL status is not
+      // a marker and must not be stranded.
+      await database.submissionDao.upsertAll([
+        SubmissionsCompanion.insert(
+          id: 'nullish',
+          userId: const Value('user-1'),
+          isUpdated: const Value(true),
+        ),
+      ]);
+
+      expect(
+        (await database.submissionDao.pendingUploads()).map((row) => row.id),
+        contains('nullish'),
+      );
+    });
+  });
+}

--- a/flutter/test/repository/submission_empty_vs_null_status_test.dart
+++ b/flutter/test/repository/submission_empty_vs_null_status_test.dart
@@ -16,7 +16,8 @@ import 'package:myplanet/repository/submissions_repository.dart';
 /// `isStepCompleted` releases the course step.
 ///
 /// The port stored `getStringOrNull`, which is null for a missing key **and**
-/// for `""` (`json_utils.dart:19-22`). `NOT (status = 'pending')` is SQL NULL
+/// for `""` (`json_utils.dart`, `getStringOrNull`). `NOT (status = 'pending')`
+/// is SQL NULL
 /// for a NULL status and `WHERE NULL` drops the row, so the count was 0 and
 /// **the step stayed locked for a learner Kotlin lets through.**
 ///
@@ -163,9 +164,15 @@ void main() {
     });
 
     test('is matched by no positive `type` predicate either way', () async {
-      // The invariant that makes the deferral safe, and the guard that trips
-      // if a later phase adds a *negated* type predicate without moving the
-      // writer with it.
+      // The invariant that makes the deferral safe.
+      //
+      // **A pin, not a tripwire, and an earlier revision of this comment
+      // claimed the latter.** It holds under either writer and under a new
+      // negated predicate elsewhere, so no plausible mutation fails it — of
+      // this file's six controls it is the one nothing reaches. What it buys
+      // is the deferral's reason checked against the code rather than
+      // asserted in prose; the positive control below is what stops it being
+      // a claim about a query that returns nothing.
       await repository.upsertDocuments([planetDocument()]);
 
       expect(
@@ -205,9 +212,10 @@ void main() {
 
   group('re-serializing a pulled row', () {
     test('sends the empty status and type Kotlin sends', () async {
-      // `serializeSubmission`'s `submission.status ?: "pending"` and
-      // `submission.type ?: "survey"` (`SubmissionsRepositoryImpl.kt:835`,
-      // `:840`) do **not** catch `""` — Kotlin's Elvis fires on null only. So
+      // `serializeSubmission`'s `submission.type ?: "survey"` (`:835`) and
+      // `submission.status ?: "pending"`
+      // (`SubmissionsRepositoryImpl.kt:840`) do **not** catch `""` — Kotlin's
+      // Elvis fires on null only. So
       // a status-less document Kotlin pulled and re-sent carries `""` back,
       // where the port used to substitute `pending`/`survey` and tell Planet
       // something the document never said.
@@ -227,8 +235,12 @@ void main() {
 
     test('still defaults a genuinely null status, as Kotlin does', () async {
       // A row with no status at all is not something the sync-in can now
-      // produce, but a local writer or an older build's row can be in that
-      // state, and Kotlin's `?:` covers exactly it.
+      // produce, and **no local writer can either** — every one of them
+      // (`createDraft`, `createSurveyDraft`, `updateSurveyAnswers`,
+      // `saveExamAnswer`, `createSurveyAdoptionSubmission`, `markComplete`)
+      // writes an explicit status. Only a row a pre-Phase-151 build stored is
+      // in this state, on a preserved table, and Kotlin's `?:` covers exactly
+      // it. Built as a companion here for that reason.
       await database.submissionDao.upsertAll([
         SubmissionsCompanion.insert(
           id: 'local-1',

--- a/flutter/test/repository/submissions_exporter_test.dart
+++ b/flutter/test/repository/submissions_exporter_test.dart
@@ -55,6 +55,12 @@ void main() {
       expect(submissionStatusLabel(rowWith(null)), 'Pending');
     });
 
+    test('trims, which the list screen deliberately does not', () {
+      // An unpinned `.trim()` is how two surfaces drift apart; the list
+      // renders `row.status!` with the padding intact.
+      expect(submissionStatusLabel(rowWith('  graded  ')), 'graded');
+    });
+
     test('falls back for the empty status the sync-in now stores', () {
       // Phase 151: `upsertDocuments` stores Kotlin's `''` for a document that
       // omits `status`, so `row.status ?? 'Pending'` stopped covering the case

--- a/flutter/test/repository/submissions_exporter_test.dart
+++ b/flutter/test/repository/submissions_exporter_test.dart
@@ -29,6 +29,41 @@ void main() {
   });
   tearDown(() => db.close());
 
+  // The Status cell cannot be asserted through the PDF: content streams are
+  // compressed, so `String.fromCharCodes(bytes).contains('Pending')` is false
+  // however the cell is drawn — verified, not assumed. (The document's
+  // *metadata* does survive as plain text, which is what the title test below
+  // relies on and why that one can genuinely fail.) So the label is a
+  // top-level function and this is what pins it, the same reasoning as Phase
+  // 99's `reportExportDateSuffix`.
+  group('submissionStatusLabel', () {
+    SubmissionRow rowWith(String? status) => SubmissionRow(
+      id: 'r',
+      startTime: 0,
+      lastUpdateTime: 0,
+      grade: 0,
+      uploaded: false,
+      isUpdated: false,
+      status: status,
+    );
+
+    test('shows the status the server sent', () {
+      expect(submissionStatusLabel(rowWith('graded')), 'graded');
+    });
+
+    test('falls back for a null status, as it always did', () {
+      expect(submissionStatusLabel(rowWith(null)), 'Pending');
+    });
+
+    test('falls back for the empty status the sync-in now stores', () {
+      // Phase 151: `upsertDocuments` stores Kotlin's `''` for a document that
+      // omits `status`, so `row.status ?? 'Pending'` stopped covering the case
+      // it was written for. Both states mean the server told us nothing.
+      expect(submissionStatusLabel(rowWith('')), 'Pending');
+      expect(submissionStatusLabel(rowWith('   ')), 'Pending');
+    });
+  });
+
   test('generates a valid PDF containing submission questions', () async {
     await repository.upsertDocuments([
       {


### PR DESCRIPTION
Lane B of the Phase 151 four-lane round. **Local gate green: `dart format` clean, `flutter analyze` clean, `flutter test` 2750 pass** (2735 before).

## The defect

Kotlin's submissions sync-in stores `JsonUtils.getString("status", …)` (`SubmissionsRepositoryImpl.kt:659`, `:679`), which is `""` for a key the document omits (`JsonUtils.kt:65-68`). `SubmissionDao.countCompletedByUserAndExamId`'s `status != 'pending'` (`SubmissionDao.kt:24`) is then satisfied, the count is 1, and `isStepCompleted` releases a course step's **Next** button.

The port stored `getStringOrNull`, which is null for a missing key *and* for `""`. `NOT (NULL = 'pending')` is SQL NULL, `WHERE NULL` drops the row, the count was 0 and the step stayed locked.

## Which side moved

**The writer, on one line. No DAO predicate changed** — so this lane needed nothing from Lane A.

The port's reader is a *faithful* port of Kotlin's query, NULL behaviour included; Kotlin's own reader also excludes a NULL status. Coalescing there would have made the port's reader diverge from Kotlin's to compensate for the port's writer diverging from Kotlin's.

Two mutation results carry that argument rather than prose: coalescing `pendingUploads`' marker test — the reader-side fix, applied uniformly — makes *a status-less local row is still swept for upload* fail, i.e. it would have stranded the row. And dropping `_repairSurveyParentId`'s `coalesce` passes, which is why the "the port paid three times for the reader side" claim is now stated as one instance rather than three.

## Two defects the audits found in this phase's own work

**The guard the fix disarmed (fixed).** `_repairSurveyParentId`'s status test exists because Phase 136 shipped `status IS NOT ''`, where `NULL IS NOT ''` is *true* — it rewrote an adoption marker into the mandatory-survey gate key and a learner's Finish sailed past an unanswered survey. The only fixture reaching that branch was a document whose `'status': ''` the old sync-in folded to NULL; with the writer fixed it stores `''`, `'' IS NOT ''` is false, and **reverting the guard left all 40 tests in the three relevant files green.** The same commit had annotated that line "unaffected either way". Now fixed with a legacy NULL row built as a companion (the sync-in can no longer produce one, and `submissions` is preserved so those rows are real); reverting the guard fails again.

**A correction that was itself wrong.** The ground-truth pass called my "self-healing by the next ordinary sync" false on the grounds that `sync()` has one caller, and I took it — into the code, the notes, and the phase's headline lesson. It has **two**: `background_entrypoint.dart:195-202` runs a submissions step headlessly on the periodic auto-sync task, with `autoSyncEnabled` defaulting to true. The original claim was substantially right. Phase 149 recorded that a supplied replacement sentence is a claim, not a patch; this is the same failure with an audit as the supplier, which is worse — the finding arrives pre-labelled as verified.

## Scope

Within this lane's set: `submissions_repository.dart`, `json_utils.dart`, `submissions_exporter.dart`, and tests for those. Two edits outside it, both **comment-only** under the *making an existing statement true* carve-out and both verified comment-only by diff: `surveys_repository.dart` and `courses_providers.dart` (the latter's `_isStepCompleted` dartdoc still described this defect as open and pointed at a closed hand-over item). **No collision with Lane A, C or D's declared files.**

`flutter/PHASE_151_NOTES.md` § *Reported, not fixed* has thirteen items. The ones worth routing:

- **`type`** carries the same divergence but no SQL predicate can see it (all positive equalities); moving it would blank two labels in `submission_detail_screen.dart:80,91`, on no lane's set. One three-line slice, deferral pinned by tests.
- **`submission_detail_screen.dart:84`** now renders a blank status label where it read "Pending" — the phase's only user-visible regression, matching Kotlin, one line to close, outside this set.
- **`app_database.dart:2907-2911` and `:2946-2954`** both justify a predicate with a clause this fix makes false. **The predicates should stay** (pre-fix rows are still NULL on a preserved table). Not edited: `app_database.dart` is Lane A's named file, and a carve-out is not a licence to edit into a live collision.
- **`course_progress.userId` is a second live instance**, already documented in-port. My first reader sweep missed it because `IS NULL`/`equalsNullable` distinguishes `''` from NULL too and, being a *positive* predicate, wasn't on my candidate list.
- **`parentId` belongs on the divergence list** my notes first presented as complete, and **`teamId`'s** readers already diverge from Kotlin's `teamId IS NULL` independently of any writer change — so tidying the `equals('')` disjunct after the `type` slice lands would break `byUserWithoutTeam` for every pulled row.

Severity is stated conditionally on purpose: the `''`→NULL fold is *proven* on wire documents the port itself writes, but whether Planet ever omits `status` from a step assessment's submission isn't establishable from this repo — neither mobile client can author one. The fix stands on parity grounds either way.
