### PR TITLE
Phase 152: recover from a 409 instead of merely surviving it

### DIFF
--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -202,6 +202,18 @@ examination row's. A row-keyed GET would 404, the arm would return the original
 `ConflictRecovery.documentUrlUnder(sendUrl, payload)` exists so that derivation
 is written once, and returns null rather than guessing.
 
+It percent-encodes the id with `Uri.encodeComponent`, which is the port's
+established convention for a CouchDB document id (`personals_uploader.dart:151`,
+`submit_photos_uploader.dart:131`, `teams_uploader.dart:123`,
+`teams_repository.dart:707`, `voices_uploader.dart:331`, and the arm this
+phase replaced). **One consequence is worth stating because it is new:** for
+`health` the id is a user id like `org.couchdb.user:ada`, so the URL carries
+`%3A` where `user_uploader.dart:80` deliberately leaves the `_users` prefix's
+colon literal and encodes only the name. CouchDB percent-decodes a path
+segment, so both resolve to the same document — but that is a *checked
+assumption*, not something the suite proves, and it is the kind of thing that
+would fail exactly as a green dead arm.
+
 ---
 
 ## Armed, and not
@@ -292,8 +304,11 @@ the shared arm and has four tests.
 
 ## Tests
 
-Gate green: `dart format` clean, `flutter analyze` clean, **2790 tests pass**
-(2735 before).
+Gate green: `dart format` clean, `flutter analyze` clean, **2767 tests pass**
+(2735 before — the 32 added reconcile: 16 in the new
+`conflict_recovery_test.dart`, 4 in the new `adopted_surveys_uploader_test.dart`,
+and one each in eleven existing uploader test files plus
+`health_legacy_conflict_test.dart`). *Counted from the run, not remembered.*
 
 New: `test/repository/conflict_recovery_test.dart` (16) pins the rule itself —
 both arms, the `adoptExisting` opt-in, the three guards, and `documentUrlUnder`.

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -165,6 +165,13 @@ tombstone is `{_id, _rev, _deleted: true}` (`teams_provider.dart:295`), so it
 is an update, and re-sending deletes a document whose latest content this
 device has never seen. Accepted deliberately: the user asked for the membership
 to be removed, and a revision bump elsewhere does not revoke that instruction.
+Adopting instead would report the delete as done while the document is still on
+the server *and* hand the row back to `deleteNotIn`. Both halves are pinned —
+a tombstone recovered under a fresh revision, and a tombstone for a document
+another device already deleted, where the read 404s and the refusal stands
+exactly as it did before this arm existed. The second also shows the arm does
+not disturb the handler's `_deleted` early return, which tolerates a response
+carrying no `rev`.
 
 ---
 
@@ -304,11 +311,11 @@ the shared arm and has four tests.
 
 ## Tests
 
-Gate green: `dart format` clean, `flutter analyze` clean, **2767 tests pass**
-(2735 before — the 32 added reconcile: 16 in the new
+Gate green: `dart format` clean, `flutter analyze` clean, **2769 tests pass**
+(2735 before — the 34 added reconcile: 16 in the new
 `conflict_recovery_test.dart`, 4 in the new `adopted_surveys_uploader_test.dart`,
 and one each in eleven existing uploader test files plus
-`health_legacy_conflict_test.dart`). *Counted from the run, not remembered.*
+`health_legacy_conflict_test.dart`, plus two for the tombstone paths). *Counted from the run, not remembered.*
 
 New: `test/repository/conflict_recovery_test.dart` (16) pins the rule itself —
 both arms, the `adoptExisting` opt-in, the three guards, and `documentUrlUnder`.
@@ -345,7 +352,8 @@ Every one failed the test it should.
 | drop the throwing-fetch guard | 1 |
 | `adoptExisting` ignored (always false) | 3 |
 | `adoptExisting` forced true everywhere | 5 |
-| un-arm each of the ten armed uploaders, one at a time | 1–2 each |
+| un-arm each of the eleven armed uploaders, one at a time | 1–2 each |
+| adopt instead of re-sending, checked against the tombstone path | 2 |
 
 The third row is the one worth keeping: **porting Kotlin's arm as written fails
 twenty-two tests in this port.** That is the phase's finding stated as a number.

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -46,18 +46,37 @@ network blip lands in that queue and is then thrown away. `:230-233` likewise
 never reads `response.body()`, so a retried news create leaves `_id` null and
 the next sync POSTs a second document.
 
-Six further 409 sites exist and **none** should be followed:
-`UploadManager.kt:369-372` and `TeamsUploader.kt:73-75` drop a `_bulk_docs`
-per-doc conflict silently; `HealthRepositoryImpl.kt:110-124` swallows it
-(a 409 body is null, so `has("id")` is false and nothing is logged);
-`AchievementUploader.kt:32-42` is an `if (response.isSuccessful)` with no
-`else`.
+Six further 409 sites exist and **none** should be followed — but they do not
+all fail the same way, and an earlier revision of this section flattened them:
+
+* `HealthRepositoryImpl.kt:110-124` and `AchievementUploader.kt:32-42` really
+  do swallow it silently (a 409 body is null, so `has("id")` is false and
+  nothing is logged; and an `if (response.isSuccessful)` with no `else`).
+* `TeamsUploader.kt:73-75` drops it too, but at `queueTeamRetry:118-119` — the
+  bulk response's `httpCode` is 200, so `retryable` is false and it is never
+  queued.
+* **News is not swallowed, and saying so was wrong.**
+  `UploadManager.kt:369-372` passes a **non-null exception**, and
+  `queueNewsRetry`'s rule is `exception != null || httpCode >= 500`, so a
+  per-doc conflict *is* queued into `RetryQueue` — and then discarded by
+  `RetryQueueWorker.kt:234-238` two paragraphs up. Queued-then-thrown-away.
+  Found by the implementation audit opening a citation this file made; the
+  verdict on the port is unchanged, the reading of Kotlin was not.
 
 **So say it plainly, because the next round will read this file and not the
-Kotlin:** of the port's twenty uploaders, only six correspond to a Kotlin path
-that runs through `UploadCoordinator` at all. For the rest this arm is **new
+Kotlin:** **six of the eleven uploaders armed here** correspond to a Kotlin
+path that runs through `UploadCoordinator` — `feedback`, `adopted_surveys`
+(`exams`), `submissions`, `events` (`meetups`), `team_tasks` (`tasks`) and
+`ratings`. The other five (`health`, `teams`, `achievements`, `user`, `voices`)
+have no config in `UploadConfigs.kt` at all, so for them this arm is **new
 behaviour, not restored parity**, and the *update* arm below has no Kotlin
 precedent anywhere.
+
+*(An earlier revision of this sentence read "of the port's twenty uploaders,
+only six" — the armed count wearing the wrong denominator. Across all twenty
+uploader files about **eleven** have a coordinator counterpart, the append
+uploaders included, so as written it told a reader the activity, search and
+photo uploaders have none. Backwards, and caught by the implementation audit.)*
 
 ---
 
@@ -123,13 +142,28 @@ same revision. Four things keep it inside the policy rather than around it:
 
 1. **Bounded.** One GET and at most one re-send per drain attempt. A second 409
    is returned as the refusal it is and `classifyStatus` makes it terminal
-   exactly as before.
+   exactly as before — **but only a second 409.** If the re-send answers a 5xx,
+   a transport failure or a throw, the drainer classifies *that*, and it is
+   `transient`: the item is retried, and because the stored payload still holds
+   the stale `_rev`, each of the five attempts repeats POST → GET → POST. Up to
+   fifteen requests for one write before abandonment. **Deliberate, and the
+   reason the re-send is not wrapped the way the fetch is:** after a failed
+   fetch a definitive 409 is still in hand, so letting it escape would relabel
+   a refusal; after a failed re-send the last thing the server said was
+   "unavailable", not "refused", and a write the server never answered is what
+   `transient` exists for. The cost is bounded requests; the alternative is
+   stranding a deliverable write on a server hiccup. The implementation audit
+   read this as a defect; I disagree, for that reason, and the claim it was
+   right about — that my note overstated "terminal exactly as before" — is
+   fixed here and at the code.
 2. **Never an identical re-ask.** If the revision the server reports is the one
    the payload already carried, the re-send is skipped and the refusal stands.
-3. **Cannot duplicate a document.** The arm fires only for a request naming its
-   own `_id`, so a re-send is an update of that id. `documentUrlUnder` returns
-   null when the payload names no document, which is the structural guard: an
-   append with a server-minted id gets no arm at all.
+3. **Cannot duplicate a document.** A re-send is an update of a named `_id`,
+   and an append with a server-minted id cannot 409 at all.
+   `documentUrlUnder` returns null when the payload names no document, so its
+   eight callers are safe by construction — but three build the URL by hand
+   and `send` does not verify the `_id`, so this is a **caller convention, not
+   a structure**. See *Reported, not fixed* item 3.
 4. **A throwing fetch cannot re-arm anything** — see the next section.
 
 ### The one place this phase had to *defend* the policy, not extend it
@@ -153,12 +187,29 @@ right about the shape.**
 ### The trade the update arm makes
 
 Re-sending under the server's current revision is last-write-wins: a concurrent
-edit on another device is overwritten. That is the port's existing stance
-elsewhere — `cacheDocuments` skips a locally dirty row
-(`health_repository.dart:772`), so the local copy is already authoritative —
-and it is the better of the two available mistakes, because the alternative
-loses the *local* edit silently in a queue whose whole purpose is delivering
-local writes.
+edit on another device is overwritten.
+
+**The justification I first gave for that was too narrow, and the correction is
+worth more than the original claim.** I cited `cacheDocuments` skipping a
+locally dirty row (`health_repository.dart:772`) as "the port's existing stance
+elsewhere". It is not: that mechanism is health-only. Most sync-ins have no
+dirty-row guard at all and end `isUpdated: false`
+(`submissions_repository.dart:1725-1774`), making the **server** authoritative
+on the way in — the opposite stance.
+
+The real reason last-write-wins was *already* the port's outcome is Phase 148's
+own recovery route: **a sync-in that writes `rev` unconditionally re-arms the
+memo with a changed request.** A pull hands the row the server's revision, the
+next sweep's payload therefore differs from the refused one, the memo re-arms,
+and the local content goes over the server's anyway — one sync later. **This arm
+changes the latency of that outcome, not the outcome.** Health is the single
+uploader where that route is closed, which is exactly why the `cacheDocuments`
+citation belongs there and only there, and why health needs the arm most.
+
+That reframing is not a way of dismissing the concern; it relocates it. Where
+the server's document holds content the payload cannot reconstruct, "one sync
+later" is still a loss, and this arm still makes it sooner. See *Reported, not
+fixed* item 1.
 
 **One case is named rather than left to fall out of the rule.** A team
 tombstone is `{_id, _rev, _deleted: true}` (`teams_provider.dart:295`), so it
@@ -250,9 +301,95 @@ the shared arm and has four tests.
 
 ---
 
+## What the second audit pass changed
+
+The mandatory pass over this lane's own finished, already-green code found
+twelve items. **Five were real defects in the code or its tests, four were
+wrong claims in this file, and three I argued and did not take** — the same
+split, and the same lesson, as the five previous rounds: *an audit of the
+ground truth does not audit the implementation.*
+
+**The one that mattered most defeated a test I had already mutation-tested.**
+`voices_uploader_test.dart` asserted `newsRev ?? rev` was `isNotNull` — but the
+fixture's own `markUploaded` had set `rev` two lines earlier, so it held whether
+or not the handler ran. The auditor proved it by commenting out `markUploaded`
+and watching the test pass. My own eighteen mutations missed it because
+un-arming the uploader still killed the *other* assertions in the same test:
+**a test can be killed by a mutation and still contain an assertion that cannot
+fail.** It now pins `rev`, `docId`, `isEdited` and the empty `imageUrls` — the
+half this uploader's own comment calls the highest-stakes in the port — and
+the skip-`markUploaded` mutation kills two tests.
+
+**Second: the health arm's rationale re-seeded a claim Phase 148 was written to
+retract.** My comment said a second examination for the same patient "conflicts
+by construction". It does not — `createExamination` defaults `userId` to the
+row's own id and the one production caller passes none, so each examination is
+its own document. `PHASE_148_NOTES.md:107-111` says exactly that. **Fifth round
+running in which a brief or a note propagated an inherited error**, and this
+time the error was one *this project had already corrected in writing*. The
+comment now names the profile blob, which is the reachable case, and says why
+health needs the arm most (its pull cannot supply the revision).
+
+The test was wrong in the same direction and worse: it seeded
+`createExamination(userId: 'user-1')`, a shape **no production caller
+produces**, and that fabricated shape was the only reason `_id` differed from
+the row id — i.e. the only reason the "derive the URL from `itemId`" mutation
+died. It now drives `saveHealthProfileBlob`, where the two genuinely differ,
+and the mutation still dies. **A fixture that cannot arise is a mutation that
+was never really killed.**
+
+Also fixed: the GET was issued **before** the create/update decision, so every
+create-conflict on the five always-`_id` uploaders spent an authenticated
+round-trip to learn a revision that was then discarded (the decision turns on
+`payload['_rev']`, known before any request); and the dangling
+`_adoptExistingDocument` reference in
+`survey_clone_survives_schema_bump_test.dart`.
+
+Three findings were argued and **not** taken — the bounded-request reading
+above, and items 2 and 3 below.
+
 ## Reported, not fixed
 
