### PR TITLE
feat(flutter): port HeavyTableSyncWorker with its resumable checkpoint

### DIFF
--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -73,258 +73,315 @@ Future<bool> executeBackgroundTask(String taskName) async {
       }
       return succeeded;
     }
-    // Port of `ServerReachabilityWorker:201`'s `scheduleIfPending` call, whose
-    // job is resuming a walk that stopped mid-table. Placed here for the
-    // reason the Kotlin's placement carries: it sits between two
-    // `if (!syncAlreadyRunning)` blocks and is therefore deliberately *not*
-    // gated on a sync being in flight — `keep` and the worker's own guard make
-    // an overlapping call harmless. Kotlin's trigger is a network
-    // reconnection; the port's nearest equivalent is any headless invocation,
-    // which is also what `sweepPendingSubmissions` is placed against.
-    //
-    // Swallowed: a scheduling failure must not turn a run that still has real
-    // work to do into an OS retry.
-    if (config != null) {
-      try {
-        await container
-            .read(heavyTableSyncSchedulerProvider)
-            .scheduleIfPending();
-      } catch (_) {
-        // Deliberately ignored — see above.
-      }
-    }
-
     final drainer = container.read(outboxDrainerProvider);
     bool completed(SyncResult result) => result is SyncComplete;
-    return await BackgroundTaskRunner(
-      configured: config != null,
-      autoSyncEnabled: prefs.autoSyncEnabled,
-      autoSyncInterval: prefs.autoSyncInterval,
-      // `PlanetPrefs.lastSync` is epoch millis with 0 meaning never — the
-      // representation `SharedPrefManager.LAST_SYNC` uses and the dashboard's
-      // last-sync strip reads. The runner speaks `DateTime?`, so the two are
-      // bridged here rather than changing either side.
-      lastSync: prefs.lastSync == 0
-          ? null
-          : DateTime.fromMillisecondsSinceEpoch(prefs.lastSync, isUtc: true),
-      recoverOutbox: drainer.recoverStuck,
-      // The submissions safety net rides here rather than in `syncSteps`, and
-      // the placement is the whole point — see [sweepPendingSubmissions]. The
-      // drain that follows is unscoped, so the swept rows go out in this same
-      // invocation without the sweep needing a drain of its own.
-      drainOutbox: () async {
-        if (config == null) return;
-        // Ahead of the submissions sweep, as both Kotlin workers have it
-        // (`AutoSyncWorker:130` before `:136`, `UserDataWorker:40` before
-        // `:48`). See [sweepPendingVoices].
-        await sweepPendingVoices(
-          container,
-          config: config,
-          userId: prefs.loggedInUserId,
-        );
-        await sweepPendingSubmissions(
-          container,
-          config: config,
-          userId: prefs.loggedInUserId,
-        );
-        await drainer.drain(
-          authHeader: PersonalsUploader.authHeaderFor(config),
-        );
-      },
-      syncSteps: config == null
-          ? const []
-          : [
-              // First, as `SyncManager.startFullSync` has it: the shelf is
-              // *pushed* before the pull phase, so a course or resource added
-              // or removed since the last sync reaches the server before the
-              // walks that would otherwise read the server's older copy back
-              // over it. Kotlin reaches this from both of `syncManager.start`'s
-              // callers — `SyncActivity` and `AutoSyncWorker` — so a port that
-              // has it only in the sync centre leaves the offline-then-closed
-              // case, which is the one the step exists for, unfixed.
-              //
-              // A failure is swallowed by returning true rather than
-              // requesting a retry: Kotlin logs and continues, and a shelf that
-              // cannot reach the server must not stop the pulls or re-run the
-              // whole task.
-              BackgroundSyncStep('shelf_push', () async {
-                final userId = prefs.loggedInUserId;
-                if (userId == null) return true;
+
+    // The headless half of the interactive-sync flag `HeavyTableSync` reads to
+    // stand down. Kotlin needs no second site because both of
+    // `syncManager.start`'s callers set the one `AtomicBoolean` —
+    // `SyncActivity:415` and `AutoSyncWorker:106` — so `isMainSyncActive()` is
+    // true during a headless sync as well as an interactive one. The port's
+    // first cut wrote the flag only in `DashboardSyncNotifier.syncAll`, which
+    // left the *usual* case unguarded: a heavy task started while this
+    // invocation was walking `resources` or `courses`, in a second engine with
+    // its own `AppDatabase` on the same file.
+    //
+    // Set before the runner and cleared in a `finally`, as
+    // `SyncManager.destroy` is (`SyncManager:233`). Both writes are swallowed:
+    // a preference failure must not fail the run, and the flag decays anyway.
+    //
+    // Set for **every** invocation rather than only for an `autoSync` that is
+    // actually due, which is one step broader than Kotlin, where only
+    // `AutoSyncWorker` sets the flag. The reason is the port's hazard rather
+    // than the Kotlin's: `drainOutbox` writes the database on a `maintenance`
+    // run too, and the thing being avoided is two Flutter engines writing one
+    // SQLite file — a question Kotlin's single process never has to ask. The
+    // cost is that a heavy task firing during a short maintenance run defers
+    // by one 30-second backoff.
+    await _markSyncActive(prefs);
+    try {
+      return await BackgroundTaskRunner(
+        configured: config != null,
+        autoSyncEnabled: prefs.autoSyncEnabled,
+        autoSyncInterval: prefs.autoSyncInterval,
+        // `PlanetPrefs.lastSync` is epoch millis with 0 meaning never — the
+        // representation `SharedPrefManager.LAST_SYNC` uses and the dashboard's
+        // last-sync strip reads. The runner speaks `DateTime?`, so the two are
+        // bridged here rather than changing either side.
+        lastSync: prefs.lastSync == 0
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(prefs.lastSync, isUtc: true),
+        recoverOutbox: drainer.recoverStuck,
+        // The submissions safety net rides here rather than in `syncSteps`, and
+        // the placement is the whole point — see [sweepPendingSubmissions]. The
+        // drain that follows is unscoped, so the swept rows go out in this same
+        // invocation without the sweep needing a drain of its own.
+        drainOutbox: () async {
+          if (config == null) return;
+          // Ahead of the submissions sweep, as both Kotlin workers have it
+          // (`AutoSyncWorker:130` before `:136`, `UserDataWorker:40` before
+          // `:48`). See [sweepPendingVoices].
+          await sweepPendingVoices(
+            container,
+            config: config,
+            userId: prefs.loggedInUserId,
+          );
+          await sweepPendingSubmissions(
+            container,
+            config: config,
+            userId: prefs.loggedInUserId,
+          );
+          await drainer.drain(
+            authHeader: PersonalsUploader.authHeaderFor(config),
+          );
+        },
+        syncSteps: config == null
+            ? const []
+            : [
+                // First, as `SyncManager.startFullSync` has it: the shelf is
+                // *pushed* before the pull phase, so a course or resource added
+                // or removed since the last sync reaches the server before the
+                // walks that would otherwise read the server's older copy back
+                // over it. Kotlin reaches this from both of `syncManager.start`'s
+                // callers — `SyncActivity` and `AutoSyncWorker` — so a port that
+                // has it only in the sync centre leaves the offline-then-closed
+                // case, which is the one the step exists for, unfixed.
+                //
+                // A failure is swallowed by returning true rather than
+                // requesting a retry: Kotlin logs and continues, and a shelf that
+                // cannot reach the server must not stop the pulls or re-run the
+                // whole task.
+                BackgroundSyncStep('shelf_push', () async {
+                  final userId = prefs.loggedInUserId;
+                  if (userId == null) return true;
+                  try {
+                    final user = await container
+                        .read(userDaoProvider)
+                        .getById(userId);
+                    final shelfDocId = user?.couchId;
+                    if (shelfDocId == null || shelfDocId.isEmpty) return true;
+                    await container
+                        .read(shelfRepositoryProvider)
+                        .upload(
+                          config: config,
+                          userId: userId,
+                          shelfDocId: shelfDocId,
+                        );
+                  } catch (_) {
+                    // Deliberately ignored — see above.
+                  }
+                  return true;
+                }),
+                BackgroundSyncStep(
+                  'resources',
+                  () async => completed(
+                    await container
+                        .read(resourcesRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'courses',
+                  () async => completed(
+                    await container
+                        .read(coursesRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'teams',
+                  () async => completed(
+                    await container
+                        .read(teamsRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'events',
+                  () async => completed(
+                    await container
+                        .read(eventsRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'surveys',
+                  () async => completed(
+                    await container
+                        .read(surveysRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'voices',
+                  () async => completed(
+                    await container
+                        .read(voicesRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'feedback',
+                  () async => completed(
+                    await container
+                        .read(feedbackRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'chat',
+                  () async => completed(
+                    await container
+                        .read(chatRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                // **`submissions` stays inline, and that is a deliberate
+                // divergence from Kotlin**, which walks it in
+                // `HeavyTableSyncWorker` like the other four heavy tables. The
+                // reason is the ordering immediately above: this step must run
+                // *after* `sweepPendingSubmissions`, because `upsertDocuments`
+                // writes `isUpdated: false` over every row it writes and keys
+                // each on the server `_id`, so a pull that lands before the
+                // sweep strips the dirty flag from a server-originated sheet the
+                // user edited locally and it never uploads. A background walk
+                // cannot be ordered against this invocation at all. The table is
+                // 1,975 documents in 20 pages and was never one of the two that
+                // aborted at depth, so it gains little from the checkpoint —
+                // see [HeavyTableSync.tables], and
+                // `test/providers/pending_submissions_sweep_test.dart`, which is
+                // what caught the first cut moving it.
+                BackgroundSyncStep(
+                  'submissions',
+                  () async => completed(
+                    await container
+                        .read(submissionsRepositoryProvider)
+                        .sync(config: config),
+                  ),
+                ),
+                BackgroundSyncStep(
+                  'health',
+                  () async => completed(
+                    await container.read(healthRepositoryProvider).sync(),
+                  ),
+                ),
+              ],
+        recordLastSync: (value) =>
+            prefs.setLastSync(value.millisecondsSinceEpoch),
+        // Port of `AutoSyncWorker`'s `uploadActivities` call after a clean sync:
+        // posts the `myplanet_activities` telemetry doc. Skipped when no user is
+        // signed in (the Kotlin's `uploadActivities` does the same) or when the
+        // upload throws — losing telemetry must not flip the run to retry.
+        onSyncComplete: config == null
+            ? null
+            : () async {
+                // Port of `SyncManager:209`'s `HeavyTableSyncWorker.schedule`,
+                // and it belongs on this hook rather than in the step list for
+                // the same reason: the Kotlin call sits at the end of
+                // `startFullSync`'s `try`, so a sync that threw never reaches
+                // it. `onSyncComplete` fires only when every step succeeded,
+                // which is the closest this runner has to "the sync finished".
+                //
+                // Unconditional over the tables, checkpoints unread: that is
+                // what recovers a table whose walk died on its first page,
+                // which `scheduleIfPending` structurally cannot see.
+                //
+                // Ahead of the telemetry upload, so a throwing upload cannot
+                // cost the heavy tables their scheduling — this whole closure is
+                // swallowed by the runner as one unit.
                 try {
-                  final user = await container
-                      .read(userDaoProvider)
-                      .getById(userId);
-                  final shelfDocId = user?.couchId;
-                  if (shelfDocId == null || shelfDocId.isEmpty) return true;
                   await container
-                      .read(shelfRepositoryProvider)
-                      .upload(
-                        config: config,
-                        userId: userId,
-                        shelfDocId: shelfDocId,
-                      );
+                      .read(heavyTableSyncSchedulerProvider)
+                      .scheduleAll();
                 } catch (_) {
-                  // Deliberately ignored — see above.
+                  // Deliberately ignored, as above.
                 }
-                return true;
-              }),
-              BackgroundSyncStep(
-                'resources',
-                () async => completed(
-                  await container
-                      .read(resourcesRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'courses',
-                () async => completed(
-                  await container
-                      .read(coursesRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'teams',
-                () async => completed(
-                  await container
-                      .read(teamsRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'events',
-                () async => completed(
-                  await container
-                      .read(eventsRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'surveys',
-                () async => completed(
-                  await container
-                      .read(surveysRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'voices',
-                () async => completed(
-                  await container
-                      .read(voicesRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'feedback',
-                () async => completed(
-                  await container
-                      .read(feedbackRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'chat',
-                () async => completed(
-                  await container
-                      .read(chatRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              // **`submissions` stays inline, and that is a deliberate
-              // divergence from Kotlin**, which walks it in
-              // `HeavyTableSyncWorker` like the other four heavy tables. The
-              // reason is the ordering immediately above: this step must run
-              // *after* `sweepPendingSubmissions`, because `upsertDocuments`
-              // writes `isUpdated: false` over every row it writes and keys
-              // each on the server `_id`, so a pull that lands before the
-              // sweep strips the dirty flag from a server-originated sheet the
-              // user edited locally and it never uploads. A background walk
-              // cannot be ordered against this invocation at all. The table is
-              // 1,975 documents in 20 pages and was never one of the two that
-              // aborted at depth, so it gains little from the checkpoint —
-              // see [HeavyTableSync.tables], and
-              // `test/providers/pending_submissions_sweep_test.dart`, which is
-              // what caught the first cut moving it.
-              BackgroundSyncStep(
-                'submissions',
-                () async => completed(
-                  await container
-                      .read(submissionsRepositoryProvider)
-                      .sync(config: config),
-                ),
-              ),
-              BackgroundSyncStep(
-                'health',
-                () async => completed(
-                  await container.read(healthRepositoryProvider).sync(),
-                ),
-              ),
-            ],
-      recordLastSync: (value) =>
-          prefs.setLastSync(value.millisecondsSinceEpoch),
-      // Port of `AutoSyncWorker`'s `uploadActivities` call after a clean sync:
-      // posts the `myplanet_activities` telemetry doc. Skipped when no user is
-      // signed in (the Kotlin's `uploadActivities` does the same) or when the
-      // upload throws — losing telemetry must not flip the run to retry.
-      onSyncComplete: config == null
-          ? null
-          : () async {
-              // Port of `SyncManager:209`'s `HeavyTableSyncWorker.schedule`,
-              // and it belongs on this hook rather than in the step list for
-              // the same reason: the Kotlin call sits at the end of
-              // `startFullSync`'s `try`, so a sync that threw never reaches
-              // it. `onSyncComplete` fires only when every step succeeded,
-              // which is the closest this runner has to "the sync finished".
-              //
-              // Unconditional over the tables, checkpoints unread: that is
-              // what recovers a table whose walk died on its first page,
-              // which `scheduleIfPending` structurally cannot see.
-              //
-              // Ahead of the telemetry upload, so a throwing upload cannot
-              // cost the heavy tables their scheduling — this whole closure is
-              // swallowed by the runner as one unit.
-              try {
+                final userId = prefs.loggedInUserId;
+                if (userId == null) return;
+                final user = await container
+                    .read(userDaoProvider)
+                    .getById(userId);
+                if (user == null) return;
                 await container
-                    .read(heavyTableSyncSchedulerProvider)
-                    .scheduleAll();
-              } catch (_) {
-                // Deliberately ignored, as above.
-              }
-              final userId = prefs.loggedInUserId;
-              if (userId == null) return;
-              final user = await container
-                  .read(userDaoProvider)
-                  .getById(userId);
-              if (user == null) return;
-              await container
-                  .read(myPlanetActivitiesUploaderProvider)
-                  .upload(user: user, config: config);
-            },
-      // Port of `TaskNotificationWorker`, which the Kotlin schedules as its own
-      // 900-second periodic worker. It reads only local state, so unlike the
-      // sync steps it needs no server config — but it does need a signed-in
-      // user, which cannot exist without one anyway.
-      onMaintenance: () async {
-        final userId = prefs.loggedInUserId;
-        if (userId == null) return;
-        final user = await container.read(userDaoProvider).getById(userId);
-        if (user == null) return;
-        await container.read(taskDeadlineNotifierProvider).run(user: user);
-      },
-      recordRun: (record) => prefs.recordBackgroundRun(
-        taskName: record.taskName,
-        attemptedAt: record.attemptedAt,
-        status: record.status.name,
-        failedSteps: record.failedSteps,
-        skipReason: record.skipReason,
-      ),
-    ).run(taskName);
+                    .read(myPlanetActivitiesUploaderProvider)
+                    .upload(user: user, config: config);
+              },
+        // Port of `TaskNotificationWorker`, which the Kotlin schedules as its own
+        // 900-second periodic worker. It reads only local state, so unlike the
+        // sync steps it needs no server config — but it does need a signed-in
+        // user, which cannot exist without one anyway.
+        onMaintenance: () async {
+          final userId = prefs.loggedInUserId;
+          if (userId == null) return;
+          final user = await container.read(userDaoProvider).getById(userId);
+          if (user == null) return;
+          await container.read(taskDeadlineNotifierProvider).run(user: user);
+        },
+        recordRun: (record) => prefs.recordBackgroundRun(
+          taskName: record.taskName,
+          attemptedAt: record.attemptedAt,
+          status: record.status.name,
+          failedSteps: record.failedSteps,
+          skipReason: record.skipReason,
+        ),
+      ).run(taskName);
+    } finally {
+      await _clearSyncActive(prefs);
+      // Port of `ServerReachabilityWorker:201`'s `scheduleIfPending`, which
+      // resumes a walk that stopped mid-table.
+      //
+      // **After the run, not before it.** Kotlin's call lives in a *different*
+      // worker from its sync, so it can never start a heavy walk alongside the
+      // sync in its own process; and where it does overlap one,
+      // `isMainSyncActive()` sees it. The port's first cut called this at the
+      // top of the invocation, before the runner's own table walks, where
+      // `keep` has nothing to keep and the network constraint is satisfied by
+      // definition — so WorkManager was free to start walking
+      // `courses_progress` in a second engine while this one wrote `resources`.
+      // Two writers on one SQLite file with no WAL and no busy timeout is
+      // `database is locked` for whichever loses.
+      //
+      // In the `finally` rather than after it, so a resumable walk is still
+      // picked up on a run that threw; and after the flag is cleared, so the
+      // task it enqueues does not immediately stand down.
+      if (config != null) {
+        try {
+          await container
+              .read(heavyTableSyncSchedulerProvider)
+              .scheduleIfPending();
+        } catch (_) {
+          // Swallowed: losing the scheduling of a background walk must not
+          // turn a completed run into an OS retry. The next invocation, and
+          // the next completed sync's unconditional `scheduleAll`, try again.
+        }
+      }
+    }
   } catch (_) {
     return false;
   } finally {
     container.dispose();
+  }
+}
+
+/// Stands in for `SyncManager.start`'s `isSyncing.compareAndSet(false, true)`
+/// on the headless path — see the call site for why the port needs two sites
+/// where Kotlin needs none.
+Future<void> _markSyncActive(PlanetPrefs prefs) async {
+  try {
+    await prefs.markInteractiveSyncStarted(DateTime.now());
+  } catch (_) {
+    // Deliberately ignored — a heavy walk may then overlap this run, which is
+    // what the Kotlin also permits for a sync started mid-walk.
+  }
+}
+
+Future<void> _clearSyncActive(PlanetPrefs prefs) async {
+  try {
+    await prefs.clearInteractiveSyncStarted();
+  } catch (_) {
+    // Deliberately ignored — the flag decays after
+    // `HeavyTableSync.interactiveSyncTimeout` rather than blocking heavy walks
+    // for ever, which is exactly what that bound is for.
   }
 }
 
@@ -402,7 +459,7 @@ Future<void> sweepPendingVoices(
 /// Two properties survive the move. It is still ahead of the `'submissions'`
 /// pull, which matters because `SubmissionsRepository.upsertDocuments` writes
 /// `isUpdated: false` over every row it writes and keys each on the server
-/// `_id` (`submissions_repository.dart:1670-1672`): a *locally authored* sheet
+/// `_id` (`submissions_repository.dart`, the `upsertDocuments` row build): a *locally authored* sheet
 /// carries a sha1 local id, so a pulled document lands beside it as a separate
 /// row and cannot touch its flags — Kotlin identically
 /// (`SubmissionsRepositoryImpl:669-670`) — while a sheet that **arrived from

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -10,6 +10,7 @@ import 'core/network/network_result.dart';
 import 'core/prefs/planet_prefs.dart';
 import 'core/sync/sync_result.dart';
 import 'providers/app_providers.dart';
+import 'providers/heavy_sync_providers.dart';
 import 'repository/personals_uploader.dart';
 
 /// WorkManager launches this in a new isolate, so it must be a retained
@@ -30,6 +31,24 @@ Future<bool> executeBackgroundTask(String taskName) async {
     overrides: [planetPrefsProvider.overrideWithValue(prefs)],
   );
   try {
+    // Port of `HeavyTableSyncWorker.doWork`, ahead of everything else because
+    // a heavy task is not a sync run: it walks exactly one table from its
+    // checkpoint and reports the retry verdict that checkpoint implies.
+    //
+    // The reload is the port's tax for the isolate boundary. `PlanetPrefs`
+    // caches every value at `getInstance()`, and this is the one path that
+    // reads state the *UI* isolate authored — the interactive-sync flag
+    // standing in for `SyncManager.isSyncing`, plus any checkpoint a previous
+    // engine wrote. Kotlin's worker shares the process and the
+    // `SharedPreferences` object with the UI and needs no equivalent.
+    final heavyTable = BackgroundTaskNames.heavyTableSyncTable(taskName);
+    if (heavyTable != null) {
+      await prefs.reload();
+      return await container
+          .read(heavyTableSyncProvider)
+          .run(heavyTable, config: prefs.serverConfig);
+    }
+
     final config = prefs.serverConfig;
     if (taskName == BackgroundTaskNames.download) {
       if (config == null) return true;
@@ -54,6 +73,27 @@ Future<bool> executeBackgroundTask(String taskName) async {
       }
       return succeeded;
     }
+    // Port of `ServerReachabilityWorker:201`'s `scheduleIfPending` call, whose
+    // job is resuming a walk that stopped mid-table. Placed here for the
+    // reason the Kotlin's placement carries: it sits between two
+    // `if (!syncAlreadyRunning)` blocks and is therefore deliberately *not*
+    // gated on a sync being in flight — `keep` and the worker's own guard make
+    // an overlapping call harmless. Kotlin's trigger is a network
+    // reconnection; the port's nearest equivalent is any headless invocation,
+    // which is also what `sweepPendingSubmissions` is placed against.
+    //
+    // Swallowed: a scheduling failure must not turn a run that still has real
+    // work to do into an OS retry.
+    if (config != null) {
+      try {
+        await container
+            .read(heavyTableSyncSchedulerProvider)
+            .scheduleIfPending();
+      } catch (_) {
+        // Deliberately ignored — see above.
+      }
+    }
+
     final drainer = container.read(outboxDrainerProvider);
     bool completed(SyncResult result) => result is SyncComplete;
     return await BackgroundTaskRunner(
@@ -192,6 +232,21 @@ Future<bool> executeBackgroundTask(String taskName) async {
                       .sync(config: config),
                 ),
               ),
+              // **`submissions` stays inline, and that is a deliberate
+              // divergence from Kotlin**, which walks it in
+              // `HeavyTableSyncWorker` like the other four heavy tables. The
+              // reason is the ordering immediately above: this step must run
+              // *after* `sweepPendingSubmissions`, because `upsertDocuments`
+              // writes `isUpdated: false` over every row it writes and keys
+              // each on the server `_id`, so a pull that lands before the
+              // sweep strips the dirty flag from a server-originated sheet the
+              // user edited locally and it never uploads. A background walk
+              // cannot be ordered against this invocation at all. The table is
+              // 1,975 documents in 20 pages and was never one of the two that
+              // aborted at depth, so it gains little from the checkpoint —
+              // see [HeavyTableSync.tables], and
+              // `test/providers/pending_submissions_sweep_test.dart`, which is
+              // what caught the first cut moving it.
               BackgroundSyncStep(
                 'submissions',
                 () async => completed(
@@ -216,6 +271,27 @@ Future<bool> executeBackgroundTask(String taskName) async {
       onSyncComplete: config == null
           ? null
           : () async {
+              // Port of `SyncManager:209`'s `HeavyTableSyncWorker.schedule`,
+              // and it belongs on this hook rather than in the step list for
+              // the same reason: the Kotlin call sits at the end of
+              // `startFullSync`'s `try`, so a sync that threw never reaches
+              // it. `onSyncComplete` fires only when every step succeeded,
+              // which is the closest this runner has to "the sync finished".
+              //
+              // Unconditional over the tables, checkpoints unread: that is
+              // what recovers a table whose walk died on its first page,
+              // which `scheduleIfPending` structurally cannot see.
+              //
+              // Ahead of the telemetry upload, so a throwing upload cannot
+              // cost the heavy tables their scheduling — this whole closure is
+              // swallowed by the runner as one unit.
+              try {
+                await container
+                    .read(heavyTableSyncSchedulerProvider)
+                    .scheduleAll();
+              } catch (_) {
+                // Deliberately ignored, as above.
+              }
               final userId = prefs.loggedInUserId;
               if (userId == null) return;
               final user = await container

--- a/flutter/lib/core/background/background_task_names.dart
+++ b/flutter/lib/core/background/background_task_names.dart
@@ -4,4 +4,33 @@ abstract final class BackgroundTaskNames {
   static const maintenance = 'myplanet.maintenance';
   static const download = 'myplanet.download';
   static const downloadWork = 'myplanet.download.work';
+
+  /// Prefix of the per-table heavy-sync task, one job per table.
+  ///
+  /// The table travels in the **task name** rather than in `inputData`, which
+  /// is where `HeavyTableSyncWorker` puts it (`workDataOf(KEY_TABLE to table)`,
+  /// read back as `inputData.getString(KEY_TABLE)`). The port dispatches on
+  /// the task name alone — `callbackDispatcher` hands `executeBackgroundTask`
+  /// nothing else — and a name per table is needed regardless, because
+  /// scheduling is `enqueueUniqueWork("heavy_sync_$table", KEEP, …)`: the
+  /// unique name is what makes a second enqueue for a table already walking a
+  /// no-op instead of a second walk of the same 114k documents.
+  ///
+  /// Being part of the persisted contract, the scheme has to stay: a name a
+  /// future build cannot parse resolves to a null table, and
+  /// [heavyTableSyncTable] returning null is treated as "do not retry" rather
+  /// than as an error, for the reason `BackgroundTaskRunner.run` gives about
+  /// renamed tasks surviving an upgrade.
+  static const heavyPrefix = 'myplanet.heavy.';
+
+  /// The task (and unique work) name for one heavy table.
+  static String heavyTableSyncTask(String table) => '$heavyPrefix$table';
+
+  /// The table a [heavyTableSyncTask] name carries, or null when [taskName] is
+  /// not one.
+  static String? heavyTableSyncTable(String taskName) {
+    if (!taskName.startsWith(heavyPrefix)) return null;
+    final table = taskName.substring(heavyPrefix.length);
+    return table.isEmpty ? null : table;
+  }
 }

--- a/flutter/lib/core/background/heavy_table_scheduler.dart
+++ b/flutter/lib/core/background/heavy_table_scheduler.dart
@@ -25,7 +25,18 @@ import 'background_task_names.dart';
 /// which is also what makes a retry-pending walk immune to being restarted
 /// from zero by an unrelated sync.
 abstract interface class HeavyTableWorkScheduler {
-  Future<void> enqueueUnique(String table);
+  /// [taskName] is both the WorkManager unique name and the task name the
+  /// dispatcher will parse the table back out of.
+  ///
+  /// The name is resolved by the caller rather than here so that the one thing
+  /// that must hold — the name scheduled is a name
+  /// `BackgroundTaskNames.heavyTableSyncTable` can parse — is a fact a test can
+  /// assert instead of a source-text guess. An audit made this method schedule
+  /// the bare table name and the whole suite stayed green: the walk then never
+  /// ran, because the dispatcher parsed no table and
+  /// `BackgroundTaskRunner.run` answers `true` for a name it does not
+  /// recognise.
+  Future<void> enqueueUnique(String taskName);
 }
 
 class WorkmanagerHeavyTableScheduler implements HeavyTableWorkScheduler {
@@ -42,21 +53,28 @@ class WorkmanagerHeavyTableScheduler implements HeavyTableWorkScheduler {
   /// many sessions should not also wait for a charged battery.
   ///
   /// **Not expedited.** The Kotlin asks for
-  /// `setExpedited(RUN_AS_NON_EXPEDITED_WORK_REQUEST)`, and that call is a
-  /// latent bug on this app's whole supported floor: below API 31 WorkManager
-  /// serves an expedited request as a foreground service and calls
-  /// `getForegroundInfo()`, which `CoroutineWorker` implements by throwing —
-  /// and `HeavyTableSyncWorker` overrides neither it nor
-  /// `setForeground`. With `minSdk` 26 that throws before `doWork` runs
-  /// whenever expedited quota is available. Copying the flag would reproduce
-  /// a bug rather than a behaviour, and non-expedited is the fallback the flag
-  /// itself names.
+  /// `setExpedited(RUN_AS_NON_EXPEDITED_WORK_REQUEST)`, and that call looks
+  /// like a bug on this app's whole supported floor. Below API 31 WorkManager
+  /// takes the foreground-service path for any expedited request and calls
+  /// `getForegroundInfoAsync()` — unconditionally, *not* subject to the quota
+  /// the `RUN_AS_NON_EXPEDITED_WORK_REQUEST` policy governs, which is a
+  /// JobScheduler concern from API 31 up. `CoroutineWorker`'s default
+  /// implementation throws, and `HeavyTableSyncWorker` overrides neither it
+  /// nor `setForeground` (nothing in `app/src/main` does). So on API 26-30
+  /// the worker should throw before `doWork` runs *every* time, which would
+  /// mean the Kotlin's whole checkpoint feature never runs there at all.
+  ///
+  /// An earlier revision of this comment said "whenever expedited quota is
+  /// available", which understates it in the direction that matters. Either
+  /// way copying the flag would reproduce a bug rather than a behaviour, and
+  /// non-expedited is the fallback the flag itself names — so the port is
+  /// ahead of the Kotlin here, and the Kotlin side is worth reporting
+  /// upstream rather than filing as a port note.
   @override
-  Future<void> enqueueUnique(String table) {
-    final name = BackgroundTaskNames.heavyTableSyncTask(table);
+  Future<void> enqueueUnique(String taskName) {
     return Workmanager().registerOneOffTask(
-      name,
-      name,
+      taskName,
+      taskName,
       existingWorkPolicy: ExistingWorkPolicy.keep,
       backoffPolicy: BackoffPolicy.linear,
       backoffPolicyDelay: const Duration(seconds: 30),
@@ -85,7 +103,9 @@ class HeavyTableSyncScheduler {
     List<String> tables = HeavyTableSync.tables,
   }) async {
     for (final table in tables) {
-      await _scheduler.enqueueUnique(table);
+      await _scheduler.enqueueUnique(
+        BackgroundTaskNames.heavyTableSyncTask(table),
+      );
     }
   }
 

--- a/flutter/lib/core/background/heavy_table_scheduler.dart
+++ b/flutter/lib/core/background/heavy_table_scheduler.dart
@@ -1,0 +1,112 @@
+import 'package:workmanager/workmanager.dart';
+
+import '../prefs/planet_prefs.dart';
+import '../sync/heavy_table_sync.dart';
+import 'background_task_names.dart';
+
+/// Enqueues one heavy table's background walk.
+///
+/// **Why this is not a method on `BackgroundScheduler`.** That seam's
+/// `scheduleOneOff` is hard-wired to `ExistingWorkPolicy.append`, and the
+/// comment there explains why it must stay that way: the download queue
+/// enqueues after inserting a row, and `keep` would drop the registration that
+/// tells a worker about an id added after it took its snapshot, stranding the
+/// download.
+///
+/// Heavy tables need the opposite policy — `keep`, which is what
+/// `HeavyTableSyncWorker.schedule` uses
+/// (`enqueueUniqueWork("heavy_sync_$table", ExistingWorkPolicy.KEEP, …)`) —
+/// and for a sharper reason than tidiness. Both entry points fire freely:
+/// every completed sync schedules all tables, and every background invocation
+/// resumes the pending ones. Under `append` each of those enqueues would
+/// become a *further complete walk* of the table, queued behind the one
+/// already running, and a `courses_progress` walk is 114,219 documents.
+/// `keep` collapses the pile into the one walk that is already in flight,
+/// which is also what makes a retry-pending walk immune to being restarted
+/// from zero by an unrelated sync.
+abstract interface class HeavyTableWorkScheduler {
+  Future<void> enqueueUnique(String table);
+}
+
+class WorkmanagerHeavyTableScheduler implements HeavyTableWorkScheduler {
+  const WorkmanagerHeavyTableScheduler();
+
+  /// `HeavyTableSyncWorker.schedule`'s request, setting for setting:
+  /// `NetworkType.CONNECTED` and nothing else (`:45-47`),
+  /// `BackoffPolicy.LINEAR` at 30 seconds (`:52`), and the table in the name.
+  ///
+  /// Two deliberate departures.
+  ///
+  /// **No `requiresBatteryNotLow`**, unlike the port's other jobs, because the
+  /// Kotlin constraint set is network-only. A walk that has to resume across
+  /// many sessions should not also wait for a charged battery.
+  ///
+  /// **Not expedited.** The Kotlin asks for
+  /// `setExpedited(RUN_AS_NON_EXPEDITED_WORK_REQUEST)`, and that call is a
+  /// latent bug on this app's whole supported floor: below API 31 WorkManager
+  /// serves an expedited request as a foreground service and calls
+  /// `getForegroundInfo()`, which `CoroutineWorker` implements by throwing —
+  /// and `HeavyTableSyncWorker` overrides neither it nor
+  /// `setForeground`. With `minSdk` 26 that throws before `doWork` runs
+  /// whenever expedited quota is available. Copying the flag would reproduce
+  /// a bug rather than a behaviour, and non-expedited is the fallback the flag
+  /// itself names.
+  @override
+  Future<void> enqueueUnique(String table) {
+    final name = BackgroundTaskNames.heavyTableSyncTask(table);
+    return Workmanager().registerOneOffTask(
+      name,
+      name,
+      existingWorkPolicy: ExistingWorkPolicy.keep,
+      backoffPolicy: BackoffPolicy.linear,
+      backoffPolicyDelay: const Duration(seconds: 30),
+      constraints: Constraints(networkType: NetworkType.connected),
+    );
+  }
+}
+
+/// Port of `HeavyTableSyncWorker.schedule` / `scheduleIfPending`.
+class HeavyTableSyncScheduler {
+  const HeavyTableSyncScheduler(this._scheduler, this._prefs);
+
+  final HeavyTableWorkScheduler _scheduler;
+  final PlanetPrefs _prefs;
+
+  /// Port of `schedule(context, tables = ALL_HEAVY_TABLES)`, called by
+  /// `SyncManager:209` at the end of a completed full sync — the port's
+  /// analogue being the end of `DashboardSyncNotifier.syncAll` and of a clean
+  /// headless run.
+  ///
+  /// Unconditional: it re-enqueues every table whatever their checkpoints say,
+  /// which is the only thing that recovers a table whose walk died on its
+  /// first page (see [HeavyTableSync.run] for why that state is invisible to
+  /// [scheduleIfPending]).
+  Future<void> scheduleAll({
+    List<String> tables = HeavyTableSync.tables,
+  }) async {
+    for (final table in tables) {
+      await _scheduler.enqueueUnique(table);
+    }
+  }
+
+  /// Port of `scheduleIfPending`, whose one Kotlin call site is
+  /// `ServerReachabilityWorker:201` — a network-reconnection-triggered run,
+  /// deliberately *not* gated on whether a sync is in flight, because `keep`
+  /// and the worker's own guard already make an overlapping call harmless.
+  ///
+  /// The predicate is the Kotlin's: a table is pending when its checkpoint is
+  /// `> 0`, and nothing is enqueued when none is. It shares the worker's blind
+  /// spot exactly — a checkpoint of `0` means "never walked", "finished" and
+  /// "died on page 1" alike — which is a quirk, not an oversight, and the two
+  /// predicates agreeing is what keeps the behaviour consistent.
+  Future<void> scheduleIfPending({
+    List<String> tables = HeavyTableSync.tables,
+  }) async {
+    final pending = [
+      for (final table in tables)
+        if (_prefs.heavyTableSkip(table) > 0) table,
+    ];
+    if (pending.isEmpty) return;
+    await scheduleAll(tables: pending);
+  }
+}

--- a/flutter/lib/core/prefs/planet_prefs.dart
+++ b/flutter/lib/core/prefs/planet_prefs.dart
@@ -53,6 +53,20 @@ class PlanetPrefs {
   static const String _keyAutoSyncInterval = 'autoSyncInterval';
   static const String _keyBackgroundRun = 'backgroundRun';
 
+  /// Prefix of the per-table heavy-sync checkpoint, matching the Kotlin's
+  /// `checkpointKey = "heavy_sync_skip_$table"`
+  /// (`TransactionSyncManager.kt:168`). The stored value is a **document
+  /// offset** — the `skip` the next `_all_docs` page should ask for — not a
+  /// page number.
+  static const String _keyHeavySyncSkipPrefix = 'heavy_sync_skip_';
+
+  /// Epoch millis at which the interactive sync began; `0` when none is
+  /// running. Stands in for `SyncManager.isSyncing`
+  /// (`SyncManager.kt:118`) — see `HeavyTableSync.isInteractiveSyncActive`
+  /// for why the port needs a persisted flag where the Kotlin has an
+  /// `AtomicBoolean`, and why the value is a timestamp rather than a bool.
+  static const String _keyInteractiveSyncStartedAt = 'interactiveSyncStartedAt';
+
   /// Prefix of the per-reminder keys, matching the Kotlin's
   /// `reminder_time_<surveyIds>` in its `survey_reminders` preferences file.
   /// The Kotlin scans `reminderPrefs.all` for this prefix; the port scans
@@ -525,4 +539,47 @@ class PlanetPrefs {
       'skipReason': ?skipReason,
     }),
   );
+
+  /// Document offset a heavy table's interrupted walk should resume from, `0`
+  /// when there is nothing to resume. Port of
+  /// `sharedPrefManager.rawPreferences.getInt(checkpointKey, 0)`
+  /// (`TransactionSyncManager.kt:178`, `HeavyTableSyncWorker.kt:33`).
+  ///
+  /// A key present with the value `0` reads the same as an absent one, exactly
+  /// as the Kotlin's `getInt(key, 0)` does — which matters because the walk
+  /// writes `0` before its first page request and only *removes* the key on a
+  /// completed walk.
+  int heavyTableSkip(String table) =>
+      _prefs.getInt('$_keyHeavySyncSkipPrefix$table') ?? 0;
+
+  Future<void> setHeavyTableSkip(String table, int skip) =>
+      _prefs.setInt('$_keyHeavySyncSkipPrefix$table', skip);
+
+  Future<void> clearHeavyTableSkip(String table) =>
+      _prefs.remove('$_keyHeavySyncSkipPrefix$table');
+
+  /// When the interactive sync began, or `null` when none is running.
+  DateTime? get interactiveSyncStartedAt {
+    final millis = _prefs.getInt(_keyInteractiveSyncStartedAt) ?? 0;
+    return millis == 0 ? null : DateTime.fromMillisecondsSinceEpoch(millis);
+  }
+
+  Future<void> markInteractiveSyncStarted(DateTime now) =>
+      _prefs.setInt(_keyInteractiveSyncStartedAt, now.millisecondsSinceEpoch);
+
+  Future<void> clearInteractiveSyncStarted() =>
+      _prefs.remove(_keyInteractiveSyncStartedAt);
+
+  /// Re-reads the backing store, discarding this instance's in-memory cache.
+  ///
+  /// `SharedPreferences` caches every value per isolate at
+  /// `getInstance()`, so a value another isolate has written since is
+  /// invisible to this one. The Kotlin has no analogue to need because its
+  /// workers run in the app process and read the same `SharedPreferences`
+  /// object the UI writes — a `HeavyTableSyncWorker` reading
+  /// `heavy_sync_skip_*` and `isSyncing` sees the UI's writes for free.
+  ///
+  /// Called by the heavy-table entry point, which is the one path that reads
+  /// state the *other* isolate authors. Everything else reads what it wrote.
+  Future<void> reload() => _prefs.reload();
 }

--- a/flutter/lib/core/prefs/planet_prefs.dart
+++ b/flutter/lib/core/prefs/planet_prefs.dart
@@ -570,14 +570,22 @@ class PlanetPrefs {
   Future<void> clearInteractiveSyncStarted() =>
       _prefs.remove(_keyInteractiveSyncStartedAt);
 
-  /// Re-reads the backing store, discarding this instance's in-memory cache.
+  /// Re-reads the `SharedPreferences` store, discarding the values this
+  /// isolate cached at `getInstance()`.
   ///
-  /// `SharedPreferences` caches every value per isolate at
-  /// `getInstance()`, so a value another isolate has written since is
-  /// invisible to this one. The Kotlin has no analogue to need because its
-  /// workers run in the app process and read the same `SharedPreferences`
-  /// object the UI writes — a `HeavyTableSyncWorker` reading
-  /// `heavy_sync_skip_*` and `isSyncing` sees the UI's writes for free.
+  /// **The secrets cache is not refreshed** — `_cachedPin` and
+  /// `_cachedCouchDbUrl` come from [hydrateSecrets] and are untouched here, so
+  /// a caller that relied on this to pick up a server change would get the new
+  /// `serverURL` beside the old PIN and CouchDB URL. Call [hydrateSecrets] for
+  /// those. No caller needs it today: the one call site runs moments after
+  /// [load], which hydrates both.
+  ///
+  /// It exists because `SharedPreferences` caches per isolate, so a value
+  /// another isolate has written since is invisible to this one. The Kotlin
+  /// has no analogue to need: its workers run in the app process, sharing both
+  /// the `SharedPreferences` object the UI writes `heavy_sync_skip_*` into and
+  /// the `SyncManager` instance whose `isSyncing` field — a field, not a
+  /// preference — the heavy worker reads directly.
   ///
   /// Called by the heavy-table entry point, which is the one path that reads
   /// state the *other* isolate authors. Everything else reads what it wrote.

--- a/flutter/lib/core/sync/heavy_table_sync.dart
+++ b/flutter/lib/core/sync/heavy_table_sync.dart
@@ -59,10 +59,12 @@ class HeavyTableSync {
     required PlanetPrefs prefs,
     required Map<String, HeavyTableWriter> writers,
     DateTime Function()? now,
+    Future<void> Function(Duration)? sleep,
   }) : _api = api,
        _prefs = prefs,
        _writers = writers,
-       _now = now ?? DateTime.now;
+       _now = now ?? DateTime.now,
+       _sleep = sleep ?? Future<void>.delayed;
 
   final PlanetApi _api;
   final PlanetPrefs _prefs;
@@ -76,7 +78,13 @@ class HeavyTableSync {
   /// and reports success for ever — the reachability shape this project keeps
   /// finding.
   Iterable<String> get writableTables => _writers.keys;
+
+  /// The writers themselves, so a test can drive the *real* ones against a
+  /// real database. Knowing the keys is not enough: an audit replaced both
+  /// bodies with no-ops and every test still passed.
+  Map<String, HeavyTableWriter> get writers => Map.unmodifiable(_writers);
   final DateTime Function() _now;
+  final Future<void> Function(Duration) _sleep;
 
   /// `HeavyTableSyncWorker.ALL_HEAVY_TABLES`, verbatim, as the reference for
   /// what the Kotlin keeps out of its interactive sync. It is **not** the set
@@ -102,13 +110,16 @@ class HeavyTableSync {
   ///   drop the area — but that is a change with a reason, not a guess.
   /// * **`team_activities` has no writer in the port at all.** Kotlin pulls it
   ///   (`teamsSyncRepository.bulkInsertTeamActivitiesFromSync`,
-  ///   `TransactionSyncManager.kt:252-254`); the port only ever *uploads*
+  ///   `TransactionSyncManager.kt:251-253`); the port only ever *uploads*
   ///   team-visit rows. Adding the table here without a writer would schedule
   ///   a job that does nothing, so the gap is reported rather than papered
   ///   over: see the phase notes. The consequence is the same shape as the
   ///   `ratings` gap this port already fixed — `TeamLogDao.teamVisitsForUsers`
   ///   and `lastTeamVisit` feed the member-detail screen's visit count and
-  ///   last-visit row, so both show only what *this* handset observed.
+  ///   last-visit row *and* the team leaderboard's ranking
+  ///   (`team_leaderboard_screen.dart:101`), so all three show only what
+  ///   *this* handset observed. A leaderboard is a comparison between members
+  ///   by construction, which makes it the sharpest case.
   /// * **`submissions` keeps its inline pull**, and this one was moved here
   ///   and moved back. It is 1,975 documents — 20 pages — and it is not one
   ///   of the two tables that aborted at depth, so the checkpoint solves a
@@ -140,6 +151,33 @@ class HeavyTableSync {
   /// stale flag is a deferred walk while the cost of ignoring a live one is
   /// two isolates walking the same table.
   static const Duration interactiveSyncTimeout = Duration(minutes: 30);
+
+  /// Backoff between attempts at one page: three retries at 1s, 2s and 4s.
+  ///
+  /// **This is a port, not an invention, and it is not from `syncDb`.** The
+  /// Kotlin walk has no retry of its own because it does not need one — its
+  /// page request is a POST to `/_all_docs`, which `RetryInterceptor`
+  /// whitelists for retry (`RetryInterceptor.kt:24,29`) and retries three
+  /// times at 1s/2s/4s on any `IOException` (a socket timeout included) or any
+  /// 5xx (`:46-52`), wired into every call by `NetworkModule.kt:86`. So
+  /// `syncDb`'s `break` on a failed page is reached only after four attempts.
+  /// The port's `PlanetApi` has no interceptor at all, so a bare `break` here
+  /// would give one attempt where the Kotlin gives four — and with a
+  /// checkpoint that is worse than it sounds: the walk would commit everything
+  /// up to the first flaky page and then freeze there, every WorkManager retry
+  /// re-attempting the same page once. That is the "could never finish"
+  /// outcome this class exists to end, relocated from `skip=0` to `skip=N`.
+  ///
+  /// One divergence remains and is **not** fixable from here:
+  /// `PlanetApi._request` pins `receiveTimeout` to 15 seconds per request
+  /// where `NetworkModule` gives OkHttp 60 (`NetworkModule.kt:51`), and the
+  /// value is hard-coded rather than a parameter. A page at depth that needs
+  /// more than 15 seconds to start answering fails all four attempts.
+  static const List<Duration> pageRetryDelays = [
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 4),
+  ];
 
   /// Page size per table, from `TransactionSyncManager.kt:171-176`. Fixed, not
   /// adaptive: the Kotlin heavy walk has no `AdaptiveBatchProcessor` in it, and
@@ -177,6 +215,37 @@ class HeavyTableSync {
     return _now().difference(startedAt) < interactiveSyncTimeout;
   }
 
+  /// One page, with the attempts `RetryInterceptor` would have given it.
+  ///
+  /// Retried on the two classes the Kotlin interceptor retries: a transport
+  /// failure or timeout (its `IOException`, the port's [NetworkException]) and
+  /// a 5xx. Anything else — 401, 403, 404, a malformed body — is returned
+  /// immediately, because the interceptor does not retry those either and
+  /// Retrofit hands `syncDb` a null body for them, which is its other `break`
+  /// condition.
+  Future<NetworkResult<Map<String, dynamic>>> _fetchPage(
+    String url,
+    String authHeader,
+  ) async {
+    var result = await _api.getJsonObject(url, authHeader: authHeader);
+    for (final delay in pageRetryDelays) {
+      if (!_worthRetrying(result)) return result;
+      await _sleep(delay);
+      result = await _api.getJsonObject(url, authHeader: authHeader);
+    }
+    return result;
+  }
+
+  static bool _worthRetrying(NetworkResult<Map<String, dynamic>> result) =>
+      switch (result) {
+        NetworkSuccess() => false,
+        NetworkException() => true,
+        // A null code is a response whose status Dio did not report; treated
+        // as not-worth-retrying, matching the interceptor, which retries on a
+        // status it can read being 5xx and otherwise passes the response on.
+        NetworkError(:final code) => code != null && code >= 500,
+      };
+
   /// Port of `HeavyTableSyncWorker.doWork`. Returns WorkManager's success
   /// flag: `false` reschedules per the registered backoff policy, which is
   /// what `Result.retry()` means.
@@ -203,11 +272,14 @@ class HeavyTableSync {
   ///   than by this worker's backoff. The quirk is ported rather than
   ///   corrected: "retry" here would mean retrying a table whose server is
   ///   simply unreachable, on a linear 30-second backoff, having done nothing.
-  /// * **A table this build cannot walk is `true`, not `false`.** Kotlin
-  ///   answers `Result.failure()`; neither retries, and nothing reads the
-  ///   distinction. Retrying instead would loop for ever on a task name a
-  ///   later build persisted — the reason `BackgroundTaskRunner.run` gives for
-  ///   the same choice.
+  /// * **A table this build cannot walk is `true`, not `false`.** Retrying
+  ///   would loop for ever on a task name a later build persisted — the
+  ///   reason `BackgroundTaskRunner.run` gives for the same choice. Kotlin
+  ///   reaches this state differently and agrees on the verdict: a missing
+  ///   `KEY_TABLE` is its `Result.failure()`, while a table name with no
+  ///   handler takes `syncDb`'s `else -> Log.e("Unknown table")` arm
+  ///   (`TransactionSyncManager.kt:279`), walks every page of it, clears the
+  ///   checkpoint and returns success. Neither retries.
   Future<bool> run(String table, {required ServerConfig? config}) async {
     if (!_writers.containsKey(table)) return true;
     if (config == null) return true;
@@ -226,6 +298,15 @@ class HeavyTableSync {
   /// walk killed mid-page must resume — the page is not committed, so it must
   /// be re-fetched. The one after the insert records that the page *is*
   /// committed, so a resume skips past it rather than re-processing it.
+  ///
+  /// **Only the first is pinned by a test, and cannot be otherwise.** In one
+  /// process the post-insert write is redundant: the next iteration's
+  /// pre-request write stores the identical value, so deleting it changes no
+  /// observable state — an audit deleted it and the whole suite stayed green.
+  /// The two diverge only across a process killed between the page's database
+  /// commit and the next request, which no unit test can reach. Said here
+  /// rather than left implied, because a claim a test does not pin should not
+  /// look like one it does.
   ///
   /// Unlike every other walk in this port there is **no `total_rows` count
   /// query and no `skip < total` bound**: the Kotlin heavy walk has neither,
@@ -266,16 +347,18 @@ class HeavyTableSync {
         // before the request that may not come back.
         await _prefs.setHeavyTableSkip(table, skip);
 
-        final pageResult = await _api.getJsonObject(
+        final pageResult = await _fetchPage(
           '$dbUrl/$table/_all_docs?include_docs=true'
           '&limit=$pageSize&skip=$skip',
-          authHeader: authHeader,
+          authHeader,
         );
         if (pageResult is! NetworkSuccess<Map<String, dynamic>>) {
           // `break`, not `return`: the checkpoint stays where it is and the
           // caller's re-read turns it into the retry. Kotlin's `break` on
           // `!response.isSuccessful` (`:205-208`) leaves
-          // `syncCompletedFully` false for exactly this reason.
+          // `syncCompletedFully` false for exactly this reason — and, note,
+          // is reached only after `RetryInterceptor` has spent its own three
+          // attempts, which is why [pageRetryDelays] exists above.
           failure = describeNetworkFailure(pageResult);
           break;
         }
@@ -284,7 +367,7 @@ class HeavyTableSync {
         if (rows is! List || rows.isEmpty) {
           // Kotlin's `getJsonArray("rows", body)` yields an empty array for a
           // body without the key, and an empty array is its
-          // `syncCompletedFully = true` exit (`:213-216`). A malformed 200 is
+          // `syncCompletedFully = true` exit (`:210-213`). A malformed 200 is
           // therefore treated as a finished walk in both apps; the cost is a
           // cleared checkpoint and a walk that starts over, not lost rows.
           completedFully = true;
@@ -318,7 +401,19 @@ class HeavyTableSync {
       // `remove`, not `setInt(0)`, matching `:323-325`. The two read alike
       // through `heavyTableSkip`, and keeping the Kotlin's shape means a
       // reader comparing the trees finds the same key absent.
-      await _prefs.clearHeavyTableSkip(table);
+      //
+      // Guarded because this is the one statement that used to sit outside
+      // the walk's own `try`: a throwing `remove` propagated to
+      // `executeBackgroundTask`'s `catch (_) { return false; }`, and `false`
+      // on a one-off with linear backoff and no attempt limit is an unbounded
+      // retry of a walk that had just finished.
+      try {
+        await _prefs.clearHeavyTableSkip(table);
+      } catch (_) {
+        // The checkpoint stays at the last page instead, so the next run
+        // re-walks the tail. `syncDb`'s `apply()` has the same shape: it can
+        // lose the removal to a process kill and re-walk too.
+      }
     }
 
     return HeavyTableWalkResult(

--- a/flutter/lib/core/sync/heavy_table_sync.dart
+++ b/flutter/lib/core/sync/heavy_table_sync.dart
@@ -1,0 +1,330 @@
+import '../config/server_config.dart';
+import '../network/network_result.dart';
+import '../prefs/planet_prefs.dart';
+import '../utils/url_utils.dart';
+import '../../data/api/planet_api.dart';
+import 'sync_result.dart';
+import 'table_walk.dart';
+
+/// Writes one page of documents for a heavy table.
+///
+/// The repositories own the merge; this walk owns only the pagination and the
+/// checkpoint, exactly as `TransactionSyncManager.syncDb` dispatches each page
+/// to a repository's `insert…FromSync` and keeps the loop to itself.
+typedef HeavyTableWriter =
+    Future<void> Function(List<Map<String, dynamic>> docs);
+
+/// What one walk did, for logging and tests. **The retry verdict is not read
+/// from this** — see [HeavyTableSync.run].
+class HeavyTableWalkResult {
+  const HeavyTableWalkResult({
+    required this.savedCount,
+    required this.completedFully,
+    this.failure,
+  });
+
+  /// Documents handed to the writer, `_design` rows excluded.
+  final int savedCount;
+
+  /// True only on the two paths `syncDb` sets `syncCompletedFully` on: an
+  /// empty page and a short page. Every other exit leaves the checkpoint
+  /// standing.
+  final bool completedFully;
+
+  /// Why the walk stopped early, or null.
+  final String? failure;
+}
+
+/// Port of `services/sync/HeavyTableSyncWorker.kt` together with the
+/// checkpoint half of `TransactionSyncManager.syncDb`
+/// (`TransactionSyncManager.kt:166-341`).
+///
+/// **Why this exists.** Five tables are too large to walk inside the
+/// interactive sync, and two of them proved it on a real handset against
+/// `planet.learning`: `courses_progress` is 114,219 documents (572 pages at
+/// this table's size) and aborted at `skip=23600`; `login_activities` is
+/// 19,324 and aborted at `skip=10400`. CouchDB answers `skip` in O(n), so each
+/// page costs more than the last, and with no checkpoint every retry began
+/// again at zero — neither walk could *ever* finish, and the courses area
+/// failed with it. The checkpoint is the whole feature: an interrupted walk
+/// resumes past the pages it already committed.
+///
+/// **The verdict is derived from the checkpoint, not from the walk.** Kotlin
+/// discards `syncDb`'s return value and re-reads the preference
+/// (`HeavyTableSyncWorker.kt:32-34`); this does the same, quirk included — see
+/// [run].
+class HeavyTableSync {
+  HeavyTableSync({
+    required PlanetApi api,
+    required PlanetPrefs prefs,
+    required Map<String, HeavyTableWriter> writers,
+    DateTime Function()? now,
+  }) : _api = api,
+       _prefs = prefs,
+       _writers = writers,
+       _now = now ?? DateTime.now;
+
+  final PlanetApi _api;
+  final PlanetPrefs _prefs;
+  final Map<String, HeavyTableWriter> _writers;
+
+  /// The tables this instance can actually walk.
+  ///
+  /// Exposed so a test can ask the question that green tests structurally miss:
+  /// does every table [tables] schedules have a writer wired to it? A
+  /// scheduled table with no writer is a job that runs, finds nothing to do
+  /// and reports success for ever — the reachability shape this project keeps
+  /// finding.
+  Iterable<String> get writableTables => _writers.keys;
+  final DateTime Function() _now;
+
+  /// `HeavyTableSyncWorker.ALL_HEAVY_TABLES`, verbatim, as the reference for
+  /// what the Kotlin keeps out of its interactive sync. It is **not** the set
+  /// the port schedules — see [tables].
+  static const List<String> kotlinHeavyTables = [
+    'ratings',
+    'courses_progress',
+    'submissions',
+    'login_activities',
+    'team_activities',
+  ];
+
+  /// The tables the port walks in the background, and the three the Kotlin
+  /// list has that this one does not:
+  ///
+  /// * **`ratings` stays an interactive sync area.** It is 116 documents on
+  ///   planet.learning — 6 pages — so the checkpoint buys it nothing, while
+  ///   the sync centre's row buys the user an error message when the walk
+  ///   fails. Scheduling it here *as well* would walk it twice every sync,
+  ///   and moving it here would mean deleting a `DashboardSyncArea`, which
+  ///   reaches into the sync-centre UI and its labels. If a server ever
+  ///   carries a large `ratings` table the fix is one line — add it below and
+  ///   drop the area — but that is a change with a reason, not a guess.
+  /// * **`team_activities` has no writer in the port at all.** Kotlin pulls it
+  ///   (`teamsSyncRepository.bulkInsertTeamActivitiesFromSync`,
+  ///   `TransactionSyncManager.kt:252-254`); the port only ever *uploads*
+  ///   team-visit rows. Adding the table here without a writer would schedule
+  ///   a job that does nothing, so the gap is reported rather than papered
+  ///   over: see the phase notes. The consequence is the same shape as the
+  ///   `ratings` gap this port already fixed — `TeamLogDao.teamVisitsForUsers`
+  ///   and `lastTeamVisit` feed the member-detail screen's visit count and
+  ///   last-visit row, so both show only what *this* handset observed.
+  /// * **`submissions` keeps its inline pull**, and this one was moved here
+  ///   and moved back. It is 1,975 documents — 20 pages — and it is not one
+  ///   of the two tables that aborted at depth, so the checkpoint solves a
+  ///   problem it does not have. What moving it *costs* is an ordering the
+  ///   port depends on and Kotlin does not: `SubmissionsRepository
+  ///   .upsertDocuments` writes `isUpdated: false` over every row it writes,
+  ///   keyed on the server `_id`, so a sheet that arrived from the server and
+  ///   was then edited locally (survey resume's `markComplete`) loses the
+  ///   flag that makes it upload. The headless path closes that window by
+  ///   running the submissions *sweep* before the submissions *pull* in the
+  ///   same invocation — see `sweepPendingSubmissions` and
+  ///   `test/providers/pending_submissions_sweep_test.dart`, which is the test
+  ///   that caught this — and a background walk that can run at any time
+  ///   cannot be ordered against it at all. Kotlin has the same exposure
+  ///   (`upsertRoomSubmissionsFromSync` hard-writes `isUpdated = false` and
+  ///   its pull is in the worker), so this is the port keeping a mitigation
+  ///   Kotlin never had rather than inventing one. **Make the merge preserve a
+  ///   pending local edit and this table can move here**; until then the
+  ///   parity gain is not worth the loss.
+  static const List<String> tables = ['courses_progress', 'login_activities'];
+
+  /// How long a persisted interactive-sync flag is believed.
+  ///
+  /// Kotlin needs no such bound: `SyncManager.isSyncing` is an
+  /// `AtomicBoolean` that dies with the process, so a killed app cannot leave
+  /// it set. A preference can, and a permanently-set flag would make every
+  /// heavy run return retry for ever — the same "never finishes" outcome this
+  /// class exists to end. Bounded generously, because the cost of believing a
+  /// stale flag is a deferred walk while the cost of ignoring a live one is
+  /// two isolates walking the same table.
+  static const Duration interactiveSyncTimeout = Duration(minutes: 30);
+
+  /// Page size per table, from `TransactionSyncManager.kt:171-176`. Fixed, not
+  /// adaptive: the Kotlin heavy walk has no `AdaptiveBatchProcessor` in it, and
+  /// a size that grows on a fast page is the opposite of what a table that
+  /// aborts at depth needs.
+  static int pageSizeFor(String table) => switch (table) {
+    'ratings' => 20,
+    'submissions' => 100,
+    'courses_progress' || 'login_activities' || 'team_activities' => 200,
+    _ => 1000,
+  };
+
+  /// Stands in for `syncManager.isMainSyncActive()`
+  /// (`HeavyTableSyncWorker.kt:31` → `SyncManager.kt:118`).
+  ///
+  /// **The port cannot have the Kotlin's version.** Android WorkManager runs a
+  /// Kotlin worker in the app process, so the worker reads the very
+  /// `AtomicBoolean` the UI sets. A `workmanager` task runs in a *separate
+  /// Flutter isolate* with its own Riverpod graph, where `DashboardSyncState`
+  /// is invisible — so the flag is persisted instead, written by
+  /// `DashboardSyncNotifier.syncAll` and read here after a
+  /// [PlanetPrefs.reload].
+  ///
+  /// Two properties of the persisted version differ, both documented rather
+  /// than hidden. It is checked once at the start of a run, as the Kotlin's is
+  /// (`doWork` tests it and never re-tests), so a sync the user starts *during*
+  /// a walk still overlaps it — identical to the Kotlin. And it decays, for
+  /// the reason [interactiveSyncTimeout] gives.
+  bool get isInteractiveSyncActive {
+    final startedAt = _prefs.interactiveSyncStartedAt;
+    if (startedAt == null) return false;
+    // A negative elapsed time is a clock corrected *backwards* under a running
+    // sync, so it counts as active; only a flag older than the timeout is
+    // disbelieved.
+    return _now().difference(startedAt) < interactiveSyncTimeout;
+  }
+
+  /// Port of `HeavyTableSyncWorker.doWork`. Returns WorkManager's success
+  /// flag: `false` reschedules per the registered backoff policy, which is
+  /// what `Result.retry()` means.
+  ///
+  /// ```kotlin
+  /// val table = inputData.getString(KEY_TABLE) ?: return Result.failure()
+  /// if (syncManager.isMainSyncActive()) return Result.retry()
+  /// transactionSyncManager.syncDb(table, useCheckpoint = true)
+  /// val interrupted = sharedPrefManager.rawPreferences
+  ///     .getInt("heavy_sync_skip_$table", 0) > 0
+  /// return if (interrupted) Result.retry() else Result.success()
+  /// ```
+  ///
+  /// Three things about that, each deliberate:
+  ///
+  /// * **The verdict ignores the walk's outcome entirely.** `syncDb` returns a
+  ///   document count that `doWork` discards, and the retry decision is a
+  ///   fresh read of the checkpoint. So a walk that failed at `skip=4000`
+  ///   retries because the checkpoint says 4000, not because it reported a
+  ///   failure.
+  /// * **A walk that fails on its *first* page reports success**, because the
+  ///   checkpoint written before that request was `0` and `getInt(key, 0) > 0`
+  ///   is false. The table is then re-scheduled by the next full sync rather
+  ///   than by this worker's backoff. The quirk is ported rather than
+  ///   corrected: "retry" here would mean retrying a table whose server is
+  ///   simply unreachable, on a linear 30-second backoff, having done nothing.
+  /// * **A table this build cannot walk is `true`, not `false`.** Kotlin
+  ///   answers `Result.failure()`; neither retries, and nothing reads the
+  ///   distinction. Retrying instead would loop for ever on a task name a
+  ///   later build persisted — the reason `BackgroundTaskRunner.run` gives for
+  ///   the same choice.
+  Future<bool> run(String table, {required ServerConfig? config}) async {
+    if (!_writers.containsKey(table)) return true;
+    if (config == null) return true;
+    if (isInteractiveSyncActive) return false;
+    await walk(table: table, config: config);
+    final interrupted = _prefs.heavyTableSkip(table) > 0;
+    return !interrupted;
+  }
+
+  /// Port of `syncDb(table, useCheckpoint = true)`: pages `_all_docs` from the
+  /// saved offset, writing the checkpoint **before** each request and **after**
+  /// each committed page, and removing it only on a fully completed walk.
+  ///
+  /// The two writes are both in the Kotlin (`:193-195` and `:308-310`) and
+  /// they mean different things. The one before the request records where a
+  /// walk killed mid-page must resume — the page is not committed, so it must
+  /// be re-fetched. The one after the insert records that the page *is*
+  /// committed, so a resume skips past it rather than re-processing it.
+  ///
+  /// Unlike every other walk in this port there is **no `total_rows` count
+  /// query and no `skip < total` bound**: the Kotlin heavy walk has neither,
+  /// stopping on a short or empty page instead. Matching it matters here —
+  /// a count taken at the start of a walk that resumes days later is a bound
+  /// computed against a table that has since grown.
+  ///
+  /// No pruning, for any of these tables, and never add one: the Kotlin issues
+  /// no `deleteNotIn` for them, and all three hold locally-authored rows that
+  /// appear in no server keep set until they have been uploaded *and* pulled
+  /// back.
+  Future<HeavyTableWalkResult> walk({
+    required String table,
+    required ServerConfig config,
+  }) async {
+    final writer = _writers[table];
+    if (writer == null) {
+      return const HeavyTableWalkResult(
+        savedCount: 0,
+        completedFully: false,
+        failure: 'no writer',
+      );
+    }
+
+    final dbUrl = UrlUtils.dbUrl(config);
+    final authHeader = UrlUtils.authHeader(config);
+    final pageSize = pageSizeFor(table);
+
+    var skip = _prefs.heavyTableSkip(table);
+    var saved = 0;
+    var completedFully = false;
+    String? failure;
+
+    try {
+      while (true) {
+        // Before the request, so a walk the OS kills mid-page resumes at this
+        // page rather than past it. Awaited, which is what makes it durable
+        // before the request that may not come back.
+        await _prefs.setHeavyTableSkip(table, skip);
+
+        final pageResult = await _api.getJsonObject(
+          '$dbUrl/$table/_all_docs?include_docs=true'
+          '&limit=$pageSize&skip=$skip',
+          authHeader: authHeader,
+        );
+        if (pageResult is! NetworkSuccess<Map<String, dynamic>>) {
+          // `break`, not `return`: the checkpoint stays where it is and the
+          // caller's re-read turns it into the retry. Kotlin's `break` on
+          // `!response.isSuccessful` (`:205-208`) leaves
+          // `syncCompletedFully` false for exactly this reason.
+          failure = describeNetworkFailure(pageResult);
+          break;
+        }
+
+        final rows = pageResult.data['rows'];
+        if (rows is! List || rows.isEmpty) {
+          // Kotlin's `getJsonArray("rows", body)` yields an empty array for a
+          // body without the key, and an empty array is its
+          // `syncCompletedFully = true` exit (`:213-216`). A malformed 200 is
+          // therefore treated as a finished walk in both apps; the cost is a
+          // cleared checkpoint and a walk that starts over, not lost rows.
+          completedFully = true;
+          break;
+        }
+
+        final docs = extractDocs(rows);
+        if (docs.isNotEmpty) await writer(docs);
+        saved += docs.length;
+
+        // `rows.length`, not `docs.length`: the offset counts what the server
+        // returned, and a `_design` row the writer skipped still occupied a
+        // slot. Advancing by the filtered count would re-fetch it for ever.
+        skip += rows.length;
+        await _prefs.setHeavyTableSkip(table, skip);
+
+        if (rows.length < pageSize) {
+          completedFully = true;
+          break;
+        }
+      }
+    } catch (error) {
+      // `syncDb` catches `Exception`, logs, and returns 0 with the checkpoint
+      // left standing (`:335-339`); a `CancellationException` is rethrown but
+      // has the same effect on the preference. Either way the walk is
+      // resumable, which is the only property that matters here.
+      failure = 'heavy sync for $table stopped early';
+    }
+
+    if (completedFully) {
+      // `remove`, not `setInt(0)`, matching `:323-325`. The two read alike
+      // through `heavyTableSkip`, and keeping the Kotlin's shape means a
+      // reader comparing the trees finds the same key absent.
+      await _prefs.clearHeavyTableSkip(table);
+    }
+
+    return HeavyTableWalkResult(
+      savedCount: saved,
+      completedFully: completedFully,
+      failure: failure,
+    );
+  }
+}

--- a/flutter/lib/providers/activities_provider.dart
+++ b/flutter/lib/providers/activities_provider.dart
@@ -189,9 +189,18 @@ final profileActivityStatsProvider = FutureProvider<ProfileActivityStats>((
 
 /// Drives the `login_activities` pull.
 ///
-/// A sync with no caller is the failure this port has shipped three times (see
-/// the migration doc), so the pull is registered as a Sync center area rather
-/// than left as library code.
+/// **This notifier is itself unreachable, and the sentence here used to claim
+/// the opposite** ("so the pull is registered as a Sync center area rather
+/// than left as library code"). It was true when written and stopped being
+/// true when the `activities` area was removed from `DashboardSyncArea`: the
+/// walk it drives could not finish inline on planet.learning — 19,324
+/// documents, 97 pages, aborted at `skip=10400` — so the area went and
+/// `activitiesSyncProvider` was left with no reader in `lib/` or `test/`.
+/// The pull now runs in `HeavyTableSync` from a persisted checkpoint, calling
+/// `ActivitiesRepository.insertLoginActivitiesFromSync` directly, so nothing
+/// needs this notifier. Corrected rather than deleted here because deleting it
+/// is a change of substance to a file outside the lane that found it; it is on
+/// that lane's reported list.
 class ActivitiesSyncNotifier extends SyncNotifier {
   @override
   Future<SyncResult> runSync(

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -660,14 +660,21 @@ class CourseSyncNotifier extends SyncNotifier {
     // because there is no checkpoint the next attempt started again at zero.
     // It could never finish, and the whole courses area failed with it.
     //
-    // **What this costs until the heavy-table path exists**, stated rather
-    // than left to be discovered: nothing pulls `courses_progress` any more,
-    // so Planet's own grading no longer reaches the handset - the route
-    // `take_exam_screen` documents for a step exam becoming `passed`. Local
-    // progress is still written and still uploaded by
-    // `CourseProgressUploader`; only the pull is gone. Restoring it needs the
-    // resumable checkpoint, not a re-add here: put it back inline and the
-    // courses sync breaks again.
+    // **Where the pull lives instead.** `HeavyTableSync` walks the table in a
+    // background WorkManager task from a persisted
+    // `heavy_sync_skip_courses_progress`, scheduled at the end of every
+    // completed sync (`HeavyTableSyncScheduler.scheduleAll`, the port's
+    // `SyncManager:209`) and resumed on any headless invocation
+    // (`scheduleIfPending`, the port's `ServerReachabilityWorker:201`). So
+    // Planet's own grading does reach the handset - the route
+    // `take_exam_screen` documents for a step exam becoming `passed` - it just
+    // does not reach it from here. Local progress is still written and still
+    // uploaded by `CourseProgressUploader`.
+    //
+    // Adding the call back to this list would not be a fix even now: inline it
+    // has no checkpoint, so it would break the courses area again exactly as
+    // before. `test/providers/courses_sync_excludes_heavy_table_test.dart`
+    // guards that.
     final courseResult = courses.sync(config: config, onProgress: onProgress);
     final certResult = progress.syncCertifications(
       config: config,

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -9,6 +9,7 @@ import 'courses_providers.dart';
 import 'events_provider.dart';
 import 'feedback_provider.dart';
 import 'health_provider.dart';
+import 'heavy_sync_providers.dart';
 import 'notifications_provider.dart';
 import 'resources_providers.dart';
 import 'surveys_provider.dart';
@@ -167,11 +168,21 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
   Future<void> syncAll() async {
     if (state.running) return;
 
+    final startedAt = DateTime.now();
     state = DashboardSyncState.idle().copyWith(
       running: true,
-      startedAt: DateTime.now(),
+      startedAt: startedAt,
       clearFinishedAt: true,
     );
+
+    // Stands in for `SyncManager.start`'s `isSyncing.compareAndSet(false, true)`
+    // (`SyncManager:91`), which `HeavyTableSyncWorker` reads to decline running
+    // beside an interactive sync. [state.running] is the port's own version of
+    // that flag and would be enough if the worker lived here — it does not: a
+    // `workmanager` task is a separate Flutter isolate with its own Riverpod
+    // graph, so the flag has to be on disk to cross the boundary. See
+    // `HeavyTableSync.isInteractiveSyncActive`.
+    await _markInteractiveSyncActive(startedAt);
 
     // First, as `startFullSync` has it -- and before the challenge write
     // below, which reads the session with `.valueOrNull`: resolving
@@ -209,7 +220,61 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
     await _uploadMyPlanetActivities();
     await _queueSearchActivities();
 
+    // Cleared *before* the heavy tables are scheduled, which is one ordering
+    // the port improves on deliberately. Kotlin enqueues at `SyncManager:209`,
+    // inside the `try`, and only clears `isSyncing` in the `finally` at `:233`
+    // — so a worker WorkManager starts promptly sees `isMainSyncActive()` true
+    // and burns a `Result.retry()` with a 30-second backoff having done
+    // nothing. Nothing depends on the Kotlin's order; reversing it costs a
+    // heavy walk one guaranteed wasted cycle less.
+    await _clearInteractiveSyncActive();
+    await _scheduleHeavyTables();
+
     state = state.copyWith(running: false, finishedAt: DateTime.now());
+  }
+
+  Future<void> _markInteractiveSyncActive(DateTime startedAt) async {
+    try {
+      await ref.read(planetPrefsProvider).markInteractiveSyncStarted(startedAt);
+    } catch (_) {
+      // A preference write that fails must not stop the sync. The cost is a
+      // heavy walk that may overlap this pass — which the Kotlin also permits
+      // for a sync started mid-walk, since its guard is read once.
+    }
+  }
+
+  Future<void> _clearInteractiveSyncActive() async {
+    try {
+      await ref.read(planetPrefsProvider).clearInteractiveSyncStarted();
+    } catch (_) {
+      // Deliberately ignored. A flag left set decays after
+      // `HeavyTableSync.interactiveSyncTimeout` rather than blocking heavy
+      // walks for ever, which is exactly what that bound is for.
+    }
+  }
+
+  /// Port of `HeavyTableSyncWorker.schedule(context)` at `SyncManager:209` —
+  /// the end of a completed full sync, after the notification-read upload and
+  /// the activity record, which is where the Kotlin has it.
+  ///
+  /// Unconditional on the pass's outcome. The Kotlin's own condition is only
+  /// "`startFullSync` did not throw", and this pass cannot throw: every area
+  /// reports failure through its own state. Gating on `successCount > 0` — the
+  /// rule [_uploadMyPlanetActivities] follows — would be worse than useless
+  /// here, because a pass that failed everywhere is precisely when a resumable
+  /// walk should be queued. A heavy job scheduled against an unreachable
+  /// server fails its first page, reports success and does not retry, so there
+  /// is no storm to avoid.
+  Future<void> _scheduleHeavyTables() async {
+    if (ref.read(serverConfigProvider) == null) return;
+    try {
+      await ref.read(heavyTableSyncSchedulerProvider).scheduleAll();
+    } catch (_) {
+      // Swallowed like the telemetry uploads above: losing the scheduling of a
+      // background walk must not flip a finished sync to failed. The next
+      // completed sync, and every headless invocation's `scheduleIfPending`,
+      // try again.
+    }
   }
 
   /// Port of `SyncManager.pushCurrentUserShelf`, which `startFullSync` runs

--- a/flutter/lib/providers/dashboard_sync_provider.dart
+++ b/flutter/lib/providers/dashboard_sync_provider.dart
@@ -56,9 +56,11 @@ import 'voices_provider.dart';
 /// (`skip=10400`, connection aborted, no checkpoint to resume from).
 /// `login_activities` is a `HeavyTableSyncWorker` table in Kotlin and appears
 /// in no interactive step there either, so removing the area is the port
-/// matching it rather than dropping a feature. Local login rows are still
-/// written and still uploaded; only the pull is gone, and
-/// `ActivitiesRepository.sync` records what restoring it needs.
+/// matching it rather than dropping a feature. **The pull is not gone** — an
+/// earlier revision of this note said it was, and stopped being true when
+/// `HeavyTableSync` landed: the table is walked in a background task from a
+/// persisted `heavy_sync_skip_login_activities`, resuming rather than
+/// restarting. It is simply not walked from here.
 ///
 /// **`shelf` must stay last.** It pulls the shelf document and stamps rows
 /// that `resources` and `courses` write and prune, so it has to follow both —
@@ -183,7 +185,34 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
     // graph, so the flag has to be on disk to cross the boundary. See
     // `HeavyTableSync.isInteractiveSyncActive`.
     await _markInteractiveSyncActive(startedAt);
+    try {
+      await _runPass();
+    } finally {
+      // In a `finally`, as `SyncManager`'s `destroy()` is (`SyncManager:233`),
+      // and for a sharper reason than symmetry: a flag left standing makes
+      // *every* heavy walk answer retry until it decays, so it must not
+      // depend on the pass reaching its last statement. Nothing in the pass
+      // throws today — each step carries its own `catch` — which is exactly
+      // the state in which an unguarded clear looks fine.
+      //
+      // Cleared before [_scheduleHeavyTables], which runs after this block:
+      // a job enqueued while the flag still stood would start, read it, and
+      // stand down for a backoff having done nothing. Kotlin has the same
+      // window in the other order (it enqueues at `SyncManager:209` and
+      // clears in the `finally` at `:233`) and it costs it little, since only
+      // a few log lines separate the two; the port simply has no reason to
+      // reproduce the ordering rather than the intent.
+      await _clearInteractiveSyncActive();
+    }
 
+    await _scheduleHeavyTables();
+
+    state = state.copyWith(running: false, finishedAt: DateTime.now());
+  }
+
+  /// The pass itself, so [syncAll] can guarantee the interactive-sync flag is
+  /// cleared however it ends.
+  Future<void> _runPass() async {
     // First, as `startFullSync` has it -- and before the challenge write
     // below, which reads the session with `.valueOrNull`: resolving
     // `sessionProvider` here means that read finds a value rather than the
@@ -219,18 +248,6 @@ class DashboardSyncNotifier extends Notifier<DashboardSyncState> {
     await _recordSyncActivity();
     await _uploadMyPlanetActivities();
     await _queueSearchActivities();
-
-    // Cleared *before* the heavy tables are scheduled, which is one ordering
-    // the port improves on deliberately. Kotlin enqueues at `SyncManager:209`,
-    // inside the `try`, and only clears `isSyncing` in the `finally` at `:233`
-    // — so a worker WorkManager starts promptly sees `isMainSyncActive()` true
-    // and burns a `Result.retry()` with a 30-second backoff having done
-    // nothing. Nothing depends on the Kotlin's order; reversing it costs a
-    // heavy walk one guaranteed wasted cycle less.
-    await _clearInteractiveSyncActive();
-    await _scheduleHeavyTables();
-
-    state = state.copyWith(running: false, finishedAt: DateTime.now());
   }
 
   Future<void> _markInteractiveSyncActive(DateTime startedAt) async {

--- a/flutter/lib/providers/heavy_sync_providers.dart
+++ b/flutter/lib/providers/heavy_sync_providers.dart
@@ -21,12 +21,12 @@ final heavyTableSyncSchedulerProvider = Provider<HeavyTableSyncScheduler>(
 ///
 /// The writers are the repositories' existing `insert…FromSync` merges —
 /// exactly the dispatch `TransactionSyncManager.syncDb`'s `when (table)` does,
-/// with the pagination and the checkpoint kept out of the repositories. Two of
-/// the three have sat here uncalled since the inline pulls were removed
-/// (`ProgressRepository.syncCourseProgress`'s dartdoc and
-/// `ActivitiesRepository.sync`'s both name this worker as what they were
-/// waiting for), which is why they are wired *here* rather than given a caller
-/// back inside the interactive sync.
+/// with the pagination and the checkpoint kept out of the repositories. Both
+/// merges were already here and reachable from nothing that runs: the walks
+/// that called them were removed as a stopgap and their dartdocs named this
+/// worker as what they were waiting for. They are wired *here* rather than
+/// given a caller back inside the interactive sync, which is what could not
+/// finish.
 ///
 /// `submissions` is deliberately absent even though Kotlin walks it here —
 /// see [HeavyTableSync.tables] for why its inline pull is worth more than the

--- a/flutter/lib/providers/heavy_sync_providers.dart
+++ b/flutter/lib/providers/heavy_sync_providers.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/background/heavy_table_scheduler.dart';
+import '../core/sync/heavy_table_sync.dart';
+import 'app_providers.dart';
+
+/// The `workmanager` side of heavy-table scheduling. Overridden in tests,
+/// which must not reach a plugin channel.
+final heavyTableWorkSchedulerProvider = Provider<HeavyTableWorkScheduler>(
+  (ref) => const WorkmanagerHeavyTableScheduler(),
+);
+
+final heavyTableSyncSchedulerProvider = Provider<HeavyTableSyncScheduler>(
+  (ref) => HeavyTableSyncScheduler(
+    ref.watch(heavyTableWorkSchedulerProvider),
+    ref.watch(planetPrefsProvider),
+  ),
+);
+
+/// The walk itself, with one writer per table.
+///
+/// The writers are the repositories' existing `insert…FromSync` merges —
+/// exactly the dispatch `TransactionSyncManager.syncDb`'s `when (table)` does,
+/// with the pagination and the checkpoint kept out of the repositories. Two of
+/// the three have sat here uncalled since the inline pulls were removed
+/// (`ProgressRepository.syncCourseProgress`'s dartdoc and
+/// `ActivitiesRepository.sync`'s both name this worker as what they were
+/// waiting for), which is why they are wired *here* rather than given a caller
+/// back inside the interactive sync.
+///
+/// `submissions` is deliberately absent even though Kotlin walks it here —
+/// see [HeavyTableSync.tables] for why its inline pull is worth more than the
+/// parity.
+final heavyTableSyncProvider = Provider<HeavyTableSync>(
+  (ref) => HeavyTableSync(
+    api: ref.watch(planetApiProvider),
+    prefs: ref.watch(planetPrefsProvider),
+    writers: {
+      'courses_progress': (docs) async {
+        await ref
+            .read(progressRepositoryProvider)
+            .insertCourseProgressFromSync(docs);
+      },
+      'login_activities': (docs) async {
+        await ref
+            .read(activitiesRepositoryProvider)
+            .insertLoginActivitiesFromSync(docs);
+      },
+    },
+  ),
+);

--- a/flutter/lib/repository/activities_repository.dart
+++ b/flutter/lib/repository/activities_repository.dart
@@ -351,15 +351,22 @@ class ActivitiesRepository {
   Future<int> markCourseUploaded(String localId, String remoteId, String rev) =>
       _courseDao.markUploaded(localId, remoteId, rev);
 
-  /// **This has no caller, deliberately — see the note on
+  /// **This is not the path production takes — see the note on
   /// `ProgressRepository.syncCourseProgress`, which is the same story.**
   /// `login_activities` is one of `HeavyTableSyncWorker.ALL_HEAVY_TABLES` and
   /// appears in no interactive step in Kotlin either. On planet.learning it is
   /// **19,324 documents**: 97 `_all_docs` pages with a deepening `skip`, which
   /// failed on a real device at `skip=10400` with the connection aborted and
-  /// no checkpoint to resume from. It needs the background worker with a
-  /// persisted skip, not a caller here. Login rows are still written locally
-  /// and still uploaded; only the pull is absent.
+  /// no checkpoint to resume from. `HeavyTableSync` now walks it in a
+  /// background task from a persisted `heavy_sync_skip_login_activities`, page
+  /// by page through [insertLoginActivitiesFromSync] — the same merge this
+  /// method uses — so an interrupted walk resumes rather than restarting.
+  ///
+  /// This un-checkpointed walk is kept rather than deleted because Kotlin has
+  /// the same pair: `SyncActivity:671` calls `syncDb("login_activities")` with
+  /// `useCheckpoint = false` from a connectivity collector, outside
+  /// `SyncManager` entirely. It has no caller in the port, and giving it an
+  /// interactive one would restore the failure above.
   ///
   /// Pulls the `login_activities` database, the direction this port lacked:
   /// Phase 33 wrote login rows and Phase 34 uploaded them, but nothing brought

--- a/flutter/lib/repository/activities_repository.dart
+++ b/flutter/lib/repository/activities_repository.dart
@@ -351,8 +351,9 @@ class ActivitiesRepository {
   Future<int> markCourseUploaded(String localId, String remoteId, String rev) =>
       _courseDao.markUploaded(localId, remoteId, rev);
 
-  /// **This is not the path production takes — see the note on
-  /// `ProgressRepository.syncCourseProgress`, which is the same story.**
+  /// **This is not the path production takes.** Its `courses_progress`
+  /// counterpart was deleted in the same phase for being unreachable; this one
+  /// survives for the Kotlin reason below.
   /// `login_activities` is one of `HeavyTableSyncWorker.ALL_HEAVY_TABLES` and
   /// appears in no interactive step in Kotlin either. On planet.learning it is
   /// **19,324 documents**: 97 `_all_docs` pages with a deepening `skip`, which
@@ -365,8 +366,18 @@ class ActivitiesRepository {
   /// This un-checkpointed walk is kept rather than deleted because Kotlin has
   /// the same pair: `SyncActivity:671` calls `syncDb("login_activities")` with
   /// `useCheckpoint = false` from a connectivity collector, outside
-  /// `SyncManager` entirely. It has no caller in the port, and giving it an
-  /// interactive one would restore the failure above.
+  /// `SyncManager` entirely — so an un-checkpointed walk of this table is a
+  /// shape the Kotlin has, not one the port invented.
+  ///
+  /// **Its one caller is dead**, and the distinction matters because "no
+  /// caller" is what an earlier revision of this sentence claimed:
+  /// `ActivitiesSyncNotifier.runSync` calls it
+  /// (`activities_provider.dart:200`), but `activitiesSyncProvider` has no
+  /// reader anywhere in `lib/` or `test/` and `DashboardSyncArea` has no
+  /// `activities` member — the area was removed when the inline pull was.
+  /// Deleting the notifier is a change to a file this lane does not own; it is
+  /// reported instead. Either way, giving this walk an interactive caller
+  /// would restore the failure above.
   ///
   /// Pulls the `login_activities` database, the direction this port lacked:
   /// Phase 33 wrote login rows and Phase 34 uploaded them, but nothing brought

--- a/flutter/lib/repository/progress_repository.dart
+++ b/flutter/lib/repository/progress_repository.dart
@@ -491,8 +491,25 @@ class ProgressRepository {
       final docId = doc['_id']?.toString() ?? '';
       if (docId.isEmpty || docId.startsWith('_design/')) continue;
 
-      final courseId = doc['courseId']?.toString();
-      final userId = doc['userId']?.toString();
+      // `getStringOrNull`, so the lookup key below is read exactly as
+      // `CourseProgressMapper.fromDoc` writes the column. `doc['userId']
+      // ?.toString()` differs for one input — a `userId` that is present but
+      // empty, where it yields `''` and the mapper stores NULL — and the
+      // triple lookup then searches for a value nothing in this port writes.
+      //
+      // **This changes no outcome today**, and the note says so rather than
+      // implying a fix: the lookup misses either way (`''` matches no row,
+      // and a null skips the lookup via the guard below), so both readings
+      // end at `localRecord == null` and a row keyed by `_id`. What it buys
+      // is that the two halves of the method agree, and agreement with the
+      // Kotlin: `courseProgressFromJson` assigns `JsonUtils.getString`
+      // (`ProgressRepositoryImpl.kt:260`, hence `""` where this stores NULL),
+      // and its local-record lookup filters the keys with
+      // `keys.userId.takeIf { it.isNotEmpty() }` (`:290`) — so an empty
+      // `userId` means "no user" there too, which is what a null means here.
+      // A reader comparing the trees should not have to work that out twice.
+      final courseId = JsonUtils.getStringOrNull('courseId', doc);
+      final userId = JsonUtils.getStringOrNull('userId', doc);
       final stepNum = (doc['stepNum'] is int)
           ? doc['stepNum'] as int
           : int.tryParse('${doc['stepNum']}') ?? 0;
@@ -527,11 +544,16 @@ class ProgressRepository {
   /// Port of the `courses_progress` pull in
   /// `services/sync/TransactionSyncManager.kt`'s `syncDb`.
   ///
-  /// **This has no caller, deliberately, and it must not be given one here.**
-  /// Recorded loudly because an uncalled sync writer is exactly the shape this
-  /// project keeps paying for — Phase 119 found four of them, plumbing laid
-  /// for a pull nobody wrote. This one is the inverse: the pull exists and its
-  /// *scheduler* is what is missing.
+  /// **This is not the path production takes, and it must not be given an
+  /// interactive caller.** The scheduler it was waiting for now exists:
+  /// `HeavyTableSync` walks this table in a background WorkManager task from a
+  /// persisted `heavy_sync_skip_courses_progress` checkpoint, writing each page
+  /// through [insertCourseProgressFromSync] — the same merge this method uses.
+  /// What remains here is the un-checkpointed walk, kept because it is the
+  /// Kotlin's own second shape (`syncDb(table)` with `useCheckpoint = false`,
+  /// which `SyncActivity:671` uses for `login_activities`) and because a caller
+  /// that wants one bounded pull rather than a resumable one has something to
+  /// call. It is not wired to anything today.
   ///
   /// `courses_progress` is one of the five tables Kotlin keeps out of the
   /// interactive sync entirely (`HeavyTableSyncWorker.ALL_HEAVY_TABLES`:
@@ -550,10 +572,12 @@ class ProgressRepository {
   /// at zero — so it could never complete, and it failed the whole courses
   /// sync with it.
   ///
-  /// To bring it back, port the worker, not the call site: a background job
-  /// per heavy table plus a persisted skip. Until then Planet's grading does
-  /// not reach the handset (see `take_exam_screen`), which is a known,
-  /// recorded gap rather than a silent one.
+  /// That is what the worker fixes, and why the fix was the worker rather than
+  /// the call site: `HeavyTableSync.walk` resumes at the page it left off at,
+  /// so a walk that gets 23,600 documents in before the connection drops keeps
+  /// them and continues. Planet's grading reaches the handset again through it
+  /// (the route `take_exam_screen` documents for a step exam becoming
+  /// `passed`).
   ///
   /// Paginates `_all_docs` with a batch size of 200 (the Kotlin's page size for
   /// this table) and merges each page via [insertCourseProgressFromSync]. There

--- a/flutter/lib/repository/progress_repository.dart
+++ b/flutter/lib/repository/progress_repository.dart
@@ -516,14 +516,7 @@ class ProgressRepository {
 
       final existing = (await _progressDao.getByIds([docId])).firstOrNull;
       final localRecord =
-          existing ??
-          (courseId != null && userId != null
-              ? (await _progressDao.findByCourseUserAndStep(
-                  courseId,
-                  userId,
-                  stepNum,
-                ))
-              : null);
+          existing ?? await _localRecordFor(courseId, userId, stepNum, docId);
 
       companions.add(
         CourseProgressMapper.fromDoc(
@@ -538,66 +531,47 @@ class ProgressRepository {
     return companions.length;
   }
 
+  /// The local row a synced document should merge onto when no row carries its
+  /// `_id` yet: matched on `(courseId, userId, stepNum)` **and** filtered to a
+  /// row that is either unsynced or already this document's.
+  ///
+  /// That filter is Kotlin's, and the port had dropped it:
+  /// `localRecordsByKey[Triple(...)]?.find { it._id == null || it._id ==
+  /// keys.docId }` (`ProgressRepositoryImpl.kt:310-311`), which
+  /// `CourseProgressMapper.fromDoc`'s own dartdoc already described. Without
+  /// it, two documents sharing the triple — routine on a server holding
+  /// 114,219 rows for a table that is logically one row per step — fight over
+  /// one local row: the second rewrites the first's `couchId` and `rev`, and
+  /// the first document ends up with no local representation at all. Kotlin
+  /// gives the second its own row. Newly worth fixing because until this phase
+  /// nothing walked the table.
+  ///
+  /// Uses `getByCourseUsersAndSteps`, which existed for exactly this and had
+  /// no caller; `findByCourseUserAndStep` cannot serve it, because its
+  /// `limit(1)` picks a row before the filter can reject it.
+  Future<CourseProgressRow?> _localRecordFor(
+    String? courseId,
+    String? userId,
+    int stepNum,
+    String docId,
+  ) async {
+    // Kotlin filters empty ids out of the key set before looking anything up
+    // (`:290`), so a document with no course or no user has no local record to
+    // find rather than matching every row that also lacks one.
+    if (courseId == null || userId == null) return null;
+    final candidates = await _progressDao.getByCourseUsersAndSteps(
+      [courseId],
+      [userId],
+      [stepNum],
+    );
+    for (final row in candidates) {
+      if (row.couchId == null || row.couchId == docId) return row;
+    }
+    return null;
+  }
+
   Future<void> upsertCertifications(List<CertificationsCompanion> rows) =>
       _certificationDao.upsertAll(rows);
-
-  /// Port of the `courses_progress` pull in
-  /// `services/sync/TransactionSyncManager.kt`'s `syncDb`.
-  ///
-  /// **This is not the path production takes, and it must not be given an
-  /// interactive caller.** The scheduler it was waiting for now exists:
-  /// `HeavyTableSync` walks this table in a background WorkManager task from a
-  /// persisted `heavy_sync_skip_courses_progress` checkpoint, writing each page
-  /// through [insertCourseProgressFromSync] — the same merge this method uses.
-  /// What remains here is the un-checkpointed walk, kept because it is the
-  /// Kotlin's own second shape (`syncDb(table)` with `useCheckpoint = false`,
-  /// which `SyncActivity:671` uses for `login_activities`) and because a caller
-  /// that wants one bounded pull rather than a resumable one has something to
-  /// call. It is not wired to anything today.
-  ///
-  /// `courses_progress` is one of the five tables Kotlin keeps out of the
-  /// interactive sync entirely (`HeavyTableSyncWorker.ALL_HEAVY_TABLES`:
-  /// `ratings`, `courses_progress`, `submissions`, `login_activities`,
-  /// `team_activities`); none appear in `startFullSync`'s `parallelTables`.
-  /// They run as one-shot WorkManager jobs calling
-  /// `syncDb(table, useCheckpoint = true)`, and the checkpoint is the point —
-  /// a `heavy_sync_skip_<table>` preference lets an interrupted walk resume
-  /// instead of restarting, and the worker returns `Result.retry()` while any
-  /// remains.
-  ///
-  /// On planet.learning this table holds **114,219 documents**: 572 pages at
-  /// the batch size below, each with a deeper `skip` that CouchDB answers in
-  /// O(n). Called inline from the courses area it reached `skip=23600`, the
-  /// connection aborted, and with no checkpoint the next attempt began again
-  /// at zero — so it could never complete, and it failed the whole courses
-  /// sync with it.
-  ///
-  /// That is what the worker fixes, and why the fix was the worker rather than
-  /// the call site: `HeavyTableSync.walk` resumes at the page it left off at,
-  /// so a walk that gets 23,600 documents in before the connection drops keeps
-  /// them and continues. Planet's grading reaches the handset again through it
-  /// (the route `take_exam_screen` documents for a step exam becoming
-  /// `passed`).
-  ///
-  /// Paginates `_all_docs` with a batch size of 200 (the Kotlin's page size for
-  /// this table) and merges each page via [insertCourseProgressFromSync]. There
-  /// is deliberately **no** `deleteNotIn` cleanup — the Kotlin does not run one
-  /// for `courses_progress`, so a row that drops off the server lingers locally,
-  /// and replicating that here keeps the behaviour identical. A locally-authored
-  /// row that the server has not echoed back would be discarded by a cleanup,
-  /// which is exactly the data the preserved-table rule exists to protect.
-  Future<SyncResult> syncCourseProgress({
-    required ServerConfig config,
-    void Function(SyncProgress)? onProgress,
-  }) async {
-    return _pullTable(
-      config: config,
-      table: 'courses_progress',
-      batchSize: 200,
-      onProgress: onProgress,
-      insert: (docs) => insertCourseProgressFromSync(docs),
-    );
-  }
 
   /// Port of the `certifications` pull in `TransactionSyncManager.syncDb`.
   ///
@@ -689,69 +663,6 @@ class ProgressRepository {
   /// Shared pagination loop for `_all_docs` pulls whose insert step takes raw
   /// docs. Used by [syncCourseProgress]; `syncCertifications` has its own body
   /// because it counts ids for the cleanup and parses with a different mapper.
-  Future<SyncResult> _pullTable({
-    required ServerConfig config,
-    required String table,
-    required int batchSize,
-    required void Function(SyncProgress)? onProgress,
-    required Future<int> Function(List<Map<String, dynamic>> docs) insert,
-  }) async {
-    final dbUrl = UrlUtils.dbUrl(config);
-    final authHeader = UrlUtils.authHeader(config);
-
-    final countResult = await _api.getJsonObject(
-      '$dbUrl/$table/_all_docs?limit=0',
-      authHeader: authHeader,
-    );
-    if (countResult is! NetworkSuccess<Map<String, dynamic>>) {
-      return SyncFailed(describeNetworkFailure(countResult));
-    }
-    final totalRows = JsonUtils.getInt('total_rows', countResult.data);
-    if (totalRows == 0) {
-      onProgress?.call(const SyncProgress(completed: 0, total: 0));
-      return const SyncComplete(0);
-    }
-
-    final batchSizer = AdaptiveBatchProcessor(initialSize: batchSize);
-    var skip = 0;
-    var totalSaved = 0;
-
-    while (skip < totalRows) {
-      final size = batchSizer.currentSize;
-      final stopwatch = Stopwatch()..start();
-      final pageResult = await _api.getJsonObject(
-        '$dbUrl/$table/_all_docs?include_docs=true&limit=$size&skip=$skip',
-        authHeader: authHeader,
-      );
-      stopwatch.stop();
-
-      if (pageResult is! NetworkSuccess<Map<String, dynamic>>) {
-        batchSizer.recordFailure();
-        return SyncFailed(describeNetworkFailure(pageResult));
-      }
-      batchSizer.recordSuccess(stopwatch.elapsedMilliseconds);
-
-      final rows = pageResult.data['rows'];
-      if (rows is! List || rows.isEmpty) break;
-
-      final docs = <Map<String, dynamic>>[
-        for (final row in rows)
-          if (row is Map<String, dynamic>)
-            JsonUtils.getObject('doc', row) ?? const <String, dynamic>{},
-      ];
-      totalSaved += await insert(docs);
-
-      skip += rows.length;
-      onProgress?.call(
-        SyncProgress(
-          completed: skip > totalRows ? totalRows : skip,
-          total: totalRows,
-        ),
-      );
-      if (rows.length < size) break;
-    }
-    return SyncComplete(totalSaved);
-  }
 }
 
 /// Port of `model/CourseProgressData.kt` — everything

--- a/flutter/lib/repository/ratings_repository.dart
+++ b/flutter/lib/repository/ratings_repository.dart
@@ -166,13 +166,24 @@ class RatingsRepository {
   /// (`:242-244`), which `HeavyTableSyncWorker` runs after a full sync
   /// (`HeavyTableSyncWorker.ALL_HEAVY_TABLES`).
   ///
-  /// The port has no background heavy-table worker, so this runs as an area of
-  /// the sync centre instead. Without it the only writer of the table is the
-  /// local [submit], whose one caller always passes the signed-in user — so
-  /// the read predicate (`type = ? AND item = ?`, deliberately unscoped by
-  /// user, because it computes a community average) could only ever see this
-  /// device's own rating, and every "average" was a single number the user had
-  /// typed themselves.
+  /// **This stays an area of the sync centre even though the port now has the
+  /// heavy-table worker** (`HeavyTableSync`), and `ratings` is deliberately
+  /// absent from `HeavyTableSync.tables`. Three reasons, in order of weight:
+  /// the table is 116 documents on planet.learning — 6 pages at the Kotlin's
+  /// size of 20 — so a resumable checkpoint solves a problem it does not have;
+  /// the sync-centre row is the only place a user is *told* the walk failed,
+  /// where a background task is silent; and scheduling it there as well would
+  /// walk the same table twice on every sync. If a server ever carries a
+  /// `ratings` table large enough to abort at depth, the fix is to add it to
+  /// `HeavyTableSync.tables` and drop the area — deliberately not done on
+  /// speculation.
+  ///
+  /// Without this walk the only writer of the table is the local [submit],
+  /// whose one caller always passes the signed-in user — so the read predicate
+  /// (`type = ? AND item = ?`, deliberately unscoped by user, because it
+  /// computes a community average) could only ever see this device's own
+  /// rating, and every "average" was a single number the user had typed
+  /// themselves.
   ///
   /// **Never prunes.** The Kotlin's walk issues no delete, and a prune here
   /// would destroy the user's own unsent ratings: a rating submitted on this

--- a/flutter/test/core/background/heavy_table_scheduler_test.dart
+++ b/flutter/test/core/background/heavy_table_scheduler_test.dart
@@ -8,10 +8,17 @@ import 'package:myplanet/core/sync/heavy_table_sync.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _RecordingScheduler implements HeavyTableWorkScheduler {
-  final enqueued = <String>[];
+  final taskNames = <String>[];
+
+  /// The tables the recorded task names parse back to — the round trip the
+  /// dispatcher performs. A `null` here is a name `executeBackgroundTask`
+  /// would fail to route, which is why the assertions read this rather than
+  /// the raw strings.
+  List<String?> get enqueued =>
+      taskNames.map(BackgroundTaskNames.heavyTableSyncTable).toList();
 
   @override
-  Future<void> enqueueUnique(String table) async => enqueued.add(table);
+  Future<void> enqueueUnique(String taskName) async => taskNames.add(taskName);
 }
 
 void main() {
@@ -36,14 +43,15 @@ void main() {
 
     test('are one per table, so each gets its own unique work', () {
       // The unique name is what makes `keep` collapse a second enqueue into
-      // the walk already running. One shared name would make the five tables
-      // compete for a single job and four of them would never run.
-      final names = {
-        for (final table in HeavyTableSync.tables)
-          BackgroundTaskNames.heavyTableSyncTask(table),
-      };
-
-      expect(names, hasLength(HeavyTableSync.tables.length));
+      // the walk already running; one shared name would make the tables
+      // compete for a single job and all but one would never run. The
+      // uniqueness itself is injective by construction — the interesting half
+      // is that a *scheduled* name round-trips through the dispatcher's
+      // parser, which is what the source assertion below adds.
+      for (final table in HeavyTableSync.tables) {
+        final name = BackgroundTaskNames.heavyTableSyncTask(table);
+        expect(BackgroundTaskNames.heavyTableSyncTable(name), table);
+      }
     });
 
     test('reject a name that is not a heavy task', () {
@@ -72,6 +80,16 @@ void main() {
       await build().scheduleAll();
 
       expect(scheduler.enqueued, HeavyTableSync.tables);
+      // The round trip, which is the half that was pinned by nothing: an audit
+      // made the scheduler pass the bare table as the task name and the whole
+      // suite stayed green, while in production the dispatcher parsed no table
+      // and the walk never ran.
+      expect(
+        scheduler.taskNames,
+        HeavyTableSync.tables
+            .map(BackgroundTaskNames.heavyTableSyncTask)
+            .toList(),
+      );
     });
 
     test('is what recovers a table whose walk died on page 1', () async {
@@ -119,7 +137,19 @@ void main() {
     final source = File(
       'lib/core/background/heavy_table_scheduler.dart',
     ).readAsStringSync();
-    final call = source.substring(source.indexOf('registerOneOffTask'));
+    // The concrete implementation's body: from `enqueueUnique` *inside*
+    // `WorkmanagerHeavyTableScheduler`, so the name construction a line above
+    // `registerOneOffTask` is in scope while the doc comments — which discuss
+    // `append` and `expedited` by name — are not. Anchoring on the first
+    // `enqueueUnique` in the file finds the abstract member and swallows the
+    // comment that explains why the flag is absent, which then reads as the
+    // flag being present.
+    final call = source.substring(
+      source.indexOf(
+        'Future<void> enqueueUnique',
+        source.indexOf('class WorkmanagerHeavyTableScheduler'),
+      ),
+    );
 
     test('keeps existing work rather than appending to it', () {
       // `append` (the policy the download queue needs, and the only one

--- a/flutter/test/core/background/heavy_table_scheduler_test.dart
+++ b/flutter/test/core/background/heavy_table_scheduler_test.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/background/background_task_names.dart';
+import 'package:myplanet/core/background/heavy_table_scheduler.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/sync/heavy_table_sync.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingScheduler implements HeavyTableWorkScheduler {
+  final enqueued = <String>[];
+
+  @override
+  Future<void> enqueueUnique(String table) async => enqueued.add(table);
+}
+
+void main() {
+  late _RecordingScheduler scheduler;
+  late PlanetPrefs prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const {});
+    prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    scheduler = _RecordingScheduler();
+  });
+
+  HeavyTableSyncScheduler build() => HeavyTableSyncScheduler(scheduler, prefs);
+
+  group('task names', () {
+    test('round-trip a table', () {
+      final name = BackgroundTaskNames.heavyTableSyncTask('courses_progress');
+
+      expect(name, 'myplanet.heavy.courses_progress');
+      expect(BackgroundTaskNames.heavyTableSyncTable(name), 'courses_progress');
+    });
+
+    test('are one per table, so each gets its own unique work', () {
+      // The unique name is what makes `keep` collapse a second enqueue into
+      // the walk already running. One shared name would make the five tables
+      // compete for a single job and four of them would never run.
+      final names = {
+        for (final table in HeavyTableSync.tables)
+          BackgroundTaskNames.heavyTableSyncTask(table),
+      };
+
+      expect(names, hasLength(HeavyTableSync.tables.length));
+    });
+
+    test('reject a name that is not a heavy task', () {
+      expect(
+        BackgroundTaskNames.heavyTableSyncTable(BackgroundTaskNames.autoSync),
+        isNull,
+      );
+      expect(
+        BackgroundTaskNames.heavyTableSyncTable(BackgroundTaskNames.download),
+        isNull,
+      );
+      // The bare prefix carries no table. Returning `''` here would have the
+      // entrypoint run a walk for a table with no writer, which is harmless
+      // but reports a verdict for a table that does not exist.
+      expect(
+        BackgroundTaskNames.heavyTableSyncTable(
+          BackgroundTaskNames.heavyPrefix,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('scheduleAll', () {
+    test('enqueues every port heavy table, checkpoints unread', () async {
+      await build().scheduleAll();
+
+      expect(scheduler.enqueued, HeavyTableSync.tables);
+    });
+
+    test('is what recovers a table whose walk died on page 1', () async {
+      // Checkpoint 0 with an unfinished walk is invisible to
+      // `scheduleIfPending`; this is the only path that re-enqueues it. Gate
+      // `scheduleAll` on the checkpoint and this fails.
+      await prefs.setHeavyTableSkip('courses_progress', 0);
+
+      await build().scheduleAll();
+
+      expect(scheduler.enqueued, contains('courses_progress'));
+    });
+  });
+
+  group('scheduleIfPending', () {
+    test('enqueues only the tables with a checkpoint above zero', () async {
+      await prefs.setHeavyTableSkip('courses_progress', 23600);
+      await prefs.setHeavyTableSkip('login_activities', 0);
+
+      await build().scheduleIfPending();
+
+      expect(scheduler.enqueued, ['courses_progress']);
+    });
+
+    test('enqueues nothing when no walk is pending', () async {
+      await build().scheduleIfPending();
+
+      expect(scheduler.enqueued, isEmpty);
+    });
+
+    test('treats a completed walk as not pending', () async {
+      await prefs.setHeavyTableSkip('login_activities', 10400);
+      await prefs.clearHeavyTableSkip('login_activities');
+
+      await build().scheduleIfPending();
+
+      expect(scheduler.enqueued, isEmpty);
+    });
+  });
+
+  /// The `workmanager` call itself cannot be driven from a unit test — there
+  /// is no plugin channel here — so the two settings whose loss is silent and
+  /// expensive are pinned against the source.
+  group('the WorkManager request', () {
+    final source = File(
+      'lib/core/background/heavy_table_scheduler.dart',
+    ).readAsStringSync();
+    final call = source.substring(source.indexOf('registerOneOffTask'));
+
+    test('keeps existing work rather than appending to it', () {
+      // `append` (the policy the download queue needs, and the only one
+      // `BackgroundScheduler.scheduleOneOff` offers) would queue a *further*
+      // complete walk behind the one in flight for every enqueue — and both
+      // entry points enqueue freely. On `courses_progress` that is another
+      // 114,219 documents per sync.
+      expect(call, contains('ExistingWorkPolicy.keep'));
+      expect(call, isNot(contains('ExistingWorkPolicy.append')));
+    });
+
+    test('retries on the Kotlin linear 30-second backoff', () {
+      expect(call, contains('BackoffPolicy.linear'));
+      expect(call, contains('Duration(seconds: 30)'));
+    });
+
+    test('requires only a network, as the Kotlin constraints do', () {
+      expect(call, contains('NetworkType.connected'));
+      // `HeavyTableSyncWorker` sets no battery constraint, unlike the port's
+      // other jobs: a walk resuming across sessions must not also wait for a
+      // charged battery.
+      expect(call, isNot(contains('requiresBatteryNotLow')));
+      // `setExpedited` is deliberately not ported — see the doc comment: on
+      // API 26-30 it makes WorkManager call a `getForegroundInfo()` that
+      // `CoroutineWorker` implements by throwing, and no override exists.
+      expect(call, isNot(contains('expedited')));
+    });
+  });
+}

--- a/flutter/test/core/sync/heavy_table_sync_test.dart
+++ b/flutter/test/core/sync/heavy_table_sync_test.dart
@@ -14,6 +14,10 @@ import '../../support/mock_planet_api.dart';
 /// claims to pin was flipped and the test confirmed red. Where a mutation is
 /// not obvious the test says which one it survives, because a test that cannot
 /// fail reads as coverage.
+/// Stands in for the 1s/2s/4s page backoff so the retry tests cost no
+/// wall-clock time; the delays themselves are pinned as a constant.
+Future<void> _noSleep(Duration _) async {}
+
 void main() {
   const config = ServerConfig(
     serverUrl: 'https://planet.example.org',
@@ -41,10 +45,15 @@ void main() {
     DateTime Function()? now,
     Set<String>? tables,
     Future<void> Function(List<Map<String, dynamic>> docs)? writer,
+    Future<void> Function(Duration)? sleep,
   }) => HeavyTableSync(
     api: api,
     prefs: prefs,
     now: now,
+    // No test wants the real 1s/2s/4s backoff: it would add ~28 seconds of
+    // wall clock across the failure cases, and the delays are pinned as a
+    // constant instead.
+    sleep: sleep ?? _noSleep,
     writers: {
       for (final table in tables ?? const {'courses_progress', 'submissions'})
         table:
@@ -63,7 +72,12 @@ void main() {
     int total, {
     Set<int> failAtSkip = const {},
     Set<int> designAtSkip = const {},
+    Map<int, int> failTimes = const {},
+    Map<int, int> throwTimes = const {},
+    int failStatus = 503,
   }) {
+    final remainingFailures = {...failTimes};
+    final remainingThrows = {...throwTimes};
     when(
       () => api.getJsonObject(
         any(that: contains('/$table/_all_docs')),
@@ -76,7 +90,19 @@ void main() {
       final limit = int.parse(query['limit']!);
       final skip = int.parse(query['skip']!);
       if (failAtSkip.contains(skip)) {
+        return NetworkError<Map<String, dynamic>>(failStatus, 'refused');
+      }
+      final failuresLeft = remainingFailures[skip] ?? 0;
+      if (failuresLeft > 0) {
+        remainingFailures[skip] = failuresLeft - 1;
         return const NetworkError<Map<String, dynamic>>(503, 'upstream down');
+      }
+      final throwsLeft = remainingThrows[skip] ?? 0;
+      if (throwsLeft > 0) {
+        remainingThrows[skip] = throwsLeft - 1;
+        return NetworkException<Map<String, dynamic>>(
+          Exception('connection closed'),
+        );
       }
       final end = (skip + limit) > total ? total : skip + limit;
       return NetworkSuccess<Map<String, dynamic>>({
@@ -216,6 +242,12 @@ void main() {
       expect(requested.where((url) => url.contains('limit=0')), isEmpty);
       expect(requested, hasLength(2));
       expect(requested.first, startsWith('$dbUrl/courses_progress/_all_docs'));
+      // `include_docs=true` was pinned by nothing: the fixture matches on the
+      // path alone. Dropping it makes every page yield zero documents while
+      // `skip` still advances by `rows.length`, so the walk completes, clears
+      // the checkpoint, and has written nothing — silent, and indistinguishable
+      // from an empty table.
+      expect(requested.first, contains('include_docs=true'));
     });
 
     test(
@@ -251,6 +283,69 @@ void main() {
       expect(skipsRequested(), [0, 200]);
       expect(result.completedFully, isTrue);
       expect(store.containsKey('heavy_sync_skip_courses_progress'), isFalse);
+    });
+  });
+
+  group('page retries', () {
+    test('a 5xx page is retried, and a later attempt lands', () async {
+      // `RetryInterceptor` whitelists `_all_docs` for POST retry and retries
+      // three times at 1s/2s/4s on a 5xx or an `IOException`, so Kotlin's
+      // `break` is reached only after four attempts. The port's `PlanetApi`
+      // has no interceptor, so the walk does it — and with a checkpoint the
+      // difference is not cosmetic: one attempt per page would freeze the walk
+      // at the first flaky page for ever, every WorkManager retry re-trying
+      // the same page once.
+      stubCorpus('courses_progress', 300, failTimes: {0: 2});
+
+      final result = await build().walk(
+        table: 'courses_progress',
+        config: config,
+      );
+
+      expect(result.completedFully, isTrue);
+      // Three requests at skip=0 (two refused, one served) then the rest.
+      expect(skipsRequested(), [0, 0, 0, 200]);
+    });
+
+    test('a transport failure is retried', () async {
+      stubCorpus('courses_progress', 100, throwTimes: {0: 1});
+
+      final result = await build().walk(
+        table: 'courses_progress',
+        config: config,
+      );
+
+      expect(result.completedFully, isTrue);
+      expect(skipsRequested(), [0, 0]);
+    });
+
+    test('four failed attempts leave the checkpoint and stop', () async {
+      stubCorpus('courses_progress', 500, failAtSkip: {200});
+
+      final result = await build().walk(
+        table: 'courses_progress',
+        config: config,
+      );
+
+      expect(result.completedFully, isFalse);
+      expect(prefs.heavyTableSkip('courses_progress'), 200);
+      // One attempt plus the three retries, and no more: an unbounded retry
+      // here would hold the worker's execution window open against a server
+      // that is simply down.
+      expect(skipsRequested().where((skip) => skip == 200), hasLength(4));
+      expect(HeavyTableSync.pageRetryDelays, hasLength(3));
+    });
+
+    test('a 404 is not retried', () async {
+      // The interceptor retries an `IOException` or a 5xx and nothing else;
+      // Retrofit hands `syncDb` a null body for a 401/404, which is its other
+      // `break`. Retrying a missing database would spend the whole window on
+      // a request that cannot start succeeding.
+      stubCorpus('courses_progress', 500, failAtSkip: {0}, failStatus: 404);
+
+      await build().walk(table: 'courses_progress', config: config);
+
+      expect(skipsRequested(), [0]);
     });
   });
 

--- a/flutter/test/core/sync/heavy_table_sync_test.dart
+++ b/flutter/test/core/sync/heavy_table_sync_test.dart
@@ -14,10 +14,6 @@ import '../../support/mock_planet_api.dart';
 /// claims to pin was flipped and the test confirmed red. Where a mutation is
 /// not obvious the test says which one it survives, because a test that cannot
 /// fail reads as coverage.
-/// Stands in for the 1s/2s/4s page backoff so the retry tests cost no
-/// wall-clock time; the delays themselves are pinned as a constant.
-Future<void> _noSleep(Duration _) async {}
-
 void main() {
   const config = ServerConfig(
     serverUrl: 'https://planet.example.org',
@@ -492,3 +488,9 @@ void main() {
     });
   });
 }
+
+/// Stands in for the 1s/2s/4s page backoff so the retry tests cost no
+/// wall-clock time. The delays themselves are pinned as a constant instead —
+/// the real ones would add ~28 seconds of wall clock across the failure cases,
+/// and a test that looks like a hang is this project's most expensive kind.
+Future<void> _noSleep(Duration _) async {}

--- a/flutter/test/core/sync/heavy_table_sync_test.dart
+++ b/flutter/test/core/sync/heavy_table_sync_test.dart
@@ -1,0 +1,399 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/sync/heavy_table_sync.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../support/mock_planet_api.dart';
+
+/// The resumable checkpoint, which is the whole of this feature.
+///
+/// Every assertion here was mutation-tested: the production behaviour it
+/// claims to pin was flipped and the test confirmed red. Where a mutation is
+/// not obvious the test says which one it survives, because a test that cannot
+/// fail reads as coverage.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  late MockPlanetApi api;
+  late SharedPreferences store;
+  late PlanetPrefs prefs;
+  late List<String> requested;
+  late List<List<Map<String, dynamic>>> written;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const {});
+    store = await SharedPreferences.getInstance();
+    prefs = PlanetPrefs(store);
+    api = MockPlanetApi();
+    requested = [];
+    written = [];
+  });
+
+  HeavyTableSync build({
+    DateTime Function()? now,
+    Set<String>? tables,
+    Future<void> Function(List<Map<String, dynamic>> docs)? writer,
+  }) => HeavyTableSync(
+    api: api,
+    prefs: prefs,
+    now: now,
+    writers: {
+      for (final table in tables ?? const {'courses_progress', 'submissions'})
+        table:
+            writer ??
+            (docs) async {
+              written.add(docs);
+            },
+    },
+  );
+
+  /// Serves a corpus of [total] documents, honouring `limit` and `skip`, and
+  /// records every URL asked for. `failAtSkip` makes that one page a 503;
+  /// `designAtSkip` puts a `_design` row at the head of that page.
+  void stubCorpus(
+    String table,
+    int total, {
+    Set<int> failAtSkip = const {},
+    Set<int> designAtSkip = const {},
+  }) {
+    when(
+      () => api.getJsonObject(
+        any(that: contains('/$table/_all_docs')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((invocation) async {
+      final url = invocation.positionalArguments[0] as String;
+      requested.add(url);
+      final query = Uri.parse(url).queryParameters;
+      final limit = int.parse(query['limit']!);
+      final skip = int.parse(query['skip']!);
+      if (failAtSkip.contains(skip)) {
+        return const NetworkError<Map<String, dynamic>>(503, 'upstream down');
+      }
+      final end = (skip + limit) > total ? total : skip + limit;
+      return NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          if (designAtSkip.contains(skip))
+            {
+              'id': '_design/x',
+              'doc': {'_id': '_design/x'},
+            },
+          for (var i = skip; i < end; i++)
+            if (!designAtSkip.contains(skip) || i > skip)
+              {
+                'id': 'doc-$i',
+                'doc': {'_id': 'doc-$i', '_rev': '1-x'},
+              },
+        ],
+      });
+    });
+  }
+
+  List<int> skipsRequested() => [
+    for (final url in requested)
+      int.parse(Uri.parse(url).queryParameters['skip']!),
+  ];
+
+  group('page sizes', () {
+    test('match the Kotlin table, else arm included', () {
+      // `TransactionSyncManager.kt:171-176`.
+      expect(HeavyTableSync.pageSizeFor('ratings'), 20);
+      expect(HeavyTableSync.pageSizeFor('submissions'), 100);
+      expect(HeavyTableSync.pageSizeFor('courses_progress'), 200);
+      expect(HeavyTableSync.pageSizeFor('login_activities'), 200);
+      expect(HeavyTableSync.pageSizeFor('team_activities'), 200);
+      expect(HeavyTableSync.pageSizeFor('news'), 1000);
+    });
+
+    test('reach the request, per table', () async {
+      stubCorpus('courses_progress', 10);
+      await build().walk(table: 'courses_progress', config: config);
+      expect(requested.single, contains('limit=200'));
+
+      requested.clear();
+      stubCorpus('submissions', 10);
+      await build().walk(table: 'submissions', config: config);
+      expect(requested.single, contains('limit=100'));
+    });
+  });
+
+  group('the checkpoint', () {
+    test('a resumed walk starts from the saved skip', () async {
+      await prefs.setHeavyTableSkip('courses_progress', 600);
+      stubCorpus('courses_progress', 700);
+
+      await build().walk(table: 'courses_progress', config: config);
+
+      // Not 0: the walk resumes rather than restarting. Seed the checkpoint
+      // reader with a constant 0 and the first skip is 0 and this fails.
+      expect(skipsRequested().first, 600);
+      expect(written.single, hasLength(100));
+    });
+
+    test(
+      'an interrupted walk leaves the checkpoint at the committed page',
+      () async {
+        // 500 documents, page 3 (skip=400) refused: pages 1 and 2 commit.
+        stubCorpus('courses_progress', 500, failAtSkip: {400});
+
+        final result = await build().walk(
+          table: 'courses_progress',
+          config: config,
+        );
+
+        expect(result.completedFully, isFalse);
+        expect(result.failure, isNotNull);
+        expect(prefs.heavyTableSkip('courses_progress'), 400);
+        // The pages that did land stayed landed — `syncDb` never rolls back.
+        expect(written.map((page) => page.length), [200, 200]);
+      },
+    );
+
+    test('a completed walk removes the key entirely', () async {
+      stubCorpus('courses_progress', 250);
+
+      final result = await build().walk(
+        table: 'courses_progress',
+        config: config,
+      );
+
+      expect(result.completedFully, isTrue);
+      expect(prefs.heavyTableSkip('courses_progress'), 0);
+      // `remove`, not `setInt(0)`, matching `TransactionSyncManager.kt:324`.
+      // Swap the production `clearHeavyTableSkip` for a `setHeavyTableSkip(0)`
+      // and only this line fails.
+      expect(store.containsKey('heavy_sync_skip_courses_progress'), isFalse);
+    });
+
+    test(
+      'is written before the first request, so the key exists at 0',
+      () async {
+        // The Kotlin's pre-request write (`:193-195`) is otherwise redundant —
+        // the previous iteration's post-insert write already stored the same
+        // value — and its one real effect is materialising the key on the first
+        // iteration. Drop that write from the walk and this fails while every
+        // other test here still passes.
+        stubCorpus('courses_progress', 500, failAtSkip: {0});
+
+        await build().walk(table: 'courses_progress', config: config);
+
+        expect(store.containsKey('heavy_sync_skip_courses_progress'), isTrue);
+        expect(prefs.heavyTableSkip('courses_progress'), 0);
+      },
+    );
+
+    test('advances by the row count, not the document count', () async {
+      // The first page carries a `_design` row the writer drops, so 200 rows
+      // yield 199 documents. `skip += docs.length` would ask for 199 next and
+      // re-fetch a document it already committed; a page that was *entirely*
+      // `_design` would never advance at all. `TransactionSyncManager.kt:305`
+      // is `skip += arr.size()`.
+      stubCorpus('courses_progress', 400, designAtSkip: {0});
+
+      await build().walk(table: 'courses_progress', config: config);
+
+      expect(skipsRequested(), [0, 200, 400]);
+      expect(written.first, hasLength(199));
+    });
+
+    test('does not page against a stale total, having asked for none', () async {
+      // Kotlin issues no `_all_docs?limit=0` count query and bounds nothing by
+      // `total_rows`; it pages until the server sends a short page. A count
+      // taken at the start of a walk that resumes days later is a bound
+      // computed against a table that has since grown.
+      stubCorpus('courses_progress', 250);
+
+      await build().walk(table: 'courses_progress', config: config);
+
+      expect(requested.where((url) => url.contains('limit=0')), isEmpty);
+      expect(requested, hasLength(2));
+      expect(requested.first, startsWith('$dbUrl/courses_progress/_all_docs'));
+    });
+
+    test(
+      'a writer that throws keeps the checkpoint and stops the walk',
+      () async {
+        stubCorpus('courses_progress', 500);
+        var pages = 0;
+
+        final result = await build(
+          writer: (docs) async {
+            pages++;
+            if (pages == 2) throw StateError('drift is closed');
+          },
+        ).walk(table: 'courses_progress', config: config);
+
+        expect(result.completedFully, isFalse);
+        expect(prefs.heavyTableSkip('courses_progress'), 200);
+        expect(store.containsKey('heavy_sync_skip_courses_progress'), isTrue);
+      },
+    );
+
+    test('an empty page completes the walk', () async {
+      // A table whose size is an exact multiple of the page size costs one
+      // extra request, which comes back with no rows. Both that and a short
+      // page are `syncCompletedFully` in the Kotlin (`:211` and `:319`).
+      stubCorpus('courses_progress', 200);
+
+      final result = await build().walk(
+        table: 'courses_progress',
+        config: config,
+      );
+
+      expect(skipsRequested(), [0, 200]);
+      expect(result.completedFully, isTrue);
+      expect(store.containsKey('heavy_sync_skip_courses_progress'), isFalse);
+    });
+  });
+
+  group('the retry verdict', () {
+    test('is derived from the checkpoint, not from the walk result', () async {
+      // The walk fails outright — every page refused — but the checkpoint it
+      // resumed from is non-zero, so the verdict is retry. Nothing reads the
+      // returned `HeavyTableWalkResult`: derive the verdict from
+      // `result.completedFully` or `result.failure` instead and this still
+      // passes, which is why the converse case below exists.
+      await prefs.setHeavyTableSkip('courses_progress', 400);
+      stubCorpus('courses_progress', 500, failAtSkip: {400});
+
+      final retryNotRequested = await build().run(
+        'courses_progress',
+        config: config,
+      );
+
+      expect(retryNotRequested, isFalse);
+      expect(prefs.heavyTableSkip('courses_progress'), 400);
+    });
+
+    test('a walk that fails on its first page reports success', () async {
+      // The Kotlin quirk, ported deliberately. `getInt(key, 0) > 0` cannot
+      // tell "absent" from "present and 0", and the pre-request write stored
+      // 0 — so a table that synced nothing reports success and is not
+      // retried. Recovery is the next completed sync's unconditional
+      // `scheduleAll`, never `scheduleIfPending`, which shares the blind spot.
+      //
+      // Derive the verdict from the walk result instead and this test goes
+      // red: `completedFully` is false and `failure` is set.
+      stubCorpus('courses_progress', 500, failAtSkip: {0});
+
+      final retryNotRequested = await build().run(
+        'courses_progress',
+        config: config,
+      );
+
+      expect(retryNotRequested, isTrue);
+      expect(written, isEmpty);
+    });
+
+    test('a completed walk reports success', () async {
+      stubCorpus('courses_progress', 150);
+
+      expect(await build().run('courses_progress', config: config), isTrue);
+      expect(prefs.heavyTableSkip('courses_progress'), 0);
+    });
+
+    test('a table with no writer is success, not retry', () async {
+      // Kotlin answers `Result.failure()` for a missing `KEY_TABLE`; neither
+      // retries, and retrying would loop for ever on a task name persisted by
+      // a later build.
+      expect(await build().run('team_activities', config: config), isTrue);
+      verifyNever(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      );
+    });
+
+    test('an unconfigured server is success, not retry', () async {
+      expect(await build().run('courses_progress', config: null), isTrue);
+      verifyNever(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      );
+    });
+  });
+
+  group('the interactive-sync guard', () {
+    final now = DateTime(2026, 9, 9, 12);
+
+    test('declines to run beside a live interactive sync', () async {
+      stubCorpus('courses_progress', 500);
+      await prefs.markInteractiveSyncStarted(
+        now.subtract(const Duration(minutes: 2)),
+      );
+
+      final sync = build(now: () => now);
+
+      expect(sync.isInteractiveSyncActive, isTrue);
+      // `Result.retry()`, and nothing walked: the guard is ahead of the walk.
+      expect(await sync.run('courses_progress', config: config), isFalse);
+      expect(requested, isEmpty);
+      expect(store.containsKey('heavy_sync_skip_courses_progress'), isFalse);
+    });
+
+    test('disbelieves a flag older than the timeout', () async {
+      stubCorpus('courses_progress', 150);
+      await prefs.markInteractiveSyncStarted(
+        now
+            .subtract(HeavyTableSync.interactiveSyncTimeout)
+            .subtract(const Duration(minutes: 1)),
+      );
+
+      final sync = build(now: () => now);
+
+      // A process killed mid-sync leaves the flag set for ever, and a flag
+      // believed for ever means every heavy run returns retry and no table
+      // ever syncs — the exact outcome this class exists to end. Remove the
+      // decay and this fails.
+      expect(sync.isInteractiveSyncActive, isFalse);
+      expect(await sync.run('courses_progress', config: config), isTrue);
+      expect(requested, isNotEmpty);
+    });
+
+    test('a clock corrected backwards still counts as active', () async {
+      await prefs.markInteractiveSyncStarted(
+        now.add(const Duration(minutes: 5)),
+      );
+
+      expect(build(now: () => now).isInteractiveSyncActive, isTrue);
+    });
+
+    test('a cleared flag is not active', () async {
+      await prefs.markInteractiveSyncStarted(now);
+      await prefs.clearInteractiveSyncStarted();
+
+      expect(build(now: () => now).isInteractiveSyncActive, isFalse);
+    });
+  });
+
+  group('the table set', () {
+    test('names the Kotlin five for reference', () {
+      expect(HeavyTableSync.kotlinHeavyTables, [
+        'ratings',
+        'courses_progress',
+        'submissions',
+        'login_activities',
+        'team_activities',
+      ]);
+    });
+
+    test('walks the two the port schedules, not the Kotlin five', () {
+      // Three of the Kotlin five are deliberately absent, each argued at
+      // [HeavyTableSync.tables]: `ratings` stays an interactive sync area,
+      // `team_activities` has no writer in this port at all, and
+      // `submissions` keeps an inline pull whose ordering against the upload
+      // sweep a background walk cannot preserve. Pinned so that adding one
+      // back is a decision somebody has to defend rather than a one-line
+      // drift.
+      expect(HeavyTableSync.tables, ['courses_progress', 'login_activities']);
+      expect(HeavyTableSync.tables, isNot(contains('ratings')));
+      expect(HeavyTableSync.tables, isNot(contains('team_activities')));
+      expect(HeavyTableSync.tables, isNot(contains('submissions')));
+    });
+  });
+}

--- a/flutter/test/providers/courses_sync_excludes_heavy_table_test.dart
+++ b/flutter/test/providers/courses_sync_excludes_heavy_table_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/sync/heavy_table_sync.dart';
 
 /// Pins the exclusion of `courses_progress` from the interactive courses sync.
 ///
@@ -9,8 +10,18 @@ import 'package:flutter_test/flutter_test.dart';
 /// uncalled, and that reads as tidying up rather than as a regression. On
 /// planet.learning the table is 114,219 documents — 572 `_all_docs` pages with
 /// a deepening `skip` — so inline it cannot finish and takes the courses area
-/// down with it. Kotlin keeps it in `HeavyTableSyncWorker`, resumable via a
-/// persisted checkpoint; the port has no such scheduler yet.
+/// down with it.
+///
+/// **The pull is not missing any more, and that does not retire this guard.**
+/// `HeavyTableSync` now owns it, walking the table in a background task from a
+/// persisted `heavy_sync_skip_courses_progress` checkpoint, which is where
+/// Kotlin has it too (`HeavyTableSyncWorker.ALL_HEAVY_TABLES`). What the guard
+/// says has therefore changed from "the port cannot do this yet" to "this is
+/// not the place it is done": an inline call would still have no checkpoint,
+/// so re-adding one would break the courses area again exactly as before. The
+/// second half of the file pins the other end of that claim — the table really
+/// is walked by the worker — so the guard cannot pass by both call sites being
+/// absent.
 void main() {
   test('the interactive courses sync does not pull courses_progress', () {
     final source = File(
@@ -28,11 +39,21 @@ void main() {
           'CourseSyncNotifier.runSync must not call syncCourseProgress. '
           'courses_progress is a heavy table (114k+ docs on planet.learning) '
           'that Kotlin runs in HeavyTableSyncWorker with a resumable '
-          'checkpoint. Inline it never completes and fails the courses sync. '
-          'Port the background worker instead of re-adding the call.',
+          'checkpoint, and HeavyTableSync is the port of that worker. Inline '
+          'the walk has no checkpoint, never completes, and fails the courses '
+          'sync with it. Leave it to the worker.',
     );
     // The pulls that do belong here are still wired.
     expect(body.contains('syncCertifications'), isTrue);
     expect(body.contains('courses.sync('), isTrue);
+  });
+
+  test('the heavy-table worker is where courses_progress is walked', () {
+    // The other half of the claim above. Without this, deleting the pull
+    // entirely would leave the guard green while Planet's grading stopped
+    // reaching the handset — which is precisely the state the stopgap that
+    // removed the inline call left the port in.
+    expect(HeavyTableSync.tables, contains('courses_progress'));
+    expect(HeavyTableSync.pageSizeFor('courses_progress'), 200);
   });
 }

--- a/flutter/test/providers/heavy_table_sync_scheduling_test.dart
+++ b/flutter/test/providers/heavy_table_sync_scheduling_test.dart
@@ -1,0 +1,272 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/background/heavy_table_scheduler.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/sync/heavy_table_sync.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/dashboard_sync_provider.dart';
+import 'package:myplanet/providers/heavy_sync_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/shelf_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+/// The interactive sync's end of the heavy-table path: the flag the background
+/// worker reads to stand down, and the scheduling that is the port's
+/// `SyncManager:209`.
+///
+/// Driven for real rather than asserted structurally, for the reason the shelf
+/// push tests give: the defect this covers is "the tables are never
+/// scheduled", which only running `syncAll` can show. The table pulls
+/// themselves are left to fail — an unusable `PlanetApi` keeps them off the
+/// network — because what is under test is what happens around them.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  late AppDatabase db;
+  late PlanetPrefs prefs;
+  late _RecordingScheduler scheduler;
+
+  setUpAll(() => registerFallbackValue(config));
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const {});
+    db = AppDatabase.memory();
+    prefs = PlanetPrefs(await SharedPreferences.getInstance());
+    scheduler = _RecordingScheduler(prefs);
+  });
+  tearDown(() => db.close());
+
+  Future<ProviderContainer> containerFor({
+    ServerConfig? serverConfig = config,
+    MockShelfRepository? shelf,
+  }) async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(_UnusablePlanetApi()),
+        planetPrefsProvider.overrideWithValue(prefs),
+        deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
+        heavyTableWorkSchedulerProvider.overrideWithValue(scheduler),
+        if (shelf != null) shelfRepositoryProvider.overrideWithValue(shelf),
+        serverConfigProvider.overrideWith(
+          () => _TestServerConfigNotifier(serverConfig),
+        ),
+        sessionProvider.overrideWith(
+          () => _TestSessionNotifier(
+            buildUserRow(
+              id: 'user-ada',
+            ).copyWith(couchId: const Value('org.couchdb.user:ada')),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('syncAll schedules every heavy table when the pass ends', () async {
+    final container = await containerFor();
+
+    await container.read(dashboardSyncProvider.notifier).syncAll();
+
+    // Port of `HeavyTableSyncWorker.schedule(context)` at `SyncManager:209`.
+    // Remove the call from `syncAll` and this fails; it is the only thing
+    // standing between the port and the state it was in before this phase,
+    // where `courses_progress` and `login_activities` were pulled by nothing
+    // at all.
+    expect(scheduler.enqueued, HeavyTableSync.tables);
+  });
+
+  test('it schedules even when every area failed', () async {
+    // Every area errors here (the api is unusable), and the tables are still
+    // scheduled. Gating on `successCount > 0` — the rule the telemetry uploads
+    // follow — would be worse than useless: a pass that failed everywhere is
+    // exactly when a resumable background walk should be queued.
+    final container = await containerFor();
+
+    await container.read(dashboardSyncProvider.notifier).syncAll();
+
+    expect(container.read(dashboardSyncProvider).successCount, 0);
+    expect(scheduler.enqueued, isNotEmpty);
+  });
+
+  test('every scheduled table has a writer wired to it', () async {
+    // The reachability question, asked of this slice: a table `scheduleAll`
+    // enqueues but `heavyTableSyncProvider` has no writer for is a job that
+    // runs, walks nothing, and reports success for ever. Add a table to
+    // `HeavyTableSync.tables` without wiring its repository and this fails.
+    final container = await containerFor();
+
+    expect(
+      container.read(heavyTableSyncProvider).writableTables,
+      containsAll(HeavyTableSync.tables),
+    );
+  });
+
+  test('no configured server schedules nothing', () async {
+    final container = await containerFor(serverConfig: null);
+
+    await container.read(dashboardSyncProvider.notifier).syncAll();
+
+    expect(scheduler.enqueued, isEmpty);
+  });
+
+  group('the headless entry point', _headlessEntryPointTests);
+
+  group('the interactive-sync flag', () {
+    test('is set for the duration of the pass and cleared after it', () async {
+      final shelf = MockShelfRepository();
+      DateTime? flagDuringPass;
+      when(
+        () => shelf.upload(
+          config: any(named: 'config'),
+          userId: any(named: 'userId'),
+          shelfDocId: any(named: 'shelfDocId'),
+        ),
+      ).thenAnswer((_) async {
+        flagDuringPass = prefs.interactiveSyncStartedAt;
+        return const SyncComplete(1);
+      });
+      final container = await containerFor(shelf: shelf);
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      // The shelf push is the first thing `syncAll` does, so the flag has to
+      // be set before it. This is what makes a heavy worker starting mid-sync
+      // return retry instead of walking a table the sync is writing.
+      expect(flagDuringPass, isNotNull);
+      expect(prefs.interactiveSyncStartedAt, isNull);
+    });
+
+    test('is cleared before the tables are scheduled', () async {
+      // Deliberately the opposite of the Kotlin's order, which enqueues at
+      // `SyncManager:209` inside the `try` and only clears `isSyncing` in the
+      // `finally` at `:233` — so a worker WorkManager starts promptly sees
+      // `isMainSyncActive()` true and burns a `Result.retry()` on a
+      // 30-second backoff having done nothing. Swap the two statements back
+      // and this fails.
+      final container = await containerFor();
+
+      await container.read(dashboardSyncProvider.notifier).syncAll();
+
+      expect(scheduler.enqueued, isNotEmpty);
+      expect(
+        scheduler.flagWhenEnqueued,
+        everyElement(isNull),
+        reason: 'a heavy job must not be enqueued while the flag still stands',
+      );
+    });
+  });
+}
+
+void _headlessEntryPointTests() {
+  final source = File('lib/background_entrypoint.dart').readAsStringSync();
+
+  /// `executeBackgroundTask` needs a Flutter binding, real preferences and a
+  /// WorkManager engine, so its dispatch cannot be driven from a unit test —
+  /// which is why the sweeps in that file are extracted behind
+  /// `@visibleForTesting` and why these three claims are pinned against the
+  /// source instead. Each is a wiring fact whose loss is silent.
+  test('dispatches a heavy task before anything else', () {
+    final heavy = source.indexOf('heavyTableSyncTable(taskName)');
+    final runner = source.indexOf('BackgroundTaskRunner(');
+
+    expect(heavy, isNonNegative);
+    // Ahead of the runner, which answers `true` for any task name it does not
+    // recognise — a heavy task reaching it would be silently discarded.
+    expect(heavy, lessThan(runner));
+    // The reload is what lets this isolate see the UI isolate's writes: the
+    // interactive-sync flag and the checkpoints. Without it `PlanetPrefs`
+    // serves the snapshot it cached at `getInstance()`.
+    expect(source, contains('prefs.reload()'));
+  });
+
+  test('resumes pending walks on every invocation', () {
+    // Port of `ServerReachabilityWorker:201`.
+    expect(source, contains('scheduleIfPending()'));
+  });
+
+  test('schedules all heavy tables after a clean sync', () {
+    // Port of `SyncManager:209`, on the hook that fires only when every step
+    // succeeded — the runner's closest thing to "the sync finished".
+    expect(source, contains('scheduleAll()'));
+  });
+
+  test('keeps the submissions pull inline, and out of the heavy set', () {
+    // The one heavy table the port deliberately does not move. Moving it was
+    // the first cut, and `pending_submissions_sweep_test.dart` caught it: that
+    // file pins the submissions *sweep* running before the submissions *pull*
+    // in the same invocation, because `upsertDocuments` writes
+    // `isUpdated: false` over every row it writes and keys each on the server
+    // `_id` — so a pull landing first strips the dirty flag from a
+    // server-originated sheet the user edited locally and it never uploads. A
+    // background walk cannot be ordered against this invocation.
+    //
+    // Both halves are pinned, because either alone can drift: the step must
+    // exist, and the table must stay out of the scheduled set — in it, it
+    // would be walked twice per run and once without the ordering.
+    final steps = source.substring(
+      source.indexOf('syncSteps:'),
+      source.indexOf('recordLastSync:'),
+    );
+    expect(steps, contains("'submissions'"));
+    expect(steps, contains("'health'"));
+    expect(HeavyTableSync.tables, isNot(contains('submissions')));
+  });
+}
+
+/// Records what was enqueued, and what the interactive-sync flag said at that
+/// moment — the ordering assertion above needs the second half.
+class _RecordingScheduler implements HeavyTableWorkScheduler {
+  _RecordingScheduler(this._prefs);
+
+  final PlanetPrefs _prefs;
+  final enqueued = <String>[];
+  final flagWhenEnqueued = <DateTime?>[];
+
+  @override
+  Future<void> enqueueUnique(String table) async {
+    enqueued.add(table);
+    flagWhenEnqueued.add(_prefs.interactiveSyncStartedAt);
+  }
+}
+
+class MockShelfRepository extends Mock implements ShelfRepository {}
+
+/// Every call returns null, which the implicit downcast to
+/// `Future<NetworkResult<…>>` turns into a `TypeError` — that is what keeps
+/// the table pulls off the network here.
+class _UnusablePlanetApi extends Mock implements PlanetApi {}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  _TestServerConfigNotifier(this._config);
+
+  final ServerConfig? _config;
+
+  @override
+  ServerConfig? build() => _config;
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this._user);
+
+  final UserRow? _user;
+
+  @override
+  Future<UserRow?> build() async => _user;
+}

--- a/flutter/test/providers/heavy_table_sync_scheduling_test.dart
+++ b/flutter/test/providers/heavy_table_sync_scheduling_test.dart
@@ -4,10 +4,12 @@ import 'package:drift/drift.dart' show Value;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/background/background_task_names.dart';
 import 'package:myplanet/core/background/heavy_table_scheduler.dart';
 import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/core/prefs/planet_prefs.dart';
 import 'package:myplanet/core/sync/heavy_table_sync.dart';
+import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
@@ -118,6 +120,59 @@ void main() {
     );
   });
 
+  test('the wired writers actually land rows in their tables', () async {
+    // The reachability question the `writableTables` assertion above cannot
+    // answer. An audit replaced both writers with `(docs) async {}` and the
+    // whole slice stayed green: nothing drove a closure, so nothing showed
+    // that a `courses_progress` document reaches `course_progress` or that a
+    // `login_activities` document reaches `offline_activity`. Every layer
+    // beneath is silent by design — a throwing writer is caught inside `walk`
+    // and its error discarded, `run` discards the walk result, a heavy task
+    // never writes a `recordBackgroundRun` row, and a writer that fails on
+    // page 1 reports success — so a dead writer would sync nothing, for ever,
+    // with no test failure and no log line.
+    final container = await containerFor();
+    final api = _StubApi({
+      'courses_progress': [
+        {
+          '_id': 'cp-1',
+          '_rev': '1-a',
+          'courseId': 'course-1',
+          'userId': 'user-ada',
+          'stepNum': 2,
+          'passed': true,
+        },
+      ],
+      'login_activities': [
+        {
+          '_id': 'la-1',
+          '_rev': '1-b',
+          'user': 'ada',
+          'type': 'login',
+          'loginTime': 1757000000000,
+        },
+      ],
+    });
+    final sync = HeavyTableSync(
+      api: api,
+      prefs: prefs,
+      writers: container.read(heavyTableSyncProvider).writers,
+    );
+
+    for (final table in HeavyTableSync.tables) {
+      final result = await sync.walk(table: table, config: config);
+      expect(
+        result.completedFully,
+        isTrue,
+        reason: 'the $table walk did not finish',
+      );
+      expect(result.savedCount, 1, reason: 'the $table page was not written');
+    }
+
+    expect(await db.courseProgressDao.getByIds(['cp-1']), hasLength(1));
+    expect(await db.offlineActivityDao.getByCouchIds(['la-1']), hasLength(1));
+  });
+
   test('no configured server schedules nothing', () async {
     final container = await containerFor(serverConfig: null);
 
@@ -196,9 +251,45 @@ void _headlessEntryPointTests() {
     expect(source, contains('prefs.reload()'));
   });
 
-  test('resumes pending walks on every invocation', () {
-    // Port of `ServerReachabilityWorker:201`.
-    expect(source, contains('scheduleIfPending()'));
+  test('resumes pending walks after its own walks, not before them', () {
+    // Port of `ServerReachabilityWorker:201` — but the *placement* is the
+    // finding. Kotlin's call lives in a different worker from its sync, so it
+    // can never start a heavy walk alongside the sync in its own process. The
+    // first cut called it at the top of the invocation, where `keep` has
+    // nothing to keep and the network constraint is satisfied by definition,
+    // so WorkManager could start walking `courses_progress` in a second
+    // Flutter engine while this one wrote `resources` — two writers on one
+    // SQLite file with no WAL and no busy timeout.
+    final pending = source.indexOf('scheduleIfPending()');
+    final runner = source.indexOf('BackgroundTaskRunner(');
+
+    expect(pending, isNonNegative);
+    expect(pending, greaterThan(runner));
+  });
+
+  test('marks the sync-active flag for its own run too', () {
+    // Kotlin needs one flag site because both of `syncManager.start`'s callers
+    // set it — `SyncActivity:415` and `AutoSyncWorker:106` — so
+    // `isMainSyncActive()` is true during a headless sync as well. The port's
+    // first cut wrote it only in `syncAll`, which left the *usual* overlap
+    // unguarded: nothing stopped a heavy task walking a table while this
+    // invocation walked its own.
+    // The *call*, not the declaration: an audit deleted the call and an
+    // earlier `contains('_markSyncActive(')` still matched the function's own
+    // signature further down the file.
+    final marked = source.indexOf('await _markSyncActive(prefs)');
+    final runner = source.indexOf('BackgroundTaskRunner(');
+    expect(marked, isNonNegative);
+    expect(marked, lessThan(runner));
+    // Cleared in a `finally`, as `SyncManager.destroy` is, so a run that
+    // throws cannot leave every heavy walk answering retry until the flag
+    // decays.
+    final clear = source.indexOf('_clearSyncActive(prefs)');
+    final finallyBlock = source.indexOf(
+      '} finally {',
+      source.indexOf('_markSyncActive('),
+    );
+    expect(clear, greaterThan(finallyBlock));
   });
 
   test('schedules all heavy tables after a clean sync', () {
@@ -225,7 +316,6 @@ void _headlessEntryPointTests() {
       source.indexOf('recordLastSync:'),
     );
     expect(steps, contains("'submissions'"));
-    expect(steps, contains("'health'"));
     expect(HeavyTableSync.tables, isNot(contains('submissions')));
   });
 }
@@ -236,21 +326,58 @@ class _RecordingScheduler implements HeavyTableWorkScheduler {
   _RecordingScheduler(this._prefs);
 
   final PlanetPrefs _prefs;
-  final enqueued = <String>[];
+  final taskNames = <String>[];
   final flagWhenEnqueued = <DateTime?>[];
 
+  /// The tables the recorded task names parse back to, so a name the
+  /// dispatcher could not route reads as `null` rather than as a table.
+  List<String?> get enqueued =>
+      taskNames.map(BackgroundTaskNames.heavyTableSyncTable).toList();
+
   @override
-  Future<void> enqueueUnique(String table) async {
-    enqueued.add(table);
+  Future<void> enqueueUnique(String taskName) async {
+    taskNames.add(taskName);
     flagWhenEnqueued.add(_prefs.interactiveSyncStartedAt);
   }
 }
 
+/// Answers one page per table and an empty page after it, so a walk over it
+/// completes. Deliberately a hand-written stub rather than a mock: the point of
+/// the test using it is that real repository writers run, so nothing about the
+/// path may be faked below the api.
+class _StubApi implements PlanetApi {
+  _StubApi(this.pages);
+
+  final Map<String, List<Map<String, dynamic>>> pages;
+
+  @override
+  Future<NetworkResult<Map<String, dynamic>>> getJsonObject(
+    String url, {
+    String? authHeader,
+  }) async {
+    final table = pages.keys.firstWhere(
+      (name) => url.contains('/$name/_all_docs'),
+      orElse: () => throw StateError('unexpected url: $url'),
+    );
+    final skip = int.parse(Uri.parse(url).queryParameters['skip']!);
+    final docs = skip == 0 ? pages[table]! : const <Map<String, dynamic>>[];
+    return NetworkSuccess<Map<String, dynamic>>({
+      'rows': [
+        for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+      ],
+    });
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('unexpected ${invocation.memberName}');
+}
+
 class MockShelfRepository extends Mock implements ShelfRepository {}
 
-/// Every call returns null, which the implicit downcast to
-/// `Future<NetworkResult<…>>` turns into a `TypeError` — that is what keeps
-/// the table pulls off the network here.
+/// Unstubbed, so mocktail throws `MissingStubError` on every call — that is
+/// what keeps the table pulls off the network here. `SyncNotifier.sync`
+/// catches it and records the area as errored.
 class _UnusablePlanetApi extends Mock implements PlanetApi {}
 
 class _TestServerConfigNotifier extends ServerConfigNotifier {


### PR DESCRIPTION
Lane 1. Ports `HeavyTableSyncWorker` and the checkpoint half of `TransactionSyncManager.syncDb`, so `courses_progress` and `login_activities` pull again — through a resumable background walk rather than inline, where every retry restarted at `skip=0` and neither could ever finish.

## Why

A live-device shakedown against `planet.learning` measured what the inline pulls were up against. CouchDB answers `skip` in O(n), so each page costs more than the last:

| Table | Documents | Pages | Device reached |
|---|---:|---:|---|
| `courses_progress` | 114,219 | 572 | `skip=23600`, connection aborted |
| `login_activities` | 19,324 | 97 | `skip=10400`, aborted |

Reported as "the 21 courses never finish". The 21 courses were never the problem. `99cf53d0e` removed both pulls as a stopgap, which cost the handset Planet's own grading of course-step exams and every login recorded on another device.

## What changed

- **`lib/core/sync/heavy_table_sync.dart`** — `run` (port of `doWork`) and `walk` (port of `syncDb(table, useCheckpoint = true)`). Per-table page sizes from the Kotlin, fixed rather than adaptive, no `total_rows` count query and no `skip < total` bound (the Kotlin pages until a short page; a count taken at the start of a walk that resumes days later bounds against a table that has since grown), `skip` advancing by the raw row count so a `_design` row cannot stall it, and no prune on any of these tables.
- **`lib/core/background/heavy_table_scheduler.dart`** — `scheduleAll`/`scheduleIfPending` on a seam of its own, with `ExistingWorkPolicy.keep`, `BackoffPolicy.linear` at 30s, and `NetworkType.connected` and nothing else. Its own seam because `BackgroundScheduler.scheduleOneOff` is hard-wired to `append` for a documented reason, and under `append` every enqueue becomes a *further* complete walk queued behind the one in flight.
- **`lib/core/prefs/planet_prefs.dart`** — the `heavy_sync_skip_<table>` checkpoint (Kotlin's key name), the persisted interactive-sync flag, and `reload()`.
- **`lib/background_entrypoint.dart`** — heavy-task dispatch ahead of everything; `scheduleIfPending` after the runner; `scheduleAll` on `onSyncComplete`; the sync-active flag marked and cleared around the run.
- **`lib/providers/dashboard_sync_provider.dart`** — marks and clears the flag around `syncAll` and schedules at the end (the port's `SyncManager:209`).
- **`lib/providers/heavy_sync_providers.dart`** — one writer per table, wired to the `insert…FromSync` merges that had been sitting reachable from nothing.

The table travels in the task name (`myplanet.heavy.<table>`), since the port dispatches on that alone where Kotlin uses `inputData`, and a distinct unique name per table is needed regardless — that is what makes `keep` collapse a second enqueue into the walk already running.

**The checkpoint** is written before each page request *and* after each committed page, and removed only on a walk the server said was finished. The retry verdict is a fresh read of it, which is what makes an interrupted walk resume.

**Two Kotlin quirks are ported rather than corrected**, both argued in place. A walk that fails on its *first* page reports success, because the checkpoint written before that request was `0` and `getInt(key, 0) > 0` cannot tell that from absent — recovery is the next completed sync's unconditional `scheduleAll`, never `scheduleIfPending`, which shares the blind spot exactly. And the verdict ignores the walk's own outcome, because `doWork` discards `syncDb`'s return value.

**`setExpedited` is deliberately not ported.** Below API 31, WorkManager serves an expedited request as a foreground service and calls `getForegroundInfoAsync()` unconditionally — not subject to the quota `RUN_AS_NON_EXPEDITED_WORK_REQUEST` governs, which is a JobScheduler concern from 31 up. `CoroutineWorker`'s default throws and nothing in `app/src/main` overrides it, so on API 26–30 the Kotlin worker should throw before `doWork` runs *every time*, which would mean the Kotlin's own checkpoint feature never runs on this app's whole supported floor. **Worth handing upstream** — the port is ahead of the Kotlin here, not behind it.

**The main-sync guard needs a persisted flag** where Kotlin reads an `AtomicBoolean`: a `workmanager` task is a separate Flutter isolate with its own Riverpod graph, so `DashboardSyncState` is invisible to it. Both sync entry points mark it, both clear it in a `finally`, and it decays after 30 minutes — a process killed mid-sync would otherwise leave every heavy run returning retry for ever, which is the outcome this change exists to end. Kotlin needs no bound because its flag dies with the process.

**Transport retries are ported from `RetryInterceptor`, not invented.** `syncDb` has no retry of its own because it does not need one: its POST to `/_all_docs` is whitelisted for three retries at 1s/2s/4s on a 5xx or any `IOException`, behind a 60-second read timeout, so its `break` is reached only after four attempts. The port's `PlanetApi` has no interceptor, so the walk spends those attempts itself — and with a checkpoint the difference is not cosmetic, since one attempt per page would commit up to the first flaky page and freeze there for ever.

## Per-table decisions

| Table | Decision | Reasoning |
|---|---|---|
| `courses_progress` | **worker** | 114,219 docs / 572 pages, aborted at depth on a real device. The case the checkpoint exists for. |
| `login_activities` | **worker** | 19,324 docs / 97 pages, aborted at `skip=10400`. Same. |
| `ratings` | **stays an interactive sync-centre area** | 116 documents in 6 pages at the Kotlin's page size — the checkpoint solves a problem it does not have, and the sync-centre row is the only place a user is *told* the walk failed, where a background task is silent. Scheduling it in both places would walk it twice per sync; moving it would mean deleting a `DashboardSyncArea`, which reaches into sync-centre UI another lane may hold. If a server ever carries a large `ratings` table the fix is one line now that the machinery exists — but that is a change with a reason rather than a guess. |
| `submissions` | **keeps its inline pull** | Established first: the port pulls it in `background_entrypoint`'s `syncSteps`, *not* in the sync centre. It is 1,975 documents in 20 pages and was never one of the tables that aborted. Moving it costs an ordering the port depends on and Kotlin does not: `upsertDocuments` writes `isUpdated: false` over every row it writes, keyed on the server `_id`, so a pull landing before the upload sweep strips the dirty flag from a server-originated sheet the user edited locally (survey resume's `markComplete`) and it never uploads. The headless path closes that window by running the sweep first in the same invocation; a background walk cannot be ordered against it at all. **I moved it, and `pending_submissions_sweep_test.dart` caught it** — the suite earning its keep. |
| `team_activities` | **not ported; reported** | The port has no writer for it at all. Reachability finding, detailed below. |

## Tests

43 new, plus the `courses_progress` guard rewritten so it says "this is not where the pull lives" rather than "the port cannot do this yet", with its other half — that the worker really does walk the table — pinned too, so it cannot pass by *both* call sites being absent.

**Mutation-tested: 24 behaviours flipped, all 24 went red.** Resuming from zero, clearing the checkpoint on every exit, never clearing it, dropping the pre-request write, advancing `skip` by the document count, deriving the verdict from the walk result, removing the guard, removing the decay, the per-table page size, `append` instead of `keep`, gating `scheduleAll` on the checkpoint, `>= 0` in the pending predicate, dropping the schedule from `syncAll`, reversing the clear/schedule order, dropping the flag mark from either entry point, dropping `courses_progress` from the set, adding a table with no writer, putting `submissions` back in the set, removing the inline submissions step, re-adding the inline call to the courses sync, removing the entrypoint's heavy branch, no page retry, retrying a 404, and dropping `include_docs=true`.

**Three of my own tests could not fail, and mutating them is how I know.** Replacing both wired writers with `(docs) async {}` left the suite green — nothing drove a closure, and every layer beneath is silent by design (a throwing writer is caught inside `walk` and discarded, `run` discards the walk result, a heavy task never writes a `recordBackgroundRun` row, and the ported page-1 quirk reports success), so a dead writer would sync nothing for ever with no failure and no log line. Scheduling the bare table name instead of the task name left it green too, while in production the dispatcher would parse no table and the walk would never run — the seam now takes the resolved name so the round trip is behavioural rather than a source-text guess. And `include_docs=true` was pinned by nothing; dropping it completes the walk having written nothing.

I ran `parity-auditor` at `effort: max` twice, once on the Kotlin before writing anything and once on the finished green code. **The second pass found more than the first**, including both real defects in the second commit, which is entirely its findings.

Gate: `dart format --set-exit-if-changed` clean, `flutter analyze` clean, **2972 tests passing** (2923 baseline + 49).

## Reported, not fixed

1. **`team_activities` has no pull in the port at all** — the Phase 119 class. Kotlin walks it (`TransactionSyncManager.kt:251-253` → `teamsSyncRepository.bulkInsertTeamActivitiesFromSync`); the port only ever *uploads* team-visit rows (`team_log_uploader.dart`). There is no `insert…FromSync` for it and no mapper, so it could not be added to the worker's table set — the machinery is ready and the writer is what is missing. **What it costs:** `TeamLogDao.teamVisitsForUsers` and `lastTeamVisit` feed the member-detail screen's visit count and last-visit row (`teams_provider.dart:75,78`) **and the team leaderboard's ranking** (`team_leaderboard_screen.dart:101`). So a leaderboard — a comparison between members by construction — ranks them on what *this handset* happened to observe. Exactly the shape of the `ratings` average bug this port already fixed. Needs a writer on `TeamsRepository` plus the table in `HeavyTableSync.tables`; page size 200 is already in `pageSizeFor`.

2. **`PlanetApi` pins a 15-second `receiveTimeout` on every request and has no retry interceptor.** `_request` sets `receiveTimeout: defaultTimeout` per call (`planet_api.dart:285`, `defaultTimeout = 15s` at `:21`) and it is not a parameter, so no caller can lengthen it; `NetworkModule.kt:51` gives OkHttp 60 seconds, and `RetryInterceptor` sits under every call. This lane ported the retries into its own walk, which is the half that could be done from here; the timeout half cannot. A deep `_all_docs` page that needs more than 15 seconds to *start* answering fails all four attempts, which for a 114k-document table at `skip=100000` is not a remote possibility. The fix is an optional per-request timeout on `PlanetApi` (or a Dio retry interceptor) — a shared file.

3. **`activitiesSyncProvider` is dead code.** `ActivitiesSyncNotifier.runSync` (`activities_provider.dart:200`) is the only caller of `ActivitiesRepository.sync`, and the provider has no reader anywhere in `lib/` or `test/`; `DashboardSyncArea` has no `activities` member since the area was removed. Its own dartdoc claimed the opposite ("so the pull is registered as a Sync center area") — I corrected that sentence in place under the "make an existing statement true" carve-out, but **deleting the notifier and provider is a change of substance to a file this lane does not own**. The repository method itself is worth keeping: Kotlin has an un-checkpointed walk of that table too (`SyncActivity.kt:671`, `syncDb("login_activities")` with `useCheckpoint = false`, from a connectivity collector outside `SyncManager`).

4. **Kotlin's `SyncActivity:671` connectivity-triggered walk has no port analogue.** Not a defect — it is an un-checkpointed duplicate of a table the worker now walks properly, and it is the one place two Kotlin walks can hit the same table (it neither reads nor writes the checkpoint, so it cannot clear a stale one either). Recorded so a future harvest does not read its absence as a gap.

5. **`SubmissionsRepository.upsertDocuments` writes `isUpdated: false` over every row it writes**, keyed on the server `_id`, which is what keeps `submissions` out of the heavy set (see the table above). Kotlin has the same exposure (`SubmissionsRepositoryImpl.kt:686`) and the port's inline ordering is a mitigation Kotlin never had. **Make the merge preserve a pending local edit — the Phase 56/74/98 shape — and this table can move to the worker**, which is the only thing standing between the port and full parity on the heavy five. `submissions_repository.dart` was outside this lane's file set.

6. **Two `AppDatabase` instances can write one SQLite file with no WAL and no busy timeout.** `_openConnection` (`app_database.dart:821-828`) passes no `setup:`, so the file is in rollback-journal mode with a zero busy handler. The heavy task runs in its own Flutter engine with its own database, so any overlap with a foreground or headless sync is `SqliteException(5, 'database is locked')` for the loser. Kotlin cannot hit this — its workers share the process and one `@Singleton` `dbWriteMutex`, whose comment says why. This lane closed the *likely* overlap (both sync paths now mark the guard, and `scheduleIfPending` runs after its own walks rather than before), but the guard is read once per run in both apps, so a sync started mid-walk still overlaps. `journal_mode = WAL` plus a `busy_timeout` in `_openConnection` would make the residual case harmless; that file is shared.

7. **`onSyncComplete` is narrower than "after a completed sync".** The headless `scheduleAll` rides that hook, which fires only when the task is `autoSync`, auto-sync is enabled, the interval is due and every step succeeded. For a user who has turned auto-sync off, `BackgroundWorkCoordinator` cancels the `autoSync` job entirely, so on that handset only the UI sync ever recovers a page-1 death (`scheduleIfPending` still runs on every `maintenance` invocation, but shares the blind spot). Kotlin's `schedule(all)` is likewise reachable only from a completed full sync, so this is close to parity — recorded because "both entry points" reads broader than it is.

8. **`state.running` has no `finally` in `DashboardSyncNotifier.syncAll`.** I wrapped the interactive-sync flag, which had to be guaranteed; `running` is still cleared by fall-through, so a future unguarded `await` in the pass would leave the sync centre permanently "running" and every subsequent `syncAll` an early return. Nothing in the pass throws today — every step carries its own `catch` — which is exactly the state in which this looks fine. Changing `running`'s lifecycle affects the sync-centre UI and belongs in its own change.

9. **A heavy walk logs nothing.** Kotlin logs every batch, every failure and every resume to `SyncPerf` and calls `e.printStackTrace()`. `HeavyTableWalkResult` carries `savedCount` and `failure` and `run` discards both; there is no `debugPrint` or `FlutterError.reportError` in the new files, and a heavy task returns before the runner so it writes no `recordBackgroundRun` row either. Combined with the ported page-1 quirk, a walk that never syncs anything is completely silent. Deliberately not addressed — the port has no logging convention for background work to follow, and inventing one is its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ugZY6JueFP4YN9Ft28T1