### PR TITLE
Phase 153 — markdown image prefetch (Lane D)

### DIFF
--- a/flutter/PHASE_153_NOTES.md
+++ b/flutter/PHASE_153_NOTES.md
@@ -1,8 +1,225 @@
 # Phase 153 — markdown image prefetch (Lane D)
 
-Brief: `PHASE_142_NOTES.md` § *Reported, not fixed* item 1 — Kotlin pre-downloads
-the images a markdown description references and renders them from a local
-`file://` base; the port ports both helpers and wires neither, so a course, voice
-or team description's images are online-only in an offline-first app.
+Brief: `PHASE_142_NOTES.md` § *Reported, not fixed* item 1. Kotlin collects the
+images a markdown description references as it ingests the document and renders
+them later from a local `file://` base; the port ported both helpers
+(`extractImageLinks`, `prependBaseUrlToImages`) and wired **neither**, so
+`CourseMarkdownBody` fetched a relative image as authenticated bytes at render
+time — which works online and not offline, in an offline-first app.
 
-Status: in progress.
+**Outcome: the courses half shipped with both halves wired and joined by one
+key derivation; the voices and teams halves deliberately not built, because the
+port has no screen that would render them.** That second sentence is the phase's
+main judgement and the rest of these notes exists to justify it.
+
+## What the ground-truth audit changed before a line was written
+
+The mandatory pre-implementation `parity-auditor` pass at `effort: max`
+corrected **four premises in the brief I was given**, two of which would have
+gone straight into the code:
+
+1. **"Does every sync re-queue the whole accumulated history?"** — the *pref* is
+   cleared at the start of every sync (`SyncManager.kt:93`,
+   `removeKey("concatenated_links")`). What actually accumulates is the two
+   in-memory collectors that repopulate it: `MyCourse.concatenatedLinks`
+   (`MyCourse.kt:77`, a companion `HashSet`, process-lifetime) and
+   `VoicesRepositoryImpl.concatenatedLinks` (`:33`, an `ArrayList` in an
+   `@Singleton`, so it accumulates **duplicates** too). A port that mirrored
+   only "clear the pref at sync start" would still have the growth. Different
+   bug, different fix.
+2. **The API-31 gate on the teams path** (`TeamsRepositoryImpl.kt:1186`) is not
+   policy. `DownloadUtils.openDownloadService` carries `@RequiresApi(S)`, which
+   is a **lint annotation with no runtime effect**, and its body already
+   branches correctly on every API level (`DownloadUtils.kt:210-220`). Six other
+   call sites invoke it with no version check at all. The one runtime gate in
+   the codebase reads as an artefact of silencing that annotation.
+3. **`FileUtils.getIdFromSegments` names the *directory*, not the file** — the
+   file and any sub-path come from `getResourceRelativePathFromSegments`, a
+   different slice of the same segment list.
+4. **A missing file does not render "nothing".** Markwon draws the replacement
+   text, and because `prependBaseUrlToImages` emits no `alt` attribute the
+   replacement is `HtmlEmptyTagReplacement.IMG_REPLACEMENT`, `U+FFFC OBJECT
+   REPLACEMENT CHARACTER`. The auditor traced this through Markwon 4.6.2's own
+   sources: `GlideImagesPlugin` calls a bare `load()` with no `.error()`, so
+   `onLoadFailed` receives null, `drawable.setResult` is never called, and
+   `AsyncDrawableSpan.draw` takes its render-the-text branch.
+
+Point 4 is what settles deviation 5 below: **nothing in the Kotlin falls back to
+the network**, so the port's render-time authenticated fetch is a *superset* of
+the Kotlin, not a port of it.
+
+## What shipped
+
+One join, written as one derivation, because that is the failure this project
+keeps paying for (Phase 74's reactions, Phase 100's verification photo, Phase
+116's community feed identifier, Phase 120's submission questions — each time a
+writer and a reader disagreed about a key and each half passed its own test).
+
+- **`markdownImageCachePath(String link)`** (`lib/core/utils/markdown_links.dart`)
+  — the single derivation. Strips a leading `resources/` (the same strip
+  `prependBaseUrlToImages` does, kept in the same file so the two cannot drift),
+  percent-decodes each segment, and returns `null` for anything that cannot name
+  a local file.
+- **`MarkdownImageFiles`** (`lib/core/files/markdown_image_files.dart`) —
+  resolves that path under **`ResourceFiles.baseDirectory`**, so a markdown
+  image lands in the same `<base>/ole/<id>/<file>` a downloaded resource
+  attachment does. Not a convenience: two roots is how a file that downloads
+  successfully becomes a file the viewer cannot find, and one root is also one
+  test seam.
+- **`MarkdownImagePrefetcher`** (`lib/core/files/markdown_image_prefetcher.dart`)
+  — downloads what is not already on disk, with the auth header a CouchDB
+  attachment needs. Keeps `resources/` on the **URL** while the on-disk path
+  drops it, which is the same asymmetry Kotlin has
+  (`CoursesRepositoryImpl:671` builds `"$baseUrl/$link"` from the *unstripped*
+  link while the render base strips it).
+- **`CoursesRepository.sync`** collects from the course description
+  (`CoursesRepositoryImpl:670`) and each embedded step's (`:684`), into a `Set`,
+  and prefetches **once after the walk** — the position of
+  `SyncActivity.onSyncComplete:566`, not per document.
+- **`_MarkdownImage`** prefers the local copy through a new
+  `markdownImageFileProvider` seam and falls back to the existing authenticated
+  fetch on a miss, on a loading lookup, and on a file that vanished between the
+  check and the read.
+
+### Where the port deliberately differs from the Kotlin
+
+Recorded here rather than left for a later audit to flag as an undocumented
+improvement.
+
+| # | Kotlin | Port | Why |
+|---|---|---|---|
+| 1 | Accumulates every link ever seen into two never-cleared in-memory collectors, flushed into a `SharedPreferences` JSON list | Keeps **no list at all** | The `courses` `_all_docs` walk re-reads every document every sync, so **the documents are the durable store**. A failed download is retried by the next sync at no storage cost, and there is nothing to grow. |
+| 2 | Download path and render path are derived separately, and **disagree** for `img/foo.png` (download flattens to `ole/foo.png`, render preserves `ole/img/foo.png`, so it never renders) | One derivation serves both | The whole point. A link the port declines is declined by *both* sides. |
+| 3 | Download side percent-decodes each segment, render side does not | Decodes on both | `a%20b.png` and a literal `a b.png` name one file, and a markdown link to an attachment lands where `ResourceDownloader` would write it. |
+| 4 | Queues `<couch>/db/…` URLs **with the `satellite:<PIN>@` userinfo** into `SharedPreferences` | Stores nothing; attaches auth as a header at request time | A persisted credential-bearing URL is the trap `UrlUtils.credentialFreeDbUrl` already exists for. |
+| 5 | A missing local file renders `U+FFFC`; nothing retries over the network | Falls back to the authenticated fetch | A **superset**, not a port. Stated as such at the code. |
+| 6 | Hands the queue to a foreground service and returns | Awaits the downloads inside `sync()` | Deterministic and testable. Bounded by the skip-if-already-on-disk check, so steady state is one `exists()` per link. |
+| 7 | No `..` guard on the download path — `![x](resources/A/../../../evil.sh)` writes outside `ole/` (the auditor verified the canonical path) | Refused by the derivation, before and after decoding | `FileUtils.resolveHtmlEntryFile` already shows the house style; `getSDPathFromUrl` was simply never given it. |
+| 8 | The API-31 gate on the teams path | Not ported | See premise 2 above — lint artefact, not policy. |
+
+**One thing the port does *not* improve on, on purpose.** A bare single-segment
+link (`![](cover.jpg)`) resolves to `<base>/ole/cover.jpg`, so two courses that
+both write `![](cover.jpg)` collide — exactly as they do in the Kotlin, where a
+bare filename is one of only two link shapes whose download and render paths
+agree. An earlier cut of this phase declined the shape on collision grounds;
+that was a **regression against the app being ported**, not a hardening of it,
+and the ground-truth audit is what caught it.
+
+## Verification
+
+- **Every claim mutation-tested.** Fifteen mutations across the derivation, the
+  files helper, the prefetcher, the sync collection and the renderer; each
+  reverted in turn and the suite re-run. Fourteen were killed by the test named
+  for them. A no-op control mutation survived, which is what says the harness
+  can distinguish the two.
+- **Two mutations survived the first round, and both were real findings about
+  my code rather than about the tests.** The raw pre-decode `..`/empty-segment
+  check and the `startsWith('/')`/backslash early return were fully **subsumed**
+  by the post-decode check — dead guards that read as guards. They are removed;
+  the surviving absolute-URL check is now pinned by the one case that only it
+  catches, a `data:` URI (an `http://` link fails the per-segment rules anyway,
+  on the empty segment after the `//`).
+- **One guard is knowingly unpinned**: the `p.isWithin` containment check in
+  `MarkdownImageFiles.fileFor` cannot fail, because the derivation already
+  refuses everything that could escape. Its mutation survives and no test can
+  kill it without reaching past the derivation. Kept as defence-in-depth against
+  a later loosening, and the code comment says exactly that. Flagged here so it
+  is not mistaken for coverage.
+- **A round-trip test, not two half-tests.**
+  `test/repository/markdown_image_round_trip_test.dart` starts from a
+  **server-shaped course document**, runs the real sync walk and the real
+  prefetcher, and asserts the file is found by *the renderer's own lookup*,
+  driven with `Uri.parse(link).toString()` — the string
+  `flutter_markdown_plus`'s `imageBuilder` produces from the same span. A
+  fixture that hand-places a file where the renderer computes it is the
+  fabricated join this project keeps catching; it proves nothing.
+- **A harness lesson worth keeping.** My first mutation script did the
+  substitution without asserting the pattern matched. One mutation silently
+  no-op'd on shell escaping and reported `SURVIVED`; re-run with an `assert old
+  in s` it was killed immediately, by four tests. **A mutation harness that
+  cannot tell "the guard is untested" from "the mutation never applied" reports
+  the first and means the second.**
+
+## Reported, not fixed
+
+Each names the file, the change, and why it was not made here.
+
+1. **A voice message's markdown images are collected by nothing, and would be
+   dead plumbing if they were.** Kotlin extracts from `news.message`
+   (`VoicesRepositoryImpl:393`) and `VoicesAdapter:448` renders it through
+   `prependBaseUrlToImages` — the ground-truth audit confirmed that site is
+   **live** (`setMessageAndDate:447`, reached from both `onBindViewHolder`
+   overloads). The port renders `Text(row.message ?? '')`
+   (`voices_screen.dart:183`): no markdown, no images, so a voice posted as
+   `**Water** notes ![chart](resources/abc/chart.png)` shows those literal
+   characters. **Collecting the links without wiring a renderer would be exactly
+   the dead-plumbing shape this phase's brief warned about** (`updateCourseProgress`,
+   Phase 119's four uncalled sync writers), so neither half was built. This is
+   `PHASE_142_NOTES.md` item 8 — a separate reported defect, and the blocker for
+   the voices half of item 1. Fix, in order: swap `voices_screen.dart:183` (and
+   the reply/detail message render points) to `CourseMarkdownBody`, then add the
+   `extractImageLinks(message)` collection to `VoicesRepository.sync`'s mapper
+   path and hand the set to `MarkdownImagePrefetcher` after the walk. Everything
+   the second half needs already exists and is tested; it is three lines and a
+   test once the renderer is there.
+2. **A team/community description's markdown images, same shape, one step
+   further back.** Kotlin's `TeamsRepositoryImpl.processDescription:1185`
+   collects them and `CommunityServicesFragment:52` renders the description as
+   markdown at 600×350 above the services list, with a `tvNoDescription` empty
+   state. The port's `services_screen.dart` renders **only the list** — there is
+   no description region at all to render into
+   (`PHASE_142_NOTES.md` item 9). So this needs a UI region built before the
+   prefetch has any meaning, which is more than a markdown-image slice.
+3. **Kotlin's teams path calls `openDownloadService` once per team document,
+   with an empty list, inside a Room transaction.** No `isNotEmpty()` guard at
+   `TeamsRepositoryImpl:1193`, and `bulkInsertFromSync` wraps a ~1000-doc page
+   in one transaction (`:1265`), so a full `teams` walk performs ~1000
+   foreground-service starts and ~2000 `SharedPreferences` round-trips inside a
+   database transaction. Recorded because whoever ports item 2 will read that
+   method and should collect across the batch and enqueue once, as the
+   courses/voices path does — not reproduce it.
+4. **Kotlin's `DownloadWorker` never drains the queue it reads.** It reads the
+   pending-URL `StringSet` and never removes what it processed — there is no
+   `preferences.edit` anywhere in the file — unlike `DownloadService.cleanupProcessedUrls`.
+   No port impact today (the port keeps no such queue, deviation 1), but it is
+   the kind of asymmetry a later "just port the worker" would inherit.
+5. **`markdownImageBytesProvider`'s cached bytes are not invalidated when a
+   prefetch lands.** A description rendered online caches its bytes under the
+   resolved URL; if a sync downloads the same image a moment later, the widget
+   keeps showing the in-memory copy until the provider is disposed. Harmless —
+   same pixels — but the local branch does not take over until the next rebuild
+   that re-reads `markdownImageFileProvider`. Noting it so a future reader does
+   not diagnose it as a broken join. `flutter/lib/ui/courses/course_markdown.dart`.
+6. **A server-side replacement of an image at the same path is never
+   re-fetched**, in either app. `existingFileFor` is `exists() && length() > 0`,
+   as Kotlin's `FileUtils.checkFileExist` is; neither carries a rev or mtime
+   check. Faithful, and a hole in both. Closing it needs a per-file revision the
+   markdown link does not carry.
+7. **`prependBaseUrlToImages` still has no caller in `lib/`, and now has a
+   documented reason.** It discards the markdown `alt` text entirely, which is
+   why the Kotlin's missing-image fallback is a bare `U+FFFC` rather than
+   anything readable. The port renders `![alt](path)` spans through
+   `flutter_markdown_plus` instead, so it never needs the rewrite. The helper is
+   kept as the line-for-line port of a live Kotlin function; that is now stated
+   at the code rather than implied.
+
+## Files touched
+
+`lib/core/utils/markdown_links.dart`, `lib/core/files/markdown_image_files.dart`
+(new), `lib/core/files/markdown_image_prefetcher.dart` (new),
+`lib/repository/courses_repository.dart`, `lib/ui/courses/course_markdown.dart`,
+`lib/providers/app_providers.dart` (one provider argument and its import).
+
+Tests: `test/core/utils/markdown_links_test.dart`,
+`test/core/files/markdown_image_files_test.dart` (new),
+`test/core/files/markdown_image_prefetcher_test.dart` (new),
+`test/ui/courses/course_markdown_test.dart` (new),
+`test/repository/markdown_image_round_trip_test.dart` (new),
+`test/repository/courses_repository_test.dart`.
+
+**No Drift table, no DAO change, no `schemaVersion` bump.** The one constraint
+the brief flagged as most likely to bite — `download_queue` living in Lane A's
+`app_database.dart`, and keyed on a `MyLibrary` **`resourceId`** that a markdown
+image does not have — is avoided rather than worked around: deviation 1 removes
+the need for a durable queue at all, so nothing was needed from Lane A and
+`schemaVersion` stays at 48.

--- a/flutter/PHASE_153_NOTES.md
+++ b/flutter/PHASE_153_NOTES.md
@@ -81,6 +81,43 @@ writer and a reader disagreed about a key and each half passed its own test).
   fetch on a miss, on a loading lookup, and on a file that vanished between the
   check and the read.
 
+### The defect the key derivation did not cover
+
+Worth its own heading, because it is the phase's one real bug and my own
+single-derivation defence walked straight past it. **The disagreement was
+upstream of the derivation: the two sides do not share a parser.**
+
+The collector is `extractImageLinks`, a line-for-line port of Kotlin's
+`DownloadUtils.extractLinks` regex, whose lazy `(.*?)` takes everything up to
+the first `)`. The renderer's link comes from `flutter_markdown_plus`'s
+CommonMark parser. Probed against the real parser rather than reasoned about:
+
+| markdown | collector sees | renderer asks for |
+|---|---|---|
+| `![a](resources/abc/c.png)` | `resources/abc/c.png` | `resources/abc/c.png` |
+| `![a](resources/abc/c.png "Title")` | `resources/abc/c.png "Title"` | `resources/abc/c.png` |
+| `![a](<resources/abc/c.png>)` | `<resources/abc/c.png>` | `resources/abc/c.png` |
+
+So for a titled or bracketed image the prefetcher requested
+`…/c.png "Title"` — a 404 — while the renderer looked up `abc/c.png`, which
+nothing had written. No wrong bytes, no crash, nothing in a log: the image
+simply stayed online-only, which is the exact condition this phase exists to
+remove. **The Phase 100 shape, at one remove.**
+
+**Kotlin does not have this bug, because it does not have a second parser.**
+`prependBaseUrlToImages` matches on the *identical* pattern, so Kotlin
+downloads and renders the same wrong path and a titled image never appears at
+all. Self-consistently broken is not a thing the port can be here, so
+`markdownImageDestination` normalises the collected link to the CommonMark
+destination — title stripped, pointy brackets unwrapped — and both the cache
+path and the download URL go through it. On a link the renderer supplies it is
+a no-op.
+
+Found by asking the question the brief told me to ask (*can the writer produce
+values the reader's predicate matches?*) and then **running the real parser**
+instead of answering it from the regex. The three round-trip tests were written
+failing first.
+
 ### Where the port deliberately differs from the Kotlin
 
 Recorded here rather than left for a later audit to flag as an undocumented
@@ -107,11 +144,15 @@ and the ground-truth audit is what caught it.
 
 ## Verification
 
-- **Every claim mutation-tested.** Fifteen mutations across the derivation, the
-  files helper, the prefetcher, the sync collection and the renderer; each
-  reverted in turn and the suite re-run. Fourteen were killed by the test named
-  for them. A no-op control mutation survived, which is what says the harness
-  can distinguish the two.
+- **Every claim mutation-tested.** Twenty-one mutations across the derivation,
+  the destination normaliser, the files helper, the prefetcher, the sync
+  collection and the renderer; each reverted in turn and the suite re-run.
+  Twenty were killed by the test named for them. A no-op control mutation
+  survived, which is what says the harness can distinguish the two.
+- **A third survivor was a real gap in a test, not in the code**: the
+  whitespace requirement before a CommonMark title (`\s+`, not `\s*`) was
+  unpinned until a case ending in a parenthesised group was added — `photo(1)`
+  is a real filename, and `\s*` eats it.
 - **Two mutations survived the first round, and both were real findings about
   my code rather than about the tests.** The raw pre-decode `..`/empty-segment
   check and the `startsWith('/')`/backslash early return were fully **subsumed**

--- a/flutter/PHASE_153_NOTES.md
+++ b/flutter/PHASE_153_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 153 — markdown image prefetch (Lane D)
+
+Brief: `PHASE_142_NOTES.md` § *Reported, not fixed* item 1 — Kotlin pre-downloads
+the images a markdown description references and renders them from a local
+`file://` base; the port ports both helpers and wires neither, so a course, voice
+or team description's images are online-only in an offline-first app.
+
+Status: in progress.