-1. **`course_progress` cannot conflict, and that is a bug wearing a
+1. **`feedback` loses a reply only the server has — and it did before this
+   phase.** `messages` is an append array both Planet's web UI and the handset
+   write, and `FeedbackMapper.fromDoc:27-31,50-54` deliberately keeps the local
+   array on a pending reply while taking the server's `rev`, leaving
+   `isUploaded = false`. So an admin reply absent locally is destroyed by the
+   next send. The implementation audit read this as destruction the recovery
+   arm introduces; **it is not, and the distinction is the whole reason this is
+   reported rather than reverted.** Both halves are now pinned in
+   `feedback_uploader_test.dart`: the re-send carries only the local array, and
+   a plain **pull** already drops the admin reply locally and leaves the row
+   swept with a changed revision — so Phase 148's memo re-arms it and the same
+   loss lands one ordinary sync later with no 409 and no arm involved. The arm
+   changes the latency, not the outcome. The fix is a real merge for that
+   column, which is a feedback-slice decision with a conflict-resolution
+   question inside it. Severity: medium-high, and older than this phase.
+2. **The same shape is *constructible* for `submissions` but I could not prove
+   it reachable, so I did not act on it.** A submission document is where
+   Planet's grading lands (`grade`, `status`, per-answer marks, all read at
+   `submissions_repository.dart:1761-1763` and all re-sent by `serialize`), so
+   a re-send under the fetched revision would replace a graded document with
+   the handset's ungraded copy. But `upsertDocuments` ends
+   `isUpdated: false`, so a pulled submission is not swept; making it swept
+   again needs a local edit after the grade arrives, and the retake path
+   deletes and re-creates rather than reusing the row. The survey-resume path
+   (`:239-245`) does reuse an uploaded row's id, which is the closest thing to
+   a route. **A chain that ends "so the port loses X" is a defect only once the
+   chain is walked** — Phase 135's rule — and I could not walk this one. Worth
+   a targeted look by someone who knows the grading round trip.
+3. **`ConflictRecovery`'s "cannot duplicate a document" guarantee is a caller
+   convention, not a structure.** `documentUrlUnder` returns null when the
+   payload names no document, so its eight callers are safe by construction —
+   but three build the URL by hand (`user`, `achievements`,
+   `adopted_surveys`) and `send` does not verify that `payload['_id']` exists
+   when handed a `documentUrl`. `user` is safe because its verb is a PUT to a
+   fixed document URL, not because of anything in the arm. A future POST-verb
+   uploader passing a hand-built URL with no `_id` would re-send an append. I
+   did not add the assertion because the honest guard is a type that carries
+   both the URL and the id together, which is a wider refactor than this phase
+   should take on its own; the risk is now written at the code.
+4. **`course_progress` cannot conflict, and that is a bug wearing a
    reachability costume.** `CourseProgressDao.getPendingUploads` is
    `couchId IS NULL`, so a row the server has acknowledged is never re-offered.
    Two consequences: the arm was reverted (an inert arm claiming a recovery
@@ -263,11 +400,11 @@ the shared arm and has four tests.
    a sync-semantics decision, not a one-liner. Severity: medium. The
    ground-truth audit called this one reachable; it read the serializer and not
    the predicate. *A citation is not a reading* — including an auditor's.
-2. **`team_log` is armed by nothing and probably should not be.**
+5. **`team_log` is armed by nothing and probably should not be.**
    `pendingTeamLogUploads` is `uploaded = false` and `markUploaded` sets it
    true, so only a failed-then-pulled row qualifies. Left alone; the same
    predicate question as item 1 sits under it.
-3. **`myplanet_activities_uploader.dart` is not an outbox uploader at all** —
+6. **`myplanet_activities_uploader.dart` is not an outbox uploader at all** —
    no `queuePending`, no `handler`; it posts directly (`:100`, `:146`). It is a
    genuine read-modify-write merge posting with a fetched `_rev` (`:128`), a
    409 there is unhandled, and `lastUsageUploaded` is not advanced (`:152`) so
@@ -275,7 +412,7 @@ the shared arm and has four tests.
    Kotlin's "re-GET and merge again" is exactly right, and it has nothing.
    Severity: low, because it self-heals. Not in the outbox, so outside this
    arm's reach by construction.
-4. **`HealthExaminationDao.markUploaded(id, null)` still erases a stored
+7. **`HealthExaminationDao.markUploaded(id, null)` still erases a stored
    `_rev`** — `app_database.dart:3962-3968`, **Lane A's file**. Phase 148's
    citation of `:3812-3819` has drifted; so have its citations of the correct
    `rev == null ? const Value.absent() : Value(rev)` pattern, which is live at
@@ -284,27 +421,46 @@ the shared arm and has four tests.
    recovery never passes a null rev — it either has a `String` from the GET,
    guarded `is String && isNotEmpty`, or it does not recover. Reported as the
    brief asks; Lane A owns the fix.
-5. **`HealthRepository.cacheDocuments` skipping a dirty row
+8. **`HealthRepository.cacheDocuments` skipping a dirty row
    (`health_repository.dart:772`) matters less than it did.** Phase 148 item 3
    called the pull-supplies-the-revision route "structurally unavailable for
    health"; the update arm now supplies the revision directly, so a stale-rev
    health write recovers without it. The underlying merge question is
    unchanged, but it is no longer the only route.
-6. **`chat` and `public_survey` are unreachable for this arm and stay that
+9. **`chat` and `public_survey` are unreachable for this arm and stay that
    way.** `chat`'s `_id`/`_rev` are nested inside `data` (`chat_uploader.dart:105-106`)
    so the top-level document has none, and `public_survey` posts to a Planet
    REST route with no document to GET. Phase 148's items 4 and 9 (the chat
    endpoint pointing at CouchDB rather than Planet's chat service) are
    untouched and still open.
-7. **The six append uploaders (nine types) are deliberately unarmed** —
+10. **The six append uploaders (nine types) are deliberately unarmed** —
    `personals`, `chat`, `submit_photos`, `search_activity`, `activities`'s
    four types, `public_survey`. A 409 is impossible for them (server-minted
    ids), and a `documentUrl` there would be a lie a future reader acts on.
-8. **`UploadConfig.additionalUpdates` is declared (`UploadConfig.kt:34`),
+11. **`UploadConfig.additionalUpdates` is declared (`UploadConfig.kt:34`),
    assigned once (`UploadConfigs.kt:263-265`) and never invoked** by
    `UploadCoordinator`. Kotlin-side dead code found while reading the ground
    truth; noted for whoever next audits that file.
-9. **Phase 148's items 5, 6, 7, 8, 10, 11, 12 remain open**; none is in this
+12. **A voices retry now re-uploads the images — exposure, not a new defect.**
+   `voices_uploader.dart:134` runs `_withImages` before every send and
+   `pendingImagesFor` is cleared only by `markUploaded`. A 409 whose re-send
+   answers a 5xx makes the row retryable (item 1 of the policy list), and the
+   retry POSTs a second set of `resources` documents plus attachments. The
+   message is rebuilt from the stored payload so it is not doubled; the
+   orphaned `private: true` resource documents are. The same path already
+   existed via a direct 5xx, so the arm widens the trigger rather than
+   creating the leak. Found by the implementation audit.
+13. **`app_database.dart:390` still names `_adoptExistingDocument`**, the method
+   this phase deleted, as the justification for the v47 `needs_sync` backfill
+   accepting one false positive. The behaviour survives (the shared arm with
+   `adoptExisting: true` plus the handler's `markUploaded`), so this is
+   documentation only. CLAUDE.md's carve-out would allow making an existing
+   statement true even in another lane's file, but `app_database.dart` is
+   **Lane A's this round and named explicitly in the brief**, and Lane A is
+   editing that file — so the sibling reference in
+   `survey_clone_survives_schema_bump_test.dart` is fixed here and this one is
+   reported instead. One line.
+14. **Phase 148's items 5, 6, 7, 8, 10, 11, 12 remain open**; none is in this
    lane's set.
 
 ---

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -467,11 +467,12 @@ above, and items 2 and 3 below.
 
 ## Tests
 
-Gate green: `dart format` clean, `flutter analyze` clean, **2769 tests pass**
-(2735 before — the 34 added reconcile: 16 in the new
+Gate green: `dart format` clean, `flutter analyze` clean, **2771 tests pass**
+(2735 before — the 36 added reconcile: 16 in the new
 `conflict_recovery_test.dart`, 4 in the new `adopted_surveys_uploader_test.dart`,
 and one each in eleven existing uploader test files plus
-`health_legacy_conflict_test.dart`, plus two for the tombstone paths). *Counted from the run, not remembered.*
+`health_legacy_conflict_test.dart`, two for the tombstone paths, and two the
+implementation audit prompted in `feedback_uploader_test.dart`). *Counted from the run, not remembered.*
 
 New: `test/repository/conflict_recovery_test.dart` (16) pins the rule itself —
 both arms, the `adoptExisting` opt-in, the three guards, and `documentUrlUnder`.

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -206,9 +206,20 @@ is written once, and returns null rather than guessing.
 
 ## Armed, and not
 
-**Armed (11 types across 10 uploaders):** `health`, `teams` (5 types),
+**Armed — 11 uploader files, 15 upload types:** `health`, `teams` (5 types),
 `feedback`, `achievements`, `adopted_surveys` (`adoptExisting: true`),
 `submissions`, `voices`, `events`, `team_tasks`, `ratings`, `user`.
+
+**Unarmed — 9 files, 11 types**, in three groups: six append uploaders where a
+409 is impossible (`personals`, `chat`, `submit_photos`, `search_activity`,
+`activities`'s four types, `public_survey` — **9 types**, not the eight both my
+first draft and the ground-truth audit said); `course_progress` and `team_log`,
+unreachable by their pending predicates (items 1 and 2 below); and
+`myplanet_activities`, which is not an outbox uploader at all (item 3).
+
+The types reconcile: 15 + 9 + 1 + 1 = 26, which is Phase 148's count of outbox
+upload types, and 11 + 9 = 20 uploader files. *Counted, not remembered — a
+number that is not the sum of the rows above it is a number nobody added up.*
 
 Reachability was verified per uploader against its *pending predicate*, not
 just its serializer — that check is what caught `course_progress` below.
@@ -266,10 +277,10 @@ the shared arm and has four tests.
    REST route with no document to GET. Phase 148's items 4 and 9 (the chat
    endpoint pointing at CouchDB rather than Planet's chat service) are
    untouched and still open.
-7. **The eight append uploaders are deliberately unarmed** — `personals`,
-   `chat`, `submit_photos`, `search_activity`, the four `activities` types,
-   `public_survey`. A 409 is impossible for them (server-minted ids), and a
-   `documentUrl` there would be a lie a future reader acts on.
+7. **The six append uploaders (nine types) are deliberately unarmed** —
+   `personals`, `chat`, `submit_photos`, `search_activity`, `activities`'s
+   four types, `public_survey`. A 409 is impossible for them (server-minted
+   ids), and a `documentUrl` there would be a lie a future reader acts on.
 8. **`UploadConfig.additionalUpdates` is declared (`UploadConfig.kt:34`),
    assigned once (`UploadConfigs.kt:263-265`) and never invoked** by
    `UploadCoordinator`. Kotlin-side dead code found while reading the ground

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -1,0 +1,9 @@
+# Phase 152 — a 409 should be recovered, not merely survived (Lane C)
+
+Phase 148 made a 409 **safe**: one row, one POST, terminal, re-armed only by a
+changed request. This phase makes it **recovered**, by porting
+`UploadCoordinator.kt:169-204` — GET the document that already exists, adopt its
+`_rev`, and report the upload as the success it effectively was.
+
+*Notes are written as the work proceeds; this file is a stub until the design
+section lands.*

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -277,3 +277,49 @@ the shared arm and has four tests.
 9. **Phase 148's items 5, 6, 7, 8, 10, 11, 12 remain open**; none is in this
    lane's set.
 
+---
+
+## Tests
+
+Gate green: `dart format` clean, `flutter analyze` clean, **2790 tests pass**
+(2735 before).
+
+New: `test/repository/conflict_recovery_test.dart` (16) pins the rule itself —
+both arms, the `adoptExisting` opt-in, the three guards, and `documentUrlUnder`.
+`test/repository/adopted_surveys_uploader_test.dart` (4) is new because that
+uploader's own 409 arm had **no coverage at all** before this phase.
+
+One end-to-end test per armed uploader, added to its existing file. Each drives
+the payload production actually builds — seed the row, `queuePending`, decode
+the operation's stored payload — rather than a hand-written one, because a
+fixture that cannot reach the branch it names reads as coverage. Where that was
+not practical the payload is passed directly and the test says so.
+
+`test/repository/health_legacy_conflict_test.dart` gains
+*a stale profile revision is recovered instead of stranded* — the phase's
+headline through the real drain path, counting POSTs and GETs against a fake
+CouchDB that enforces `_id` uniqueness. Its fake also gained a **document read**;
+without it the new arm's fetch threw, and the five Phase 148 tests in that file
+would have passed because of `ConflictRecovery`'s throw guard rather than
+because a create-conflict stands as a refusal. That distinction is the whole
+point of those tests, so the fake serves documents now.
+
+### Mutations
+
+Eighteen, each applied alone with the suite run in between, then reverted.
+Every one failed the test it should.
+
+| Mutation | Tests killed |
+|---|---:|
+| health derives the doc URL from `row.itemId` instead of `payload['_id']` | 1 |
+| no split — always re-send, ignoring the create case | 9 |
+| **no split — always adopt, i.e. Kotlin's arm ported literally** | **22** |
+| drop the identical-re-ask guard (`rev == sentRev`) | 1 |
+| drop the null-`documentUrl` guard, so an append is recoverable | 1 |
+| drop the throwing-fetch guard | 1 |
+| `adoptExisting` ignored (always false) | 3 |
+| `adoptExisting` forced true everywhere | 5 |
+| un-arm each of the ten armed uploaders, one at a time | 1–2 each |
+
+The third row is the one worth keeping: **porting Kotlin's arm as written fails
+twenty-two tests in this port.** That is the phase's finding stated as a number.

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -1,9 +1,279 @@
-# Phase 152 — a 409 should be recovered, not merely survived (Lane C)
+# Phase 152 — a 409 recovered, not merely survived (Lane C)
 
 Phase 148 made a 409 **safe**: one row, one POST, terminal, re-armed only by a
-changed request. This phase makes it **recovered**, by porting
-`UploadCoordinator.kt:169-204` — GET the document that already exists, adopt its
-`_rev`, and report the upload as the success it effectively was.
+changed request. Its own *Reported, not fixed* item 1 called the recovery arm
+"the single highest-value follow-up here". This is that phase.
 
-*Notes are written as the work proceeds; this file is a stub until the design
-section lands.*
+**The headline is not the arm; it is that porting Kotlin's arm literally would
+have lost data in every uploader but one.**
+
+---
+
+## What Kotlin does, read rather than cited
+
+`UploadCoordinator.kt:169-204` answers a 409 by GETting the document that
+already exists, adopting its `_rev`, and reporting the upload as a **success**.
+Three details the brief's summary rounds off, all confirmed against source by
+the ground-truth `parity-auditor` pass:
+
+* **"Runs the same `afterUpload` callback" is structurally true and
+  operationally hollow.** `afterUpload` is `null` for every config in the tree
+  (`UploadConfig.kt:31-32` and the two call sites are the only occurrences).
+  What actually happens is that the recovered item joins `succeeded`, so
+  `updateDatabaseBatch` (`:241-257`) runs the config's `persistUploaded` —
+  the `markUploaded` a port has to reproduce.
+* **The field names differ between the two paths, correctly.** The accepted
+  path reads `id`/`rev` (a CouchDB *write* response); the recovery path reads
+  the literals `_id`/`_rev` (`:177-182`) because a document *read* returns the
+  document. `config.responseHandler` is ignored on the recovery path; nothing
+  turns on it today, since the only `Custom` handler (`Meetups`,
+  `UploadConfigs.kt:178`) is declared identically to `Standard`.
+* **The arm is not broken for appends — it is unreachable for them.** The GET
+  URL is `$baseUrl/${config.endpoint}/${preparedItem.dbId ?: preparedItem.localId}`,
+  and `localId` is always `{ it.id }`, the Room primary key. Every POST-only
+  config that can 409 (`TeamTask`, `Meetups`, `AdoptedSurveys`, `Feedback`) is
+  one where `item.id` *is* the document `_id` by construction; every config
+  where they would differ emits no `_id`, so CouchDB mints one and a conflict
+  cannot occur. There is no broken half to copy.
+
+Also confirmed, and deliberately **not** ported, per the brief:
+`RetryQueueWorker.kt:234-238` treats a 409 as "already synced", deletes the
+queue row and logs success, leaving the subject row untouched — a user's edit
+discarded with a success log. It is reachable in practice, because
+`UploadCoordinator` marks the recovery GET's `IOException` case
+`retryable = true, httpCode = 409` (`:197`), so a 409 whose recovery hit a
+network blip lands in that queue and is then thrown away. `:230-233` likewise
+never reads `response.body()`, so a retried news create leaves `_id` null and
+the next sync POSTs a second document.
+
+Six further 409 sites exist and **none** should be followed:
+`UploadManager.kt:369-372` and `TeamsUploader.kt:73-75` drop a `_bulk_docs`
+per-doc conflict silently; `HealthRepositoryImpl.kt:110-124` swallows it
+(a 409 body is null, so `has("id")` is false and nothing is logged);
+`AchievementUploader.kt:32-42` is an `if (response.isSuccessful)` with no
+`else`.
+
+**So say it plainly, because the next round will read this file and not the
+Kotlin:** of the port's twenty uploaders, only six correspond to a Kotlin path
+that runs through `UploadCoordinator` at all. For the rest this arm is **new
+behaviour, not restored parity**, and the *update* arm below has no Kotlin
+precedent anywhere.
+
+---
+
+## The correction that reframed the phase
+
+Kotlin's arm never compares the document it fetched with the one it was
+sending. **A 409 does not mean "your write is already there."** It means a
+document with this `_id` exists and the `_rev` supplied — or omitted — is not
+its current revision, so *these bytes were not stored*.
+
+Adopt-and-report-success is therefore only equivalent to delivery when the
+document already on the server **is** the document being sent. Ported
+wholesale it would have:
+
+| Uploader | What adopting loses |
+|---|---|
+| `health` | the clinician's examination or profile edit, with `isUpdated` cleared — and `cacheDocuments` skips a dirty row only *while* it is dirty, so the local copy is then overwritten too. **Both copies gone.** |
+| `submissions` | answers a learner added to an already-uploaded sheet (`uploaded: true, isUpdated: false`) |
+| `voices` | the edited post *and* the images: `markUploaded` clears `imageUrls` and deletes the local bytes (`voices_repository.dart:1053, 1062`) |
+| `achievements` | a new ledger entry, plus the resume attachment is then PUT against somebody else's ledger |
+| `user` | a name or photo edit, on a handler that already holds a rev fetched seconds earlier |
+| `teams` | a report edit — or, on a tombstone, the delete is reported done while the document is still there *and* the row is handed back to `deleteNotIn` |
+
+The payload answers the question well enough to act on, and the two answers
+need **opposite** handling. That split is the phase.
+
+### The rule, stated plainly
+
+> **An update is re-sent under the revision the GET reports. A create is
+> neither re-sent nor adopted — the refusal stands — unless the uploader can
+> prove the content identical.**
+
+* **Update** — the payload carries a `_rev`, so this device has published this
+  document before and is sending a change to it. Fetch the current revision,
+  re-send the same content under it. The write lands.
+* **Create** — no `_rev`, so as far as this device knows the document has never
+  been published and the one on the server is content it has never seen.
+  Re-sending would overwrite that; adopting would report a delivery that did
+  not happen. Neither is safe in general, so the default is **neither**: the
+  refusal stands, terminal, and `OutboxDao.abandoned` keeps reporting the row
+  as stranded — the honest answer.
+* **`adoptExisting`** is the opt-in to Kotlin's original semantics for a
+  create, and exactly **one** uploader sets it. `adopted_surveys`'s clone is a
+  pure function of the survey and the team, and its id (`'${surveyId}_$teamId'`)
+  makes two leaders author the same document, so taking the winner's revision
+  loses nothing. Nothing else in the port can make that claim.
+
+Note what the create default preserves: `health_legacy_conflict_test.dart`,
+which pins Phase 148's behaviour for a legacy examination colliding with the
+patient's profile, **passes unchanged** — with the fake now serving real
+document reads, so it pins the create-arm refusal rather than a missing stub.
+
+### Why this does not weaken Phase 148's policy
+
+The policy: *an `outbox` item owns exactly one row, for ever; a terminal row is
+a memo, and nothing re-asks the identical question unattended. What re-arms it
+is a changed request.*
+
+The re-send **is** a changed request — it carries a `_rev` the first one did
+not, fetched from the server between the two. That is the recovery route the
+policy already names, taken inline instead of waiting for a pull to supply the
+same revision. Four things keep it inside the policy rather than around it:
+
+1. **Bounded.** One GET and at most one re-send per drain attempt. A second 409
+   is returned as the refusal it is and `classifyStatus` makes it terminal
+   exactly as before.
+2. **Never an identical re-ask.** If the revision the server reports is the one
+   the payload already carried, the re-send is skipped and the refusal stands.
+3. **Cannot duplicate a document.** The arm fires only for a request naming its
+   own `_id`, so a re-send is an update of that id. `documentUrlUnder` returns
+   null when the payload names no document, which is the structural guard: an
+   append with a server-minted id gets no arm at all.
+4. **A throwing fetch cannot re-arm anything** — see the next section.
+
+### The one place this phase had to *defend* the policy, not extend it
+
+`OutboxDrainer._send` wraps a handler in a catch-all and treats a throw as
+**transient** — correctly, since a throw is not evidence the server refused
+anything. But here the server *has* refused something: the 409 is already in
+hand. An unguarded recovery whose GET threw would propagate out of the handler
+and relabel a terminal rejection as a retryable failure, re-offering the row on
+every sweep until its attempts ran out. **That is Phase 148's accretion,
+re-entering through the recovery arm.**
+
+`ConflictRecovery.send` therefore catches around the fetch and returns the
+original 409. `PlanetApi` returns a `NetworkException` rather than throwing, so
+this is not reachable through it — it was found because
+`health_legacy_conflict_test.dart`'s fake CouchDB is a `Mock` with only
+`postJsonObject` stubbed, so the new GET threw and five Phase 148 tests went
+from `abandoned` to `pending`. **A test that broke for the "wrong" reason was
+right about the shape.**
+
+### The trade the update arm makes
+
+Re-sending under the server's current revision is last-write-wins: a concurrent
+edit on another device is overwritten. That is the port's existing stance
+elsewhere — `cacheDocuments` skips a locally dirty row
+(`health_repository.dart:772`), so the local copy is already authoritative —
+and it is the better of the two available mistakes, because the alternative
+loses the *local* edit silently in a queue whose whole purpose is delivering
+local writes.
+
+**One case is named rather than left to fall out of the rule.** A team
+tombstone is `{_id, _rev, _deleted: true}` (`teams_provider.dart:295`), so it
+is an update, and re-sending deletes a document whose latest content this
+device has never seen. Accepted deliberately: the user asked for the membership
+to be removed, and a revision bump elsewhere does not revoke that instruction.
+
+---
+
+## Where the arm lives, and why not the drainer
+
+Phase 148's lesson — *one rule at the right layer beat twenty special cases* —
+was the design question the brief posed. The answer is that the **policy** is
+in one place and the **call** cannot be.
+
+`OutboxDrainer._send` sees only a `NetworkResult`. It cannot know the document
+URL (it is `row.endpoint` for `user`, `${row.endpoint}/${payload['_id']}` for
+most, `${row.endpoint}/achievements/${payload['_id']}` for `achievements`),
+cannot know the verb, and — decisively — cannot run the handler's DAO write.
+The outbox repository owns rows and policy, not HTTP or domain DAOs.
+
+So `ConflictRecovery` sits beside `OutboxHandler` in `outbox_drainer.dart` and
+wraps only the **send**. Every uploader supplies exactly two things — a
+document URL and its own send as a closure — and because a recovered result
+returns *through* the wrap, each handler's existing
+`if (result case NetworkSuccess…)` branch runs on it unchanged. **No uploader
+duplicates its own `markUploaded`, and none can forget to run it.** That is the
+property that made a per-call-site arm acceptable.
+
+### The trap that would have shipped a green, dead arm
+
+**The document id is the payload's, not the outbox row's.** Phase 148's item 1
+reads as though `row.itemId` is the document id for all six of its "deterministic
+`_id`" uploaders. It is not. `outbox.itemId` is the *local* row key; the CouchDB
+`_id` is whatever the serializer chose, and of the eleven candidates **seven**
+differ in the reachable case. `health` is the sharpest: `serialize` writes the
+patient's id as `_id` (`health_repository.dart:845-849`) while `itemId` is the
+examination row's. A row-keyed GET would 404, the arm would return the original
+409, and nothing would be recovered — silently, with every test green.
+
+`ConflictRecovery.documentUrlUnder(sendUrl, payload)` exists so that derivation
+is written once, and returns null rather than guessing.
+
+---
+
+## Armed, and not
+
+**Armed (11 types across 10 uploaders):** `health`, `teams` (5 types),
+`feedback`, `achievements`, `adopted_surveys` (`adoptExisting: true`),
+`submissions`, `voices`, `events`, `team_tasks`, `ratings`, `user`.
+
+Reachability was verified per uploader against its *pending predicate*, not
+just its serializer — that check is what caught `course_progress` below.
+
+**`adopted_surveys` also lost its bespoke arm.** It was a working port of
+Kotlin's, ~45 lines, with **no test coverage at all** — the sweep tests drive
+`queuePending` and the conflict branch was reachable from nothing. It now uses
+the shared arm and has four tests.
+
+---
+
+## Reported, not fixed
+
+1. **`course_progress` cannot conflict, and that is a bug wearing a
+   reachability costume.** `CourseProgressDao.getPendingUploads` is
+   `couchId IS NULL`, so a row the server has acknowledged is never re-offered.
+   Two consequences: the arm was reverted (an inert arm claiming a recovery
+   that cannot happen is worse than none — pinned by *a progress row that
+   reached the server is never re-offered*), and `_toDoc`'s `_id`/`_rev` branch
+   is **dead on the upload path**, which means **a later edit to an
+   acknowledged progress row never uploads at all**. Changing the predicate is
+   a sync-semantics decision, not a one-liner. Severity: medium. The
+   ground-truth audit called this one reachable; it read the serializer and not
+   the predicate. *A citation is not a reading* — including an auditor's.
+2. **`team_log` is armed by nothing and probably should not be.**
+   `pendingTeamLogUploads` is `uploaded = false` and `markUploaded` sets it
+   true, so only a failed-then-pulled row qualifies. Left alone; the same
+   predicate question as item 1 sits under it.
+3. **`myplanet_activities_uploader.dart` is not an outbox uploader at all** —
+   no `queuePending`, no `handler`; it posts directly (`:100`, `:146`). It is a
+   genuine read-modify-write merge posting with a fetched `_rev` (`:128`), a
+   409 there is unhandled, and `lastUsageUploaded` is not advanced (`:152`) so
+   it self-heals on the next interval. It is the one place in the port where
+   Kotlin's "re-GET and merge again" is exactly right, and it has nothing.
+   Severity: low, because it self-heals. Not in the outbox, so outside this
+   arm's reach by construction.
+4. **`HealthExaminationDao.markUploaded(id, null)` still erases a stored
+   `_rev`** — `app_database.dart:3962-3968`, **Lane A's file**. Phase 148's
+   citation of `:3812-3819` has drifted; so have its citations of the correct
+   `rev == null ? const Value.absent() : Value(rev)` pattern, which is live at
+   **`:1208`** (`UserDao.markUploaded`) and **`:4765`** (`AchievementDao`), not
+   `:1198`/`:2066`. **The health arm did not need it and does not touch it**: a
+   recovery never passes a null rev — it either has a `String` from the GET,
+   guarded `is String && isNotEmpty`, or it does not recover. Reported as the
+   brief asks; Lane A owns the fix.
+5. **`HealthRepository.cacheDocuments` skipping a dirty row
+   (`health_repository.dart:772`) matters less than it did.** Phase 148 item 3
+   called the pull-supplies-the-revision route "structurally unavailable for
+   health"; the update arm now supplies the revision directly, so a stale-rev
+   health write recovers without it. The underlying merge question is
+   unchanged, but it is no longer the only route.
+6. **`chat` and `public_survey` are unreachable for this arm and stay that
+   way.** `chat`'s `_id`/`_rev` are nested inside `data` (`chat_uploader.dart:105-106`)
+   so the top-level document has none, and `public_survey` posts to a Planet
+   REST route with no document to GET. Phase 148's items 4 and 9 (the chat
+   endpoint pointing at CouchDB rather than Planet's chat service) are
+   untouched and still open.
+7. **The eight append uploaders are deliberately unarmed** — `personals`,
+   `chat`, `submit_photos`, `search_activity`, the four `activities` types,
+   `public_survey`. A 409 is impossible for them (server-minted ids), and a
+   `documentUrl` there would be a lie a future reader acts on.
+8. **`UploadConfig.additionalUpdates` is declared (`UploadConfig.kt:34`),
+   assigned once (`UploadConfigs.kt:263-265`) and never invoked** by
+   `UploadCoordinator`. Kotlin-side dead code found while reading the ground
+   truth; noted for whoever next audits that file.
+9. **Phase 148's items 5, 6, 7, 8, 10, 11, 12 remain open**; none is in this
+   lane's set.
+

--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -510,6 +510,31 @@ Every one failed the test it should.
 | `adoptExisting` forced true everywhere | 5 |
 | un-arm each of the eleven armed uploaders, one at a time | 1–2 each |
 | adopt instead of re-sending, checked against the tombstone path | 2 |
+| fetch before the create decision (revert the hoist) | 1 |
+| skip `markUploaded` in the voices success branch | 2 |
+| `fromDoc` takes the server's `messages` instead of keeping the local array | 1 |
 
 The third row is the one worth keeping: **porting Kotlin's arm as written fails
 twenty-two tests in this port.** That is the phase's finding stated as a number.
+
+The last three were added after the implementation audit, and the second of
+them is a correction rather than an addition: the voices assertion it replaced
+**could not fail**, and my own eighteen mutations had not caught that because
+un-arming the uploader still killed the *other* assertions in the same test.
+**A test being killed by a mutation does not mean every assertion in it can
+fail.** Mutate toward the specific clause, not just the feature.
+
+### A trap in the mutation harness itself, worth writing down
+
+The harness reverts with `git checkout -- lib/` between mutations. Run against
+an **uncommitted** fix, that silently reverts the fix. It happened here: the
+hoist, the health rationale and the `documentUrlUnder` dartdoc were all undone
+by a later mutation's cleanup, and the only reason it surfaced was the full
+gate going red on a test whose assertion had just been made stricter. Had that
+assertion not existed, three shipped corrections would have quietly not
+shipped, with a green suite and a commit message describing them.
+
+**Commit before mutating.** This is the same shape CLAUDE.md already records
+for an audit subagent leaving reverts in the working tree (Phase 135) — the
+tree is shared with whatever you spawn *and* with your own tooling, and
+`git status` after a mutation run is not a formality.

--- a/flutter/lib/repository/achievements_uploader.dart
+++ b/flutter/lib/repository/achievements_uploader.dart
@@ -62,10 +62,19 @@ class AchievementsUploader {
     if (couchId is! String || couchId.isEmpty) {
       return const NetworkError(null, 'Achievement ledger carried no _id');
     }
-    final result = await _api.putJsonObject(
-      '${row.endpoint}/achievements/$couchId',
-      payload,
+    // The 409 arm. The ledger is PUT to its own id, so the request *is* the
+    // document URL and no derivation is needed. A conflict here is a second
+    // device editing the same user's ledger; re-sending under the fetched
+    // revision delivers this device's entries rather than adopting the other
+    // one's and reporting success. See [ConflictRecovery].
+    final documentUrl = '${row.endpoint}/achievements/$couchId';
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: documentUrl,
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.putJsonObject(documentUrl, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final rev = data['rev'];

--- a/flutter/lib/repository/adopted_surveys_uploader.dart
+++ b/flutter/lib/repository/adopted_surveys_uploader.dart
@@ -151,10 +151,37 @@ class AdoptedSurveysUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm, which this uploader had first and now shares.
+    //
+    // **The port needs it more than Kotlin does, because its clone id is
+    // deterministic.** Kotlin mints one with `UUID.randomUUID()`
+    // (`SurveysRepositoryImpl.kt:86`), so two leaders adopting the same survey
+    // for the same team write two documents; the port's `'${surveyId}_$teamId'`
+    // (`surveys_repository.dart:105`) converges on one, which is better — but
+    // it makes a conflict ordinary rather than freakish, since neither leader
+    // has synced yet and `adoptedTeamSurvey` can only dedupe locally.
+    //
+    // Without recovery the loser is permanently stuck: the row is abandoned as
+    // a terminal refusal and **no later walk rescues it** — a mapper's
+    // companion leaves `needsSync` absent, and Drift's `insertOnConflictUpdate`
+    // writes only the columns present, so a re-pull hands the row a `rev` and
+    // leaves the flag set. Probed: `needsSync=true rev=1-winner`, still swept.
+    //
+    // This is the **only** uploader that sets `adoptExisting`, and the reason
+    // is a property of the content rather than of the verb: the clone is a
+    // pure function of the survey and the team, so the document already on the
+    // server *is* the document being sent, and taking its revision loses
+    // nothing. No other uploader in the port can make that claim, which is why
+    // a create-conflict stands as a refusal everywhere else — see
+    // [ConflictRecovery].
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: '${row.endpoint}/${Uri.encodeComponent(row.itemId)}',
+      payload: payload,
       authHeader: authHeader,
+      adoptExisting: true,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final couchId = data['id'];
@@ -182,62 +209,6 @@ class AdoptedSurveysUploader {
       }
       await _surveyDao.markUploaded(row.itemId, rev);
     }
-    if (result case NetworkError<Map<String, dynamic>>(
-      :final code,
-    ) when code == 409) {
-      return _adoptExistingDocument(row, authHeader, result);
-    }
     return result;
   };
-
-  /// Port of `UploadCoordinator`'s 409 arm (`UploadCoordinator.kt:169-204`):
-  /// GET the document that already exists, take its `_rev`, and report the
-  /// upload as the success it effectively was.
-  ///
-  /// **The port needs this more than Kotlin does, because its clone id is
-  /// deterministic.** Kotlin mints one with `UUID.randomUUID()`
-  /// (`SurveysRepositoryImpl.kt:86`), so two leaders adopting the same survey
-  /// for the same team write two documents; the port's
-  /// `'${surveyId}_$teamId'` (`surveys_repository.dart:105`) converges on one,
-  /// which is better — but it makes a conflict ordinary rather than freakish,
-  /// since neither leader has synced yet and `adoptedTeamSurvey` can only
-  /// dedupe locally.
-  ///
-  /// Without this the loser is permanently stuck: `OutboxDrainer` classifies
-  /// any `code < 500` as permanent (`outbox_drainer.dart:160-172`) so the row
-  /// is abandoned, and **a later walk does not rescue it** — a mapper's
-  /// companion leaves `needsSync` absent, and Drift's `insertOnConflictUpdate`
-  /// writes only the columns present, so the re-pull hands the row a `rev` and
-  /// leaves the flag set. Probed: `needsSync=true rev=1-winner`, still swept.
-  /// `OutboxDao.findOpen` ignores an `abandoned` row, so every sweep
-  /// thereafter inserts a fresh one and makes a fresh doomed POST, for the
-  /// life of the install, in a table schema bumps preserve.
-  ///
-  /// A GET that fails returns the original 409 rather than inventing success:
-  /// clearing the flag without a rev would drop the clone out of the prune
-  /// exemption while it is still, as far as this device knows, unpublished.
-  Future<NetworkResult<Map<String, dynamic>>> _adoptExistingDocument(
-    OutboxRow row,
-    String? authHeader,
-    NetworkResult<Map<String, dynamic>> conflict,
-  ) async {
-    final existing = await _api.getJsonObject(
-      '${row.endpoint}/${row.itemId}',
-      // The drain's credential, not none: `outbox.endpoint` is stored
-      // credential-free on purpose, so an unauthenticated read of a CouchDB
-      // document is a 401 and this recovery would never fire.
-      authHeader: authHeader,
-    );
-    if (existing case NetworkSuccess<Map<String, dynamic>>(:final data)) {
-      final rev = data['_rev'];
-      if (rev is String && rev.isNotEmpty) {
-        await _surveyDao.markUploaded(row.itemId, rev);
-        return NetworkSuccess<Map<String, dynamic>>({
-          'id': row.itemId,
-          'rev': rev,
-        });
-      }
-    }
-    return conflict;
-  }
 }

--- a/flutter/lib/repository/course_progress_uploader.dart
+++ b/flutter/lib/repository/course_progress_uploader.dart
@@ -52,16 +52,18 @@ class CourseProgressUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    // The 409 arm. A divergence from Kotlin worth noting: `serializeProgress` there emits no
-    // `_id` at all, so the Kotlin path can never conflict. The port's does.
-    // See [ConflictRecovery] for why a create stands as a refusal instead.
-    final result = await ConflictRecovery.send(
-      api: _api,
-      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
-      payload: payload,
+    // **Deliberately not armed**, and the reason is a reachability finding
+    // rather than a preference. `CourseProgressDao.getPendingUploads` is
+    // `couchId IS NULL`, so a row the server has acknowledged is never
+    // re-offered — which makes `_toDoc`'s `_id`/`_rev` branch dead on this
+    // path and a 409 unreachable. An arm here would be inert code claiming a
+    // recovery that cannot happen. See `PHASE_152_NOTES.md`; the dead branch
+    // is reported there too, because it means a progress row's later edits
+    // never upload at all.
+    final result = await _api.postJsonObject(
+      row.endpoint,
+      payload,
       authHeader: authHeader,
-      attempt: (body) =>
-          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final remoteId = data['id']?.toString();

--- a/flutter/lib/repository/course_progress_uploader.dart
+++ b/flutter/lib/repository/course_progress_uploader.dart
@@ -52,10 +52,16 @@ class CourseProgressUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm. A divergence from Kotlin worth noting: `serializeProgress` there emits no
+    // `_id` at all, so the Kotlin path can never conflict. The port's does.
+    // See [ConflictRecovery] for why a create stands as a refusal instead.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final remoteId = data['id']?.toString();

--- a/flutter/lib/repository/events_uploader.dart
+++ b/flutter/lib/repository/events_uploader.dart
@@ -52,10 +52,16 @@ class EventsUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm. An edited meetup is an update once `meetupId` is set; adopting would
+    // report the edit delivered.
+    // See [ConflictRecovery] for why a create stands as a refusal instead.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final couchId = data['id'];

--- a/flutter/lib/repository/feedback_uploader.dart
+++ b/flutter/lib/repository/feedback_uploader.dart
@@ -65,10 +65,16 @@ class FeedbackUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm: `FeedbackMapper.toDoc` sends a device-generated `_id` so a
+    // reply updates the thread rather than duplicating it, which also means a
+    // stale `_rev` conflicts. See [ConflictRecovery].
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final rev = data['rev'];

--- a/flutter/lib/repository/health_uploader.dart
+++ b/flutter/lib/repository/health_uploader.dart
@@ -61,10 +61,21 @@ class HealthUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm. This is the uploader that needs it most: the document id is
+    // the *patient's* user id, not the examination's, so a second examination
+    // for a patient the server already holds a document for conflicts by
+    // construction — and `HealthRepository.cacheDocuments` skips a locally
+    // dirty row (`health_repository.dart:772`), so no pull can ever supply the
+    // revision that would unstick it. Phase 148 could only stop the reading
+    // being re-POSTed for ever; this delivers it. See [ConflictRecovery] for
+    // why the arm re-sends rather than adopting as Kotlin does.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final rev = data['rev'];

--- a/flutter/lib/repository/health_uploader.dart
+++ b/flutter/lib/repository/health_uploader.dart
@@ -61,14 +61,27 @@ class HealthUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    // The 409 arm. This is the uploader that needs it most: the document id is
-    // the *patient's* user id, not the examination's, so a second examination
-    // for a patient the server already holds a document for conflicts by
-    // construction — and `HealthRepository.cacheDocuments` skips a locally
-    // dirty row (`health_repository.dart:772`), so no pull can ever supply the
-    // revision that would unstick it. Phase 148 could only stop the reading
-    // being re-POSTed for ever; this delivers it. See [ConflictRecovery] for
-    // why the arm re-sends rather than adopting as Kotlin does.
+    // The 409 arm, and this is the uploader that needs it most — though **not
+    // for the reason an earlier revision of this comment gave.** It said a
+    // second examination for the same patient conflicts by construction; it
+    // does not. `createExamination` defaults `userId` to the row's own
+    // generated id (`health_repository.dart:95-100`) and the one production
+    // caller passes none (`health_provider.dart:470`), so each examination is
+    // its own document. That is verbatim the claim `PHASE_148_NOTES.md` was
+    // written to retract, re-seeded here.
+    //
+    // What is keyed on the patient is the **profile blob**:
+    // `saveHealthProfileBlob` writes `id = patientId, userId = user.couchId`
+    // (`health_repository.dart:283-296`) and it is re-saved on every
+    // examination save, so its writes after the first are updates against a
+    // revision that can go stale. An edited examination is the other route.
+    //
+    // Health needs the arm most because it is the one uploader whose *pull*
+    // cannot supply the revision instead: `cacheDocuments` skips a locally
+    // dirty row (`health_repository.dart:772`), so the recovery route Phase
+    // 148 relies on — a pull changes the payload, the memo re-arms — is
+    // structurally unavailable here. Everywhere else it merely arrives a sync
+    // later. See [ConflictRecovery].
     final result = await ConflictRecovery.send(
       api: _api,
       documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -36,6 +36,116 @@ typedef OutboxHandler =
       String? authHeader,
     );
 
+/// The 409 arm: port of `UploadCoordinator.kt:169-204`, **corrected**.
+///
+/// Kotlin answers a conflict by GETting the document that already exists,
+/// adopting its `_rev` and reporting the upload as a **success** — it runs the
+/// same `afterUpload` callback the accepted path runs
+/// (`UploadCoordinator.kt:169-186`). Ported literally that is a data-loss bug
+/// for every uploader in this port but one, and the reason is worth stating
+/// before the mechanism.
+///
+/// **A 409 never means "your write is already there".** It means the document
+/// with this `_id` exists and the `_rev` you supplied — or the one you omitted
+/// — is not its current revision, so *your bytes were not stored*. Adopting
+/// the revision and reporting success marks the local row uploaded while the
+/// server holds somebody else's content. The examination's readings, the
+/// team document's edit, the achievement ledger: none of them ever leave the
+/// device, and the outbox row is deleted as delivered.
+///
+/// The one place adopting is equivalent is a document whose content is a pure
+/// function of shared inputs. `adopted_surveys_uploader.dart` is exactly that
+/// — the clone id is `'${surveyId}_$teamId'` and two leaders adopting the same
+/// survey for the same team author the *same* document — which is why the
+/// port's single existing arm is correct where a general one would not be.
+///
+/// So the rule this class implements is the one that subsumes Kotlin's without
+/// inheriting its loss: **GET the current revision and re-send the same
+/// content under it.** The write lands. Where the content was idempotent
+/// anyway the re-send is a harmless overwrite that yields the same `rev`
+/// adopting would have.
+///
+/// ### Why this does not weaken Phase 148's policy
+///
+/// That policy is: *an `outbox` item owns exactly one row, for ever; a
+/// terminal row is a memo, and nothing re-asks the identical question
+/// unattended. What re-arms it is a changed request.*
+///
+/// The re-send here **is** a changed request — it carries a `_rev` the first
+/// one did not, fetched from the server between the two. That is the recovery
+/// route the policy names, taken inline instead of waiting for a pull to
+/// supply the same revision. Three things keep it inside the policy rather
+/// than around it:
+///
+/// * **It is bounded.** One GET and at most one re-send per drain attempt,
+///   never a loop. A second 409 is returned as the refusal it is, and
+///   [OutboxRepository.classifyStatus] makes it terminal exactly as before.
+/// * **It never re-asks an identical question.** If the revision the server
+///   reports is the one already in the payload, the re-send is skipped and the
+///   original refusal is returned — there is nothing new to ask.
+/// * **It cannot duplicate a document.** The arm fires only for a request that
+///   names its own document, so the re-send is an update of that `_id`. An
+///   append with a server-minted id cannot 409 in the first place, which is
+///   why the eleven uploaders in that class are untouched and unaffected.
+///
+/// ### The trade it does make
+///
+/// Re-sending under the server's current revision is last-write-wins: a
+/// concurrent edit made on another device is overwritten. That is the port's
+/// existing stance everywhere else — `HealthRepository.cacheDocuments` skips a
+/// locally dirty row (`health_repository.dart:772`), so the local copy is
+/// already authoritative over the server's — and it is the better of the two
+/// available mistakes. The alternative loses the *local* edit, silently, in a
+/// queue whose entire purpose is delivering local writes; Kotlin's arm loses
+/// it and reports success as well.
+class ConflictRecovery {
+  const ConflictRecovery._();
+
+  /// Runs [attempt], and on a 409 fetches [documentUrl] and runs it once more
+  /// under the revision that comes back.
+  ///
+  /// [attempt] is the uploader's own send, passed as a closure so the verb,
+  /// the URL and any per-uploader decoration of the body stay where they
+  /// belong. Everything the recovery itself decides lives here, once.
+  ///
+  /// A GET that fails returns the **original** 409 rather than inventing a
+  /// verdict of its own — the same choice `adopted_surveys_uploader.dart`
+  /// made, and the same one Kotlin makes for a non-successful fetch
+  /// (`UploadCoordinator.kt:187-192`, `retryable = false`, `httpCode = 409`).
+  static Future<NetworkResult<Map<String, dynamic>>> send({
+    required PlanetApi api,
+    required String documentUrl,
+    required Map<String, dynamic> payload,
+    required Future<NetworkResult<Map<String, dynamic>>> Function(
+      Map<String, dynamic> body,
+    )
+    attempt,
+    String? authHeader,
+  }) async {
+    final first = await attempt(payload);
+    if (first is! NetworkError<Map<String, dynamic>> || first.code != 409) {
+      return first;
+    }
+
+    // The drain's credential, not none: `outbox.endpoint` is stored
+    // credential-free on purpose, so an unauthenticated read of a CouchDB
+    // document is a 401 and this recovery would never fire.
+    final existing = await api.getJsonObject(
+      documentUrl,
+      authHeader: authHeader,
+    );
+    if (existing is! NetworkSuccess<Map<String, dynamic>>) return first;
+
+    final rev = existing.data['_rev'];
+    if (rev is! String || rev.isEmpty) return first;
+    // Nothing new to ask. Re-sending the bytes the server has just refused is
+    // precisely what Phase 148's memo exists to stop.
+    if (rev == payload['_rev']) return first;
+
+    return attempt({...payload, '_rev': rev});
+  }
+}
+
 /// Replaces `services/retry/RetryQueueWorker.kt`.
 ///
 /// The queue remains SQLite-backed and therefore survives process death.

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -36,34 +36,50 @@ typedef OutboxHandler =
       String? authHeader,
     );
 
-/// The 409 arm: port of `UploadCoordinator.kt:169-204`, **corrected**.
+/// The 409 arm: port of `UploadCoordinator.kt:169-204`, **split in two**.
 ///
 /// Kotlin answers a conflict by GETting the document that already exists,
-/// adopting its `_rev` and reporting the upload as a **success** — it runs the
-/// same `afterUpload` callback the accepted path runs
-/// (`UploadCoordinator.kt:169-186`). Ported literally that is a data-loss bug
-/// for every uploader in this port but one, and the reason is worth stating
-/// before the mechanism.
+/// adopting its `_rev` and reporting the upload as a **success** — the
+/// recovered item joins `succeeded`, so `updateDatabaseBatch` runs the
+/// config's `markUploaded` exactly as an accepted write would
+/// (`UploadCoordinator.kt:169-204`, `:241-257`). It never compares the
+/// document it fetched with the one it was sending, and that is the half a
+/// port cannot take on trust.
 ///
-/// **A 409 never means "your write is already there".** It means the document
-/// with this `_id` exists and the `_rev` you supplied — or the one you omitted
-/// — is not its current revision, so *your bytes were not stored*. Adopting
-/// the revision and reporting success marks the local row uploaded while the
-/// server holds somebody else's content. The examination's readings, the
-/// team document's edit, the achievement ledger: none of them ever leave the
-/// device, and the outbox row is deleted as delivered.
+/// **A 409 does not mean "your write is already there".** It means a document
+/// with this `_id` exists and the `_rev` supplied — or omitted — is not its
+/// current revision, so *these bytes were not stored*. Whether adopting is
+/// harmless therefore depends on something Kotlin never asks: is the document
+/// already on the server the document being sent?
 ///
-/// The one place adopting is equivalent is a document whose content is a pure
-/// function of shared inputs. `adopted_surveys_uploader.dart` is exactly that
-/// — the clone id is `'${surveyId}_$teamId'` and two leaders adopting the same
-/// survey for the same team author the *same* document — which is why the
-/// port's single existing arm is correct where a general one would not be.
+/// The payload answers it well enough to act on, and the two answers need
+/// opposite treatment:
 ///
-/// So the rule this class implements is the one that subsumes Kotlin's without
-/// inheriting its loss: **GET the current revision and re-send the same
-/// content under it.** The write lands. Where the content was idempotent
-/// anyway the re-send is a harmless overwrite that yields the same `rev`
-/// adopting would have.
+/// * **An update** — the payload carries a `_rev`, so this device has
+///   published this document before and is sending a change to it. The 409
+///   says that revision is stale. Adopting would clear the dirty flag with the
+///   change still on the handset: the learner's added answers, the clinician's
+///   edited profile, the achievement entry. So an update is **re-sent under
+///   the revision the GET reports**. The write lands.
+/// * **A create** — no `_rev`, so as far as this device knows the document has
+///   never been published, and the one on the server is content it has never
+///   seen. Re-sending would overwrite that; adopting would report a delivery
+///   that did not happen. Neither is safe in general, so the default is
+///   **neither**: the refusal stands, terminal, and `OutboxDao.abandoned`
+///   keeps reporting the row as stranded — which is the honest answer.
+///   [adoptExisting] is the opt-in for the one uploader that can prove the
+///   question away.
+///
+/// ### Where this sits relative to Kotlin
+///
+/// Only six of the port's twenty uploaders have a Kotlin counterpart that runs
+/// through `UploadCoordinator` at all. Kotlin's own health, achievements, news
+/// and teams paths swallow a 409 in silence
+/// (`HealthRepositoryImpl.kt:110-124`, `AchievementUploader.kt:32-42`,
+/// `UploadManager.kt:369-372`, `TeamsUploader.kt:73-75`), and
+/// `RetryQueueWorker.kt:234-238` discards the edit with a success log. So for
+/// most uploaders here this is **new behaviour, not restored parity**, and the
+/// update arm has no Kotlin precedent anywhere.
 ///
 /// ### Why this does not weaken Phase 148's policy
 ///
@@ -71,8 +87,8 @@ typedef OutboxHandler =
 /// terminal row is a memo, and nothing re-asks the identical question
 /// unattended. What re-arms it is a changed request.*
 ///
-/// The re-send here **is** a changed request — it carries a `_rev` the first
-/// one did not, fetched from the server between the two. That is the recovery
+/// The re-send **is** a changed request — it carries a `_rev` the first one
+/// did not, fetched from the server between the two. That is the recovery
 /// route the policy names, taken inline instead of waiting for a pull to
 /// supply the same revision. Three things keep it inside the policy rather
 /// than around it:
@@ -82,50 +98,100 @@ typedef OutboxHandler =
 ///   [OutboxRepository.classifyStatus] makes it terminal exactly as before.
 /// * **It never re-asks an identical question.** If the revision the server
 ///   reports is the one already in the payload, the re-send is skipped and the
-///   original refusal is returned — there is nothing new to ask.
+///   original refusal stands — there is nothing new to ask.
 /// * **It cannot duplicate a document.** The arm fires only for a request that
-///   names its own document, so the re-send is an update of that `_id`. An
+///   names its own document, so a re-send is an update of that `_id`. An
 ///   append with a server-minted id cannot 409 in the first place, which is
-///   why the eleven uploaders in that class are untouched and unaffected.
+///   why the eight uploaders in that class are deliberately not armed —
+///   see [documentUrlUnder].
 ///
-/// ### The trade it does make
+/// ### The trade the update arm makes
 ///
 /// Re-sending under the server's current revision is last-write-wins: a
 /// concurrent edit made on another device is overwritten. That is the port's
-/// existing stance everywhere else — `HealthRepository.cacheDocuments` skips a
+/// existing stance elsewhere — `HealthRepository.cacheDocuments` skips a
 /// locally dirty row (`health_repository.dart:772`), so the local copy is
 /// already authoritative over the server's — and it is the better of the two
-/// available mistakes. The alternative loses the *local* edit, silently, in a
-/// queue whose entire purpose is delivering local writes; Kotlin's arm loses
-/// it and reports success as well.
+/// available mistakes, because the alternative loses the *local* edit silently
+/// in a queue whose whole purpose is delivering local writes.
+///
+/// **One case deserves naming rather than falling out of the rule.** A team
+/// tombstone is `{_id, _rev, _deleted: true}` (`teams_provider.dart:295`), so
+/// it is an update and re-sending deletes a document whose latest content this
+/// device has never seen. That is accepted deliberately: the user asked for
+/// the membership to be removed, and a revision bump from another device does
+/// not revoke that instruction. The alternative — adopting — would report the
+/// delete as done while the document is still on the server *and* hand the row
+/// back to `deleteNotIn`.
 class ConflictRecovery {
   const ConflictRecovery._();
 
-  /// Runs [attempt], and on a 409 fetches [documentUrl] and runs it once more
-  /// under the revision that comes back.
+  /// Where CouchDB keeps the document [payload] names, given the URL the write
+  /// was sent to.
+  ///
+  /// Null when the payload names no document, which is the guard that keeps
+  /// the arm off appends — see [send].
+  ///
+  /// **The id is the payload's, not the outbox row's**, and conflating the two
+  /// is the trap here. `outbox.itemId` is the *local* row's key; the CouchDB
+  /// `_id` is whatever the serializer chose, and for health those are
+  /// different values — the row's key is the examination's, while
+  /// `HealthRepository.serialize` writes the **patient's** user id as `_id`
+  /// (`health_repository.dart:845-849`). A recovery keyed on `itemId` would
+  /// GET a document that does not exist, take the 404, and quietly return the
+  /// original conflict for ever.
+  static String? documentUrlUnder(
+    String sendUrl,
+    Map<String, dynamic> payload,
+  ) {
+    final id = payload['_id'];
+    if (id is! String || id.isEmpty) return null;
+    return '$sendUrl/${Uri.encodeComponent(id)}';
+  }
+
+  /// Runs [attempt], and on a 409 decides between re-sending and standing
+  /// down, per the class docs.
   ///
   /// [attempt] is the uploader's own send, passed as a closure so the verb,
   /// the URL and any per-uploader decoration of the body stay where they
-  /// belong. Everything the recovery itself decides lives here, once.
+  /// belong. Everything the recovery itself decides lives here, once — and
+  /// because a recovered result comes back through this method's return, the
+  /// handler's existing `if (result case NetworkSuccess…)` branch runs on it
+  /// unchanged. No uploader duplicates its own `markUploaded`, and none can
+  /// forget to run it.
+  ///
+  /// [adoptExisting] opts one uploader into Kotlin's original semantics for a
+  /// **create**: fetch the revision and report success without sending
+  /// anything. It is sound only where the document already on the server is
+  /// necessarily the document being sent, which is a property of the content,
+  /// not of the verb. `adopted_surveys_uploader.dart` has it — a team's clone
+  /// is a pure function of the survey and the team, and its id
+  /// (`'${surveyId}_$teamId'`) makes two leaders author the same document.
+  /// Nothing else in the port can make that claim, so nothing else sets it.
   ///
   /// A GET that fails returns the **original** 409 rather than inventing a
-  /// verdict of its own — the same choice `adopted_surveys_uploader.dart`
-  /// made, and the same one Kotlin makes for a non-successful fetch
-  /// (`UploadCoordinator.kt:187-192`, `retryable = false`, `httpCode = 409`).
+  /// verdict of its own — the same choice Kotlin makes for a non-successful
+  /// fetch (`UploadCoordinator.kt:185-192`).
   static Future<NetworkResult<Map<String, dynamic>>> send({
     required PlanetApi api,
-    required String documentUrl,
+    required String? documentUrl,
     required Map<String, dynamic> payload,
     required Future<NetworkResult<Map<String, dynamic>>> Function(
       Map<String, dynamic> body,
     )
     attempt,
     String? authHeader,
+    bool adoptExisting = false,
   }) async {
     final first = await attempt(payload);
     if (first is! NetworkError<Map<String, dynamic>> || first.code != 409) {
       return first;
     }
+    // A request that does not name its own document cannot be recovered and
+    // must not be: without an `_id` the re-send would be an append, and a
+    // second copy of a document with a server-minted id is undetectable
+    // afterwards. [documentUrlUnder] returns null for exactly that case.
+    if (documentUrl == null) return first;
 
     // The drain's credential, not none: `outbox.endpoint` is stored
     // credential-free on purpose, so an unauthenticated read of a CouchDB
@@ -138,9 +204,21 @@ class ConflictRecovery {
 
     final rev = existing.data['_rev'];
     if (rev is! String || rev.isEmpty) return first;
-    // Nothing new to ask. Re-sending the bytes the server has just refused is
+
+    final sentRev = payload['_rev'];
+    final isUpdate = sentRev is String && sentRev.isNotEmpty;
+    if (!isUpdate) {
+      if (!adoptExisting) return first;
+      // Kotlin's arm, shaped like the create response the handler expects: it
+      // reads `id`/`rev` from a write, while a document read carries `_id` and
+      // `_rev` (`UploadCoordinator.kt:177-182` does the same translation).
+      final id = existing.data['_id'] ?? payload['_id'];
+      return NetworkSuccess<Map<String, dynamic>>({'id': id, 'rev': rev});
+    }
+
+    // Nothing new to ask. Re-sending bytes the server has just refused is
     // precisely what Phase 148's memo exists to stop.
-    if (rev == payload['_rev']) return first;
+    if (rev == sentRev) return first;
 
     return attempt({...payload, '_rev': rev});
   }

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -196,10 +196,25 @@ class ConflictRecovery {
     // The drain's credential, not none: `outbox.endpoint` is stored
     // credential-free on purpose, so an unauthenticated read of a CouchDB
     // document is a 401 and this recovery would never fire.
-    final existing = await api.getJsonObject(
-      documentUrl,
-      authHeader: authHeader,
-    );
+    //
+    // The `try` is load-bearing rather than defensive, and it is the one part
+    // of this class that exists to protect Phase 148's policy rather than to
+    // extend it. `OutboxDrainer._send` wraps a handler in a catch-all and
+    // treats a throw as **transient** — correctly, since a throw is not
+    // evidence the server refused anything. But the server *has* refused
+    // something here: the 409 is already in hand. Letting a failed recovery
+    // throw out of the handler would relabel a terminal rejection as a
+    // retryable failure, and the row would be re-offered on every sweep until
+    // its attempts ran out — the accretion Phase 148 removed, re-entering
+    // through the recovery arm. `PlanetApi` returns a `NetworkException`
+    // rather than throwing, so this is not reachable through it; a fake or a
+    // future transport that throws would reach it.
+    final NetworkResult<Map<String, dynamic>> existing;
+    try {
+      existing = await api.getJsonObject(documentUrl, authHeader: authHeader);
+    } catch (_) {
+      return first;
+    }
     if (existing is! NetworkSuccess<Map<String, dynamic>>) return first;
 
     final rev = existing.data['_rev'];

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -72,14 +72,33 @@ typedef OutboxHandler =
 ///
 /// ### Where this sits relative to Kotlin
 ///
-/// Only six of the port's twenty uploaders have a Kotlin counterpart that runs
-/// through `UploadCoordinator` at all. Kotlin's own health, achievements, news
-/// and teams paths swallow a 409 in silence
-/// (`HealthRepositoryImpl.kt:110-124`, `AchievementUploader.kt:32-42`,
-/// `UploadManager.kt:369-372`, `TeamsUploader.kt:73-75`), and
-/// `RetryQueueWorker.kt:234-238` discards the edit with a success log. So for
-/// most uploaders here this is **new behaviour, not restored parity**, and the
-/// update arm has no Kotlin precedent anywhere.
+/// **Six of the eleven uploaders armed here** have a Kotlin counterpart that
+/// runs through `UploadCoordinator` — `feedback`, `adopted_surveys` (`exams`),
+/// `submissions`, `events` (`meetups`), `team_tasks` (`tasks`) and `ratings`.
+/// The other five (`health`, `teams`, `achievements`, `user`, `voices`) have
+/// no config in `UploadConfigs.kt` at all, so for them this is **new
+/// behaviour, not restored parity** — and the *update* arm has no Kotlin
+/// precedent anywhere.
+///
+/// (Across all twenty port uploader files about eleven do have a coordinator
+/// counterpart, the append uploaders included. An earlier revision said "only
+/// six of twenty", which is the armed count wearing the wrong denominator and
+/// tells a reader the activity, search and photo uploaders have no
+/// counterpart — backwards.)
+///
+/// Where Kotlin does meet a 409 outside the coordinator it mishandles it, but
+/// not uniformly, and the difference is worth keeping straight:
+/// `HealthRepositoryImpl.kt:110-124` and `AchievementUploader.kt:32-42` do
+/// swallow it silently (a 409 body is null, so `has("id")` is false; and an
+/// `if (response.isSuccessful)` with no `else`). `TeamsUploader.kt:73-75`
+/// drops it too, though at `queueTeamRetry:118-119` — the bulk response's
+/// `httpCode` is 200, so `retryable` is false and it is never queued.
+/// **News is different, and an earlier revision had it wrong**:
+/// `UploadManager.kt:369-372` passes a non-null exception, and
+/// `queueNewsRetry`'s rule is `exception != null || httpCode >= 500`, so a
+/// per-doc conflict *is* queued — then discarded by
+/// `RetryQueueWorker.kt:234-238`, which deletes the queue row on a 409 and
+/// logs success. Queued-then-thrown-away, not swallowed.
 ///
 /// ### Why this does not weaken Phase 148's policy
 ///
@@ -96,24 +115,66 @@ typedef OutboxHandler =
 /// * **It is bounded.** One GET and at most one re-send per drain attempt,
 ///   never a loop. A second 409 is returned as the refusal it is, and
 ///   [OutboxRepository.classifyStatus] makes it terminal exactly as before.
+///
+///   Be precise about what that does *not* say: only a second **409** is
+///   terminal. If the re-send answers a 5xx, a transport failure or a throw,
+///   that is what the drainer classifies, and it is `transient` — so the item
+///   is retried, and because the *stored* payload still holds the stale
+///   `_rev`, each of the five attempts repeats POST → GET → POST. Up to
+///   fifteen requests for one write before it is abandoned. That is
+///   deliberate rather than an oversight, and it is why the re-send is *not*
+///   wrapped the way the fetch is: after a failed fetch a definitive 409 is
+///   still in hand, but after a failed re-send the last thing the server said
+///   was "unavailable", not "refused" — and a write the server never answered
+///   is exactly what `transient` is for. The cost is bounded requests; the
+///   alternative is stranding a deliverable write on a server hiccup.
 /// * **It never re-asks an identical question.** If the revision the server
 ///   reports is the one already in the payload, the re-send is skipped and the
 ///   original refusal stands — there is nothing new to ask.
-/// * **It cannot duplicate a document.** The arm fires only for a request that
-///   names its own document, so a re-send is an update of that `_id`. An
-///   append with a server-minted id cannot 409 in the first place, which is
-///   why the eight uploaders in that class are deliberately not armed —
-///   see [documentUrlUnder].
+/// * **It cannot duplicate a document.** A re-send is an update of a named
+///   `_id`, and an append with a server-minted id cannot 409 in the first
+///   place, which is why the append uploaders are deliberately not armed.
+///   **But be clear what enforces that: a caller convention, not this class.**
+///   [documentUrlUnder] returns null when the payload names no document, so
+///   its eight callers are safe by construction — three build the URL by hand
+///   (`user`, `achievements`, `adopted_surveys`) and [send] does not check
+///   that `payload['_id']` exists when it is handed a `documentUrl`. `user` is
+///   safe because its verb is a PUT to a fixed document URL, not because of
+///   anything here. A future POST-verb uploader passing a hand-built URL with
+///   no `_id` in the body would re-send an append.
 ///
 /// ### The trade the update arm makes
 ///
 /// Re-sending under the server's current revision is last-write-wins: a
-/// concurrent edit made on another device is overwritten. That is the port's
-/// existing stance elsewhere — `HealthRepository.cacheDocuments` skips a
-/// locally dirty row (`health_repository.dart:772`), so the local copy is
-/// already authoritative over the server's — and it is the better of the two
-/// available mistakes, because the alternative loses the *local* edit silently
-/// in a queue whose whole purpose is delivering local writes.
+/// concurrent edit made on another device is overwritten.
+///
+/// **The justification an earlier revision gave for that was too narrow, and
+/// the correction matters.** It cited `HealthRepository.cacheDocuments`
+/// skipping a locally dirty row (`health_repository.dart:772`) as "the port's
+/// existing stance elsewhere". That mechanism is health-only — most sync-ins
+/// have no dirty-row guard at all and end `isUpdated: false`, making the
+/// *server* authoritative on the way in.
+///
+/// The real reason last-write-wins was already the port's outcome is Phase
+/// 148's own recovery route: **a sync-in that writes `rev` unconditionally
+/// re-arms the memo with a changed request.** A pull hands the row the
+/// server's revision, the next sweep's payload therefore differs from the
+/// refused one, the memo re-arms, and the local content goes over the
+/// server's anyway — one sync later. This arm changes the *latency* of that
+/// outcome, not the outcome. Health is the one uploader where the route is
+/// closed (hence the `cacheDocuments` citation, which belongs there and only
+/// there), which is why health needs the arm most.
+///
+/// **The exception, and it is a real one.** Where the server's document holds
+/// content the payload cannot reconstruct, "one sync later" is still a loss
+/// and this arm still makes it sooner. `feedback` is that case: `messages` is
+/// an append array both Planet's web UI and the handset write, and
+/// `FeedbackMapper.fromDoc:27-31` deliberately keeps the local array on a
+/// pending reply while taking the server's `rev`. So an admin reply present
+/// on the server and absent locally is destroyed by the next send — with or
+/// without this arm. That is a pre-existing merge defect, not one the arm
+/// introduces, and it is written up under *Reported, not fixed* in
+/// `PHASE_152_NOTES.md` rather than papered over here.
 ///
 /// **One case deserves naming rather than falling out of the rule.** A team
 /// tombstone is `{_id, _rev, _deleted: true}` (`teams_provider.dart:295`), so
@@ -134,12 +195,19 @@ class ConflictRecovery {
   ///
   /// **The id is the payload's, not the outbox row's**, and conflating the two
   /// is the trap here. `outbox.itemId` is the *local* row's key; the CouchDB
-  /// `_id` is whatever the serializer chose, and for health those are
-  /// different values — the row's key is the examination's, while
-  /// `HealthRepository.serialize` writes the **patient's** user id as `_id`
-  /// (`health_repository.dart:845-849`). A recovery keyed on `itemId` would
-  /// GET a document that does not exist, take the 404, and quietly return the
-  /// original conflict for ever.
+  /// `_id` is whatever the serializer chose. A recovery keyed on `itemId`
+  /// where they differ would GET a document that does not exist, take the
+  /// 404, and quietly return the original conflict for ever — green, and dead.
+  ///
+  /// The health **profile blob** is the concrete case: `saveHealthProfileBlob`
+  /// writes `id = patientId, userId = user.couchId`
+  /// (`health_repository.dart:283-296`) and `serialize` sends `userId` as
+  /// `_id` (`:845-849`), so the two differ whenever the patient's local id is
+  /// not their CouchDB id. Note the narrowness — for an *examination* they are
+  /// the **same** value, since `createExamination` defaults `userId` to the
+  /// row's own id. Six of the eleven candidate uploaders differ in their
+  /// reachable case; do not generalise from either direction, read the
+  /// serializer.
   static String? documentUrlUnder(
     String sendUrl,
     Map<String, dynamic> payload,
@@ -193,6 +261,15 @@ class ConflictRecovery {
     // afterwards. [documentUrlUnder] returns null for exactly that case.
     if (documentUrl == null) return first;
 
+    // Decided before the fetch, because for a create that cannot adopt the
+    // fetch cannot change the outcome — issuing it first spent one
+    // authenticated round-trip per create-conflict on the five uploaders whose
+    // payload always names an `_id` (`health`, `feedback`, `teams`,
+    // `achievements`, `user`) to learn a revision that was then discarded.
+    final sentRev = payload['_rev'];
+    final isUpdate = sentRev is String && sentRev.isNotEmpty;
+    if (!isUpdate && !adoptExisting) return first;
+
     // The drain's credential, not none: `outbox.endpoint` is stored
     // credential-free on purpose, so an unauthenticated read of a CouchDB
     // document is a 401 and this recovery would never fire.
@@ -220,10 +297,7 @@ class ConflictRecovery {
     final rev = existing.data['_rev'];
     if (rev is! String || rev.isEmpty) return first;
 
-    final sentRev = payload['_rev'];
-    final isUpdate = sentRev is String && sentRev.isNotEmpty;
     if (!isUpdate) {
-      if (!adoptExisting) return first;
       // Kotlin's arm, shaped like the create response the handler expects: it
       // reads `id`/`rev` from a write, while a document read carries `_id` and
       // `_rev` (`UploadCoordinator.kt:177-182` does the same translation).

--- a/flutter/lib/repository/ratings_uploader.dart
+++ b/flutter/lib/repository/ratings_uploader.dart
@@ -63,10 +63,16 @@ class RatingsUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm. The uploader records no revision of its own, so the `_rev` a rating
+    // carries is whatever the last pull said and goes stale readily.
+    // See [ConflictRecovery] for why a create stands as a refusal instead.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       if (data['rev'] is! String) {

--- a/flutter/lib/repository/submissions_uploader.dart
+++ b/flutter/lib/repository/submissions_uploader.dart
@@ -82,10 +82,17 @@ class SubmissionsUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm. An answer sheet edited after its first upload is an update, and
+    // adopting would clear `uploaded`/`isUpdated` with the learner's added
+    // answers still on the handset.
+    // See [ConflictRecovery] for why a create stands as a refusal instead.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final couchId = data['id'];

--- a/flutter/lib/repository/team_tasks_uploader.dart
+++ b/flutter/lib/repository/team_tasks_uploader.dart
@@ -48,10 +48,16 @@ class TeamTasksUploader {
   }
 
   OutboxHandler get handler => (row, payload, authHeader) async {
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      payload,
+    // The 409 arm. `pending()` is `isUpdated = true` unfiltered, so a rescheduled task that
+    // already has a `docId` is an ordinary update here.
+    // See [ConflictRecovery] for why a create stands as a refusal instead.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, payload),
+      payload: payload,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final id = data['id'];

--- a/flutter/lib/repository/teams_uploader.dart
+++ b/flutter/lib/repository/teams_uploader.dart
@@ -56,10 +56,18 @@ class TeamsUploader {
 
   OutboxHandler get handler => (row, payload, authHeader) async {
     final document = {...payload, ...(await _identity.read()).documentFields};
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      document,
+    // The 409 arm. A team document carries a device-generated `_id`, so a
+    // second device writing the same document — or a row whose local `rev`
+    // went stale — conflicts, and the edit would otherwise never leave the
+    // handset. See [ConflictRecovery] for why the arm re-sends rather than
+    // adopting the server's revision as Kotlin does.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, document),
+      payload: document,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       // A tombstone's subject was already deleted locally; there is no row

--- a/flutter/lib/repository/user_uploader.dart
+++ b/flutter/lib/repository/user_uploader.dart
@@ -157,10 +157,21 @@ class UserUploader {
       }
     }
 
-    final result = await _api.putJsonObject(
-      row.endpoint,
-      body,
+    // The 409 arm, which here closes a race this handler opens itself: the
+    // `_rev` above was fetched moments ago, so a conflict means another write
+    // landed in between and the profile edit — name, photo — would otherwise
+    // be dropped with `isUpdated` cleared. The `_users` endpoint *is* the
+    // document URL, so no id derivation is needed. A creation carries no
+    // `_rev` and so stands as a refusal, which is right: a 409 on a create
+    // here means the account already exists and this device has never
+    // published it.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: row.endpoint,
+      payload: body,
       authHeader: authHeader,
+      attempt: (sent) =>
+          _api.putJsonObject(row.endpoint, sent, authHeader: authHeader),
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       final id = data['id'];

--- a/flutter/lib/repository/voices_uploader.dart
+++ b/flutter/lib/repository/voices_uploader.dart
@@ -154,10 +154,20 @@ class VoicesUploader {
           NetworkError<Map<String, dynamic>>(null, failure.message);
     }
 
-    final result = await _api.postJsonObject(
-      row.endpoint,
-      document,
+    // The 409 arm. An edited post is an update once `docId` is set, and
+    // adopting would be worse here than anywhere else: `markUploaded` clears
+    // `imageUrls` and deletes the local image bytes
+    // (`voices_repository.dart:1053, 1062`), so the edit *and* the images
+    // would be unrecoverable while the server still shows the other device's
+    // text. Only the news document is armed — the image resource POSTs above
+    // are appends with server-minted ids and cannot conflict.
+    final result = await ConflictRecovery.send(
+      api: _api,
+      documentUrl: ConflictRecovery.documentUrlUnder(row.endpoint, document),
+      payload: document,
       authHeader: authHeader,
+      attempt: (body) =>
+          _api.postJsonObject(row.endpoint, body, authHeader: authHeader),
     );
 
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {

--- a/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
+++ b/flutter/test/data/local/survey_clone_survives_schema_bump_test.dart
@@ -281,7 +281,7 @@ void main() {
   /// nothing about.
   ///
   /// The document here is the one that reaches this handset in the two-leader
-  /// case `_adoptExistingDocument` exists for: another leader adopted the same
+  /// case the 409 recovery arm exists for: another leader adopted the same
   /// source for the same team and published first, so the walk delivers a
   /// document under the port's deterministic clone id while this device's own
   /// row is still pending.

--- a/flutter/test/repository/achievements_uploader_test.dart
+++ b/flutter/test/repository/achievements_uploader_test.dart
@@ -52,6 +52,12 @@ void main() {
     ).thenAnswer((_) async => result);
   }
 
+  /// Queues the pending ledger and returns the single outbox row it made.
+  Future<OutboxRow> queueAndTake() async {
+    await uploader.queuePending(config: config);
+    return (await outbox.due()).single;
+  }
+
   OutboxDrainer drainer() => OutboxDrainer(
     api,
     outbox,
@@ -86,6 +92,75 @@ void main() {
       expect(rows.single.endpoint, AchievementsUploader.endpointFor(config));
     },
   );
+
+  test('a conflicting ledger is re-sent under the server revision', () async {
+    // The ledger is PUT to `achievements/<couchId>`, one document per user, so
+    // a second device editing the same account conflicts. Adopting the
+    // server's revision — Kotlin's arm — would clear `uploaded` with this
+    // device's entries still on the handset.
+    await repository.update(
+      'ada@earth',
+      const AchievementInput(achievementsJson: '[{"title":"First"}]'),
+    );
+    await (database.update(
+      database.achievements,
+    )..where((a) => a.id.equals('ada@earth'))).write(
+      const AchievementsCompanion(
+        couchId: Value('couch-ada'),
+        rev: Value('1-stale'),
+        uploaded: Value(false),
+      ),
+    );
+
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () =>
+          api.putJsonObject(any(), any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '6-server'
+          ? const NetworkSuccess<Map<String, dynamic>>({
+              'id': 'couch-ada',
+              'rev': '7-r',
+            })
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => const NetworkSuccess<Map<String, dynamic>>({
+        '_id': 'couch-ada',
+        '_rev': '6-server',
+      }),
+    );
+
+    final row = (await outbox.due()).isEmpty
+        ? await queueAndTake()
+        : (await outbox.due()).single;
+    final payload = jsonDecode(row.payload) as Map<String, dynamic>;
+    final result = await uploader.handler(row, payload, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[1]['_rev'], '6-server');
+    expect(sent[1]['achievements'], sent[0]['achievements']);
+    final after = await database.achievementDao.getById('ada@earth');
+    expect(after?.rev, '7-r');
+    expect(after?.uploaded, isTrue);
+
+    // The ledger's own URL is fetched — the PUT target, not a derivation.
+    final url = verify(
+      () =>
+          api.getJsonObject(captureAny(), authHeader: any(named: 'authHeader')),
+    ).captured.single;
+    expect(
+      url,
+      '${AchievementsUploader.endpointFor(config)}/achievements/couch-ada',
+    );
+  });
 
   test(
     'handler PUTs the ledger, marks uploaded, and PUTs the resume bytes',

--- a/flutter/test/repository/adopted_surveys_uploader_test.dart
+++ b/flutter/test/repository/adopted_surveys_uploader_test.dart
@@ -1,0 +1,235 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/adopted_surveys_uploader.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
+
+import 'device_identity_fixture.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The 409 arm this uploader had first, and which Phase 152 moved into
+/// [ConflictRecovery] so every uploader shares it.
+///
+/// It had **no test coverage at all** before this file: the sweep tests drive
+/// `queuePending`, and the handler's conflict branch was reachable from
+/// nothing. That is why the conversion needed pinning rather than trusting.
+void main() {
+  late AppDatabase database;
+  late MockPlanetApi api;
+  late AdoptedSurveysUploader uploader;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+  const cloneId = 'survey-1_team-9';
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    api = MockPlanetApi();
+    registerFallbackValue(<String, dynamic>{});
+    uploader = AdoptedSurveysUploader(
+      api,
+      database.surveyDao,
+      OutboxRepository(database.outboxDao),
+      testDeviceIdentity,
+    );
+    await database.surveyDao.upsertAll([
+      SurveysCompanion.insert(
+        id: cloneId,
+        name: const Value('Water access'),
+        sourceSurveyId: const Value('survey-1'),
+        teamId: const Value('team-9'),
+        needsSync: const Value(true),
+      ),
+    ], const {});
+  });
+  tearDown(() => database.close());
+
+  OutboxRow rowFor(String itemId) => OutboxRow(
+    id: 'op-1',
+    uploadType: AdoptedSurveysUploader.type,
+    itemId: itemId,
+    payload: '{}',
+    endpoint: AdoptedSurveysUploader.endpointFor(config),
+    httpMethod: 'POST',
+    status: 'in_progress',
+    attemptCount: 0,
+    maxAttempts: 5,
+    createdAt: 0,
+    lastAttemptAt: 0,
+    nextAttemptAt: 0,
+  );
+
+  test('an accepted clone records its revision', () async {
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => const NetworkSuccess<Map<String, dynamic>>({
+        'id': cloneId,
+        'rev': '1-a',
+      }),
+    );
+
+    final result = await uploader.handler(rowFor(cloneId), const {
+      '_id': cloneId,
+    }, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    final row = await (database.select(
+      database.surveys,
+    )..where((s) => s.id.equals(cloneId))).getSingle();
+    expect(row.rev, '1-a');
+    expect(row.needsSync, isFalse);
+  });
+
+  test('the leader who loses the race still publishes the clone', () async {
+    // Two leaders adopt the same survey for the same team. The port's clone id
+    // is deterministic (`'${surveyId}_$teamId'`) where Kotlin's is a random
+    // UUID, so the second POST conflicts instead of writing a second document.
+    // Before the arm existed the loser's row was abandoned terminally, and no
+    // later walk could rescue it — a mapper's companion leaves `needsSync`
+    // absent, so a re-pull hands the row a `rev` and leaves the flag set.
+    //
+    // This is the one uploader that *adopts*: the clone's content is a pure
+    // function of the survey and the team, so the winner's document is the
+    // loser's document and taking its revision loses nothing. Note the single
+    // POST — no second write is made, which is what distinguishes this arm
+    // from the update arm every other uploader gets.
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      sent.add(
+        Map<String, dynamic>.from(
+          invocation.positionalArguments[1] as Map<String, dynamic>,
+        ),
+      );
+      return const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => const NetworkSuccess<Map<String, dynamic>>({
+        '_id': cloneId,
+        '_rev': '1-winner',
+      }),
+    );
+
+    final result = await uploader.handler(rowFor(cloneId), const {
+      '_id': cloneId,
+      'name': 'Water access',
+    }, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(1), reason: 'adopted, not re-sent');
+    final row = await (database.select(
+      database.surveys,
+    )..where((s) => s.id.equals(cloneId))).getSingle();
+    expect(row.rev, '1-winner');
+    // The flag is what keeps the clone out of `SurveyDao.deleteNotIn`'s reach
+    // once it is published; a stuck clone loses its members' answer sheets.
+    expect(row.needsSync, isFalse);
+
+    final url = verify(
+      () =>
+          api.getJsonObject(captureAny(), authHeader: any(named: 'authHeader')),
+    ).captured.single;
+    expect(url, endsWith('/exams/$cloneId'));
+  });
+
+  test('an edited clone is re-sent rather than adopted', () async {
+    // Once the clone has a revision the request is an *update*, and adopting
+    // would clear `needsSync` with this device's edit still on the handset.
+    // The update arm applies here as it does everywhere else — `adoptExisting`
+    // only changes what a create does.
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '3-server'
+          ? const NetworkSuccess<Map<String, dynamic>>({
+              'id': cloneId,
+              'rev': '4-b',
+            })
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => const NetworkSuccess<Map<String, dynamic>>({
+        '_id': cloneId,
+        '_rev': '3-server',
+      }),
+    );
+
+    final result = await uploader.handler(rowFor(cloneId), const {
+      '_id': cloneId,
+      '_rev': '2-stale',
+      'name': 'Water access, revised',
+    }, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[1]['name'], 'Water access, revised');
+    final row = await (database.select(
+      database.surveys,
+    )..where((s) => s.id.equals(cloneId))).getSingle();
+    expect(row.rev, '4-b');
+  });
+
+  test(
+    'a conflict the fetch cannot resolve leaves the clone unpublished',
+    () async {
+      // Clearing `needsSync` without a revision would drop the clone out of the
+      // prune exemption while it is still, as far as this device knows, unsent.
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async => const NetworkError<Map<String, dynamic>>(409, 'conflict'),
+      );
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => const NetworkError<Map<String, dynamic>>(500, 'boom'),
+      );
+
+      final result = await uploader.handler(rowFor(cloneId), const {
+        '_id': cloneId,
+      }, 'auth');
+
+      expect((result as NetworkError).code, 409);
+      final row = await (database.select(
+        database.surveys,
+      )..where((s) => s.id.equals(cloneId))).getSingle();
+      expect(row.needsSync, isTrue);
+      expect(row.rev, isNull);
+    },
+  );
+}

--- a/flutter/test/repository/conflict_recovery_test.dart
+++ b/flutter/test/repository/conflict_recovery_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/repository/outbox_drainer.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The 409 arm in isolation: `ConflictRecovery.send`.
+///
+/// The end-to-end consequences are pinned per uploader; these pin the rule
+/// itself, including the two guards that keep it inside Phase 148's policy.
+void main() {
+  late MockPlanetApi api;
+
+  const docUrl = 'https://planet.example.org/db/health/patient-1';
+  const conflict = NetworkError<Map<String, dynamic>>(409, 'conflict');
+
+  setUp(() => api = MockPlanetApi());
+
+  void stubGet(NetworkResult<Map<String, dynamic>> result) {
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((_) async => result);
+  }
+
+  /// Records every body handed to the send, so a test can assert both *how
+  /// many* requests were made and *what changed* between them.
+  ({
+    List<Map<String, dynamic>> sent,
+    Future<NetworkResult<Map<String, dynamic>>> Function(
+      Map<String, dynamic>,
+    )
+    attempt,
+  })
+  recorder(List<NetworkResult<Map<String, dynamic>>> answers) {
+    final sent = <Map<String, dynamic>>[];
+    var index = 0;
+    return (
+      sent: sent,
+      attempt: (body) async {
+        sent.add(Map<String, dynamic>.from(body));
+        return answers[index++ < answers.length ? index - 1 : answers.length - 1];
+      },
+    );
+  }
+
+  Future<NetworkResult<Map<String, dynamic>>> run(
+    ({
+      List<Map<String, dynamic>> sent,
+      Future<NetworkResult<Map<String, dynamic>>> Function(
+        Map<String, dynamic>,
+      )
+      attempt,
+    })
+    r, {
+    Map<String, dynamic> payload = const {'_id': 'patient-1', 'pulse': 70},
+  }) => ConflictRecovery.send(
+    api: api,
+    documentUrl: docUrl,
+    payload: payload,
+    attempt: r.attempt,
+    authHeader: 'Basic abc',
+  );
+
+  test('an accepted send never fetches anything', () async {
+    final r = recorder([const NetworkSuccess<Map<String, dynamic>>({'rev': '1-a'})]);
+
+    expect(await run(r), isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(r.sent, hasLength(1));
+    verifyNever(() => api.getJsonObject(any(), authHeader: any(named: 'authHeader')));
+  });
+
+  test('a refusal that is not a conflict is returned untouched', () async {
+    final r = recorder([const NetworkError<Map<String, dynamic>>(400, 'bad')]);
+
+    expect((await run(r) as NetworkError).code, 400);
+    expect(r.sent, hasLength(1));
+    verifyNever(() => api.getJsonObject(any(), authHeader: any(named: 'authHeader')));
+  });
+
+  test('a conflict re-sends the same content under the fetched revision', () async {
+    final r = recorder([
+      conflict,
+      const NetworkSuccess<Map<String, dynamic>>({'id': 'patient-1', 'rev': '8-b'}),
+    ]);
+    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+    final result = await run(r);
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect((result as NetworkSuccess).data['rev'], '8-b');
+    expect(r.sent, hasLength(2));
+    // The whole point: the *content* survives. Kotlin's arm would have marked
+    // this uploaded with the server's document still holding somebody else's
+    // reading.
+    expect(r.sent[1]['pulse'], 70);
+    expect(r.sent[1]['_rev'], '7-a', reason: 'the request changed');
+    expect(r.sent[0].containsKey('_rev'), isFalse);
+  });
+
+  test('the fetch carries the drain credential', () async {
+    final r = recorder([conflict, const NetworkSuccess<Map<String, dynamic>>({})]);
+    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+    await run(r);
+
+    final captured = verify(
+      () => api.getJsonObject(captureAny(), authHeader: captureAny(named: 'authHeader')),
+    ).captured;
+    expect(captured[0], docUrl);
+    expect(captured[1], 'Basic abc');
+  });
+
+  test('a stale revision already in the payload is not re-sent', () async {
+    // The guard that keeps this inside Phase 148's memo: the server reports
+    // the revision the request already carried, so there is nothing new to
+    // ask and the refusal stands.
+    final r = recorder([conflict]);
+    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+    final result = await run(r, payload: const {'_id': 'x', '_rev': '7-a'});
+
+    expect((result as NetworkError).code, 409);
+    expect(r.sent, hasLength(1), reason: 'no identical re-ask');
+  });
+
+  test('a failed fetch returns the original conflict, not a verdict of its own', () async {
+    final r = recorder([conflict]);
+    stubGet(const NetworkError<Map<String, dynamic>>(401, 'unauthorized'));
+
+    expect((await run(r) as NetworkError).code, 409);
+    expect(r.sent, hasLength(1));
+  });
+
+  test('a fetched document with no revision returns the original conflict', () async {
+    final r = recorder([conflict]);
+    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_id': 'patient-1'}));
+
+    expect((await run(r) as NetworkError).code, 409);
+    expect(r.sent, hasLength(1));
+  });
+
+  test('a second conflict is terminal — the arm does not loop', () async {
+    // Another writer raced in between. Two sends, no third, and the refusal
+    // classifies exactly as it did before this arm existed.
+    final r = recorder([conflict, conflict]);
+    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+    final result = await run(r);
+
+    expect((result as NetworkError).code, 409);
+    expect(r.sent, hasLength(2));
+  });
+}

--- a/flutter/test/repository/conflict_recovery_test.dart
+++ b/flutter/test/repository/conflict_recovery_test.dart
@@ -210,6 +210,13 @@ void main() {
 
       expect((result as NetworkError).code, 409);
       expect(r.sent, hasLength(1), reason: 'nothing is overwritten');
+      // And no document is fetched. The decision turns on `payload['_rev']`,
+      // which is known before any request, so fetching first would spend an
+      // authenticated round-trip to learn a revision that is then discarded —
+      // once per create-conflict on every uploader that does not adopt.
+      verifyNever(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      );
     });
 
     test(

--- a/flutter/test/repository/conflict_recovery_test.dart
+++ b/flutter/test/repository/conflict_recovery_test.dart
@@ -181,6 +181,20 @@ void main() {
     expect(r.sent, hasLength(2));
   });
 
+  test('a fetch that throws leaves the refusal terminal', () async {
+    // `OutboxDrainer._send` treats a throw as transient, so an unguarded
+    // recovery would relabel a rejection the server has already made as a
+    // retryable failure and re-offer the row on every sweep — Phase 148's
+    // accretion, re-entering through the recovery arm.
+    final r = recorder([conflict]);
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenThrow(StateError('transport blew up'));
+
+    expect((await run(r) as NetworkError).code, 409);
+    expect(r.sent, hasLength(1));
+  });
+
   group('a create conflict', () {
     const create = {'_id': 'patient-1', 'pulse': 70};
 

--- a/flutter/test/repository/conflict_recovery_test.dart
+++ b/flutter/test/repository/conflict_recovery_test.dart
@@ -28,9 +28,7 @@ void main() {
   /// many* requests were made and *what changed* between them.
   ({
     List<Map<String, dynamic>> sent,
-    Future<NetworkResult<Map<String, dynamic>>> Function(
-      Map<String, dynamic>,
-    )
+    Future<NetworkResult<Map<String, dynamic>>> Function(Map<String, dynamic>)
     attempt,
   })
   recorder(List<NetworkResult<Map<String, dynamic>>> answers) {
@@ -40,7 +38,9 @@ void main() {
       sent: sent,
       attempt: (body) async {
         sent.add(Map<String, dynamic>.from(body));
-        return answers[index++ < answers.length ? index - 1 : answers.length - 1];
+        return answers[index++ < answers.length
+            ? index - 1
+            : answers.length - 1];
       },
     );
   }
@@ -48,27 +48,35 @@ void main() {
   Future<NetworkResult<Map<String, dynamic>>> run(
     ({
       List<Map<String, dynamic>> sent,
-      Future<NetworkResult<Map<String, dynamic>>> Function(
-        Map<String, dynamic>,
-      )
+      Future<NetworkResult<Map<String, dynamic>>> Function(Map<String, dynamic>)
       attempt,
     })
     r, {
-    Map<String, dynamic> payload = const {'_id': 'patient-1', 'pulse': 70},
+    Map<String, dynamic> payload = const {
+      '_id': 'patient-1',
+      '_rev': '6-stale',
+      'pulse': 70,
+    },
+    bool adoptExisting = false,
   }) => ConflictRecovery.send(
     api: api,
     documentUrl: docUrl,
     payload: payload,
     attempt: r.attempt,
     authHeader: 'Basic abc',
+    adoptExisting: adoptExisting,
   );
 
   test('an accepted send never fetches anything', () async {
-    final r = recorder([const NetworkSuccess<Map<String, dynamic>>({'rev': '1-a'})]);
+    final r = recorder([
+      const NetworkSuccess<Map<String, dynamic>>({'rev': '1-a'}),
+    ]);
 
     expect(await run(r), isA<NetworkSuccess<Map<String, dynamic>>>());
     expect(r.sent, hasLength(1));
-    verifyNever(() => api.getJsonObject(any(), authHeader: any(named: 'authHeader')));
+    verifyNever(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    );
   });
 
   test('a refusal that is not a conflict is returned untouched', () async {
@@ -76,37 +84,51 @@ void main() {
 
     expect((await run(r) as NetworkError).code, 400);
     expect(r.sent, hasLength(1));
-    verifyNever(() => api.getJsonObject(any(), authHeader: any(named: 'authHeader')));
+    verifyNever(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    );
   });
 
-  test('a conflict re-sends the same content under the fetched revision', () async {
-    final r = recorder([
-      conflict,
-      const NetworkSuccess<Map<String, dynamic>>({'id': 'patient-1', 'rev': '8-b'}),
-    ]);
-    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+  test(
+    'a conflict re-sends the same content under the fetched revision',
+    () async {
+      final r = recorder([
+        conflict,
+        const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'patient-1',
+          'rev': '8-b',
+        }),
+      ]);
+      stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
 
-    final result = await run(r);
+      final result = await run(r);
 
-    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
-    expect((result as NetworkSuccess).data['rev'], '8-b');
-    expect(r.sent, hasLength(2));
-    // The whole point: the *content* survives. Kotlin's arm would have marked
-    // this uploaded with the server's document still holding somebody else's
-    // reading.
-    expect(r.sent[1]['pulse'], 70);
-    expect(r.sent[1]['_rev'], '7-a', reason: 'the request changed');
-    expect(r.sent[0].containsKey('_rev'), isFalse);
-  });
+      expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+      expect((result as NetworkSuccess).data['rev'], '8-b');
+      expect(r.sent, hasLength(2));
+      // The whole point: the *content* survives. Kotlin's arm would have marked
+      // this uploaded with the server's document still holding somebody else's
+      // reading.
+      expect(r.sent[1]['pulse'], 70);
+      expect(r.sent[1]['_rev'], '7-a', reason: 'the request changed');
+      expect(r.sent[0]['_rev'], '6-stale', reason: 'the stale one');
+    },
+  );
 
   test('the fetch carries the drain credential', () async {
-    final r = recorder([conflict, const NetworkSuccess<Map<String, dynamic>>({})]);
+    final r = recorder([
+      conflict,
+      const NetworkSuccess<Map<String, dynamic>>({}),
+    ]);
     stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
 
     await run(r);
 
     final captured = verify(
-      () => api.getJsonObject(captureAny(), authHeader: captureAny(named: 'authHeader')),
+      () => api.getJsonObject(
+        captureAny(),
+        authHeader: captureAny(named: 'authHeader'),
+      ),
     ).captured;
     expect(captured[0], docUrl);
     expect(captured[1], 'Basic abc');
@@ -125,21 +147,27 @@ void main() {
     expect(r.sent, hasLength(1), reason: 'no identical re-ask');
   });
 
-  test('a failed fetch returns the original conflict, not a verdict of its own', () async {
-    final r = recorder([conflict]);
-    stubGet(const NetworkError<Map<String, dynamic>>(401, 'unauthorized'));
+  test(
+    'a failed fetch returns the original conflict, not a verdict of its own',
+    () async {
+      final r = recorder([conflict]);
+      stubGet(const NetworkError<Map<String, dynamic>>(401, 'unauthorized'));
 
-    expect((await run(r) as NetworkError).code, 409);
-    expect(r.sent, hasLength(1));
-  });
+      expect((await run(r) as NetworkError).code, 409);
+      expect(r.sent, hasLength(1));
+    },
+  );
 
-  test('a fetched document with no revision returns the original conflict', () async {
-    final r = recorder([conflict]);
-    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_id': 'patient-1'}));
+  test(
+    'a fetched document with no revision returns the original conflict',
+    () async {
+      final r = recorder([conflict]);
+      stubGet(const NetworkSuccess<Map<String, dynamic>>({'_id': 'patient-1'}));
 
-    expect((await run(r) as NetworkError).code, 409);
-    expect(r.sent, hasLength(1));
-  });
+      expect((await run(r) as NetworkError).code, 409);
+      expect(r.sent, hasLength(1));
+    },
+  );
 
   test('a second conflict is terminal — the arm does not loop', () async {
     // Another writer raced in between. Two sends, no third, and the refusal
@@ -151,5 +179,120 @@ void main() {
 
     expect((result as NetworkError).code, 409);
     expect(r.sent, hasLength(2));
+  });
+
+  group('a create conflict', () {
+    const create = {'_id': 'patient-1', 'pulse': 70};
+
+    test('stands as a refusal by default', () async {
+      // No `_rev`, so as far as this device knows the document has never been
+      // published and the one on the server is content it has never seen.
+      // Re-sending would overwrite that; adopting would report a delivery that
+      // did not happen. The refusal stands and the row stays inspectable.
+      final r = recorder([conflict]);
+      stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+      final result = await run(r, payload: create);
+
+      expect((result as NetworkError).code, 409);
+      expect(r.sent, hasLength(1), reason: 'nothing is overwritten');
+    });
+
+    test(
+      'is adopted when the uploader can prove the content identical',
+      () async {
+        // Kotlin's original arm, kept for the one uploader whose document is a
+        // pure function of shared inputs. Shaped like the create response the
+        // handler expects: a write answers `id`/`rev`, a document read `_id`
+        // and `_rev`.
+        final r = recorder([conflict]);
+        stubGet(
+          const NetworkSuccess<Map<String, dynamic>>({
+            '_id': 'patient-1',
+            '_rev': '7-a',
+          }),
+        );
+
+        final result = await run(r, payload: create, adoptExisting: true);
+
+        expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+        expect((result as NetworkSuccess).data, {
+          'id': 'patient-1',
+          'rev': '7-a',
+        });
+        expect(r.sent, hasLength(1), reason: 'adopted, never re-sent');
+      },
+    );
+
+    test('adopting falls back to the id the payload named', () async {
+      final r = recorder([conflict]);
+      stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+      final result = await run(r, payload: create, adoptExisting: true);
+
+      expect((result as NetworkSuccess).data['id'], 'patient-1');
+    });
+  });
+
+  test('adoptExisting does not change what an update does', () async {
+    // The opt-in is about creates only. An update still re-sends, because
+    // adopting would clear the dirty flag with the edit still on the handset.
+    final r = recorder([
+      conflict,
+      const NetworkSuccess<Map<String, dynamic>>({'id': 'x', 'rev': '8-b'}),
+    ]);
+    stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+    await run(r, adoptExisting: true);
+
+    expect(r.sent, hasLength(2));
+    expect(r.sent[1]['pulse'], 70);
+  });
+
+  group('documentUrlUnder', () {
+    test('appends the payload id, encoded', () {
+      expect(
+        ConflictRecovery.documentUrlUnder('https://x/db/health', const {
+          '_id': 'user/one two',
+        }),
+        'https://x/db/health/user%2Fone%20two',
+      );
+    });
+
+    test('is null when the payload names no document', () {
+      expect(
+        ConflictRecovery.documentUrlUnder('https://x/db/health', const {}),
+        isNull,
+      );
+      expect(
+        ConflictRecovery.documentUrlUnder('https://x/db/health', const {
+          '_id': '',
+        }),
+        isNull,
+      );
+    });
+
+    test('an append is never recovered', () async {
+      // The structural guard against a duplicate: no `_id`, no recovery, and
+      // therefore no second send that CouchDB would file under a fresh id.
+      final r = recorder([conflict]);
+      stubGet(const NetworkSuccess<Map<String, dynamic>>({'_rev': '7-a'}));
+
+      final result = await ConflictRecovery.send(
+        api: api,
+        documentUrl: ConflictRecovery.documentUrlUnder(
+          'https://x/db/personals',
+          const {'title': 'A note'},
+        ),
+        payload: const {'title': 'A note'},
+        attempt: r.attempt,
+      );
+
+      expect((result as NetworkError).code, 409);
+      expect(r.sent, hasLength(1));
+      verifyNever(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      );
+    });
   });
 }

--- a/flutter/test/repository/course_progress_uploader_test.dart
+++ b/flutter/test/repository/course_progress_uploader_test.dart
@@ -74,6 +74,32 @@ void main() {
     expect(endpoint, endsWith('/courses_progress'));
   });
 
+  test('a progress row that reached the server is never re-offered', () async {
+    // Why `course_progress` is not armed with the 409 recovery arm: the
+    // pending predicate is `couchId IS NULL`
+    // (`CourseProgressDao.getPendingUploads`), so once a row is acknowledged
+    // it leaves the sweep for good. `_toDoc`'s `_id`/`_rev` branch is
+    // therefore dead on this path and no request it builds can conflict.
+    //
+    // That also means a later edit to an acknowledged progress row never
+    // uploads at all — reported in `PHASE_152_NOTES.md` rather than fixed
+    // here, because changing the predicate is a sync-semantics decision.
+    await database.courseProgressDao.upsert(
+      CourseProgressCompanion.insert(
+        id: 'progress-1',
+        courseId: const Value('course-1'),
+        userId: const Value('user-1'),
+        stepNum: const Value(1),
+        passed: const Value(true),
+        couchId: const Value('progress-couch'),
+        rev: const Value('1-stale'),
+      ),
+    );
+
+    expect(await uploader.queuePending(config: config), 0);
+    expect(await outbox.due(), isEmpty);
+  });
+
   test('queues only progress rows that have not reached the server', () async {
     await seedPending();
     // A row the server already acknowledged carries a `couchId` and is not

--- a/flutter/test/repository/events_uploader_test.dart
+++ b/flutter/test/repository/events_uploader_test.dart
@@ -77,6 +77,80 @@ void main() {
     expect(uploaded?.meetupIdRev, '1-abc');
   });
 
+  test('an edited meetup conflicting on its revision is re-sent', () async {
+    // Once `meetupId` is set the payload names its document
+    // (`events_repository.dart:245-247`), so a second edit against a revision
+    // another device has moved past is a 409. Adopting would report the edit
+    // delivered with it still on the handset.
+    await events.create(
+      title: 'Meetup',
+      description: 'First',
+      startDate: 0,
+      endDate: 0,
+      startTime: '',
+      endTime: '',
+      location: '',
+      link: '',
+      recurring: 'none',
+      creator: 'Ada',
+    );
+    final created = (await events.pendingUploads()).single;
+    await events.markUploaded(created.id, 'remote-1', '1-abc');
+    await events.update(
+      created.id,
+      title: 'Meetup',
+      description: 'Second',
+      startDate: 0,
+      endDate: 0,
+      startTime: '',
+      endTime: '',
+      location: '',
+      link: '',
+      recurring: 'none',
+    );
+
+    await uploader.queuePending(config: config, userId: 'user-1');
+    final operation = (await outbox.due()).single;
+    final payload = jsonDecode(operation.payload) as Map<String, dynamic>;
+    expect(payload['_id'], 'remote-1');
+    expect(payload['_rev'], '1-abc', reason: 'an update, not a create');
+
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '5-server'
+          ? NetworkSuccess<Map<String, dynamic>>({
+              'id': 'remote-1',
+              'rev': '6-z',
+            })
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        '_id': 'remote-1',
+        '_rev': '5-server',
+      }),
+    );
+
+    final result = await uploader.handler(operation, payload, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[1]['description'], 'Second');
+    expect((await events.getById(created.id))?.meetupIdRev, '6-z');
+  });
+
   test('queues an endpoint that carries no credentials', () async {
     // The endpoint is persisted in `outbox.endpoint`, and that table survives
     // schema upgrades, so a `satellite:PIN@` userinfo would leave the server

--- a/flutter/test/repository/feedback_uploader_test.dart
+++ b/flutter/test/repository/feedback_uploader_test.dart
@@ -93,6 +93,52 @@ void main() {
     expect(queued.map((row) => row.itemId), ['feedback-1']);
   });
 
+  test(
+    'a conflicting feedback document is re-sent under the server revision',
+    () async {
+      // `FeedbackMapper.toDoc` sends a device-generated `_id` deliberately, so a
+      // reply to an already-uploaded thread is an update rather than a duplicate
+      // — and an update against a stale `_rev` is a 409.
+      await seedPending();
+      final sent = <Map<String, dynamic>>[];
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((invocation) async {
+        final body = Map<String, dynamic>.from(
+          invocation.positionalArguments[1] as Map<String, dynamic>,
+        );
+        sent.add(body);
+        return body['_rev'] == '3-server'
+            ? NetworkSuccess<Map<String, dynamic>>({'rev': '4-d'})
+            : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+      });
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': 'feedback-1',
+          '_rev': '3-server',
+        }),
+      );
+
+      final result = await uploader.handler(rowFor('feedback-1'), const {
+        '_id': 'feedback-1',
+        '_rev': '2-stale',
+        'title': 'Sync fails offline',
+      }, 'auth');
+
+      expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+      expect(sent, hasLength(2));
+      expect(sent[1]['title'], 'Sync fails offline');
+      expect(sent[1]['_rev'], '3-server');
+      expect((await database.feedbackDao.getById('feedback-1'))?.rev, '4-d');
+    },
+  );
+
   test('a successful upload records the revision', () async {
     await seedPending();
     when(

--- a/flutter/test/repository/feedback_uploader_test.dart
+++ b/flutter/test/repository/feedback_uploader_test.dart
@@ -19,6 +19,7 @@ void main() {
   late MockPlanetApi api;
   late FeedbackUploader uploader;
   late OutboxRepository outbox;
+  late FeedbackRepositoryImpl repository;
 
   const config = ServerConfig(
     serverUrl: 'https://planet.example',
@@ -31,9 +32,13 @@ void main() {
     api = MockPlanetApi();
     registerFallbackValue(<String, dynamic>{});
     outbox = OutboxRepository(database.outboxDao);
+    repository = FeedbackRepositoryImpl(
+      feedbackDao: database.feedbackDao,
+      planetApi: api,
+    );
     uploader = FeedbackUploader(
       api,
-      FeedbackRepositoryImpl(feedbackDao: database.feedbackDao, planetApi: api),
+      repository,
       database.feedbackDao,
       outbox,
       testDeviceIdentity,
@@ -136,6 +141,133 @@ void main() {
       expect(sent[1]['title'], 'Sync fails offline');
       expect(sent[1]['_rev'], '3-server');
       expect((await database.feedbackDao.getById('feedback-1'))?.rev, '4-d');
+    },
+  );
+
+  test(
+    'a re-send drops a reply only the server has — pre-existing, not new',
+    () async {
+      // The trade the update arm makes, demonstrated rather than argued: the
+      // re-send carries the payload's own content, so anything the server has
+      // and the payload does not is overwritten.
+      //
+      // `feedback` is the one armed uploader where that is a *merge* loss rather
+      // than a revision bump — `messages` is an append array both Planet's web
+      // UI and the handset write. **And the loss is pre-existing.** The second
+      // half of this test is the proof: `FeedbackMapper.fromDoc` keeps the local
+      // array on a pending reply while taking the server's `rev`
+      // (`feedback_mapper.dart:27-31, 50-54`) and leaves `isUploaded = false`,
+      // so the next sweep's payload differs from the refused one, Phase 148's
+      // memo re-arms it, and the admin reply goes over the side one sync later
+      // with no recovery arm involved at all.
+      await seedPending();
+      await (database.update(
+        database.feedbackEntries,
+      )..where((f) => f.id.equals('feedback-1'))).write(
+        FeedbackEntriesCompanion(
+          rev: const Value('1-local'),
+          messages: Value(
+            jsonEncode([
+              {'message': 'mine'},
+            ]),
+          ),
+        ),
+      );
+
+      final sent = <Map<String, dynamic>>[];
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((invocation) async {
+        final body = Map<String, dynamic>.from(
+          invocation.positionalArguments[1] as Map<String, dynamic>,
+        );
+        sent.add(body);
+        return body['_rev'] == '2-admin'
+            ? NetworkSuccess<Map<String, dynamic>>({'rev': '3-x'})
+            : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+      });
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': 'feedback-1',
+          '_rev': '2-admin',
+          // The admin's reply, which this device has never seen.
+          'messages': [
+            {'message': 'mine'},
+            {'message': 'from the admin'},
+          ],
+        }),
+      );
+
+      await uploader.handler(rowFor('feedback-1'), {
+        '_id': 'feedback-1',
+        '_rev': '1-local',
+        'messages': [
+          {'message': 'mine'},
+        ],
+      }, 'auth');
+
+      // The re-send carries only this device's array. This is the documented
+      // trade, asserted so a future reader sees it rather than reading three
+      // paragraphs about it.
+      expect(sent, hasLength(2));
+      expect(sent[1]['messages'], [
+        {'message': 'mine'},
+      ]);
+    },
+  );
+
+  test(
+    'a pull already loses that reply, with no recovery arm involved',
+    () async {
+      // The proof that the loss above is **pre-existing**, and the reason it is
+      // reported rather than treated as something this phase introduced.
+      //
+      // `FeedbackMapper.fromDoc` keeps the local `messages` on a pending reply
+      // while taking the server's `rev` (`feedback_mapper.dart:27-31, 50-54`)
+      // and leaves `isUploaded = false`. So the admin's reply is gone locally
+      // the moment the pull lands, the row is still swept, and its payload now
+      // carries a revision the refused one did not — which is exactly what
+      // Phase 148's memo treats as a changed request. The next sweep sends the
+      // local array over the server's with no 409 and no arm in sight.
+      await seedPending();
+      await (database.update(
+        database.feedbackEntries,
+      )..where((f) => f.id.equals('feedback-1'))).write(
+        FeedbackEntriesCompanion(
+          rev: const Value('1-local'),
+          messages: Value(
+            jsonEncode([
+              {'message': 'mine'},
+            ]),
+          ),
+        ),
+      );
+
+      await repository.insertFromJson([
+        {
+          '_id': 'feedback-1',
+          '_rev': '9-admin',
+          'messages': [
+            {'message': 'mine'},
+            {'message': 'from the admin'},
+          ],
+        },
+      ]);
+
+      final pulled = await database.feedbackDao.getById('feedback-1');
+      expect(pulled!.rev, '9-admin', reason: "the server's revision is taken");
+      expect(pulled.isUploaded, isFalse, reason: 'so the row is still swept');
+      expect(
+        pulled.messages,
+        isNot(contains('from the admin')),
+        reason: 'the local array is kept, so the reply is already lost locally',
+      );
     },
   );
 

--- a/flutter/test/repository/health_legacy_conflict_test.dart
+++ b/flutter/test/repository/health_legacy_conflict_test.dart
@@ -7,6 +7,7 @@ import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/health_models.dart';
 import 'package:myplanet/repository/health_repository.dart';
 import 'package:myplanet/repository/health_uploader.dart';
 import 'package:myplanet/repository/outbox_drainer.dart';
@@ -279,6 +280,58 @@ void main() {
     );
   });
 
+  test('a stale profile revision is recovered instead of stranded', () async {
+    // Phase 152's headline, end to end through the real drain path.
+    //
+    // The profile blob is re-saved on every examination save under a stable
+    // `_id`, so once published its next write is an update — and
+    // `cacheDocuments` skips a locally dirty row
+    // (`health_repository.dart:772`), so nothing on the device can refresh
+    // the revision it carries. Before the recovery arm, a revision that went
+    // stale on another handset stranded every subsequent edit on this one,
+    // for the life of the install.
+    await repository.saveHealthProfileBlob(
+      patientId,
+      HealthRepository.initHealth(),
+    );
+    await queueAndDrain();
+    expect((await repository.getById(patientId))!.rev, isNotNull);
+
+    // Another clinician writes the same document, so this device's stored
+    // revision is now behind.
+    couch.documents[patientId] = {
+      ...couch.documents[patientId]!,
+      '_rev': '99-elsewhere',
+    };
+
+    // This device edits the profile again.
+    await repository.saveHealthProfileBlob(
+      patientId,
+      MyHealth(
+        profile: MyHealthProfile(emergencyContactName: 'Grace'),
+        userKey: HealthRepository.initHealth().userKey,
+        lastExamination: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+    final postsBefore = couch.postCount;
+
+    await queueAndDrain();
+
+    // One GET and one re-send: the edit is on the server, not merely
+    // reported as delivered.
+    expect(couch.getCount, 1);
+    expect(couch.postCount, postsBefore + 2);
+    expect(couch.documents[patientId]!['_rev'], isNot('99-elsewhere'));
+    final stored = await repository.getById(patientId);
+    expect(stored!.isUpdated, isFalse);
+    expect(stored.rev, couch.documents[patientId]!['_rev']);
+    // And the queue is empty — no memo, because nothing was refused.
+    expect(
+      await database.outboxDao.forItem(HealthUploader.type, patientId),
+      isEmpty,
+    );
+  });
+
   test('creatorId is serialized from profileId, as Kotlin does', () async {
     // `JsonUtils.addString(object, "creatorId", health.profileId)`
     // (`HealthExamination.kt:111`). The columns are equal for anything either
@@ -351,6 +404,21 @@ class _FakeCouchDb extends Mock implements PlanetApi {
       (invocation) async =>
           _post(invocation.positionalArguments[1] as Map<String, dynamic>),
     );
+    // The document read the 409 recovery arm makes. Without it the arm's
+    // fetch would throw and the tests below would pass because of
+    // `ConflictRecovery`'s guard rather than because a create-conflict stands
+    // as a refusal — which is the thing they are meant to pin.
+    when(
+      () => getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((invocation) async {
+      getCount++;
+      final url = invocation.positionalArguments[0] as String;
+      final id = Uri.decodeComponent(url.split('/').last);
+      final doc = documents[id];
+      return doc == null
+          ? const NetworkError(404, 'not_found')
+          : NetworkSuccess({'_id': id, ...doc});
+    });
   }
 
   final Map<String, Map<String, dynamic>> documents = {};
@@ -359,6 +427,10 @@ class _FakeCouchDb extends Mock implements PlanetApi {
   /// Every POST that reached this fake, so a test can assert that a refused
   /// request was not asked a second time.
   var postCount = 0;
+
+  /// Every document read, so a test can tell a recovery that was attempted
+  /// from one that never fired.
+  var getCount = 0;
 
   /// Answers an accepted write with `id` and no `rev` — the shape
   /// `HealthUploader`'s handler refuses to interpret.

--- a/flutter/test/repository/health_uploader_test.dart
+++ b/flutter/test/repository/health_uploader_test.dart
@@ -138,6 +138,91 @@ void main() {
     },
   );
 
+  test(
+    'a conflicting examination is re-sent under the server revision',
+    () async {
+      // The loop Phase 148 could only make *safe*. The `health` document id is
+      // the patient's user id (`HealthRepository.serialize`), so every
+      // examination for a patient the server already holds a document for
+      // POSTs into a 409 — and `cacheDocuments` skips a locally dirty row
+      // (`health_repository.dart:772`), so nothing on the device can ever
+      // learn the revision that would unstick it. Before the recovery arm the
+      // reading stayed on the handset for the life of the install.
+      final id = await repository.createExamination(
+        userId: 'user-1',
+        temperature: 36.5,
+        pulse: 70,
+        height: 170,
+        weight: 65,
+      );
+      // The reachable case, per the audit: the *profile* blob is re-saved on
+      // every examination save under a stable `_id`, so once it has been
+      // published its next write is an update — and `cacheDocuments` skips a
+      // locally dirty row (`health_repository.dart:772`), so the revision it
+      // carries is the one the last successful upload left and can go stale
+      // with nothing on the device able to refresh it.
+      await (database.update(database.healthExaminations)
+            ..where((h) => h.id.equals(id)))
+          .write(const HealthExaminationsCompanion(rev: Value('2-stale')));
+      final row = await repository.getById(id);
+      final payload = HealthRepository.serialize(row!);
+      expect(payload['_id'], 'user-1');
+      expect(payload['_rev'], '2-stale', reason: 'an update, not a create');
+
+      final sent = <Map<String, dynamic>>[];
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((invocation) async {
+        final body = Map<String, dynamic>.from(
+          invocation.positionalArguments[1] as Map<String, dynamic>,
+        );
+        sent.add(body);
+        return body['_rev'] == '7-a'
+            ? NetworkSuccess<Map<String, dynamic>>({
+                'id': 'user-1',
+                'rev': '8-b',
+              })
+            : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+      });
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': 'user-1',
+          '_rev': '7-a',
+        }),
+      );
+
+      final result = await uploader.handler(rowFor(id), payload, 'auth');
+
+      expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+      // The reading reached the server, rather than the server's `_rev` being
+      // adopted over a document that never carried it.
+      expect(sent, hasLength(2));
+      expect(sent[1]['pulse'], 70);
+      expect(sent[1]['_rev'], '7-a');
+      final after = await repository.getById(id);
+      expect(after!.rev, '8-b');
+      expect(after.isUpdated, isFalse);
+
+      // The document is fetched at the *patient's* id, not the examination
+      // row's — those are different values here, and keying on the row would
+      // GET a document that does not exist.
+      final url = verify(
+        () => api.getJsonObject(
+          captureAny(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).captured.single;
+      expect(url, endsWith('/health/user-1'));
+      expect(url, isNot(contains(id)));
+    },
+  );
+
   test('a response without a revision is not treated as uploaded', () async {
     final id = await repository.createExamination(
       userId: 'user-1',

--- a/flutter/test/repository/health_uploader_test.dart
+++ b/flutter/test/repository/health_uploader_test.dart
@@ -139,34 +139,45 @@ void main() {
   );
 
   test(
-    'a conflicting examination is re-sent under the server revision',
+    'a conflicting profile blob is re-sent under the server revision',
     () async {
-      // The loop Phase 148 could only make *safe*. The `health` document id is
-      // the patient's user id (`HealthRepository.serialize`), so every
-      // examination for a patient the server already holds a document for
-      // POSTs into a 409 — and `cacheDocuments` skips a locally dirty row
-      // (`health_repository.dart:772`), so nothing on the device can ever
-      // learn the revision that would unstick it. Before the recovery arm the
-      // reading stayed on the handset for the life of the install.
-      final id = await repository.createExamination(
-        userId: 'user-1',
-        temperature: 36.5,
-        pulse: 70,
-        height: 170,
-        weight: 65,
+      // **The reachable case, and not the one an earlier draft of this test
+      // claimed.** An *examination* cannot conflict with a previous one:
+      // `createExamination` defaults `userId` to the row's own generated id
+      // (`health_repository.dart:95-100`) and the only production caller passes
+      // none (`health_provider.dart:470`), so each examination is its own
+      // document. That is verbatim what `PHASE_148_NOTES.md` was written to
+      // retract, and this file had re-seeded it.
+      //
+      // What is keyed on the patient is the **profile blob**:
+      // `saveHealthProfileBlob` writes `id = patientId` and
+      // `userId = user.couchId` (`health_repository.dart:283-296`), it is
+      // re-saved on every examination save, and `serialize` sends `userId` as
+      // `_id`. So its `_id` differs from its row id *and* its next write after
+      // publication is an update — while `cacheDocuments` skips a locally dirty
+      // row (`health_repository.dart:772`), so no pull can refresh the revision
+      // it carries. Before the recovery arm that edit stayed on the handset for
+      // the life of the install.
+      await database.userDao.upsert(
+        UsersCompanion.insert(
+          id: 'patient-1',
+          name: const Value('bea'),
+          couchId: const Value('org.couchdb.user:bea'),
+        ),
       );
-      // The reachable case, per the audit: the *profile* blob is re-saved on
-      // every examination save under a stable `_id`, so once it has been
-      // published its next write is an update — and `cacheDocuments` skips a
-      // locally dirty row (`health_repository.dart:772`), so the revision it
-      // carries is the one the last successful upload left and can go stale
-      // with nothing on the device able to refresh it.
+      final row = await repository.saveHealthProfileBlob(
+        'patient-1',
+        HealthRepository.initHealth(),
+      );
       await (database.update(database.healthExaminations)
-            ..where((h) => h.id.equals(id)))
+            ..where((h) => h.id.equals(row!.id)))
           .write(const HealthExaminationsCompanion(rev: Value('2-stale')));
-      final row = await repository.getById(id);
-      final payload = HealthRepository.serialize(row!);
-      expect(payload['_id'], 'user-1');
+      final stored = await repository.getById('patient-1');
+      final payload = HealthRepository.serialize(stored!);
+      // The two ids differ — which is the whole reason the recovery URL must
+      // come from the payload rather than from `outbox.itemId`.
+      expect(stored.id, 'patient-1');
+      expect(payload['_id'], 'org.couchdb.user:bea');
       expect(payload['_rev'], '2-stale', reason: 'an update, not a create');
 
       final sent = <Map<String, dynamic>>[];
@@ -183,7 +194,7 @@ void main() {
         sent.add(body);
         return body['_rev'] == '7-a'
             ? NetworkSuccess<Map<String, dynamic>>({
-                'id': 'user-1',
+                'id': 'org.couchdb.user:bea',
                 'rev': '8-b',
               })
             : const NetworkError<Map<String, dynamic>>(409, 'conflict');
@@ -192,34 +203,38 @@ void main() {
         () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
       ).thenAnswer(
         (_) async => NetworkSuccess<Map<String, dynamic>>({
-          '_id': 'user-1',
+          '_id': 'org.couchdb.user:bea',
           '_rev': '7-a',
         }),
       );
 
-      final result = await uploader.handler(rowFor(id), payload, 'auth');
+      final result = await uploader.handler(
+        rowFor('patient-1'),
+        payload,
+        'auth',
+      );
 
       expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
-      // The reading reached the server, rather than the server's `_rev` being
-      // adopted over a document that never carried it.
+      // The profile reached the server, rather than the server's `_rev` being
+      // adopted over a document that never carried this device's edit.
       expect(sent, hasLength(2));
-      expect(sent[1]['pulse'], 70);
+      expect(sent[1]['data'], payload['data']);
       expect(sent[1]['_rev'], '7-a');
-      final after = await repository.getById(id);
+      final after = await repository.getById('patient-1');
       expect(after!.rev, '8-b');
       expect(after.isUpdated, isFalse);
 
-      // The document is fetched at the *patient's* id, not the examination
-      // row's — those are different values here, and keying on the row would
-      // GET a document that does not exist.
+      // Fetched at the *payload's* `_id`, not the row's. Keyed on the row this
+      // would GET a document that does not exist, take the 404, and quietly
+      // return the original conflict for ever.
       final url = verify(
         () => api.getJsonObject(
           captureAny(),
           authHeader: any(named: 'authHeader'),
         ),
       ).captured.single;
-      expect(url, endsWith('/health/user-1'));
-      expect(url, isNot(contains(id)));
+      expect(url, endsWith('/health/org.couchdb.user%3Abea'));
+      expect(url, isNot(contains('patient-1')));
     },
   );
 

--- a/flutter/test/repository/ratings_uploader_test.dart
+++ b/flutter/test/repository/ratings_uploader_test.dart
@@ -79,6 +79,62 @@ void main() {
     expect(endpoint, endsWith('/ratings'));
   });
 
+  test('a rating whose revision went stale is re-sent, not stranded', () async {
+    // A rating carries `_id`/`_rev` once a pull has supplied them
+    // (`ratings_uploader.dart:122-127`) — and the uploader records no
+    // revision of its own (`RatingDao.markUploaded` stores none), so the one
+    // it sends is whatever the last pull said and goes stale readily.
+    await database.ratingDao.upsert(
+      RatingsCompanion.insert(
+        id: 'rating-1',
+        time: DateTime.now().millisecondsSinceEpoch,
+        userId: 'user-1',
+        rate: 5,
+        item: 'resource-1',
+        type: 'resource',
+        couchId: const Value('rating-couch'),
+        rev: const Value('1-stale'),
+      ),
+    );
+    await uploader.queuePending(config: config);
+    final operation = (await outbox.due()).single;
+    final payload = jsonDecode(operation.payload) as Map<String, dynamic>;
+    expect(payload['_id'], 'rating-couch');
+    expect(payload['_rev'], '1-stale');
+
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '4-server'
+          ? NetworkSuccess<Map<String, dynamic>>({'rev': '5-e'})
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        '_id': 'rating-couch',
+        '_rev': '4-server',
+      }),
+    );
+
+    final result = await uploader.handler(operation, payload, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[1]['rate'], 5);
+    expect((await database.ratingDao.findById('rating-1'))?.isUpdated, isFalse);
+  });
+
   test('queues only ratings that have not reached the server', () async {
     await seedPendingRating();
     await database.ratingDao.upsert(

--- a/flutter/test/repository/submissions_uploader_test.dart
+++ b/flutter/test/repository/submissions_uploader_test.dart
@@ -43,6 +43,71 @@ void main() {
   });
   tearDown(() => db.close());
 
+  test(
+    'an edited answer sheet conflicting on its revision is re-sent',
+    () async {
+      // `pendingUploads` is `isUpdated = true`, so a sheet edited after its
+      // first upload is re-offered carrying `_id` and `_rev`
+      // (`submissions_repository.dart:1263-1264`). Adopting the server's
+      // revision would set `uploaded: true, isUpdated: false` with the answers
+      // the learner added still on the handset.
+      final id = await repository.createDraft(
+        userId: 'user-1',
+        type: 'exam',
+        title: 'Draft',
+        answers: const [],
+      );
+      await repository.markUploaded(id, 'sub-couch', '1-stale');
+      // The edit that re-offers it.
+      await (db.update(db.submissions)..where((r) => r.id.equals(id))).write(
+        const SubmissionsCompanion(isUpdated: Value(true)),
+      );
+
+      expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+      final operation = (await outbox.due()).single;
+      final payload = jsonDecode(operation.payload) as Map<String, dynamic>;
+      expect(payload['_id'], 'sub-couch');
+      expect(payload['_rev'], '1-stale');
+
+      final sent = <Map<String, dynamic>>[];
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((invocation) async {
+        final body = Map<String, dynamic>.from(
+          invocation.positionalArguments[1] as Map<String, dynamic>,
+        );
+        sent.add(body);
+        return body['_rev'] == '4-server'
+            ? NetworkSuccess<Map<String, dynamic>>({
+                'id': 'sub-couch',
+                'rev': '5-j',
+              })
+            : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+      });
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': 'sub-couch',
+          '_rev': '4-server',
+        }),
+      );
+
+      final result = await uploader.handler(operation, payload, 'auth');
+
+      expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+      expect(sent, hasLength(2));
+      expect(sent[1]['_rev'], '4-server');
+      final stored = await db.submissionDao.getById(id);
+      expect(stored?.rev, '5-j');
+      expect(stored?.isUpdated, isFalse);
+    },
+  );
+
   test('queues a draft once and adopts CouchDB ids after upload', () async {
     final id = await repository.createDraft(
       userId: 'user-1',

--- a/flutter/test/repository/team_tasks_uploader_test.dart
+++ b/flutter/test/repository/team_tasks_uploader_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/outbox_repository.dart';
@@ -51,6 +53,61 @@ void main() {
     expect(endpoint, isNot(contains('satellite')));
     expect(endpoint, isNot(contains('1234')));
     expect(endpoint, endsWith('/tasks'));
+  });
+
+  test('an edited task conflicting on its revision is re-sent', () async {
+    // `pending()` is `isUpdated = true` unfiltered, so a task already carrying
+    // a `docId` is re-offered after any edit — and that request is an update
+    // whose `_rev` can be stale.
+    await seedPending();
+    final created = (await tasks.pending()).single;
+    await tasks.markUploaded(created.id, 'task-couch', '1-stale');
+    await tasks.update(
+      created.id,
+      title: 'Fix the pump today',
+      description: 'Before the rains',
+      deadline: 900,
+    );
+
+    await uploader.queuePending(config: config);
+    final operation = (await outbox.due()).single;
+    final payload = jsonDecode(operation.payload) as Map<String, dynamic>;
+    expect(payload['_id'], 'task-couch');
+    expect(payload['_rev'], '1-stale');
+
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '2-server'
+          ? NetworkSuccess<Map<String, dynamic>>({
+              'id': 'task-couch',
+              'rev': '3-g',
+            })
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        '_id': 'task-couch',
+        '_rev': '2-server',
+      }),
+    );
+
+    final result = await uploader.handler(operation, payload, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[1]['title'], 'Fix the pump today');
   });
 
   test('the queued task is stamped with its origin', () async {

--- a/flutter/test/repository/teams_uploader_test.dart
+++ b/flutter/test/repository/teams_uploader_test.dart
@@ -92,6 +92,64 @@ void main() {
     expect(row?.isUpdated, isFalse);
   });
 
+  test(
+    'a conflicting team document is re-sent under the server revision',
+    () async {
+      // Team documents carry a device-generated `_id`
+      // (`TeamsRepository.serializeTeamDocument`), so a document the server
+      // already holds — a second device in the same team, or a row whose local
+      // `rev` went stale — conflicts. Kotlin would adopt the server's revision
+      // and report success, leaving this device's edit unsent and the row
+      // cleared as delivered.
+      await seedLocalReport();
+      final sent = <Map<String, dynamic>>[];
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((invocation) async {
+        final body = Map<String, dynamic>.from(
+          invocation.positionalArguments[1] as Map<String, dynamic>,
+        );
+        sent.add(body);
+        return body['_rev'] == '4-server'
+            ? NetworkSuccess<Map<String, dynamic>>({
+                'id': 'report-1',
+                'rev': '5-c',
+              })
+            : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+      });
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': 'report-1',
+          '_rev': '4-server',
+        }),
+      );
+
+      final result = await uploader.handler(rowFor('report-1'), const {
+        '_id': 'report-1',
+        '_rev': '3-stale',
+        'description': 'Q1',
+      }, 'auth');
+
+      expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+      expect(sent, hasLength(2));
+      expect(sent[1]['description'], 'Q1', reason: 'the edit is what lands');
+      expect(sent[1]['_rev'], '4-server');
+      // The device fields still travel on the re-send.
+      for (final field in testDeviceFields.entries) {
+        expect(sent[1], containsPair(field.key, field.value));
+      }
+      final row = await database.teamDao.getById('report-1');
+      expect(row?.rev, '5-c');
+      expect(row?.isUpdated, isFalse);
+    },
+  );
+
   test('a response without a revision is not treated as uploaded', () async {
     await seedLocalReport();
     when(

--- a/flutter/test/repository/teams_uploader_test.dart
+++ b/flutter/test/repository/teams_uploader_test.dart
@@ -150,6 +150,93 @@ void main() {
     },
   );
 
+  test('a tombstone that lost its revision still deletes the document', () async {
+    // A tombstone is `{_id, _rev, _deleted: true}` (`teams_provider.dart:295`),
+    // so it is an *update* and the recovery arm re-sends it under the fetched
+    // revision. That is accepted deliberately: the user asked for the
+    // membership to be removed, and a revision bump from another device does
+    // not revoke the instruction. Adopting instead would report the delete as
+    // done while the document is still on the server *and* hand the row back
+    // to `deleteNotIn`.
+    //
+    // The early return on `_deleted` still applies afterwards: the subject is
+    // already gone locally, so there is no row to stamp and no attachment to
+    // push.
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '7-server'
+          ? NetworkSuccess<Map<String, dynamic>>({'id': 'report-1'})
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        '_id': 'report-1',
+        '_rev': '7-server',
+      }),
+    );
+
+    final result = await uploader.handler(rowFor('report-1'), const {
+      '_id': 'report-1',
+      '_rev': '6-stale',
+      '_deleted': true,
+    }, 'auth');
+
+    // The response carries no `rev`, which the early return tolerates for a
+    // tombstone — so this also pins that recovery does not push it down the
+    // "carried no rev" failure branch.
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[1]['_deleted'], isTrue);
+    expect(sent[1]['_rev'], '7-server');
+  });
+
+  test(
+    'a tombstone for an already-deleted document stands as a refusal',
+    () async {
+      // The other half: another device deleted it first, so CouchDB 404s the
+      // read of a deleted document and there is no revision to re-send under.
+      // The refusal stands — terminal, one row, exactly as before this arm
+      // existed. Nothing is stranded that was not already gone locally.
+      var posts = 0;
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async {
+        posts++;
+        return const NetworkError<Map<String, dynamic>>(409, 'conflict');
+      });
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => const NetworkError<Map<String, dynamic>>(404, 'deleted'),
+      );
+
+      final result = await uploader.handler(rowFor('report-1'), const {
+        '_id': 'report-1',
+        '_rev': '6-stale',
+        '_deleted': true,
+      }, 'auth');
+
+      expect((result as NetworkError).code, 409);
+      expect(posts, 1);
+    },
+  );
+
   test('a response without a revision is not treated as uploaded', () async {
     await seedLocalReport();
     when(

--- a/flutter/test/repository/user_uploader_test.dart
+++ b/flutter/test/repository/user_uploader_test.dart
@@ -194,6 +194,57 @@ void main() {
     },
   );
 
+  test('a PUT that loses a race is re-sent under the newer revision', () async {
+    // This handler fetches `_rev` moments before it PUTs, so a 409 here is a
+    // genuine lost update: another write landed inside that window. Without
+    // the recovery arm the profile edit — name, photo — was abandoned with
+    // `isUpdated` left set and nothing able to re-arm the row, because
+    // `UserMapper.toDoc` emits no `_rev` and so a later sweep builds the
+    // identical request.
+    await seedEditedUser();
+    var revs = ['9-latest', '11-elsewhere'];
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((_) async {
+      final rev = revs.first;
+      if (revs.length > 1) revs = revs.sublist(1);
+      return NetworkSuccess<Map<String, dynamic>>({
+        '_id': 'org.couchdb.user:ada',
+        '_rev': rev,
+      });
+    });
+
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () =>
+          api.putJsonObject(any(), any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '11-elsewhere'
+          ? NetworkSuccess<Map<String, dynamic>>({
+              'id': 'org.couchdb.user:ada',
+              'rev': '12-new',
+            })
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+
+    final result = await uploader.handler(rowFor('user-1'), {
+      'name': 'ada',
+    }, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[0]['_rev'], '9-latest', reason: 'the rev that lost');
+    expect(sent[1]['_rev'], '11-elsewhere');
+    expect(sent[1]['name'], 'ada', reason: 'the edit is what lands');
+    final user = await database.userDao.getById('user-1');
+    expect(user?.rev, '12-new');
+    expect(user?.isUpdated, isFalse);
+  });
+
   test('a 404 on the GET falls back to a creation', () async {
     await seedEditedUser();
     when(

--- a/flutter/test/repository/voices_uploader_test.dart
+++ b/flutter/test/repository/voices_uploader_test.dart
@@ -52,6 +52,61 @@ void main() {
   Future<String> seedPost() =>
       voices.createPost(message: 'Hello', userId: 'user-1', userName: 'Ada');
 
+  test('an edited post conflicting on its revision is re-sent', () async {
+    // `pendingUploads` includes a row with a `docId` when `isEdited`, so an
+    // edit is an update whose `_rev` can be stale. Adopting would be worse
+    // here than anywhere else: `markUploaded` clears `imageUrls` and deletes
+    // the local image bytes, so the edit *and* the images would be
+    // unrecoverable while the server still shows the other device's text.
+    final id = await seedPost();
+    await voices.markUploaded(id, 'news-couch', '1-stale');
+    await voices.editPost(newsId: id, message: 'Hello again');
+
+    await uploader.queuePending(config: config, userId: 'user-1');
+    final operation = (await outbox.due()).single;
+    final payload = payloadOf(operation);
+    expect(payload['_id'], 'news-couch');
+    expect(payload['_rev'], '1-stale');
+
+    final sent = <Map<String, dynamic>>[];
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final body = Map<String, dynamic>.from(
+        invocation.positionalArguments[1] as Map<String, dynamic>,
+      );
+      sent.add(body);
+      return body['_rev'] == '2-server'
+          ? NetworkSuccess<Map<String, dynamic>>({
+              'id': 'news-couch',
+              'rev': '3-h',
+            })
+          : const NetworkError<Map<String, dynamic>>(409, 'conflict');
+    });
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        '_id': 'news-couch',
+        '_rev': '2-server',
+      }),
+    );
+
+    final result = await uploader.handler(operation, payload, 'auth');
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(sent, hasLength(2));
+    expect(sent[1]['message'], 'Hello again');
+    expect(
+      (await voices.getById(id))?.newsRev ?? (await voices.getById(id))?.rev,
+      isNotNull,
+    );
+  });
+
   test('queues an endpoint that carries no credentials', () async {
     // Persisted in `outbox.endpoint`, a table that survives schema upgrades.
     final endpoint = VoicesUploader.endpointFor(config);

--- a/flutter/test/repository/voices_uploader_test.dart
+++ b/flutter/test/repository/voices_uploader_test.dart
@@ -101,10 +101,19 @@ void main() {
     expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
     expect(sent, hasLength(2));
     expect(sent[1]['message'], 'Hello again');
-    expect(
-      (await voices.getById(id))?.newsRev ?? (await voices.getById(id))?.rev,
-      isNotNull,
-    );
+    // The DAO write, asserted on the values the *recovered* send produced.
+    // An earlier cut of this test read `newsRev ?? rev` and asserted only
+    // `isNotNull` — but the fixture's own `markUploaded` above had already set
+    // `rev`, so it held whether or not the handler ran at all. Mutation-proven:
+    // skipping `markUploaded` in the success branch left it green.
+    final stored = await voices.getById(id);
+    expect(stored?.rev, '3-h');
+    expect(stored?.docId, 'news-couch');
+    expect(stored?.isEdited, isFalse);
+    // The half this uploader's own comment calls the highest-stakes in the
+    // port: `markUploaded` clears `imageUrls` and deletes the local bytes, so
+    // a recovered send must reach it rather than leaving the post half-done.
+    expect(stored?.imageUrls, isEmpty);
   });
 
   test('queues an endpoint that carries no credentials', () async {


### PR DESCRIPTION
**Lane C of the four-lane round.** Phase 152: port `UploadCoordinator`'s 409 recovery arm beyond the single uploader that had it.

## The finding

**Porting `UploadCoordinator.kt:169-204` literally would have lost data in every uploader here but one.** Mutation-tested: forcing Kotlin's adopt-and-report-success behaviour fails **22 tests**.

A 409 never means "your write is already there" — it means the document exists and your bytes were *not* stored. Kotlin never compares the fetched document against what it was sending, so adopting the revision clears the dirty flag with the clinician's examination, the learner's added answers, or the edited post still on the handset.

## The rule shipped

| Case | Behaviour |
|---|---|
| **update** (payload carries `_rev`) | re-send the same content under the fetched revision — the write lands |
| **create** (no `_rev`) | **neither** re-sent nor adopted; the refusal stands, terminal, row stays inspectable |
| create + `adoptExisting` | Kotlin's original semantics — **one** uploader (`adopted_surveys`, whose clone is a pure function of survey + team) |

The create default means Phase 148's health-conflict tests pass unchanged.

**Armed:** 11 uploaders / 15 types — `health`, `teams` (×5), `feedback`, `achievements`, `adopted_surveys`, `submissions`, `voices`, `events`, `team_tasks`, `ratings`, `user`. `adopted_surveys` lost its bespoke arm (which had **no test coverage at all**) to the shared one.

**`course_progress` was armed and reverted** — its pending predicate is `couchId IS NULL`, so a 409 is unreachable and the arm would be inert. That also means an edited progress row never uploads at all; reported, not fixed.

## Layering

The mechanism lives once, beside `OutboxHandler` in `outbox_drainer.dart`; it wraps only the *send*, so each handler's existing `NetworkSuccess` branch runs on a recovered result unchanged — no uploader duplicates its `markUploaded` and none can forget it. Each call site is ~12 lines, mostly comment. The drainer can't own the call: it sees only a `NetworkResult` and cannot run the handler's DAO write.

The trap avoided: **the document id is the payload's, not `outbox.itemId`** — for health's profile blob those differ, and a row-keyed GET would 404 and recover nothing, silently, with every test green.

## Both audit passes

Ground truth before implementing; implementation after. The second found five real defects in my own green code — including a test that **could not fail** (my 18 mutations missed it because un-arming still killed the test's *other* assertions) and a comment that re-seeded a claim `PHASE_148_NOTES.md` was written to retract. Three findings argued and declined with reasons, the largest being `feedback`'s merge loss, which a plain pull already causes one sync later — so the arm changes latency, not outcome.

## Gate

`dart format` clean · `flutter analyze` clean · **2771 tests pass** (2735 before) · **23 mutations, all killed**.

Full reasoning and a 14-item *Reported, not fixed* list in `flutter/PHASE_152_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmBB2aww4wdGCPfgqwssYc