--- a/flutter/PHASE_153_NOTES.md
+++ b/flutter/PHASE_153_NOTES.md
@@ -142,17 +142,119 @@ agree. An earlier cut of this phase declined the shape on collision grounds;
 that was a **regression against the app being ported**, not a hardening of it,
 and the ground-truth audit is what caught it.
 
+## What the second audit found in my own finished, green code
+
+Eight defects, in code that passed format, analyze and 2784 tests. Two of them
+were the feature not working; one would have broken background sync outright.
+Recorded at this length because the pass is mandatory precisely because of
+rounds like this one.
+
+**1. A Latin-1 percent-escape threw out of `sync()` and permanently broke
+auto-sync.** `Uri.decodeComponent` throws **two** types: `ArgumentError` for bad
+hex, and **`FormatException` for valid hex that is not valid UTF-8**. I caught
+only the first. `caf%E9.png` is Latin-1 `café.png` — the shape any pre-UTF-8
+attachment name on an older Planet install has — and it threw straight through
+`_fetch` → `prefetch` → `CoursesRepository.sync`. Foreground that is a failed
+sync whose documents were already written. In the background isolate
+`BackgroundTaskRunner` records it as a failed step, `recordLastSync` is skipped,
+`run()` returns false, WorkManager retries, `_isDue()` is still true — **one bad
+character in one course description would stop auto-sync for as long as that
+document existed on the server.** Before this phase `CoursesRepository.sync`
+touched no filesystem at all, so this and two sibling throw sites
+(`path_provider`'s channel in a headless engine, a file vanishing between
+`exists()` and `length()`) were all new failure modes I introduced. Fixed twice
+over: the specific catch, and an unconditional per-link `try` in `prefetch` —
+the class doc claimed failures were swallowed and the code did not implement it.
+
+**2. The production wiring was pinned by nothing.** `markdownImages` is optional
+with a null default and the call site is `_markdownImages?.prefetch(...)`, so
+deleting the argument from `coursesRepositoryProvider` was a **silent no-op** —
+analyze clean, every prefetch test green (each builds its own repository), the
+feature simply absent from the app. That is the ported-tested-green-and-dead
+class this phase's brief warned about, reproduced by the phase that was warned.
+`test/providers/courses_repository_wiring_test.dart` now drives the real
+provider graph and asserts the bytes reach disk; the mutation that deletes the
+argument kills it.
+
+**3. `sync()` could hang forever.** `PlanetApi.getBytes` sets
+`receiveTimeout: null` — correct for a large user-initiated download, and an
+unbounded stall once it runs inside a sync, where `SyncNotifier` refuses a
+second attempt while one is running so the sync button never re-enables. Added
+a per-link timeout and an overall budget; deviation 6's "steady state is one
+`exists()` per link" was true and irrelevant, because a first sync on a fresh
+install is not steady state and WorkManager kills the task at ~10 minutes.
+Kotlin needs neither budget: the foreground service is how it outlives that.
+
+**4. The local copy never took over until the app restarted.**
+`markdownImageFileProvider` had no `.autoDispose`, and a `FutureProvider.family`
+caches per argument for the life of the container — so a first render while the
+image was still downloading cached `null` for the whole process, and the sync's
+file was never picked up. Open a course while the dashboard sync is walking
+`courses`, then go offline: the image is on disk and does not render. **The
+feature not working, in exactly the situation it exists for.** My own notes
+described this wrongly — I wrote that the local branch takes over "on the next
+rebuild", and a rebuild re-watches the *cached* instance; there was no rebuild
+that fixed it.
+
+**5. A 49-line dartdoc was attached to the wrong function.** The new
+`markdownImageDestination` doc ran into the `markdownImageCachePath` block with
+no separator, so Dart bound all 71 lines to `markdownImageDestination` and the
+single key derivation this phase is built on had **no doc at all**. Neither
+`dart format` nor `flutter analyze` catches it. Fixed by ordering the file so
+each doc sits on its own function.
+
+**6. A code comment asserted what these very notes disprove.** The prefetcher
+said Kotlin's link list "grows for the life of the install"; `SyncManager.kt:93`
+clears the pref on every sync, and what grows is the two process-lifetime
+collectors that repopulate it. The notes said this correctly and cited the line;
+the comment was never updated to match — and **the comment is what a future lane
+reads**. Same defect class this file takes credit for catching.
+
+**7. Two wrong Kotlin line citations** carried in from the brief:
+`VoicesRepositoryImpl:393` is `val baseUrl`, `extractLinks` is at **393**; and
+`TeamsRepositoryImpl:1187` is a closing brace, the call is at **1187**.
+Corrected in code and in these notes. (Every other citation on both sides was
+independently re-derived and holds.)
+
+**8. `_titleSuffix`'s parenthesised-title branch was unreachable.**
+`extractImageLinks`' lazy capture stops at the first `)`, so `![a](p (T))`
+yields `p (T` and never a string ending in `)`; the renderer's destinations are
+percent-encoded with no whitespace. Removed, with a test pinning that a
+parenthesised title is *not* stripped so its absence stays a decision. The
+`\s+`-vs-`\s*` distinction the earlier draft of these notes celebrated was
+pinned by `photo(1)` — an input no producer can generate — so that test was
+replaced with the reachable one, `![a](abc/"T")`. **Two sections of these notes
+were bragging about a guard of exactly the kind they claim to remove.**
+
+### Reported by the audit and deliberately not fixed
+
+Five further collector/renderer disagreements remain, all of which fall back to
+the network and lose nothing: a `#fragment` (the one case that writes a file
+nothing will read, at `<base>/ole/A/b.png#100x50`), an HTML entity
+(`b&amp;amp;c.png` vs `b&amp;c.png`), a backslash-escaped paren, a balanced-paren
+destination, and a reference-style `![a][ref]` link, which the regex collector
+does not see at all. Closing them properly means parsing markdown in the
+collector rather than pattern-matching it, which is a different change from this
+one. `markdownImageDestination`'s dartdoc names what it does and does not
+reconcile rather than implying it covers everything.
+
 ## Verification
 
-- **Every claim mutation-tested.** Twenty-one mutations across the derivation,
-  the destination normaliser, the files helper, the prefetcher, the sync
-  collection and the renderer; each reverted in turn and the suite re-run.
-  Twenty were killed by the test named for them. A no-op control mutation
-  survived, which is what says the harness can distinguish the two.
-- **A third survivor was a real gap in a test, not in the code**: the
-  whitespace requirement before a CommonMark title (`\s+`, not `\s*`) was
-  unpinned until a case ending in a parenthesised group was added — `photo(1)`
-  is a real filename, and `\s*` eats it.
+- **Every claim mutation-tested, twice** — once on the first cut and again on
+  everything the second audit's fixes added. Thirty mutations in total across
+  the derivation, the destination normaliser, the files helper, the prefetcher,
+  the sync collection, the renderer and the provider wiring; each reverted in
+  turn and the suite re-run. Twenty-nine were killed by the test named for
+  them. A no-op control mutation survived, which is what says the harness can
+  distinguish the two.
+- **Four survivors were real, and every one of them was a finding about my code
+  or my tests rather than a shrug.** Two dead guards (below), one unpinned
+  regex rule, and — the one worth repeating — **the test named "prefetches
+  once, after the walk rather than per page" could not fail for the property it
+  named**: `stubCount(2)` yields a single page, so `calls == 1` held whether the
+  prefetch sat after the loop or inside it. Rewritten with a real page boundary,
+  and the inside-the-loop mutation now kills it. That test was cited in the
+  first draft of these notes as evidence for a claim it did not test.
 - **Two mutations survived the first round, and both were real findings about
   my code rather than about the tests.** The raw pre-decode `..`/empty-segment
   check and the `startsWith('/')`/backslash early return were fully **subsumed**
@@ -204,7 +306,7 @@ Each names the file, the change, and why it was not made here.
    the second half needs already exists and is tested; it is three lines and a
    test once the renderer is there.
 2. **A team/community description's markdown images, same shape, one step
-   further back.** Kotlin's `TeamsRepositoryImpl.processDescription:1185`
+   further back.** Kotlin's `TeamsRepositoryImpl.processDescription:1185` (the `extractLinks` call at `:1187`)
    collects them and `CommunityServicesFragment:52` renders the description as
    markdown at 600×350 above the services list, with a `tvNoDescription` empty
    state. The port's `services_screen.dart` renders **only the list** — there is
@@ -224,13 +326,12 @@ Each names the file, the change, and why it was not made here.
    `preferences.edit` anywhere in the file — unlike `DownloadService.cleanupProcessedUrls`.
    No port impact today (the port keeps no such queue, deviation 1), but it is
    the kind of asymmetry a later "just port the worker" would inherit.
-5. **`markdownImageBytesProvider`'s cached bytes are not invalidated when a
-   prefetch lands.** A description rendered online caches its bytes under the
-   resolved URL; if a sync downloads the same image a moment later, the widget
-   keeps showing the in-memory copy until the provider is disposed. Harmless —
-   same pixels — but the local branch does not take over until the next rebuild
-   that re-reads `markdownImageFileProvider`. Noting it so a future reader does
-   not diagnose it as a broken join. `flutter/lib/ui/courses/course_markdown.dart`.
+5. **`markdownImageBytesProvider` is not `autoDispose`.** A description
+   rendered online caches its bytes under the resolved URL for the life of the
+   container. Genuinely harmless — the same pixels — and *unlike* its sibling
+   `markdownImageFileProvider`, which had the same shape and where it was the
+   feature not working (finding 4 above). Left alone to keep the diff to what
+   the audit showed was broken. `flutter/lib/ui/courses/course_markdown.dart`.
 6. **A server-side replacement of an image at the same path is never
    re-fetched**, in either app. `existingFileFor` is `exists() && length() > 0`,
    as Kotlin's `FileUtils.checkFileExist` is; neither carries a rev or mtime

--- a/flutter/lib/core/files/markdown_image_files.dart
+++ b/flutter/lib/core/files/markdown_image_files.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../utils/markdown_links.dart';
+import 'resource_files.dart';
+
+/// Where a markdown description's inline image lives on disk.
+///
+/// The Kotlin renders these from `file://<externalFilesDir>/ole/` with a
+/// leading `resources/` stripped (`CourseStepFragment:125`,
+/// `CourseDetailViewModel:65`), which is the same `<base>/ole/<docId>/<file>`
+/// layout `ResourceFiles` already owns for a downloaded resource attachment —
+/// markdown images *are* resource attachments, reached by path instead of by
+/// `my_library` row. So this delegates its root to [ResourceFiles.baseDirectory]
+/// rather than resolving its own: two roots is how a file that downloads
+/// successfully becomes a file the viewer cannot find, and it is also what
+/// makes both sides overridable from one place in a test.
+///
+/// The path inside that root comes from [markdownImageCachePath], which is
+/// the only derivation either side uses.
+class MarkdownImageFiles {
+  const MarkdownImageFiles._();
+
+  /// `<base>/ole/<markdownImageCachePath(link)>`, or `null` when the link
+  /// cannot name a local file.
+  static Future<File?> fileFor(String link) async {
+    final relative = markdownImageCachePath(link);
+    if (relative == null) return null;
+    final ole = await ResourceFiles.oleDirectory();
+    final basePath = ole.absolute.path;
+    final resolved = p.normalize(p.absolute(p.join(basePath, relative)));
+    // `markdownImageCachePath` already refuses `..` and an absolute link, so
+    // this cannot currently fail. It is kept because the containment check is
+    // the property that actually matters, and a later loosening of the
+    // derivation should fail here rather than write outside `ole/`.
+    if (!p.isWithin(basePath, resolved)) return null;
+    return File(resolved);
+  }
+
+  /// The file only when it is actually usable.
+  ///
+  /// A zero-length file is what an interrupted download leaves behind, and
+  /// `exists()` alone would report it as present — the renderer would then
+  /// prefer an empty local copy over the network fetch that still works. Same
+  /// `length() > 0` test as [ResourceFiles.existingFileFor] and Kotlin's
+  /// `FileUtils.checkFileExist`.
+  static Future<File?> existingFileFor(String link) async {
+    final file = await fileFor(link);
+    if (file == null) return null;
+    if (!await file.exists()) return null;
+    if (await file.length() <= 0) return null;
+    return file;
+  }
+}

--- a/flutter/lib/core/files/markdown_image_files.dart
+++ b/flutter/lib/core/files/markdown_image_files.dart
@@ -48,8 +48,18 @@ class MarkdownImageFiles {
   static Future<File?> existingFileFor(String link) async {
     final file = await fileFor(link);
     if (file == null) return null;
-    if (!await file.exists()) return null;
-    if (await file.length() <= 0) return null;
-    return file;
+    return await hasBytes(file) ? file : null;
+  }
+
+  /// Whether [file] is a usable download rather than an interrupted one.
+  ///
+  /// Split out so a caller that already holds the `File` does not derive it a
+  /// second time: [fileFor] awaits `ResourceFiles.oleDirectory()`, which goes
+  /// through `path_provider`'s platform channel and is not cached, so the
+  /// prefetcher's `fileFor`-then-`existingFileFor` pair was two channel hops
+  /// per link — in the headless isolate as well.
+  static Future<bool> hasBytes(File file) async {
+    if (!await file.exists()) return false;
+    return await file.length() > 0;
   }
 }

--- a/flutter/lib/core/files/markdown_image_prefetcher.dart
+++ b/flutter/lib/core/files/markdown_image_prefetcher.dart
@@ -1,0 +1,91 @@
+import '../../data/api/planet_api.dart';
+import '../config/server_config.dart';
+import '../network/network_result.dart';
+import '../utils/url_utils.dart';
+import 'markdown_image_files.dart';
+
+/// Downloads the images a synced markdown description references, so they
+/// render with no network.
+///
+/// Port of the download half of Kotlin's concatenated-links path: three
+/// repositories call `DownloadUtils.extractLinks` on a description as they
+/// ingest it (`CoursesRepositoryImpl:670`/`:684`, `VoicesRepositoryImpl:394`,
+/// `TeamsRepositoryImpl:1183`) and the collected paths are handed to
+/// `DownloadService`, which writes each under `<externalFilesDir>/ole/`. The
+/// port had neither half: `CourseMarkdownBody` fetched a relative path as
+/// authenticated bytes at render time, which works online and not offline —
+/// in an offline-first app.
+///
+/// **Two deliberate deviations from the Kotlin**, both about *what is
+/// remembered*:
+///
+/// * Kotlin accumulates every link it has ever seen into a `SharedPreferences`
+///   JSON list (`MyCourse.saveConcatenatedLinksToPrefs`,
+///   `VoicesRepositoryImpl.saveConcatenatedLinksToPrefs`) and never removes an
+///   entry, so the list grows for the life of the install and every sync
+///   re-queues the whole history. The port keeps no list: the sync walk that
+///   collects a link is a full `_all_docs` walk that re-reads every document
+///   every time, so **the documents are the durable store** and a link whose
+///   download failed is retried by the next sync at no storage cost.
+/// * Kotlin hands the queue to a foreground service and returns; this awaits
+///   its downloads inside the sync. Bounded by [prefetch] skipping anything
+///   already on disk, so the steady-state cost is one `exists()` per link.
+///
+/// Failures are swallowed on purpose. A missing image must not fail a sync
+/// that has already written the documents, and the renderer still falls back
+/// to the authenticated network fetch when it is online.
+class MarkdownImagePrefetcher {
+  const MarkdownImagePrefetcher(this._api);
+
+  final PlanetApi _api;
+
+  /// Materialises each of [links] that is not already on disk.
+  ///
+  /// Returns the number newly written, which is what the tests assert on;
+  /// callers ignore it.
+  Future<int> prefetch(
+    Iterable<String> links, {
+    required ServerConfig config,
+  }) async {
+    var written = 0;
+    // Sequential rather than concurrent: these run behind a sync that has just
+    // finished paging the same server, and the Kotlin's download service is
+    // serial too.
+    for (final link in links) {
+      if (await _fetch(link, config)) written++;
+    }
+    return written;
+  }
+
+  Future<bool> _fetch(String link, ServerConfig config) async {
+    final file = await MarkdownImageFiles.fileFor(link);
+    // Null means the link names nothing local — an absolute URL, or a path
+    // that cannot be trusted on the filesystem. Not an error; the renderer
+    // resolves those itself.
+    if (file == null) return false;
+    if (await MarkdownImageFiles.existingFileFor(link) != null) return false;
+
+    // The *download* URL keeps the `resources/` prefix that the on-disk path
+    // drops — the same asymmetry the Kotlin has, where the queued URL is
+    // `"$baseUrl/$link"` from the unstripped link (`CoursesRepositoryImpl:671`)
+    // while the render base strips it.
+    final result = await _api.getBytes(
+      '${UrlUtils.dbUrl(config)}/$link',
+      authHeader: UrlUtils.authHeader(config),
+    );
+    if (result is! NetworkSuccess<List<int>>) return false;
+    // An empty body is a failure that looks like a success: the file would be
+    // created, `existingFileFor` would still reject it as zero-length, and
+    // every later sync would re-download it. Same guard as `ResourceDownloader`.
+    if (result.data.isEmpty) return false;
+
+    try {
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(result.data, flush: true);
+    } catch (_) {
+      // A full disk or an unwritable path is not a sync failure.
+      return false;
+    }
+    return true;
+  }
+}

--- a/flutter/lib/core/files/markdown_image_prefetcher.dart
+++ b/flutter/lib/core/files/markdown_image_prefetcher.dart
@@ -1,6 +1,7 @@
 import '../../data/api/planet_api.dart';
 import '../config/server_config.dart';
 import '../network/network_result.dart';
+import '../utils/markdown_links.dart';
 import '../utils/url_utils.dart';
 import 'markdown_image_files.dart';
 
@@ -68,9 +69,11 @@ class MarkdownImagePrefetcher {
     // The *download* URL keeps the `resources/` prefix that the on-disk path
     // drops — the same asymmetry the Kotlin has, where the queued URL is
     // `"$baseUrl/$link"` from the unstripped link (`CoursesRepositoryImpl:671`)
-    // while the render base strips it.
+    // while the render base strips it. It does *not* keep a markdown title or
+    // pointy brackets, which the regex collector captures and the renderer's
+    // CommonMark parser does not — see [markdownImageDestination].
     final result = await _api.getBytes(
-      '${UrlUtils.dbUrl(config)}/$link',
+      '${UrlUtils.dbUrl(config)}/${markdownImageDestination(link)}',
       authHeader: UrlUtils.authHeader(config),
     );
     if (result is! NetworkSuccess<List<int>>) return false;

--- a/flutter/lib/core/files/markdown_image_prefetcher.dart
+++ b/flutter/lib/core/files/markdown_image_prefetcher.dart
@@ -10,8 +10,8 @@ import 'markdown_image_files.dart';
 ///
 /// Port of the download half of Kotlin's concatenated-links path: three
 /// repositories call `DownloadUtils.extractLinks` on a description as they
-/// ingest it (`CoursesRepositoryImpl:670`/`:684`, `VoicesRepositoryImpl:394`,
-/// `TeamsRepositoryImpl:1183`) and the collected paths are handed to
+/// ingest it (`CoursesRepositoryImpl:670`/`:684`, `VoicesRepositoryImpl:393`,
+/// `TeamsRepositoryImpl:1187`) and the collected paths are handed to
 /// `DownloadService`, which writes each under `<externalFilesDir>/ole/`. The
 /// port had neither half: `CourseMarkdownBody` fetched a relative path as
 /// authenticated bytes at render time, which works online and not offline —
@@ -20,11 +20,14 @@ import 'markdown_image_files.dart';
 /// **Two deliberate deviations from the Kotlin**, both about *what is
 /// remembered*:
 ///
-/// * Kotlin accumulates every link it has ever seen into a `SharedPreferences`
-///   JSON list (`MyCourse.saveConcatenatedLinksToPrefs`,
-///   `VoicesRepositoryImpl.saveConcatenatedLinksToPrefs`) and never removes an
-///   entry, so the list grows for the life of the install and every sync
-///   re-queues the whole history. The port keeps no list: the sync walk that
+/// * Kotlin flushes every link it has seen into a `SharedPreferences` JSON list
+///   (`MyCourse.saveConcatenatedLinksToPrefs`,
+///   `VoicesRepositoryImpl.saveConcatenatedLinksToPrefs`). The **pref** is
+///   cleared at the start of each sync (`SyncManager.kt:93`); what grows is the
+///   two collectors that repopulate it — `MyCourse.concatenatedLinks`
+///   (`MyCourse.kt:77`) and `VoicesRepositoryImpl.concatenatedLinks` (`:33`),
+///   neither ever cleared and both process-lifetime, so a sync re-queues links
+///   from documents the server no longer has. The port keeps no list: the sync walk that
 ///   collects a link is a full `_all_docs` walk that re-reads every document
 ///   every time, so **the documents are the durable store** and a link whose
 ///   download failed is retried by the next sync at no storage cost.
@@ -32,13 +35,42 @@ import 'markdown_image_files.dart';
 ///   its downloads inside the sync. Bounded by [prefetch] skipping anything
 ///   already on disk, so the steady-state cost is one `exists()` per link.
 ///
-/// Failures are swallowed on purpose. A missing image must not fail a sync
-/// that has already written the documents, and the renderer still falls back
-/// to the authenticated network fetch when it is online.
+/// Failures are swallowed on purpose, and that is enforced rather than
+/// implied: every link runs inside its own `try`, because this sits at the end
+/// of `CoursesRepository.sync` and anything that escapes it fails a sync whose
+/// documents are already written. In the background isolate such an escape is
+/// worse than a lost image — `recordLastSync` is skipped, `run()` returns
+/// false, and WorkManager re-runs the whole walk, so **one bad link would stop
+/// auto-sync for as long as its document existed on the server**. The
+/// filesystem, `path_provider`'s platform channel, a percent-escape that is
+/// not valid UTF-8, and the transport can all throw here; none of them is a
+/// sync failure. The renderer still falls back to the authenticated network
+/// fetch when it is online.
+///
+/// Two budgets bound the work, because neither existed before this ran inside
+/// a sync. [perLinkTimeout] covers `PlanetApi.getBytes` deliberately setting
+/// `receiveTimeout: null` — right for a large user-initiated download, and an
+/// unbounded stall inside a sync, where `SyncNotifier` refuses a second
+/// attempt while one is running and the button never re-enables. [budget]
+/// covers a first sync on a fresh install, which is not the steady state the
+/// skip-if-present check makes cheap, and which WorkManager will kill at
+/// around ten minutes. Kotlin needs neither: it hands the queue to a
+/// foreground service precisely so it can outlive that budget.
 class MarkdownImagePrefetcher {
-  const MarkdownImagePrefetcher(this._api);
+  const MarkdownImagePrefetcher(
+    this._api, {
+    this.perLinkTimeout = const Duration(seconds: 30),
+    this.budget = const Duration(minutes: 3),
+  });
 
   final PlanetApi _api;
+
+  /// How long one image may take before it is abandoned for this sync.
+  final Duration perLinkTimeout;
+
+  /// How long the whole prefetch may take before the remaining links are left
+  /// to the next sync. Nothing is lost: the walk re-collects them.
+  final Duration budget;
 
   /// Materialises each of [links] that is not already on disk.
   ///
@@ -49,11 +81,18 @@ class MarkdownImagePrefetcher {
     required ServerConfig config,
   }) async {
     var written = 0;
+    final deadline = DateTime.now().add(budget);
     // Sequential rather than concurrent: these run behind a sync that has just
     // finished paging the same server, and the Kotlin's download service is
     // serial too.
     for (final link in links) {
-      if (await _fetch(link, config)) written++;
+      if (!DateTime.now().isBefore(deadline)) break;
+      try {
+        if (await _fetch(link, config)) written++;
+      } catch (_) {
+        // Deliberately unconditional. Anything at all that this link throws is
+        // one missing image, never a failed sync — see the class doc.
+      }
     }
     return written;
   }
@@ -64,7 +103,7 @@ class MarkdownImagePrefetcher {
     // that cannot be trusted on the filesystem. Not an error; the renderer
     // resolves those itself.
     if (file == null) return false;
-    if (await MarkdownImageFiles.existingFileFor(link) != null) return false;
+    if (await MarkdownImageFiles.hasBytes(file)) return false;
 
     // The *download* URL keeps the `resources/` prefix that the on-disk path
     // drops — the same asymmetry the Kotlin has, where the queued URL is
@@ -72,10 +111,12 @@ class MarkdownImagePrefetcher {
     // while the render base strips it. It does *not* keep a markdown title or
     // pointy brackets, which the regex collector captures and the renderer's
     // CommonMark parser does not — see [markdownImageDestination].
-    final result = await _api.getBytes(
-      '${UrlUtils.dbUrl(config)}/${markdownImageDestination(link)}',
-      authHeader: UrlUtils.authHeader(config),
-    );
+    final result = await _api
+        .getBytes(
+          '${UrlUtils.dbUrl(config)}/${markdownImageDestination(link)}',
+          authHeader: UrlUtils.authHeader(config),
+        )
+        .timeout(perLinkTimeout);
     if (result is! NetworkSuccess<List<int>>) return false;
     // An empty body is a failure that looks like a success: the file would be
     // created, `existingFileFor` would still reject it as zero-length, and

--- a/flutter/lib/core/utils/markdown_links.dart
+++ b/flutter/lib/core/utils/markdown_links.dart
@@ -128,8 +128,45 @@ String prependBaseUrlToImages(
 /// resource downloader would write. The Kotlin's *render* side does not
 /// decode, so those two disagree there for an encoded path; here one
 /// derivation serves both, so they cannot.
+/// The image destination a markdown link actually points at, with a CommonMark
+/// title removed and a pointy-bracket destination unwrapped.
+///
+/// **This is where two parsers are reconciled, and it is load-bearing.** The
+/// collector is [extractImageLinks], a line-for-line port of Kotlin's
+/// `DownloadUtils.extractLinks` regex, whose lazy `(.*?)` captures everything
+/// up to the first `)` — so `![a](p "Title")` yields `p "Title"` and
+/// `![a](<p>)` yields `<p>`. The renderer's link comes from
+/// `flutter_markdown_plus`'s CommonMark parser, which yields `p` for both.
+/// Verified against the real parser rather than assumed.
+///
+/// Kotlin has the same regex quirk and is *self-consistent* with it, because
+/// `prependBaseUrlToImages` matches on the identical pattern: it downloads and
+/// renders the same wrong path, so a titled image simply never appears. The
+/// port cannot be self-consistent that way — its renderer is a real markdown
+/// parser — so the collector is normalised to what the renderer will ask for.
+/// Without this the prefetcher 404s on `…/c.png "Title"` while the renderer
+/// looks up `abc/c.png`, which nothing wrote: the exact writer/reader key
+/// disagreement of Phase 100, and just as silent.
+///
+/// Applied to a link the renderer supplies this is a no-op — a parsed
+/// destination carries neither a title nor brackets.
+String markdownImageDestination(String link) {
+  var value = link.trim();
+  // CommonMark: `<destination> "title"`, so the title comes off first. The
+  // title may be double-quoted, single-quoted or parenthesised, and must be
+  // separated from the destination by whitespace.
+  final title = _titleSuffix.firstMatch(value);
+  if (title != null) value = value.substring(0, title.start).trimRight();
+  if (value.length >= 2 && value.startsWith('<') && value.endsWith('>')) {
+    value = value.substring(1, value.length - 1).trim();
+  }
+  return value;
+}
+
+final RegExp _titleSuffix = RegExp(r"""\s+("[^"]*"|'[^']*'|\([^()]*\))$""");
+
 String? markdownImageCachePath(String link) {
-  final trimmed = link.trim();
+  final trimmed = markdownImageDestination(link);
   if (trimmed.isEmpty) return null;
   // A scheme means an absolute URL — including a `data:` URI, which is the
   // only absolute shape the per-segment checks below would otherwise let

--- a/flutter/lib/core/utils/markdown_links.dart
+++ b/flutter/lib/core/utils/markdown_links.dart
@@ -79,6 +79,52 @@ String prependBaseUrlToImages(
   });
 }
 
+/// The image destination a markdown link actually points at, with a CommonMark
+/// title removed and a pointy-bracket destination unwrapped.
+///
+/// **This is where two parsers are reconciled, and it is load-bearing.** The
+/// collector is [extractImageLinks], a line-for-line port of Kotlin's
+/// `DownloadUtils.extractLinks` regex, whose lazy `(.*?)` captures everything
+/// up to the first `)` — so `![a](p "Title")` yields `p "Title"` and
+/// `![a](<p>)` yields `<p>`. The renderer's link comes from
+/// `flutter_markdown_plus`'s CommonMark parser, which yields `p` for both.
+/// Verified against the real parser rather than assumed.
+///
+/// Kotlin has the same regex quirk and is *self-consistent* with it, because
+/// `prependBaseUrlToImages` matches on the identical pattern: it downloads and
+/// renders the same wrong path, so a titled image simply never appears. The
+/// port cannot be self-consistent that way — its renderer is a real markdown
+/// parser — so the collector is normalised to what the renderer will ask for.
+/// Without this the prefetcher 404s on `…/c.png "Title"` while the renderer
+/// looks up `abc/c.png`, which nothing wrote: the exact writer/reader key
+/// disagreement of Phase 100, and just as silent.
+///
+/// Applied to a link the renderer supplies this is a no-op — a parsed
+/// destination carries neither a title nor brackets.
+String markdownImageDestination(String link) {
+  var value = link.trim();
+  // CommonMark: `<destination> "title"`, so the title comes off first. The
+  // title may be double-quoted, single-quoted or parenthesised, and must be
+  // separated from the destination by whitespace.
+  final title = _titleSuffix.firstMatch(value);
+  if (title != null) value = value.substring(0, title.start).trimRight();
+  if (value.length >= 2 && value.startsWith('<') && value.endsWith('>')) {
+    value = value.substring(1, value.length - 1).trim();
+  }
+  return value;
+}
+
+/// A trailing CommonMark title: quoted, and preceded by whitespace.
+///
+/// CommonMark also allows a **parenthesised** title (`p (T)`), deliberately
+/// absent here because neither producer can emit one. [extractImageLinks]'s
+/// lazy `(.*?)` stops at the first `)`, so `![a](p (T))` yields `p (T` — never
+/// a string ending in `)` — and the renderer's destinations are
+/// percent-encoded with no whitespace, so `\s+` cannot match there either. A
+/// branch no producer can reach reads as a guard while pinning nothing, which
+/// is a shape this file has already removed two of.
+final RegExp _titleSuffix = RegExp(r"""\s+("[^"]*"|'[^']*')$""");
+
 /// The cache-relative path a markdown image [link] names, or `null` when the
 /// link cannot name a locally cached file.
 ///
@@ -123,54 +169,23 @@ String prependBaseUrlToImages(
 /// Each segment is percent-decoded, so `a%20b.png` and a literal `a b.png`
 /// name the same file. That matches the Kotlin's *download* side
 /// (`FileUtils.getResourceRelativePathFromSegments` runs `URLDecoder.decode`
-/// per segment) and `ResourceFiles.resourceRelativePathFromUrl` here, which
-/// is what lets a markdown link to an attachment land on the same file the
-/// resource downloader would write. The Kotlin's *render* side does not
+/// per segment). The Kotlin's *render* side does not
 /// decode, so those two disagree there for an encoded path; here one
 /// derivation serves both, so they cannot.
-/// The image destination a markdown link actually points at, with a CommonMark
-/// title removed and a pointy-bracket destination unwrapped.
 ///
-/// **This is where two parsers are reconciled, and it is load-bearing.** The
-/// collector is [extractImageLinks], a line-for-line port of Kotlin's
-/// `DownloadUtils.extractLinks` regex, whose lazy `(.*?)` captures everything
-/// up to the first `)` — so `![a](p "Title")` yields `p "Title"` and
-/// `![a](<p>)` yields `<p>`. The renderer's link comes from
-/// `flutter_markdown_plus`'s CommonMark parser, which yields `p` for both.
-/// Verified against the real parser rather than assumed.
-///
-/// Kotlin has the same regex quirk and is *self-consistent* with it, because
-/// `prependBaseUrlToImages` matches on the identical pattern: it downloads and
-/// renders the same wrong path, so a titled image simply never appears. The
-/// port cannot be self-consistent that way — its renderer is a real markdown
-/// parser — so the collector is normalised to what the renderer will ask for.
-/// Without this the prefetcher 404s on `…/c.png "Title"` while the renderer
-/// looks up `abc/c.png`, which nothing wrote: the exact writer/reader key
-/// disagreement of Phase 100, and just as silent.
-///
-/// Applied to a link the renderer supplies this is a no-op — a parsed
-/// destination carries neither a title nor brackets.
-String markdownImageDestination(String link) {
-  var value = link.trim();
-  // CommonMark: `<destination> "title"`, so the title comes off first. The
-  // title may be double-quoted, single-quoted or parenthesised, and must be
-  // separated from the destination by whitespace.
-  final title = _titleSuffix.firstMatch(value);
-  if (title != null) value = value.substring(0, title.start).trimRight();
-  if (value.length >= 2 && value.startsWith('<') && value.endsWith('>')) {
-    value = value.substring(1, value.length - 1).trim();
-  }
-  return value;
-}
-
-final RegExp _titleSuffix = RegExp(r"""\s+("[^"]*"|'[^']*'|\([^()]*\))$""");
-
+/// It does **not** follow that a markdown link always lands on the same file
+/// `ResourceDownloader` would write — that holds for a flat attachment and not
+/// for a nested one, because `ResourceFiles.fileFor` runs `p.basename` over
+/// its `filename` and so flattens `sub/chart.png`. Only the **root** is
+/// shared.
 String? markdownImageCachePath(String link) {
   final trimmed = markdownImageDestination(link);
   if (trimmed.isEmpty) return null;
-  // A scheme means an absolute URL — including a `data:` URI, which is the
-  // only absolute shape the per-segment checks below would otherwise let
-  // through (`http://…` fails them on its empty segment after the `//`).
+  // A scheme means an absolute URL. `http://…` and `https://…` would fail the
+  // per-segment checks anyway, on the empty segment their `//` leaves; what
+  // this actually catches are the authority-less schemes — `data:`, `mailto:`,
+  // `tel:`, a bare `file:a.png` — which split into ordinary-looking segments
+  // and would otherwise be requested from the server.
   if (Uri.tryParse(trimmed)?.hasScheme ?? false) return null;
 
   final stripped = trimmed.startsWith('resources/')
@@ -184,7 +199,16 @@ String? markdownImageCachePath(String link) {
     try {
       plain = Uri.decodeComponent(segment);
     } on ArgumentError {
-      // A malformed escape (`%zz`). Nothing can name a file from this.
+      // Bad hex (`%zz`, a truncated `%2`). Nothing can name a file from this.
+      return null;
+    } on FormatException {
+      // **Valid hex that is not valid UTF-8**, which is a different exception
+      // and the one that matters: `caf%E9.png` is Latin-1 `café.png`, the
+      // shape any pre-UTF-8 attachment name on an older Planet install has.
+      // Catching only `ArgumentError` let this escape the prefetch and the
+      // whole `CoursesRepository.sync` — and in the background isolate that
+      // left `recordLastSync` unwritten and WorkManager retrying the entire
+      // walk for as long as that one document existed on the server.
       return null;
     }
     // Checked *after* decoding, and only after: `%2e%2e` decodes to `..` and

--- a/flutter/lib/core/utils/markdown_links.dart
+++ b/flutter/lib/core/utils/markdown_links.dart
@@ -50,10 +50,19 @@ List<String> extractImageLinks(String? text) {
 /// path containing a space runs into the following `width=` attribute and the
 /// tag is mis-parsed.
 ///
-/// Nothing in `lib/` calls this yet — see `PHASE_142_NOTES.md`. The port's
-/// `CourseMarkdownBody` renders `![alt](path)` spans directly and resolves
-/// relative paths as authenticated bytes, so it never needs the rewrite; the
-/// Kotlin uses it in four places.
+/// Nothing in `lib/` calls this, and Phase 153 established that nothing should.
+/// The port's `CourseMarkdownBody` renders `![alt](path)` spans through
+/// `flutter_markdown_plus`, preferring the pre-downloaded local copy
+/// ([markdownImageCachePath]) and falling back to an authenticated fetch, so it
+/// never needs the rewrite. The Kotlin uses it in four places, all live.
+///
+/// One property worth knowing before anyone wires this up: it **discards the
+/// markdown alt text**. Markwon draws an `<img>` whose file is missing as
+/// `HtmlEmptyTagReplacement`'s `IMG_REPLACEMENT`, the alt attribute if there is
+/// one and `U+FFFC OBJECT REPLACEMENT CHARACTER` if there is not — so the
+/// Kotlin's missing-image state is one unlabelled box glyph rather than the
+/// image's description. Kept here as the line-for-line port of a live Kotlin
+/// function, quirk included.
 String prependBaseUrlToImages(
   String? markdownContent,
   String baseUrl, {
@@ -101,25 +110,60 @@ String prependBaseUrlToImages(
 ///   escaped (`AchievementFiles._segment` and
 ///   `ResourceFiles.resolveHtmlEntryFile` are the precedents), and a legitimate
 ///   attachment path never contains one.
-/// * a link that does not have at least an id segment and a file segment after
-///   the strip. `<base>/ole/<file>` with no id directory is what makes two
-///   unrelated `cover.jpg` attachments overwrite each other — the reason
-///   `ResourceFiles.fileFor` keys the directory on the document id.
+/// * a link that is left with no segments at all after the strip.
+///
+/// A **single**-segment link (a bare `cover.jpg`) is accepted, resolving to
+/// `<base>/ole/cover.jpg`. That is what the Kotlin does — the ground-truth
+/// audit for this phase confirmed a bare filename is one of the only two
+/// shapes whose download path and render path agree there — so two courses
+/// that both write `![](cover.jpg)` collide in this port exactly as they do in
+/// the Kotlin. Declining the shape instead would have been a regression
+/// against the app being ported, not a hardening of it.
+///
+/// Each segment is percent-decoded, so `a%20b.png` and a literal `a b.png`
+/// name the same file. That matches the Kotlin's *download* side
+/// (`FileUtils.getResourceRelativePathFromSegments` runs `URLDecoder.decode`
+/// per segment) and `ResourceFiles.resourceRelativePathFromUrl` here, which
+/// is what lets a markdown link to an attachment land on the same file the
+/// resource downloader would write. The Kotlin's *render* side does not
+/// decode, so those two disagree there for an encoded path; here one
+/// derivation serves both, so they cannot.
 String? markdownImageCachePath(String link) {
   final trimmed = link.trim();
   if (trimmed.isEmpty) return null;
-  if (trimmed.startsWith('/') || trimmed.contains(r'\')) return null;
-  // A scheme means an absolute URL. Checked before the `..` guard so the
-  // rejection reason in a failing test is the accurate one.
+  // A scheme means an absolute URL — including a `data:` URI, which is the
+  // only absolute shape the per-segment checks below would otherwise let
+  // through (`http://…` fails them on its empty segment after the `//`).
   if (Uri.tryParse(trimmed)?.hasScheme ?? false) return null;
 
   final stripped = trimmed.startsWith('resources/')
       ? trimmed.substring('resources/'.length)
       : trimmed;
   final segments = stripped.split('/');
-  if (segments.length < 2) return null;
+  if (segments.isEmpty) return null;
+  final decoded = <String>[];
   for (final segment in segments) {
-    if (segment.isEmpty || segment == '.' || segment == '..') return null;
+    final String plain;
+    try {
+      plain = Uri.decodeComponent(segment);
+    } on ArgumentError {
+      // A malformed escape (`%zz`). Nothing can name a file from this.
+      return null;
+    }
+    // Checked *after* decoding, and only after: `%2e%2e` decodes to `..` and
+    // `%2f` to a separator, so a check on the raw segment alone is one
+    // encoding away from useless — and a check on both is the raw one dead,
+    // which reads as a guard while pinning nothing. A leading `/` and a
+    // backslash-separated path fail here too, on their empty first segment
+    // and on the separator respectively.
+    if (plain.isEmpty ||
+        plain == '.' ||
+        plain == '..' ||
+        plain.contains('/') ||
+        plain.contains(r'\')) {
+      return null;
+    }
+    decoded.add(plain);
   }
-  return segments.join('/');
+  return decoded.join('/');
 }

--- a/flutter/lib/core/utils/markdown_links.dart
+++ b/flutter/lib/core/utils/markdown_links.dart
@@ -69,3 +69,57 @@ String prependBaseUrlToImages(
     return '<img src="$baseUrl$stripped" width=$width height=$height/>';
   });
 }
+
+/// The cache-relative path a markdown image [link] names, or `null` when the
+/// link cannot name a locally cached file.
+///
+/// This is the **single key derivation** shared by the prefetcher that writes
+/// the bytes and the renderer that reads them back. Phase 100 lost a certified
+/// exam's verification photo because the writer and the reader each derived
+/// their own key and the lookup missed on every capture, silently; the same
+/// trap is why this is one function rather than two similar ones.
+///
+/// The shape it resolves is the one [prependBaseUrlToImages] documents: a
+/// Planet markdown author writes `resources/<attachmentId>/<file>`, the
+/// download lands at `<base>/ole/<attachmentId>/<file>`, and the Kotlin's
+/// render base (`file://<externalFilesDir>/ole/`) plus the `resources/`-
+/// stripped path point at it. So the returned path is the link with a leading
+/// `resources/` removed — the same strip, kept in the same file as the
+/// rewrite so the two cannot drift apart.
+///
+/// Returns `null` — meaning "there is no local copy of this, resolve it some
+/// other way" — for:
+///
+/// * an **absolute** URL (`http:`, `https:`, `file:`, or any other scheme).
+///   The Kotlin has no such guard and mishandles these at both ends: it builds
+///   a download URL of `<serverUrl>/http://…` and renders
+///   `file://…/ole/http://…`, neither of which resolves. The port's
+///   `_MarkdownImage` already handles an absolute URL correctly, so declining
+///   here hands it back to the path that works.
+/// * a link containing a `..` segment, a leading `/`, or a backslash. A
+///   server-supplied path reaching the filesystem is how a directory is
+///   escaped (`AchievementFiles._segment` and
+///   `ResourceFiles.resolveHtmlEntryFile` are the precedents), and a legitimate
+///   attachment path never contains one.
+/// * a link that does not have at least an id segment and a file segment after
+///   the strip. `<base>/ole/<file>` with no id directory is what makes two
+///   unrelated `cover.jpg` attachments overwrite each other — the reason
+///   `ResourceFiles.fileFor` keys the directory on the document id.
+String? markdownImageCachePath(String link) {
+  final trimmed = link.trim();
+  if (trimmed.isEmpty) return null;
+  if (trimmed.startsWith('/') || trimmed.contains(r'\')) return null;
+  // A scheme means an absolute URL. Checked before the `..` guard so the
+  // rejection reason in a failing test is the accurate one.
+  if (Uri.tryParse(trimmed)?.hasScheme ?? false) return null;
+
+  final stripped = trimmed.startsWith('resources/')
+      ? trimmed.substring('resources/'.length)
+      : trimmed;
+  final segments = stripped.split('/');
+  if (segments.length < 2) return null;
+  for (final segment in segments) {
+    if (segment.isEmpty || segment == '.' || segment == '..') return null;
+  }
+  return segments.join('/');
+}

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/config/server_config.dart';
 import '../core/background/background_download_queue.dart';
+import '../core/files/markdown_image_prefetcher.dart';
 import '../core/background/background_scheduler.dart';
 import '../core/notifications/notification_presenter.dart';
 import '../core/notifications/task_deadline_notifier.dart';
@@ -595,6 +596,7 @@ final coursesRepositoryProvider = Provider<CoursesRepository>(
     ref.watch(removedLogDaoProvider),
     ref.watch(examDaoProvider),
     ref.watch(surveyDaoProvider),
+    markdownImages: MarkdownImagePrefetcher(ref.watch(planetApiProvider)),
   ),
 );
 

--- a/flutter/lib/repository/courses_repository.dart
+++ b/flutter/lib/repository/courses_repository.dart
@@ -1,8 +1,10 @@
 import '../core/config/server_config.dart';
+import '../core/files/markdown_image_prefetcher.dart';
 import '../core/network/network_result.dart';
 import '../core/sync/adaptive_batch_processor.dart';
 import '../core/sync/sync_result.dart';
 import '../core/utils/json_utils.dart';
+import '../core/utils/markdown_links.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
@@ -30,8 +32,9 @@ class CoursesRepository {
     this._dao,
     this._removedLogDao,
     this._examDao,
-    this._surveyDao,
-  );
+    this._surveyDao, {
+    MarkdownImagePrefetcher? markdownImages,
+  }) : _markdownImages = markdownImages;
 
   /// Courses carry embedded steps, so documents are much larger than resource
   /// documents — a smaller starting page keeps the first batch responsive on a
@@ -48,6 +51,11 @@ class CoursesRepository {
   /// same, through `examDao`/`questionDao` (`CoursesRepositoryImpl.kt:650-651`).
   final ExamDao _examDao;
   final SurveyDao _surveyDao;
+
+  /// Downloads the images a course or step description references, so they
+  /// render offline. Optional so the repository's other tests need no stub;
+  /// `coursesRepositoryProvider` always supplies one.
+  final MarkdownImagePrefetcher? _markdownImages;
 
   /// Reactive, offline-first course list.
   Stream<List<CourseRow>> watchCourses({
@@ -157,6 +165,10 @@ class CoursesRepository {
 
     final batchSizer = AdaptiveBatchProcessor(initialSize: initialBatchSize);
     final savedIds = <String>[];
+    // The markdown images this walk's descriptions reference. A `Set` because
+    // one course commonly repeats a cover image across its steps, and because
+    // Kotlin's collector is a `HashSet` too (`MyCourse.concatenatedLinks`).
+    final markdownImageLinks = <String>{};
     var skip = 0;
     // A short page means the server changed under us mid-walk. `savedIds` is
     // then only a prefix of what exists, so the cleanup below must not run —
@@ -232,6 +244,24 @@ class CoursesRepository {
         courseRows.add(parsed.course);
         stepRows.addAll(parsed.steps);
         savedIds.add(parsed.course.id.value);
+
+        // Port of `buildCoursePayload`'s two `extractLinks` calls
+        // (`CoursesRepositoryImpl:670` for the course description, `:684` for
+        // each step's). Read from the raw document rather than from `parsed`
+        // for the same reason the Kotlin reads its `JsonObject`: the step
+        // description is on the document whether or not the mapper keeps it.
+        markdownImageLinks.addAll(
+          extractImageLinks(JsonUtils.getString('description', doc)),
+        );
+        final steps = doc['steps'];
+        if (steps is List) {
+          for (final step in steps) {
+            if (step is! Map<String, dynamic>) continue;
+            markdownImageLinks.addAll(
+              extractImageLinks(JsonUtils.getString('description', step)),
+            );
+          }
+        }
 
         parsedResources.addAll(parsed.resources);
 
@@ -315,6 +345,17 @@ class CoursesRepository {
 
     if (walkedEveryPage && savedIds.isNotEmpty) {
       await _dao.deleteNotIn(savedIds);
+    }
+
+    // Kotlin queues each link as it parses the document and downloads the
+    // whole set once the sync finishes (`SyncActivity:566`); the same order
+    // here, so a course whose description names an image is readable offline
+    // rather than only while the device is online. Runs after the walk even if
+    // it ended short, because the links collected so far are still valid — and
+    // never on the early-return failure paths above, where the next sync
+    // re-collects them from the same documents.
+    if (markdownImageLinks.isNotEmpty) {
+      await _markdownImages?.prefetch(markdownImageLinks, config: config);
     }
 
     return SyncComplete(savedIds.length);

--- a/flutter/lib/ui/courses/course_markdown.dart
+++ b/flutter/lib/ui/courses/course_markdown.dart
@@ -95,7 +95,10 @@ class _MarkdownImage extends ConsumerWidget {
       }
       return _AuthedBytesImage(url: uri.toString(), config: config);
     }
-    // Relative path. Prefer the copy the sync pre-downloaded — that is the
+    // Anything left resolves against the server — a relative path, or an
+    // authority-less absolute one (`data:`, `mailto:`), which
+    // `markdownImageCachePath` declines so the lookup below simply misses.
+    // Prefer the copy the sync pre-downloaded — that is the
     // whole point of the prefetch, and it is the only branch that renders with
     // no network. Falls back to the authenticated fetch while the lookup is in
     // flight, when nothing has been downloaded yet, and when the derivation
@@ -136,9 +139,21 @@ class _MarkdownImage extends ConsumerWidget {
 ///
 /// Returns the *path* rather than the `File` so an override can be written
 /// without importing `dart:io`.
-final markdownImageFileProvider = FutureProvider.family<String?, String>(
-  (ref, link) async => (await MarkdownImageFiles.existingFileFor(link))?.path,
-);
+/// **`autoDispose` is load-bearing, not hygiene.** A plain `FutureProvider
+/// .family` caches per argument for the life of the `ProviderContainer`, so
+/// the first render of a description whose image is not yet downloaded would
+/// cache `null` for the rest of the process: the sync writes the file a minute
+/// later, the widget re-watches the same cached instance, and the local copy
+/// never takes over — the image goes on being fetched from the network, which
+/// renders nothing once the device is offline. That is the feature not
+/// working, in exactly the situation it exists for. Disposing when nothing is
+/// watching means the next screen that renders the description looks at the
+/// disk again.
+final markdownImageFileProvider = FutureProvider.autoDispose
+    .family<String?, String>(
+      (ref, link) async =>
+          (await MarkdownImageFiles.existingFileFor(link))?.path,
+    );
 
 /// The host of the active server, for deciding whether an absolute image URL
 /// is one of ours (authed) or external (plain network).

--- a/flutter/lib/ui/courses/course_markdown.dart
+++ b/flutter/lib/ui/courses/course_markdown.dart
@@ -7,6 +7,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/config/server_config.dart';
+import '../../core/files/markdown_image_files.dart';
+import '../../core/files/markdown_image_prefetcher.dart';
 import '../../core/network/network_result.dart';
 import '../../core/utils/url_utils.dart';
 import '../../providers/app_providers.dart';
@@ -16,12 +18,17 @@ import '../../providers/app_providers.dart';
 ///
 /// The Kotlin rewrites each `![alt](path)` to `<img src=file://…/ole/path>`
 /// and relies on the sync's concatenated-links download to materialise those
-/// files locally; Markwon then reads them off disk. The Flutter port has no
-/// such pre-download path yet, so images are resolved against the server and
-/// fetched as bytes through the authenticated [PlanetApi.getBytes] path — the
-/// same pattern [profileImageProvider] and [courseCoverImageProvider] use —
-/// because a CouchDB attachment is behind Basic auth and `Image.network`
-/// cannot send the header.
+/// files locally; Markwon then reads them off disk. Phase 153 gave the port
+/// the same pre-download ([MarkdownImagePrefetcher], driven from the courses
+/// sync walk), so a relative image resolves to that local copy first — which
+/// is what makes a description's images readable offline.
+///
+/// When there is no local copy the image is still resolved against the server
+/// and fetched as bytes through the authenticated [PlanetApi.getBytes] path —
+/// the same pattern [profileImageProvider] and [courseCoverImageProvider] use
+/// — because a CouchDB attachment is behind Basic auth and `Image.network`
+/// cannot send the header. That fallback is a **superset** of the Kotlin,
+/// which renders nothing at all when the pre-download has not run.
 ///
 /// Text formatting (headers, lists, bold, code) renders regardless of network
 /// state, which is the immediate improvement over the plain `Text` the screens
@@ -88,12 +95,50 @@ class _MarkdownImage extends ConsumerWidget {
       }
       return _AuthedBytesImage(url: uri.toString(), config: config);
     }
-    // Relative path — resolve against the server's /db root.
-    if (config == null) return const SizedBox.shrink();
-    final resolved = '${UrlUtils.dbUrl(config)}/${uri.toString()}';
-    return _AuthedBytesImage(url: resolved, config: config);
+    // Relative path. Prefer the copy the sync pre-downloaded — that is the
+    // whole point of the prefetch, and it is the only branch that renders with
+    // no network. Falls back to the authenticated fetch while the lookup is in
+    // flight, when nothing has been downloaded yet, and when the derivation
+    // declines the link.
+    final link = uri.toString();
+    final local = ref.watch(markdownImageFileProvider(link));
+    final networkFallback = config == null
+        ? const SizedBox.shrink()
+        : _AuthedBytesImage(
+            url: '${UrlUtils.dbUrl(config)}/$link',
+            config: config,
+          );
+    return local.maybeWhen(
+      data: (path) => path == null
+          ? networkFallback
+          : Image.file(
+              File(path),
+              // A file that vanished between the check and the read is not a
+              // reason to show a broken-image icon; fall back rather than
+              // shrink, so an online device still renders it.
+              errorBuilder: (_, _, _) => networkFallback,
+            ),
+      orElse: () => networkFallback,
+    );
   }
 }
+
+/// The pre-downloaded copy of a relative markdown image link, or `null` when
+/// there is none on disk.
+///
+/// A seam, not a convenience: [MarkdownImageFiles.existingFileFor] is real
+/// `dart:io`, whose futures never complete inside a widget test's fake-async
+/// zone — `pumpAndSettle` then spins to its ten-minute default and looks
+/// exactly like a hang (the trap `resource_viewer_screen` and
+/// `take_exam_screen` both documented). Overriding this provider lets a widget
+/// test drive both branches with no filesystem, the same shape as
+/// `resourceContentReaderProvider`.
+///
+/// Returns the *path* rather than the `File` so an override can be written
+/// without importing `dart:io`.
+final markdownImageFileProvider = FutureProvider.family<String?, String>(
+  (ref, link) async => (await MarkdownImageFiles.existingFileFor(link))?.path,
+);
 
 /// The host of the active server, for deciding whether an absolute image URL
 /// is one of ours (authed) or external (plain network).

--- a/flutter/test/core/files/markdown_image_files_test.dart
+++ b/flutter/test/core/files/markdown_image_files_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/files/markdown_image_files.dart';
+import 'package:myplanet/core/files/resource_files.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory tempDir;
+  late Future<Directory> Function() savedBaseDirectory;
+
+  setUp(() async {
+    savedBaseDirectory = ResourceFiles.baseDirectory;
+    tempDir = await Directory.systemTemp.createTemp('markdown_image_files');
+    ResourceFiles.baseDirectory = () async => tempDir;
+  });
+
+  tearDown(() async {
+    ResourceFiles.baseDirectory = savedBaseDirectory;
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  test(
+    'resolves a link to the same <base>/ole/<id>/<file> a resource uses',
+    () async {
+      final markdown = await MarkdownImageFiles.fileFor(
+        'resources/abc123/chart.png',
+      );
+      final resource = await ResourceFiles.fileFor(
+        docId: 'abc123',
+        filename: 'chart.png',
+      );
+      // The two must agree: a markdown image *is* a resource attachment reached
+      // by path instead of by my_library row, and the whole point of routing
+      // both through ResourceFiles.baseDirectory is that they cannot drift.
+      expect(markdown, isNotNull);
+      expect(markdown!.path, resource.path);
+      expect(markdown.path, p.join(tempDir.path, 'ole', 'abc123', 'chart.png'));
+    },
+  );
+
+  test('returns null for a link that names nothing local', () async {
+    expect(
+      await MarkdownImageFiles.fileFor('https://cdn.example/a.png'),
+      isNull,
+    );
+    expect(
+      await MarkdownImageFiles.fileFor('resources/../../escape.png'),
+      isNull,
+    );
+  });
+
+  test('keeps every resolved file inside the ole directory', () async {
+    for (final link in <String>[
+      'resources/abc/chart.png',
+      'abc/def/ghi/chart.png',
+    ]) {
+      final file = await MarkdownImageFiles.fileFor(link);
+      expect(file, isNotNull, reason: link);
+      expect(
+        p.isWithin(p.join(tempDir.path, 'ole'), file!.path),
+        isTrue,
+        reason: link,
+      );
+    }
+  });
+
+  group('existingFileFor', () {
+    test('returns null when nothing has been downloaded', () async {
+      expect(
+        await MarkdownImageFiles.existingFileFor('resources/abc/chart.png'),
+        isNull,
+      );
+    });
+
+    test('returns the file once it holds bytes', () async {
+      final file = (await MarkdownImageFiles.fileFor(
+        'resources/abc/chart.png',
+      ))!;
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(const [1, 2, 3]);
+      final found = await MarkdownImageFiles.existingFileFor(
+        'resources/abc/chart.png',
+      );
+      expect(found, isNotNull);
+      expect(found!.path, file.path);
+    });
+
+    test(
+      'rejects a zero-length file an interrupted download left behind',
+      () async {
+        // exists() alone would report this as present and the renderer would
+        // prefer an empty local copy over the network fetch that still works.
+        final file = (await MarkdownImageFiles.fileFor(
+          'resources/abc/chart.png',
+        ))!;
+        await file.parent.create(recursive: true);
+        await file.writeAsBytes(const []);
+        expect(
+          await MarkdownImageFiles.existingFileFor('resources/abc/chart.png'),
+          isNull,
+        );
+      },
+    );
+  });
+}

--- a/flutter/test/core/files/markdown_image_prefetcher_test.dart
+++ b/flutter/test/core/files/markdown_image_prefetcher_test.dart
@@ -166,7 +166,7 @@ void main() {
     final written = await prefetcher.prefetch(const [
       'https://cdn.example/a.png',
       'resources/../../escape.png',
-      'cover.jpg',
+      'resources/%2e%2e/escape.png',
     ], config: config);
 
     expect(written, 0);

--- a/flutter/test/core/files/markdown_image_prefetcher_test.dart
+++ b/flutter/test/core/files/markdown_image_prefetcher_test.dart
@@ -162,6 +162,56 @@ void main() {
     );
   });
 
+  test('stops requesting once the budget is spent', () async {
+    // The prefetch runs inside a sync now, and a first sync on a fresh
+    // install is not the steady state the skip-if-present check makes cheap.
+    // WorkManager kills the background task at around ten minutes; Kotlin
+    // needs no budget because it hands the queue to a foreground service.
+    final bounded = MarkdownImagePrefetcher(api, budget: Duration.zero);
+
+    expect(
+      await bounded.prefetch(const ['resources/abc/c.png'], config: config),
+      0,
+    );
+    verifyNever(
+      () => api.getBytes(any(), authHeader: any(named: 'authHeader')),
+    );
+  });
+
+  test(
+    'abandons a link whose download stalls past the per-link timeout',
+    () async {
+      // PlanetApi.getBytes sets receiveTimeout: null — right for a large
+      // user-initiated download, an unbounded stall inside a sync, where
+      // SyncNotifier refuses a second attempt while one is running so the
+      // button never re-enables.
+      final quick = MarkdownImagePrefetcher(
+        api,
+        perLinkTimeout: const Duration(milliseconds: 30),
+      );
+      when(
+        () => api.getBytes(
+          '$dbUrl/resources/abc/c.png',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) => Future<NetworkResult<List<int>>>.delayed(
+          const Duration(seconds: 30),
+          () => const NetworkSuccess<List<int>>([1]),
+        ),
+      );
+
+      expect(
+        await quick.prefetch(const ['resources/abc/c.png'], config: config),
+        0,
+      );
+      expect(
+        await MarkdownImageFiles.existingFileFor('resources/abc/c.png'),
+        isNull,
+      );
+    },
+  );
+
   test('never requests a link that names nothing local', () async {
     final written = await prefetcher.prefetch(const [
       'https://cdn.example/a.png',

--- a/flutter/test/core/files/markdown_image_prefetcher_test.dart
+++ b/flutter/test/core/files/markdown_image_prefetcher_test.dart
@@ -1,0 +1,177 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/files/markdown_image_files.dart';
+import 'package:myplanet/core/files/markdown_image_prefetcher.dart';
+import 'package:myplanet/core/files/resource_files.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late MockPlanetApi api;
+  late MarkdownImagePrefetcher prefetcher;
+  late Directory tempDir;
+  late Future<Directory> Function() savedBaseDirectory;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example:443/db';
+
+  setUp(() async {
+    api = MockPlanetApi();
+    prefetcher = MarkdownImagePrefetcher(api);
+    tempDir = await Directory.systemTemp.createTemp('markdown_prefetch');
+    savedBaseDirectory = ResourceFiles.baseDirectory;
+    ResourceFiles.baseDirectory = () async => tempDir;
+  });
+
+  tearDown(() async {
+    ResourceFiles.baseDirectory = savedBaseDirectory;
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  void stubBytes(String url, NetworkResult<List<int>> result) {
+    when(
+      () => api.getBytes(url, authHeader: any(named: 'authHeader')),
+    ).thenAnswer((_) async => result);
+  }
+
+  test('downloads a link and writes it where the renderer looks', () async {
+    stubBytes(
+      '$dbUrl/resources/abc123/chart.png',
+      const NetworkSuccess<List<int>>([1, 2, 3]),
+    );
+
+    final written = await prefetcher.prefetch(const [
+      'resources/abc123/chart.png',
+    ], config: config);
+
+    expect(written, 1);
+    // The assertion that matters is not "a file exists" but "the file the
+    // reader's own lookup finds" — the Phase 100 shape, where the writer and
+    // reader derived different keys and the miss was silent.
+    final found = await MarkdownImageFiles.existingFileFor(
+      'resources/abc123/chart.png',
+    );
+    expect(found, isNotNull);
+    expect(await found!.readAsBytes(), const [1, 2, 3]);
+  });
+
+  test('keeps the resources/ prefix on the download URL', () async {
+    // The download URL and the on-disk path deliberately disagree: Kotlin
+    // queues "$baseUrl/$link" from the unstripped link
+    // (CoursesRepositoryImpl:671) while the render base strips the marker.
+    stubBytes(
+      '$dbUrl/resources/abc123/chart.png',
+      const NetworkSuccess<List<int>>([9]),
+    );
+    await prefetcher.prefetch(const [
+      'resources/abc123/chart.png',
+    ], config: config);
+    verify(
+      () => api.getBytes(
+        '$dbUrl/resources/abc123/chart.png',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).called(1);
+  });
+
+  test('skips a link already on disk', () async {
+    final file = (await MarkdownImageFiles.fileFor('resources/abc/c.png'))!;
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(const [7, 7]);
+
+    final written = await prefetcher.prefetch(const [
+      'resources/abc/c.png',
+    ], config: config);
+
+    expect(written, 0);
+    verifyNever(
+      () => api.getBytes(any(), authHeader: any(named: 'authHeader')),
+    );
+    expect(await file.readAsBytes(), const [7, 7]);
+  });
+
+  test(
+    're-downloads a zero-length leftover rather than treating it as done',
+    () async {
+      final file = (await MarkdownImageFiles.fileFor('resources/abc/c.png'))!;
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(const []);
+      stubBytes(
+        '$dbUrl/resources/abc/c.png',
+        const NetworkSuccess<List<int>>([4]),
+      );
+
+      expect(
+        await prefetcher.prefetch(const [
+          'resources/abc/c.png',
+        ], config: config),
+        1,
+      );
+      expect(await file.readAsBytes(), const [4]);
+    },
+  );
+
+  test('writes nothing for an empty response body', () async {
+    // A success with no bytes would otherwise create a file that exists,
+    // renders nothing, and is never retried.
+    stubBytes(
+      '$dbUrl/resources/abc/c.png',
+      const NetworkSuccess<List<int>>([]),
+    );
+
+    expect(
+      await prefetcher.prefetch(const ['resources/abc/c.png'], config: config),
+      0,
+    );
+    expect(
+      await MarkdownImageFiles.existingFileFor('resources/abc/c.png'),
+      isNull,
+    );
+  });
+
+  test('swallows a failed download and keeps going', () async {
+    stubBytes(
+      '$dbUrl/resources/a/one.png',
+      const NetworkError<List<int>>(500, 'boom'),
+    );
+    stubBytes(
+      '$dbUrl/resources/b/two.png',
+      const NetworkSuccess<List<int>>([2]),
+    );
+
+    final written = await prefetcher.prefetch(const [
+      'resources/a/one.png',
+      'resources/b/two.png',
+    ], config: config);
+
+    // A missing image must not stop the rest, and must not fail the sync that
+    // has already written the documents.
+    expect(written, 1);
+    expect(
+      await MarkdownImageFiles.existingFileFor('resources/b/two.png'),
+      isNotNull,
+    );
+  });
+
+  test('never requests a link that names nothing local', () async {
+    final written = await prefetcher.prefetch(const [
+      'https://cdn.example/a.png',
+      'resources/../../escape.png',
+      'cover.jpg',
+    ], config: config);
+
+    expect(written, 0);
+    verifyNever(
+      () => api.getBytes(any(), authHeader: any(named: 'authHeader')),
+    );
+  });
+}

--- a/flutter/test/core/utils/markdown_links_test.dart
+++ b/flutter/test/core/utils/markdown_links_test.dart
@@ -173,4 +173,72 @@ void main() {
       expect(markdownImageCachePath('abc//chart.png'), isNull);
     });
   });
+
+  group('markdownImageDestination', () {
+    test('is a no-op on what the renderer supplies', () {
+      // The renderer hands a parsed CommonMark destination, which carries
+      // neither a title nor brackets. Verified against the real parser.
+      expect(
+        markdownImageDestination('resources/abc/c.png'),
+        'resources/abc/c.png',
+      );
+    });
+
+    test('strips a title in any of CommonMark three forms', () {
+      for (final title in <String>["\"T\"", "'T'", '(T)']) {
+        expect(
+          markdownImageDestination('resources/abc/c.png $title'),
+          'resources/abc/c.png',
+          reason: title,
+        );
+      }
+    });
+
+    test('unwraps a pointy-bracket destination', () {
+      expect(
+        markdownImageDestination('<resources/abc/c.png>'),
+        'resources/abc/c.png',
+      );
+      expect(
+        markdownImageDestination('<resources/abc/c.png> "T"'),
+        'resources/abc/c.png',
+      );
+    });
+
+    test('leaves a quote that is part of the path alone', () {
+      // No whitespace before it, so it is not a title.
+      expect(markdownImageDestination('abc/say"hi".png'), 'abc/say"hi".png');
+    });
+
+    test('needs whitespace before a title, so a filename keeps its suffix', () {
+      // `photo(1)` is a real filename shape. Without the whitespace
+      // requirement the parenthesised-title branch would eat it.
+      expect(markdownImageDestination('abc/photo(1)'), 'abc/photo(1)');
+      expect(markdownImageDestination(r'abc/track[1]'), r'abc/track[1]');
+    });
+
+    test('leaves an unterminated quote alone', () {
+      expect(markdownImageDestination('abc/c.png "T'), 'abc/c.png "T');
+    });
+  });
+
+  group('markdownImageCachePath reconciles the two parsers', () {
+    test('a titled link resolves to the path the renderer asks for', () {
+      // extractImageLinks captures 'resources/abc/c.png "Title"' where
+      // flutter_markdown_plus yields 'resources/abc/c.png'. Both must land on
+      // the same cache path or the prefetch writes where nothing looks.
+      expect(
+        markdownImageCachePath('resources/abc/c.png "Title"'),
+        markdownImageCachePath('resources/abc/c.png'),
+      );
+      expect(
+        markdownImageCachePath('resources/abc/c.png "Title"'),
+        'abc/c.png',
+      );
+    });
+
+    test('a bracketed link resolves to the path the renderer asks for', () {
+      expect(markdownImageCachePath('<resources/abc/c.png>'), 'abc/c.png');
+    });
+  });
 }

--- a/flutter/test/core/utils/markdown_links_test.dart
+++ b/flutter/test/core/utils/markdown_links_test.dart
@@ -120,6 +120,12 @@ void main() {
       expect(markdownImageCachePath('https://cdn.example/a.png'), isNull);
       expect(markdownImageCachePath('http://cdn.example/a.png'), isNull);
       expect(markdownImageCachePath('file:///tmp/a.png'), isNull);
+      // The one absolute shape the per-segment checks would let through: a
+      // data: URI splits into two non-empty segments.
+      expect(
+        markdownImageCachePath('data:image/png;base64,iVBORw0KGgo='),
+        isNull,
+      );
     });
 
     test('declines a link that could escape the cache directory', () {
@@ -129,11 +135,33 @@ void main() {
       expect(markdownImageCachePath(r'abc\..\x.png'), isNull);
     });
 
-    test('declines a link with no id segment', () {
-      // <base>/ole/cover.jpg with no id directory is how two unrelated
-      // cover.jpg attachments overwrite each other.
-      expect(markdownImageCachePath('cover.jpg'), isNull);
-      expect(markdownImageCachePath('resources/cover.jpg'), isNull);
+    test('accepts a bare filename, as the Kotlin does', () {
+      // One of only two link shapes whose Kotlin download path and render
+      // path agree. Declining it would regress against the app being ported.
+      expect(markdownImageCachePath('cover.jpg'), 'cover.jpg');
+      expect(markdownImageCachePath('resources/cover.jpg'), 'cover.jpg');
+    });
+
+    test('percent-decodes each segment', () {
+      // So an encoded link and a literal-space link name one file, and a
+      // markdown link to an attachment lands where the resource downloader
+      // would write it.
+      expect(
+        markdownImageCachePath('resources/abc/my%20chart.png'),
+        'abc/my chart.png',
+      );
+      expect(
+        markdownImageCachePath('resources/abc/my chart.png'),
+        'abc/my chart.png',
+      );
+    });
+
+    test('declines an escape that decodes into a traversal or separator', () {
+      // %2e%2e is '..' and %2f is '/', so checking only the raw form leaves
+      // the guard one encoding away from useless.
+      expect(markdownImageCachePath('resources/%2e%2e/%2e%2e/passwd'), isNull);
+      expect(markdownImageCachePath('resources/abc/a%2fb.png'), isNull);
+      expect(markdownImageCachePath('resources/abc/bad%zz.png'), isNull);
     });
 
     test('declines an empty or blank link', () {

--- a/flutter/test/core/utils/markdown_links_test.dart
+++ b/flutter/test/core/utils/markdown_links_test.dart
@@ -91,4 +91,58 @@ void main() {
       );
     });
   });
+
+  group('markdownImageCachePath', () {
+    test('strips a leading resources/ and keeps the id and file segments', () {
+      expect(
+        markdownImageCachePath('resources/abc123/chart.png'),
+        'abc123/chart.png',
+      );
+    });
+
+    test('accepts a link that already omits the resources/ marker', () {
+      expect(markdownImageCachePath('abc123/chart.png'), 'abc123/chart.png');
+    });
+
+    test('keeps a nested path under the id directory', () {
+      // A multi-file attachment bundle keeps its subfolder, the same reason
+      // ResourceFiles.resourceRelativePathFromUrl does not flatten one.
+      expect(
+        markdownImageCachePath('resources/abc123/figures/chart.png'),
+        'abc123/figures/chart.png',
+      );
+    });
+
+    test('declines an absolute URL so the network path keeps handling it', () {
+      // The Kotlin has no such guard: it queues "<serverUrl>/http://..." for
+      // download and renders "file://.../ole/http://...", neither of which
+      // resolves. _MarkdownImage already fetches these correctly.
+      expect(markdownImageCachePath('https://cdn.example/a.png'), isNull);
+      expect(markdownImageCachePath('http://cdn.example/a.png'), isNull);
+      expect(markdownImageCachePath('file:///tmp/a.png'), isNull);
+    });
+
+    test('declines a link that could escape the cache directory', () {
+      expect(markdownImageCachePath('resources/../../etc/passwd'), isNull);
+      expect(markdownImageCachePath('../secrets/key.png'), isNull);
+      expect(markdownImageCachePath('/etc/passwd'), isNull);
+      expect(markdownImageCachePath(r'abc\..\x.png'), isNull);
+    });
+
+    test('declines a link with no id segment', () {
+      // <base>/ole/cover.jpg with no id directory is how two unrelated
+      // cover.jpg attachments overwrite each other.
+      expect(markdownImageCachePath('cover.jpg'), isNull);
+      expect(markdownImageCachePath('resources/cover.jpg'), isNull);
+    });
+
+    test('declines an empty or blank link', () {
+      expect(markdownImageCachePath(''), isNull);
+      expect(markdownImageCachePath('   '), isNull);
+    });
+
+    test('declines a link with an empty interior segment', () {
+      expect(markdownImageCachePath('abc//chart.png'), isNull);
+    });
+  });
 }

--- a/flutter/test/core/utils/markdown_links_test.dart
+++ b/flutter/test/core/utils/markdown_links_test.dart
@@ -164,6 +164,17 @@ void main() {
       expect(markdownImageCachePath('resources/abc/bad%zz.png'), isNull);
     });
 
+    test(
+      'declines a valid escape that is not valid UTF-8, without throwing',
+      () {
+        // `caf%E9.png` is Latin-1 `café.png`. Uri.decodeComponent throws
+        // FormatException here and ArgumentError only for bad hex, so catching
+        // ArgumentError alone let this escape all the way out of sync().
+        expect(markdownImageCachePath('resources/abc/caf%E9.png'), isNull);
+        expect(markdownImageCachePath('resources/abc/%FF.png'), isNull);
+      },
+    );
+
     test('declines an empty or blank link', () {
       expect(markdownImageCachePath(''), isNull);
       expect(markdownImageCachePath('   '), isNull);
@@ -184,8 +195,8 @@ void main() {
       );
     });
 
-    test('strips a title in any of CommonMark three forms', () {
-      for (final title in <String>["\"T\"", "'T'", '(T)']) {
+    test('strips a quoted title in either form', () {
+      for (final title in <String>["\"T\"", "'T'"]) {
         expect(
           markdownImageDestination('resources/abc/c.png $title'),
           'resources/abc/c.png',
@@ -210,11 +221,26 @@ void main() {
       expect(markdownImageDestination('abc/say"hi".png'), 'abc/say"hi".png');
     });
 
-    test('needs whitespace before a title, so a filename keeps its suffix', () {
-      // `photo(1)` is a real filename shape. Without the whitespace
-      // requirement the parenthesised-title branch would eat it.
-      expect(markdownImageDestination('abc/photo(1)'), 'abc/photo(1)');
-      expect(markdownImageDestination(r'abc/track[1]'), r'abc/track[1]');
+    test(
+      'leaves a parenthesised title alone, because no producer emits one',
+      () {
+        // CommonMark allows `p (T)`, and the branch for it is deliberately
+        // absent: extractImageLinks' lazy capture stops at the first ')', so
+        // `![a](p (T))` yields `p (T` and never a string ending in ')'. Pinned
+        // so removing the branch stays a decision rather than a regression.
+        expect(extractImageLinks('![a](p (T))'), ['p (T']);
+        expect(
+          markdownImageDestination('resources/abc/c.png (T)'),
+          'resources/abc/c.png (T)',
+        );
+      },
+    );
+
+    test('needs whitespace before a quoted title', () {
+      // A path whose last segment is quoted is reachable: `![a](abc/"T")`.
+      // Without the whitespace requirement the title branch would eat it.
+      expect(extractImageLinks(r'![a](abc/"T")'), [r'abc/"T"']);
+      expect(markdownImageDestination(r'abc/"T"'), r'abc/"T"');
     });
 
     test('leaves an unterminated quote alone', () {

--- a/flutter/test/providers/courses_repository_wiring_test.dart
+++ b/flutter/test/providers/courses_repository_wiring_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/files/markdown_image_files.dart';
+import 'package:myplanet/core/files/resource_files.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Does the **app, as wired**, prefetch a markdown image?
+///
+/// `CoursesRepository`'s `markdownImages` argument is optional with a null
+/// default and the call site is `_markdownImages?.prefetch(...)`, so deleting
+/// the argument from `coursesRepositoryProvider` is a silent no-op: analyze
+/// stays clean, every prefetch test stays green — because each builds its own
+/// repository — and the feature is simply gone from the shipping app. That is
+/// the ported-tested-green-and-dead class Phases 113, 116 and 119 exist for,
+/// and a dartdoc saying "the provider always supplies one" is a comment where
+/// a test is needed. This is the test.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late Directory tempDir;
+  late Future<Directory> Function() savedBaseDirectory;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+  const link = 'resources/cover-doc/cover.png';
+
+  setUp(() async {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    tempDir = await Directory.systemTemp.createTemp('courses_wiring');
+    savedBaseDirectory = ResourceFiles.baseDirectory;
+    ResourceFiles.baseDirectory = () async => tempDir;
+  });
+
+  tearDown(() async {
+    ResourceFiles.baseDirectory = savedBaseDirectory;
+    await db.close();
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  test(
+    'the wired courses repository pre-downloads a description image',
+    () async {
+      when(
+        () => api.getJsonObject(
+          '$dbUrl/courses/_all_docs?limit=0',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 1}),
+      );
+      when(
+        () => api.getJsonObject(
+          '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          'rows': [
+            {
+              'id': 'course-1',
+              'doc': {
+                '_id': 'course-1',
+                'courseTitle': 'Algebra',
+                'description': 'Intro ![cover]($link)',
+              },
+            },
+          ],
+        }),
+      );
+      when(
+        () =>
+            api.getBytes('$dbUrl/$link', authHeader: any(named: 'authHeader')),
+      ).thenAnswer((_) async => const NetworkSuccess<List<int>>([1, 2, 3]));
+
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          planetApiProvider.overrideWithValue(api),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(coursesRepositoryProvider).sync(config: config);
+
+      // Not "a prefetcher was constructed" — the bytes are on disk, found by the
+      // renderer's own lookup.
+      expect(await MarkdownImageFiles.existingFileFor(link), isNotNull);
+    },
+  );
+}

--- a/flutter/test/repository/courses_repository_test.dart
+++ b/flutter/test/repository/courses_repository_test.dart
@@ -7,14 +7,32 @@ import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/data/local/course_mapper.dart';
 import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/core/files/markdown_image_prefetcher.dart';
 import 'package:myplanet/repository/courses_repository.dart';
 
 class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Records the links a sync hands over, without touching the filesystem.
+class _RecordingPrefetcher implements MarkdownImagePrefetcher {
+  final List<String> links = [];
+  int calls = 0;
+
+  @override
+  Future<int> prefetch(
+    Iterable<String> links, {
+    required ServerConfig config,
+  }) async {
+    calls++;
+    this.links.addAll(links);
+    return links.length;
+  }
+}
 
 void main() {
   late AppDatabase db;
   late MockPlanetApi api;
   late CoursesRepository repository;
+  late _RecordingPrefetcher prefetcher;
 
   const config = ServerConfig(
     serverUrl: 'https://planet.example.org',
@@ -27,12 +45,14 @@ void main() {
   setUp(() {
     db = AppDatabase.memory();
     api = MockPlanetApi();
+    prefetcher = _RecordingPrefetcher();
     repository = CoursesRepository(
       api,
       db.courseDao,
       db.removedLogDao,
       db.examDao,
       db.surveyDao,
+      markdownImages: prefetcher,
     );
   });
 
@@ -597,5 +617,137 @@ void main() {
       expect(await db.examDao.getByStepIds(['course-1:0']), isEmpty);
       expect(await db.surveyDao.getByStepId('course-1:0'), isEmpty);
     });
+  });
+
+  group('markdown image prefetch', () {
+    test('collects the images a course description references', () async {
+      // The gap this closes: nothing in the port ever collected these, so an
+      // image in a course description was fetched at render time and was
+      // therefore missing on an offline device — in an offline-first app.
+      stubCount(1);
+      stubPage(0, 50, [
+        {
+          'id': 'course-1',
+          'doc': {
+            '_id': 'course-1',
+            'courseTitle': 'Algebra',
+            'description': 'Intro ![cover](resources/cover-doc/cover.png)',
+          },
+        },
+      ]);
+
+      await repository.sync(config: config);
+
+      expect(prefetcher.links, ['resources/cover-doc/cover.png']);
+    });
+
+    test("collects the images a step's description references", () async {
+      // Kotlin extracts from the course description and from each step's,
+      // separately (CoursesRepositoryImpl:670 and :684).
+      stubCount(1);
+      stubPage(0, 50, [
+        {
+          'id': 'course-1',
+          'doc': {
+            '_id': 'course-1',
+            'courseTitle': 'Algebra',
+            'steps': [
+              {
+                'stepTitle': 'One',
+                'description': 'See ![a](resources/s1/a.png)',
+              },
+              {
+                'stepTitle': 'Two',
+                'description': 'And ![b](resources/s2/b.png)',
+              },
+            ],
+          },
+        },
+      ]);
+
+      await repository.sync(config: config);
+
+      expect(prefetcher.links, ['resources/s1/a.png', 'resources/s2/b.png']);
+    });
+
+    test('hands over one entry for an image repeated across steps', () async {
+      stubCount(1);
+      stubPage(0, 50, [
+        {
+          'id': 'course-1',
+          'doc': {
+            '_id': 'course-1',
+            'courseTitle': 'Algebra',
+            'description': '![c](resources/c/c.png)',
+            'steps': [
+              {'stepTitle': 'One', 'description': '![c](resources/c/c.png)'},
+            ],
+          },
+        },
+      ]);
+
+      await repository.sync(config: config);
+
+      expect(prefetcher.links, ['resources/c/c.png']);
+    });
+
+    test('prefetches once, after the walk rather than per page', () async {
+      stubCount(2);
+      stubPage(0, 50, [
+        {
+          'id': 'course-1',
+          'doc': {
+            '_id': 'course-1',
+            'courseTitle': 'A',
+            'description': '![a](resources/a/a.png)',
+          },
+        },
+        {
+          'id': 'course-2',
+          'doc': {
+            '_id': 'course-2',
+            'courseTitle': 'B',
+            'description': '![b](resources/b/b.png)',
+          },
+        },
+      ]);
+
+      await repository.sync(config: config);
+
+      expect(prefetcher.calls, 1);
+      expect(prefetcher.links, ['resources/a/a.png', 'resources/b/b.png']);
+    });
+
+    test(
+      'does not call the prefetcher when no description carries an image',
+      () async {
+        stubCount(1);
+        stubPage(0, 50, [row('course-1', 'Algebra')]);
+
+        await repository.sync(config: config);
+
+        expect(prefetcher.calls, 0);
+      },
+    );
+
+    test(
+      'does not prefetch when the walk fails before writing anything',
+      () async {
+        // The next sync re-collects these from the same documents, so dropping
+        // them here costs nothing — the documents are the durable store.
+        stubCount(1);
+        when(
+          () => api.getJsonObject(
+            '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+            authHeader: any(named: 'authHeader'),
+          ),
+        ).thenAnswer(
+          (_) async => const NetworkError<Map<String, dynamic>>(500, 'boom'),
+        );
+
+        expect(await repository.sync(config: config), isA<SyncFailed>());
+        expect(prefetcher.calls, 0);
+      },
+    );
   });
 }

--- a/flutter/test/repository/courses_repository_test.dart
+++ b/flutter/test/repository/courses_repository_test.dart
@@ -18,6 +18,12 @@ class _RecordingPrefetcher implements MarkdownImagePrefetcher {
   int calls = 0;
 
   @override
+  Duration get perLinkTimeout => const Duration(seconds: 30);
+
+  @override
+  Duration get budget => const Duration(minutes: 3);
+
+  @override
   Future<int> prefetch(
     Iterable<String> links, {
     required ServerConfig config,
@@ -692,7 +698,20 @@ void main() {
     });
 
     test('prefetches once, after the walk rather than per page', () async {
-      stubCount(2);
+      // Two *pages*, not two rows: with one page `calls == 1` holds whether
+      // the prefetch sits after the loop or inside it, so the test would be
+      // green for the mutation it is named for.
+      stubCount(3);
+      stubPage(2, 50, [
+        {
+          'id': 'course-3',
+          'doc': {
+            '_id': 'course-3',
+            'courseTitle': 'C',
+            'description': '![c](resources/c/c.png)',
+          },
+        },
+      ]);
       stubPage(0, 50, [
         {
           'id': 'course-1',
@@ -715,7 +734,11 @@ void main() {
       await repository.sync(config: config);
 
       expect(prefetcher.calls, 1);
-      expect(prefetcher.links, ['resources/a/a.png', 'resources/b/b.png']);
+      expect(prefetcher.links, [
+        'resources/a/a.png',
+        'resources/b/b.png',
+        'resources/c/c.png',
+      ]);
     });
 
     test(

--- a/flutter/test/repository/markdown_image_round_trip_test.dart
+++ b/flutter/test/repository/markdown_image_round_trip_test.dart
@@ -1,0 +1,193 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/files/markdown_image_files.dart';
+import 'package:myplanet/core/files/markdown_image_prefetcher.dart';
+import 'package:myplanet/core/files/resource_files.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/courses_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The join, end to end: a **server-shaped course document** goes through the
+/// real sync walk and the real prefetcher, and the file that comes out is
+/// found by the *renderer's own lookup*.
+///
+/// Not a fixture that hand-places a file where the renderer computes it —
+/// that is the fabricated join this project keeps catching (Phase 113's
+/// unreachable exam screen, Phase 100's verification photo). If the collector,
+/// the writer and the reader are only ever tested apart, a disagreement
+/// between the key one writes and the key another reads passes every suite and
+/// fails on every device.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late CoursesRepository repository;
+  late Directory tempDir;
+  late Future<Directory> Function() savedBaseDirectory;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() async {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = CoursesRepository(
+      api,
+      db.courseDao,
+      db.removedLogDao,
+      db.examDao,
+      db.surveyDao,
+      markdownImages: MarkdownImagePrefetcher(api),
+    );
+    tempDir = await Directory.systemTemp.createTemp('markdown_round_trip');
+    savedBaseDirectory = ResourceFiles.baseDirectory;
+    ResourceFiles.baseDirectory = () async => tempDir;
+  });
+
+  tearDown(() async {
+    ResourceFiles.baseDirectory = savedBaseDirectory;
+    await db.close();
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  void stubWalk(List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  /// The lookup `markdownImageFileProvider` performs, driven with the link the
+  /// renderer would hand it — `Uri.parse(...).toString()` is what
+  /// `flutter_markdown`'s `imageBuilder` produces from the same span.
+  Future<File?> asTheRendererLooksItUp(String link) =>
+      MarkdownImageFiles.existingFileFor(Uri.parse(link).toString());
+
+  test(
+    'a synced course description image is on disk where the renderer looks',
+    () async {
+      const link = 'resources/cover-doc/cover.png';
+      stubWalk([
+        {
+          '_id': 'course-1',
+          'courseTitle': 'Algebra',
+          'description': 'Intro ![cover]($link)',
+        },
+      ]);
+      when(
+        () =>
+            api.getBytes('$dbUrl/$link', authHeader: any(named: 'authHeader')),
+      ).thenAnswer((_) async => const NetworkSuccess<List<int>>([1, 2, 3, 4]));
+
+      await repository.sync(config: config);
+
+      final found = await asTheRendererLooksItUp(link);
+      expect(
+        found,
+        isNotNull,
+        reason: 'the renderer cannot find what sync wrote',
+      );
+      expect(await found!.readAsBytes(), const [1, 2, 3, 4]);
+    },
+  );
+
+  test("a synced step description's image makes the same round trip", () async {
+    const link = 'resources/step-doc/diagram.png';
+    stubWalk([
+      {
+        '_id': 'course-1',
+        'courseTitle': 'Algebra',
+        'steps': [
+          {'stepTitle': 'One', 'description': 'See ![d]($link)'},
+        ],
+      },
+    ]);
+    when(
+      () => api.getBytes('$dbUrl/$link', authHeader: any(named: 'authHeader')),
+    ).thenAnswer((_) async => const NetworkSuccess<List<int>>([9]));
+
+    await repository.sync(config: config);
+
+    expect(await asTheRendererLooksItUp(link), isNotNull);
+  });
+
+  test(
+    'an encoded link and its literal-space twin resolve to one file',
+    () async {
+      // The Kotlin's download side decodes each segment and its render side does
+      // not, so these two disagree there. One derivation serves both here.
+      const encoded = 'resources/doc/my%20chart.png';
+      stubWalk([
+        {
+          '_id': 'course-1',
+          'courseTitle': 'Algebra',
+          'description': '![c]($encoded)',
+        },
+      ]);
+      when(
+        () => api.getBytes(
+          '$dbUrl/$encoded',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async => const NetworkSuccess<List<int>>([5]));
+
+      await repository.sync(config: config);
+
+      expect(await asTheRendererLooksItUp(encoded), isNotNull);
+      expect(
+        await MarkdownImageFiles.existingFileFor('resources/doc/my chart.png'),
+        isNotNull,
+      );
+    },
+  );
+
+  test(
+    'a failed image download leaves nothing for the renderer to prefer',
+    () async {
+      // The renderer must fall through to its authenticated fetch rather than
+      // find a zero-length file and render an empty box.
+      const link = 'resources/doc/missing.png';
+      stubWalk([
+        {
+          '_id': 'course-1',
+          'courseTitle': 'Algebra',
+          'description': '![m]($link)',
+        },
+      ]);
+      when(
+        () =>
+            api.getBytes('$dbUrl/$link', authHeader: any(named: 'authHeader')),
+      ).thenAnswer((_) async => const NetworkError<List<int>>(404, 'gone'));
+
+      expect(await repository.sync(config: config), isA<SyncComplete>());
+      expect(await asTheRendererLooksItUp(link), isNull);
+    },
+  );
+}

--- a/flutter/test/repository/markdown_image_round_trip_test.dart
+++ b/flutter/test/repository/markdown_image_round_trip_test.dart
@@ -241,4 +241,65 @@ void main() {
       },
     );
   });
+
+  group('a bad link cannot fail the sync that already wrote the documents', () {
+    test('a Latin-1 percent-escape does not throw out of sync()', () async {
+      // `caf%E9.png` is Latin-1 `café.png` — valid hex, invalid UTF-8, from
+      // any pre-UTF-8 attachment name. Uri.decodeComponent throws
+      // FormatException for it and ArgumentError only for bad hex, so
+      // catching ArgumentError alone let it escape _fetch -> prefetch ->
+      // sync(). In the background isolate that leaves recordLastSync
+      // unwritten and WorkManager retrying the whole walk for as long as the
+      // document exists on the server.
+      stubWalk([
+        {
+          '_id': 'course-1',
+          'courseTitle': 'Algebra',
+          'description': '![logo](resources/abc/caf%E9.png)',
+        },
+      ]);
+
+      expect(await repository.sync(config: config), isA<SyncComplete>());
+      expect(await repository.localCount(), 1);
+    });
+
+    test('a download that throws does not throw out of sync()', () async {
+      stubWalk([
+        {
+          '_id': 'course-1',
+          'courseTitle': 'Algebra',
+          'description': '![a](resources/abc/c.png)',
+        },
+      ]);
+      when(
+        () => api.getBytes(
+          '$dbUrl/resources/abc/c.png',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenThrow(StateError('transport exploded'));
+
+      expect(await repository.sync(config: config), isA<SyncComplete>());
+    });
+
+    test('one bad link does not stop the links after it', () async {
+      stubWalk([
+        {
+          '_id': 'course-1',
+          'courseTitle': 'Algebra',
+          'description':
+              '![bad](resources/abc/caf%E9.png) ![good](resources/xyz/ok.png)',
+        },
+      ]);
+      when(
+        () => api.getBytes(
+          '$dbUrl/resources/xyz/ok.png',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async => const NetworkSuccess<List<int>>([1]));
+
+      await repository.sync(config: config);
+
+      expect(await asTheRendererLooksItUp('resources/xyz/ok.png'), isNotNull);
+    });
+  });
 }

--- a/flutter/test/repository/markdown_image_round_trip_test.dart
+++ b/flutter/test/repository/markdown_image_round_trip_test.dart
@@ -190,4 +190,55 @@ void main() {
       expect(await asTheRendererLooksItUp(link), isNull);
     },
   );
+
+  // Two parsers meet here, and that is the risk this group exists for: the
+  // collector is `extractImageLinks`, a line-for-line port of Kotlin's regex,
+  // while the renderer's link comes from `flutter_markdown_plus`'s CommonMark
+  // parser. Kotlin is self-consistent because *both* its sides use the same
+  // regex (and are both wrong together, so the image simply never renders);
+  // the port is not, so the collector has to be normalised to what the
+  // renderer will actually ask for. Verified against the real parser, not
+  // assumed — `imageBuilder` receives `resources/abc/c.png` for every shape
+  // below.
+  group('the collector agrees with the renderer about the path', () {
+    Future<void> syncOne(String span, String expectedDownloadPath) async {
+      stubWalk([
+        {'_id': 'course-1', 'courseTitle': 'Algebra', 'description': span},
+      ]);
+      when(
+        () => api.getBytes(
+          '$dbUrl/$expectedDownloadPath',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async => const NetworkSuccess<List<int>>([1]));
+      await repository.sync(config: config);
+    }
+
+    test('a markdown title is not part of the path', () async {
+      // Without normalisation the prefetcher requests
+      // `.../c.png "Title"` — a 404 — and the renderer looks up `abc/c.png`,
+      // which nothing wrote. Silent: the image just stays online-only.
+      await syncOne('![a](resources/abc/c.png "Title")', 'resources/abc/c.png');
+      expect(await asTheRendererLooksItUp('resources/abc/c.png'), isNotNull);
+    });
+
+    test('a pointy-bracket destination is unwrapped', () async {
+      await syncOne('![a](<resources/abc/c.png>)', 'resources/abc/c.png');
+      expect(await asTheRendererLooksItUp('resources/abc/c.png'), isNotNull);
+    });
+
+    test(
+      'a title on an encoded path strips without disturbing the escape',
+      () async {
+        await syncOne(
+          '![a](resources/abc/c%20d.png "T")',
+          'resources/abc/c%20d.png',
+        );
+        expect(
+          await asTheRendererLooksItUp('resources/abc/c%20d.png'),
+          isNotNull,
+        );
+      },
+    );
+  });
 }

--- a/flutter/test/ui/courses/course_markdown_test.dart
+++ b/flutter/test/ui/courses/course_markdown_test.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/files/markdown_image_files.dart';
+import 'package:myplanet/core/files/resource_files.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/ui/courses/course_markdown.dart';
 
@@ -24,6 +27,47 @@ class _TestServerConfig extends ServerConfigNotifier {
 }
 
 void main() {
+  group('markdownImageFileProvider re-reads the disk', () {
+    late Directory tempDir;
+    late Future<Directory> Function() savedBaseDirectory;
+    const link = 'resources/abc123/chart.png';
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('markdown_provider');
+      savedBaseDirectory = ResourceFiles.baseDirectory;
+      ResourceFiles.baseDirectory = () async => tempDir;
+    });
+
+    tearDown(() async {
+      ResourceFiles.baseDirectory = savedBaseDirectory;
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('a miss is not cached for the life of the container', () async {
+      // The scenario: the user opens a course while the sync is still walking
+      // `courses`, so the first lookup misses; the sync writes the file a
+      // moment later; the user goes offline. Without autoDispose the null is
+      // cached for the whole process and the image never renders from disk
+      // again — the feature not working, in the situation it exists for.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        await container.read(markdownImageFileProvider(link).future),
+        isNull,
+      );
+
+      final file = (await MarkdownImageFiles.fileFor(link))!;
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(const [1, 2, 3]);
+
+      expect(
+        await container.read(markdownImageFileProvider(link).future),
+        file.path,
+      );
+    });
+  });
+
   const config = ServerConfig(
     serverUrl: 'https://planet.example',
     couchDbUrl: 'https://satellite:1234@planet.example:443',

--- a/flutter/test/ui/courses/course_markdown_test.dart
+++ b/flutter/test/ui/courses/course_markdown_test.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/ui/courses/course_markdown.dart';
+
+/// The renderer half of Phase 153.
+///
+/// Note the trap these overrides exist for: `markdownImageFileProvider` is
+/// real `dart:io`, whose futures never complete in a widget test's fake-async
+/// zone — pumping on it looks exactly like a hang. Every test here overrides
+/// it, so nothing touches the filesystem.
+class _TestServerConfig extends ServerConfigNotifier {
+  _TestServerConfig(this.config);
+
+  final ServerConfig? config;
+
+  @override
+  ServerConfig? build() => config;
+}
+
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example:443/db';
+  const link = 'resources/abc123/chart.png';
+  const markdown = 'Before ![chart](resources/abc123/chart.png) after';
+
+  Future<void> pumpBody(
+    WidgetTester tester, {
+    required String? localPath,
+    Uint8List? bytes,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          serverConfigProvider.overrideWith(() => _TestServerConfig(config)),
+          markdownImageFileProvider.overrideWith((ref, _) async => localPath),
+          markdownImageBytesProvider.overrideWith((ref, _) async => bytes),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: CourseMarkdownBody(data: markdown)),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  Finder fileImageAt(String path) => find.byWidgetPredicate(
+    (w) =>
+        w is Image &&
+        w.image is FileImage &&
+        (w.image as FileImage).file.path == path,
+  );
+
+  final memoryImage = find.byWidgetPredicate(
+    (w) => w is Image && w.image is MemoryImage,
+  );
+
+  testWidgets('renders the pre-downloaded copy when one is on disk', (
+    tester,
+  ) async {
+    // The offline case, and the whole point of the prefetch: no network is
+    // consulted at all.
+    await pumpBody(tester, localPath: '/cache/ole/abc123/chart.png');
+
+    expect(fileImageAt('/cache/ole/abc123/chart.png'), findsOneWidget);
+    expect(memoryImage, findsNothing);
+  });
+
+  testWidgets('falls back to the authenticated fetch with no local copy', (
+    tester,
+  ) async {
+    await pumpBody(
+      tester,
+      localPath: null,
+      bytes: Uint8List.fromList(const [1, 2, 3]),
+    );
+
+    expect(
+      find.byWidgetPredicate((w) => w is Image && w.image is FileImage),
+      findsNothing,
+    );
+    expect(memoryImage, findsOneWidget);
+  });
+
+  testWidgets('falls back while the local lookup is still in flight', (
+    tester,
+  ) async {
+    // Loading must not render nothing: an online device would flash an empty
+    // gap on every rebuild.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          serverConfigProvider.overrideWith(() => _TestServerConfig(config)),
+          markdownImageFileProvider.overrideWith(
+            (ref, _) => Completer<String?>().future,
+          ),
+          markdownImageBytesProvider.overrideWith(
+            (ref, _) async => Uint8List.fromList(const [1, 2, 3]),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: CourseMarkdownBody(data: markdown)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(memoryImage, findsOneWidget);
+  });
+
+  testWidgets('resolves the fallback URL against the server /db root', (
+    tester,
+  ) async {
+    final requested = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          serverConfigProvider.overrideWith(() => _TestServerConfig(config)),
+          markdownImageFileProvider.overrideWith((ref, _) async => null),
+          markdownImageBytesProvider.overrideWith((ref, url) async {
+            requested.add(url);
+            return Uint8List.fromList(const [1]);
+          }),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: CourseMarkdownBody(data: markdown)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(requested, ['$dbUrl/$link']);
+  });
+
+  testWidgets('an absolute image URL never consults the local cache', (
+    tester,
+  ) async {
+    // markdownImageCachePath declines these, so the lookup would return null
+    // anyway; asserting the provider is not even read pins the branch order.
+    var lookups = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          serverConfigProvider.overrideWith(() => _TestServerConfig(config)),
+          markdownImageFileProvider.overrideWith((ref, _) async {
+            lookups++;
+            return null;
+          }),
+          markdownImageBytesProvider.overrideWith(
+            (ref, _) async => Uint8List.fromList(const [1]),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: CourseMarkdownBody(
+              data: '![x](https://planet.example/db/resources/a/b.png)',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(lookups, 0);
+  });
+}


### PR DESCRIPTION
Lane D of the Phase 153 round. Closes `flutter/PHASE_142_NOTES.md` § *Reported, not fixed* item 1 for the **courses** half. Full write-up in `flutter/PHASE_153_NOTES.md`.

**The gap.** Kotlin collects the images a markdown description references as it ingests the document (`CoursesRepositoryImpl:670`/`:684`) and renders them from a local `file://` base (`CourseStepFragment:125`, `CourseDetailViewModel:65`). The port ported both helpers and wired neither, so `CourseMarkdownBody` fetched a relative image as authenticated bytes at render time — online-only, in an offline-first app.

**Both halves, joined by one key derivation.** `markdownImageCachePath` is the single derivation the writer and reader share; `MarkdownImageFiles` resolves it under `ResourceFiles.baseDirectory` so a markdown image lands in the same `<base>/ole/<id>/<file>` a downloaded resource does; `MarkdownImagePrefetcher` downloads what is not on disk; `CoursesRepository.sync` collects and prefetches once after the walk; `_MarkdownImage` prefers the local copy and falls back to the authenticated fetch.

**No Drift table, no DAO change, no `schemaVersion` bump.** The `download_queue` constraint (Lane A's `app_database.dart`, keyed on a `MyLibrary` `resourceId` a markdown image does not have) is avoided rather than worked around: the `courses` `_all_docs` walk re-reads every document every sync, so the documents are the durable store and no persisted link list is needed. Nothing was needed from Lane A; `schemaVersion` stays at 48.

**Diff is lane-scoped.** `markdown_links.dart`, `core/files/markdown_image_{files,prefetcher}.dart` (new), `courses_repository.dart`, `course_markdown.dart`, plus **two lines** in `providers/app_providers.dart` (one provider argument and its import) — the only file outside the lane's set, flagged here because it is a busy file. No Lane A/B/C file touched.

**Two of three repositories deliberately not built.** Voices and teams would be dead plumbing: the port renders a voice message as `Text(row.message ?? '')` (no markdown, no images) and has no community description region at all. Both are specified in the notes' *Reported, not fixed* with the render site named as the blocker — `PHASE_142_NOTES.md` items 8 and 9.

**Two `parity-auditor` passes at `effort: max`, both of which paid.** The ground-truth pass corrected four premises before a line was written (Kotlin's pref *is* cleared each sync; the API-31 gate is a lint artefact; a missing image renders `U+FFFC`, and nothing falls back to the network — so the port's fetch is a superset). The post-implementation pass found **eight defects in already-green code**, including a `FormatException` from a Latin-1 percent-escape that escaped `sync()` and would have stopped background auto-sync for as long as the document existed, and a missing `.autoDispose` that meant the downloaded file never rendered until app restart. All eight fixed and pinned.

**Verification:** 30 mutations across both rounds, 29 killed by the test named for them; the one survivor is a documented unreachable containment guard, flagged rather than counted as coverage. One test that *could not fail* for the property it named was rewritten. An end-to-end round-trip test drives a server-shaped course document through the real sync walk and prefetcher and asserts with the renderer's own lookup — not a fixture placed where the renderer computes.

Gate green locally: `dart format --set-exit-if-changed`, `flutter analyze`, `flutter test` (2793 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gUGeQpC1hXrGbevKhVDnc