### PR TITLE
feat(flutter): port the resource upload direction the port never had

### DIFF
--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1793,6 +1793,79 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
           .toList(growable: false),
     );
   }
+
+  /// Resources this device authored that have never reached the server.
+  ///
+  /// Port of `MyLibraryDao.getPendingUploads`, **with the predicate widened by
+  /// one clause**, and the extra clause is the whole point of this doc comment.
+  ///
+  /// Kotlin's query is exactly `SELECT * FROM my_library WHERE _rev IS NULL`
+  /// (`MyLibraryDao.kt:94-95`). Copying that literally into the port would
+  /// have uploaded the catalog. `my_library` has two writers and only one of
+  /// them sees a `_rev`: the `resources` walk pulls whole CouchDB documents,
+  /// while the courses walk pulls the *thinner* copy embedded in a course
+  /// step, and a sub-object carries no revision
+  /// (`CoursesRepository._ingestCourseResources`, and
+  /// [MyLibraryMapper._revOrAbsent], which documents the pair). So a course
+  /// resource the resources walk has not reached yet sits here with a genuinely
+  /// null `_rev` — and POSTing it to `resources` would file a **second copy of
+  /// a document that already exists on the server**, one per course resource,
+  /// on the first drain after the first courses sync.
+  ///
+  /// Kotlin is spared that by a quirk rather than by design.
+  /// `MyLibrary.insertMyLibrary` assigns `_rev = JsonUtils.getString("_rev",
+  /// doc)` unconditionally (`MyLibrary.kt:237`) and `getString` returns `""`
+  /// for a missing key, so Kotlin's course-embedded rows carry an *empty*
+  /// revision, which `_rev IS NULL` does not match. Phase 150 deliberately
+  /// fixed that quirk in the port — writing [Value.absent] instead, for good
+  /// reasons set out at [MyLibraryMapper._revOrAbsent] — and in doing so
+  /// removed the accidental guard that Kotlin's pending predicate leans on.
+  /// Nothing noticed, because until now the port had no resource uploader.
+  ///
+  /// The honest discriminator is therefore `_id`, not `_rev`: **every** sync
+  /// writer sets `couchId` from the document's own `_id` and
+  /// [MyLibraryMapper.fromDoc] returns null outright when that id is empty, so
+  /// a row with no `_id` cannot have come from the server. Only
+  /// [ResourcesRepository.saveLocalResource] leaves it unset. `_rev IS NULL` is
+  /// kept alongside it so a row that *has* been uploaded is never offered
+  /// twice, which is the clause Kotlin was actually relying on.
+  ///
+  /// The `_id = ''` arm covers a row an older build may have written with a
+  /// blank rather than absent id, the same way `deleteNotIn` spares both.
+  Future<List<MyLibraryRow>> pendingUploads() =>
+      (select(myLibraryTable)..where(
+            (r) => r.rev.isNull() & (r.couchId.isNull() | r.couchId.equals('')),
+          ))
+          .get();
+
+  /// Adopts the `_id` and `_rev` CouchDB assigned to a freshly POSTed
+  /// resource.
+  ///
+  /// Port of the first half of `ResourcesRepositoryImpl.markResourceUploaded`
+  /// (`:803-806`), which looks the row up by its local id, assigns `_id` and
+  /// `_rev`, and upserts. Writing both is what takes the row out of
+  /// [pendingUploads] — either clause alone would do it, and both are written
+  /// because the row genuinely has both now.
+  ///
+  /// Returns false when no row matched, mirroring Kotlin's
+  /// `myLibraryDao.getById(localId) ?: return false`. That return value is
+  /// load-bearing upstream: `UploadConfigs.getResourcesConfig`'s
+  /// `markUploaded` is `results.filter { !markResourceUploaded(...) }`, i.e. it
+  /// hands back the results whose local row could **not** be found, so a
+  /// vanished row is reported as a failure rather than silently succeeding.
+  ///
+  /// Kotlin also creates a team-resource-link document here for a private
+  /// resource, using the `planetCode` argument. That half is **not** ported:
+  /// `TeamsRepository.createLocalResourceLink` does not exist in the port at
+  /// all, so there is nothing to call. Reported rather than reached for —
+  /// `teams_repository.dart` belongs to no lane this round.
+  Future<bool> markUploaded(String id, String couchId, String rev) async {
+    final updated =
+        await (update(myLibraryTable)..where((r) => r.id.equals(id))).write(
+          MyLibraryTableCompanion(couchId: Value(couchId), rev: Value(rev)),
+        );
+    return updated > 0;
+  }
 }
 
 /// Comfortably under SQLite's 999-variable floor.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1860,12 +1860,58 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   /// all, so there is nothing to call. Reported rather than reached for —
   /// `teams_repository.dart` belongs to no lane this round.
   Future<bool> markUploaded(String id, String couchId, String rev) async {
-    final updated =
-        await (update(myLibraryTable)..where((r) => r.id.equals(id))).write(
-          MyLibraryTableCompanion(couchId: Value(couchId), rev: Value(rev)),
-        );
-    return updated > 0;
+    final row = await getById(id);
+    if (row == null) return false;
+    await (update(myLibraryTable)..where((r) => r.id.equals(id))).write(
+      MyLibraryTableCompanion(
+        couchId: Value(couchId),
+        rev: Value(rev),
+        // `downloadedRev` moves with `rev` **when there are bytes on disk**,
+        // and leaving it behind would have introduced a defect rather than
+        // preserved one.
+        //
+        // [watchResourcesNeedingUpdateCount] counts a shelf row where
+        // `_rev IS NOT downloaded_rev`. Before a resource is uploaded both are
+        // null, and SQLite's `IS NOT` between two nulls is false, so the row is
+        // not counted. Writing `_rev` alone flips that to true and the bell
+        // starts asking the user to **download the resource they just
+        // created**, over the copy already sitting under `ole/<id>/`.
+        //
+        // The honest reading is that the two are equal: the file on disk *is*
+        // the attachment of the revision being recorded, because this device
+        // authored both. Kotlin leaves `downloadedRev` null here
+        // (`ResourcesRepositoryImpl.kt:804-806` writes only the two columns),
+        // which also makes `MyLibrary.isResourceOffline` read false for a
+        // resource whose file is present. A deliberate divergence: copying it
+        // would ship a prompt that cannot be satisfied.
+        //
+        // Only when there really are bytes. A metadata-only row — which the
+        // port's form allows and Kotlin's does not — has nothing downloaded,
+        // and saying otherwise is the `resourceOffline` lie Phase 150 removed.
+        downloadedRev: (row.resourceOffline && row.resourceLocalAddress != null)
+            ? Value(rev)
+            : const Value.absent(),
+      ),
+    );
+    return true;
   }
+
+  /// Adopts the revision the **attachment** PUT returned.
+  ///
+  /// CouchDB bumps a document's revision when an attachment lands, and Kotlin
+  /// discards that response entirely — `FileUploader.onDataReceived` reads
+  /// only `ok` (`FileUploader.kt:70-78`). So the Kotlin row stays at the POST's
+  /// revision while the server has moved on, and the next resources sync pulls
+  /// the newer `_rev` over it, leaving `_rev != downloaded_rev` and the bell
+  /// asking to re-download a file the device already has.
+  ///
+  /// Recording it costs nothing and keeps the pair equal through that sync,
+  /// which is the point [markUploaded] makes above. Both columns move together
+  /// for the same reason they do there.
+  Future<void> adoptAttachmentRev(String id, String rev) =>
+      (update(myLibraryTable)..where((r) => r.id.equals(id))).write(
+        MyLibraryTableCompanion(rev: Value(rev), downloadedRev: Value(rev)),
+      );
 }
 
 /// Comfortably under SQLite's 999-variable floor.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1855,10 +1855,14 @@ class MyLibraryDao extends DatabaseAccessor<AppDatabase>
   /// vanished row is reported as a failure rather than silently succeeding.
   ///
   /// Kotlin also creates a team-resource-link document here for a private
-  /// resource, using the `planetCode` argument. That half is **not** ported:
-  /// `TeamsRepository.createLocalResourceLink` does not exist in the port at
-  /// all, so there is nothing to call. Reported rather than reached for —
-  /// `teams_repository.dart` belongs to no lane this round.
+  /// resource, using the `planetCode` argument. In the port that lives one
+  /// layer up, in `ResourcesUploader._linkPrivateResourceToTeam`, because the
+  /// link has to carry the CouchDB id and this DAO method is handed one — see
+  /// `ResourcesRepository.markResourceUploaded`. (An earlier revision of this
+  /// comment claimed the port had no equivalent of
+  /// `createLocalResourceLink`. It has `TeamsRepository.addResourceLink`; the
+  /// search that missed it was for the Kotlin name rather than the
+  /// behaviour.)
   Future<bool> markUploaded(String id, String couchId, String rev) async {
     final row = await getById(id);
     if (row == null) return false;

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -659,6 +659,9 @@ final resourcesUploaderProvider = Provider<ResourcesUploader>(
   (ref) => ResourcesUploader(
     ref.watch(planetApiProvider),
     ref.watch(resourcesRepositoryProvider),
+    // For the private-team-resource link Kotlin writes in the same step —
+    // see `ResourcesUploader._linkPrivateResourceToTeam`.
+    ref.watch(teamsRepositoryProvider),
     ref.watch(outboxRepositoryProvider),
     ref.watch(deviceIdentitySourceProvider),
   ),

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -39,6 +39,7 @@ import '../repository/notifications_repository.dart';
 import '../repository/outbox_drainer.dart';
 import '../repository/outbox_repository.dart';
 import '../repository/personals_uploader.dart';
+import '../repository/resources_uploader.dart';
 import '../repository/personals_repository.dart';
 import '../repository/progress_repository.dart';
 import '../repository/public_survey_uploader.dart';
@@ -649,6 +650,20 @@ final personalsUploaderProvider = Provider<PersonalsUploader>(
   ),
 );
 
+/// Carries a resource the user created on this device to the server.
+///
+/// The direction did not exist before: `saveLocalResource` wrote the row and
+/// nothing sent it. See [ResourcesUploader] for the three places its Kotlin
+/// counterpart is wrong and this one deliberately differs.
+final resourcesUploaderProvider = Provider<ResourcesUploader>(
+  (ref) => ResourcesUploader(
+    ref.watch(planetApiProvider),
+    ref.watch(resourcesRepositoryProvider),
+    ref.watch(outboxRepositoryProvider),
+    ref.watch(deviceIdentitySourceProvider),
+  ),
+);
+
 /// Replaces `RetryQueueWorker`'s WorkManager registration in `MainApplication`.
 ///
 /// Handlers are registered per `uploadType`; anything without one is replayed
@@ -692,6 +707,7 @@ final outboxDrainerProvider = Provider<OutboxDrainer>((ref) {
       AchievementsUploader.type: ref
           .watch(achievementsUploaderProvider)
           .handler,
+      ResourcesUploader.type: ref.watch(resourcesUploaderProvider).handler,
     },
   );
 });

--- a/flutter/lib/repository/resources_repository.dart
+++ b/flutter/lib/repository/resources_repository.dart
@@ -321,6 +321,44 @@ class ResourcesRepository {
     return null;
   }
 
+  /// Port of `ResourcesRepositoryImpl.getPendingResourceUploads` (`:793-795`)
+  /// — resources this device authored that have never reached the server.
+  ///
+  /// The predicate is widened by one clause against Kotlin's, and
+  /// [MyLibraryDao.pendingUploads] sets out why at length: copying `_rev IS
+  /// NULL` verbatim would also match every course-embedded resource and
+  /// duplicate documents that already exist on the server.
+  Future<List<MyLibraryRow>> pendingUploads() => _dao.pendingUploads();
+
+  /// Port of `ResourcesRepositoryImpl.markResourceUploaded` (`:797-818`),
+  /// minus its private-team-resource link.
+  ///
+  /// Returns false when no local row matched, exactly as Kotlin's
+  /// `myLibraryDao.getById(localId) ?: return false` does; `ResourcesUploader`
+  /// documents what that answer is used for.
+  ///
+  /// **Kotlin's second half is not ported, and this is the gap.** For a
+  /// private resource it also writes a local `resourceLink` team document via
+  /// `TeamsRepository.createLocalResourceLink` (`TeamsRepositoryImpl
+  /// .kt:719-740`), stamped with the user's planet code — which is the only
+  /// consumer of the `planetCode` argument, and why this method does not take
+  /// one. `createLocalResourceLink` does not exist anywhere in the port, so
+  /// there is nothing to call, and adding it means reaching into
+  /// `teams_repository.dart`. Reported rather than reached for.
+  Future<bool> markResourceUploaded(
+    String localId,
+    String couchId,
+    String rev,
+  ) => _dao.markUploaded(localId, couchId, rev);
+
+  /// Records the revision the attachment PUT returned — see
+  /// [MyLibraryDao.adoptAttachmentRev]. Kotlin throws that response away.
+  Future<void> adoptAttachmentRev(String localId, String rev) =>
+      _dao.adoptAttachmentRev(localId, rev);
+
+  /// Port of `ResourcesRepositoryImpl.getLibraryItemById` (`:162-164`).
+  Future<MyLibraryRow?> getLibraryItemById(String id) => _dao.getById(id);
+
   /// Port of `ResourcesRepositoryImpl.getAllLibraries` — the achievement
   /// editor's resource picker lists the whole catalog.
   Future<List<MyLibraryRow>> getAllLibraries() => _dao.getAll();

--- a/flutter/lib/repository/resources_repository.dart
+++ b/flutter/lib/repository/resources_repository.dart
@@ -337,14 +337,18 @@ class ResourcesRepository {
   /// `myLibraryDao.getById(localId) ?: return false` does; `ResourcesUploader`
   /// documents what that answer is used for.
   ///
-  /// **Kotlin's second half is not ported, and this is the gap.** For a
-  /// private resource it also writes a local `resourceLink` team document via
-  /// `TeamsRepository.createLocalResourceLink` (`TeamsRepositoryImpl
-  /// .kt:719-740`), stamped with the user's planet code — which is the only
-  /// consumer of the `planetCode` argument, and why this method does not take
-  /// one. `createLocalResourceLink` does not exist anywhere in the port, so
-  /// there is nothing to call, and adding it means reaching into
-  /// `teams_repository.dart`. Reported rather than reached for.
+  /// **Kotlin's second half lives in [ResourcesUploader], not here.** For a
+  /// private resource `markResourceUploaded` also writes a local
+  /// `resourceLink` team document (`TeamsRepositoryImpl.kt:719-740`), stamped
+  /// with the user's planet code — which is the only consumer of Kotlin's
+  /// `planetCode` argument, and why this method does not take one.
+  /// [ResourcesUploader._linkPrivateResourceToTeam] does it, after the POST,
+  /// because the link has to carry the CouchDB id.
+  ///
+  /// An earlier revision of this comment said `createLocalResourceLink` "does
+  /// not exist anywhere in the port". It does — as
+  /// [TeamsRepository.addResourceLink] — and the search that missed it was for
+  /// the Kotlin *name* rather than the behaviour.
   Future<bool> markResourceUploaded(
     String localId,
     String couchId,

--- a/flutter/lib/repository/resources_uploader.dart
+++ b/flutter/lib/repository/resources_uploader.dart
@@ -16,6 +16,8 @@ import '../providers/app_providers.dart';
 import 'outbox_drainer.dart';
 import 'outbox_repository.dart';
 import 'resources_repository.dart';
+import 'teams_repository.dart';
+import 'teams_uploader.dart';
 
 /// Durable two-step write-back for resources this device authored, porting
 /// `UploadManager.uploadResource` (`:167-216`) together with
@@ -92,13 +94,20 @@ import 'resources_repository.dart';
 /// that reason, and [queuePending] passes the row's own `createdDate`. Same
 /// fix, same reasoning, as `PersonalsUploader.queuePending`'s `uploadedAt`.
 class ResourcesUploader {
-  ResourcesUploader(this._api, this._resources, this._outbox, this._identity);
+  ResourcesUploader(
+    this._api,
+    this._resources,
+    this._teams,
+    this._outbox,
+    this._identity,
+  );
 
   /// The `uploadType` these operations carry in the outbox.
   static const String type = 'resources';
 
   final PlanetApi _api;
   final ResourcesRepository _resources;
+  final TeamsRepository _teams;
   final OutboxRepository _outbox;
   final DeviceIdentitySource _identity;
 
@@ -204,7 +213,7 @@ class ResourcesUploader {
   /// `(uploadType, itemId)`, so a resource already queued has its payload
   /// refreshed rather than being POSTed twice. That refresh is what carries a
   /// later [ResourcesRepository.updateLocalResource] edit onto the wire — see
-  /// [queueOne].
+  /// [_enqueue], reached through this method on every path.
   ///
   /// [user] is the signed-in account, and it is a parameter rather than a
   /// dependency because Kotlin resolves it the same way, once per upload pass
@@ -220,10 +229,36 @@ class ResourcesUploader {
     if (pending.isEmpty) return 0;
     final endpoint = endpointFor(config);
     final identity = await _identity.read();
+    var queued = 0;
     for (final row in pending) {
+      // **A resource POST is an append, so an in-flight row must be left
+      // alone.** [OutboxRepository.enqueue] deliberately puts an `in_progress`
+      // row back to `pending` so a payload edited mid-flight is not lost with
+      // the row `markCompleted` deletes — and `markCompleted` is
+      // `deleteIfInProgress`, so the send that succeeds moments later deletes
+      // nothing, the row survives `pending` with the same body, and the next
+      // drain POSTs a **second CouchDB document**. Nothing downstream catches
+      // it: the handler carries no `_id`, so the server mints a fresh one, and
+      // `markResourceUploaded` then points the local row at the duplicate
+      // while the first document becomes an unidentifiable orphan in the
+      // shared Planet catalog.
+      //
+      // Reached without any exotic timing: a drain claims this row on a slow
+      // link while the user saves a second resource in `AddResourceScreen`,
+      // whose `_save` sweeps every pending row including this one. Also
+      // cross-isolate, between the headless drain and the UI — the case
+      // [OutboxRepository.isInFlight] documents — and more reachable once
+      // [sweepPendingResources] is wired.
+      //
+      // Same guard, same reasoning, as `SubmissionsUploader.queuePending`,
+      // `VoicesUploader` and `AdoptedSurveysUploader`. The shelf can skip it
+      // because its payload is derived state a replay recomputes; an append
+      // cannot.
+      if (await _outbox.isInFlight(type, row.id)) continue;
+      queued++;
       await _enqueue(row, endpoint, identity, user);
     }
-    return pending.length;
+    return queued;
   }
 
   Future<void> _enqueue(
@@ -313,10 +348,98 @@ class ResourcesUploader {
         log('Resource ${row.itemId} disappeared before its id could be stored');
         return result;
       }
+      await _linkPrivateResourceToTeam(row, couchId, payload);
       await _uploadAttachment(row, couchId, rev, authHeader);
     }
     return result;
   };
+
+  /// Port of the second half of `ResourcesRepositoryImpl.markResourceUploaded`
+  /// (`:808-816`): a private team resource also gets a local `resourceLink`
+  /// team document, so the resource appears under that team.
+  ///
+  /// **This was omitted in this phase's first cut, on a false premise, and the
+  /// premise is worth recording.** Two doc comments claimed
+  /// `TeamsRepository.createLocalResourceLink` "does not exist anywhere in the
+  /// port". It exists — as [TeamsRepository.addResourceLink], a field-for-field
+  /// match for the Kotlin (blank guard, generated id, `docType`
+  /// `'resourceLink'`, `teamType` `'local'`, `isUpdated` true) plus a duplicate
+  /// check Kotlin lacks. The search was for the Kotlin *name* rather than the
+  /// behaviour, which is the same mistake as matching `<basename>_test.dart`
+  /// instead of grepping for the symbol. Without this, a team leader's private
+  /// resource uploads its own document and **no team ever links to it**: the
+  /// team's Resources tab is empty on Planet and on every other member's
+  /// handset, for bytes that are already on the server.
+  ///
+  /// **It has to run here, after the POST**, because the link must carry the
+  /// **CouchDB** id. `markUploaded` leaves `resourceId` at the local uuid, so
+  /// `TeamResourceActions.add`'s `resource.resourceId` would name a document
+  /// that does not exist. Kotlin puts it inside `markResourceUploaded` for
+  /// exactly this reason.
+  ///
+  /// The link is then enqueued the way `TeamResourceActions.add` enqueues one
+  /// — `TeamsUploader.resourceType` against `<db>/teams` — because writing the
+  /// row alone would leave it local. Kotlin needs no equivalent: its
+  /// `updated = true` is swept by the team upload pass.
+  ///
+  /// `planetCode` comes out of the payload rather than a session read: the
+  /// drain may run days later in a headless isolate, and `sourcePlanet` is the
+  /// planet code this very document was serialized with, so it cannot drift
+  /// from it. **Note that [TeamsRepository.addResourceLink] currently accepts
+  /// `planetCode` and ignores it**, where Kotlin stamps `sourcePlanet` *and*
+  /// `teamPlanetCode` from it (`TeamsRepositoryImpl.kt:726-735`). Fixing that
+  /// means editing `teams_repository.dart`, which is outside this lane's file
+  /// set — it is passed here so the call is already correct once that lands,
+  /// and reported rather than reached for.
+  ///
+  /// Best-effort, like the attachment: the resource document is already filed,
+  /// and reporting failure would re-POST it and duplicate it to fix a missing
+  /// link.
+  Future<void> _linkPrivateResourceToTeam(
+    OutboxRow row,
+    String couchId,
+    Map<String, dynamic> payload,
+  ) async {
+    final resource = await _resources.getLibraryItemById(row.itemId);
+    final teamId = resource?.privateFor;
+    // Kotlin's condition is `library.isPrivate && !library.privateFor
+    // .isNullOrBlank()` (`ResourcesRepositoryImpl.kt:809`), and
+    // `createLocalResourceLink` re-checks both ids for blankness (`:725`).
+    if (resource == null || !resource.isPrivate) return;
+    if (teamId == null || teamId.isEmpty) return;
+
+    try {
+      final link = await _teams.addResourceLink(
+        teamId: teamId,
+        resourceId: couchId,
+        title: resource.title ?? '',
+        planetCode: payload['sourcePlanet'] as String?,
+      );
+      if (link == null) return;
+      await _outbox.enqueue(
+        uploadType: TeamsUploader.resourceType,
+        itemId: link.id,
+        endpoint: _siblingDatabase(row.endpoint, 'teams'),
+        payload: TeamsRepository.serializeTeamDocument(link),
+        userId: row.userId,
+      );
+    } on Exception catch (e, stack) {
+      log('Could not link resource to team', error: e, stackTrace: stack);
+    }
+  }
+
+  /// `<db>/resources` -> `<db>/<name>`.
+  ///
+  /// Derived from the stored endpoint rather than a `ServerConfig` read,
+  /// because a handler runs at drain time with no config in scope — the same
+  /// reason `PersonalsUploader._uploadAttachment` rebuilds its base this way.
+  static String _siblingDatabase(String endpoint, String name) {
+    const suffix = '/resources';
+    final base = endpoint.endsWith(suffix)
+        ? endpoint.substring(0, endpoint.length - suffix.length)
+        : endpoint;
+    return '$base/$name';
+  }
 
   /// PUTs the picked file to `resources/<id>/<name>` once the document POST
   /// lands — the port of `FileUploader.uploadAttachment(id, rev, personal:
@@ -330,7 +453,7 @@ class ResourcesUploader {
   /// [OutboxRepository.enqueue] is keyed on `MyLibraryRow.id`. One derivation,
   /// one helper, both sides. Phase 100's verification photo is what happens
   /// when the two sides each pick their own key, and
-  /// `resource_upload_round_trip_test.dart` drives the writer and this method
+  /// `resources_uploader_test.dart`'s *the round trip* group drives the writer and this method
   /// together rather than trusting either half's own fixture.
   ///
   /// A row with **no file** is a no-op, not an error, and that case is real
@@ -418,15 +541,20 @@ class ResourcesUploader {
 /// `add_resource_screen._save`, so a resource whose enqueue never ran has
 /// nothing to deliver it.
 ///
-/// That window is narrower than the submissions one Phase 134 closed, because
-/// the write site calls [ResourcesUploader.queuePending] — an *unscoped* sweep
-/// — rather than enqueuing the one row it just wrote, so saving any resource
-/// rescues every stranded one. It is not closed. A user who creates a resource
-/// with no server configured (`serverConfigProvider` null, which is the whole
-/// offline-first premise), or whose process dies between the row write and the
-/// enqueue, and who never returns to that screen, never uploads it — and the
-/// row is invisible in Planet for ever, with the reset-app action able to
-/// destroy it in the meantime.
+/// The write site does call [ResourcesUploader.queuePending] — an *unscoped*
+/// sweep rather than an enqueue of the one row it just wrote — so saving any
+/// resource rescues every stranded one. That is the only thing standing in for
+/// the sweep today, and it is not enough.
+///
+/// **This is the widest such window the port has had**, not a narrow one.
+/// Every resource created on any previous build has a `my_library` row with no
+/// `_id` and no outbox row, and `my_library` is preserved, so no schema bump
+/// clears them: they upload only if the user happens to open the add-resource
+/// screen and save something. A user who creates a resource with no server
+/// configured (`serverConfigProvider` null, which is the offline-first
+/// premise), or whose process dies between the row write and the enqueue, and
+/// who never returns to that screen, never uploads it — invisible in Planet
+/// for ever, with the reset-app action able to destroy it meanwhile.
 ///
 /// **`lib/background_entrypoint.dart` belongs to another lane this round**, so
 /// the two calls that close it are reported rather than made. They belong
@@ -436,8 +564,31 @@ class ResourcesUploader {
 /// which is precisely not the user most likely to have an undelivered write.
 /// Ordering against the other sweeps is free: no sync step writes `my_library`
 /// rows over a locally authored one ([MyLibraryMapper.fromDoc] keys on the
-/// CouchDB `_id`, and a pending resource has none), and the port's own
-/// `deleteNotIn` already spares a row with no `_rev`.
+/// CouchDB `_id`, and a *pending* resource has none), and `deleteNotIn` spares
+/// a row with no `_rev`.
+///
+/// **That second clause protects the row only while it is pending, and this
+/// direction is what ends that.** `MyLibraryDao.markUploaded` writes `_rev`,
+/// which makes the row eligible for `deleteNotIn` — whose keep set is document
+/// `_id`s while the locally authored row's primary key is still its local
+/// uuid. So the first resources sync after a successful upload inserts a
+/// *second* row keyed on the CouchDB id, with an empty shelf and
+/// `resourceOffline` at its default, and prunes the original — detaching the
+/// user from their own resource and orphaning the bytes under
+/// `ole/<uuid>/`. **Kotlin reaches the identical outcome** (its
+/// `deleteStalePublicNotIn` matches `resourceId`, which `saveLocalResource`
+/// also sets to the same uuid and `markResourceUploaded` does not update), so
+/// this is inherited rather than introduced — but it is not benign, and
+/// nothing before this note recorded it. See the PR's *Reported, not fixed*.
+///
+/// A second sweep site is missing too. Kotlin calls `uploadResource` from
+/// three places, of which two are the port's headless and foreground sync
+/// paths: this function belongs in `background_entrypoint.dart`'s
+/// `drainOutbox` **and** in `DashboardSyncNotifier` beside
+/// `queuePendingVoices`/`queuePendingSubmissions`. The third
+/// (`TeamsRepositoryImpl:928`, via `saveLocalResource`'s `teamId != null`
+/// tail) needs no port counterpart, because the screen enqueues on every save
+/// rather than only for a team.
 ///
 /// [userId] is nullable and a null one is not an early return: Kotlin passes
 /// `user?.id` and `user?.planetCode` straight through, so a handset whose

--- a/flutter/lib/repository/resources_uploader.dart
+++ b/flutter/lib/repository/resources_uploader.dart
@@ -1,0 +1,473 @@
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mime/mime.dart';
+import 'package:path/path.dart' as p;
+
+import '../core/config/server_config.dart';
+import '../core/files/resource_files.dart';
+import '../core/network/network_result.dart';
+import '../core/system/device_identity.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
+import '../data/local/app_database.dart';
+import '../providers/app_providers.dart';
+import 'outbox_drainer.dart';
+import 'outbox_repository.dart';
+import 'resources_repository.dart';
+
+/// Durable two-step write-back for resources this device authored, porting
+/// `UploadManager.uploadResource` (`:167-216`) together with
+/// `UploadConfigs.getResourcesConfig` (`:270-290`) and
+/// `FileUploader.uploadAttachment(id, rev, personal: MyLibrary)` (`:36-42`).
+///
+/// **This direction did not exist in the port at all.** A Phase 119-class
+/// reachability gap: [ResourcesRepository.saveLocalResource] has been a
+/// careful port for several phases — it writes the `my_library` row, copies the
+/// picked file to `<base>/ole/<id>/<basename>`, marks the row offline and adds
+/// it to the user's shelf — and nothing ever sent it anywhere. A resource the
+/// user created existed on that handset and nowhere else: absent from Planet,
+/// absent from their other devices, and destroyed outright by the reset-app
+/// action. `my_library` is a preserved table, so a schema bump spared it; that
+/// is the only reason this was survivable rather than routinely lossy.
+///
+/// The Kotlin shape is a per-document POST to the `resources` database
+/// (`RoomUploadConfig(endpoint = "resources", …)` through
+/// `UploadCoordinator.uploadRoom`), then, for each document CouchDB accepted,
+/// a PUT of the file to `resources/<id>/<name>` carrying the returned revision
+/// as `If-Match`. Routed here through the [OutboxDrainer] like every other
+/// append in the port, so a create survives process death.
+///
+/// ## Three deliberate divergences, each because the Kotlin is wrong
+///
+/// **1. The pending predicate.** See [MyLibraryDao.pendingUploads]. Kotlin's is
+/// `_rev IS NULL`, which in *this* codebase also matches every course-embedded
+/// resource and would file a second copy of documents that already exist on
+/// the server.
+///
+/// **2. In Kotlin the attachment never uploads at all, for two independent
+/// reasons — so the port must not treat that path as a working reference.**
+///
+/// *The lookup finds nothing.* `uploadResource` maps its succeeded items back
+/// to library rows with `resourcesRepository.getLibraryItemsByIds(localIds)`
+/// (`UploadManager.kt:177`), which is `getByUnderscoreIds` — `WHERE _id IN
+/// (:ids)` (`MyLibraryDao.kt:40`) — while `localId` is `config.idExtractor`,
+/// i.e. the **local** primary key (`UploadConfigs.kt:278`). Worse, by the time
+/// this runs `markResourceUploaded` has already overwritten `_id` with the
+/// CouchDB id inside the coordinator's batch loop, before `uploadRoom`
+/// returns. So the query is local ids against a column now holding remote
+/// ones, `libMap` is empty, `uploadAttachment` is never invoked — and
+/// `notifyListener(…, "Uploaded N resources successfully")` fires anyway
+/// (`:187`). The map is even built on `it.id` while the query is on `_id`
+/// (`:178`), which is the tell.
+///
+/// *And the file handle would be wrong if it did.*
+/// `FileUploader.uploadAttachment` builds the file as
+/// `File(personal.resourceLocalAddress)` (`FileUploader.kt:37`), but
+/// `saveLocalResource` stores a **basename** in that column
+/// (`ResourcesRepositoryImpl.kt:278`) and copies the bytes to
+/// `FileUtils.getLibraryFile(dir, id, filename)` — `<ext>/ole/<id>/<name>`.
+/// `File("mybook.pdf")` is relative, resolved against the process working
+/// directory, so it does not exist; `asRequestBody` throws `FileNotFoundException`
+/// and `uploadDoc` catches it and reports "Unable to upload resource" through
+/// `onSuccess`, which has no failure channel.
+///
+/// Either way the document lands with no `_attachments`, the bytes stay on the
+/// handset, the row is no longer pending so nothing retries, and **nothing
+/// fails loudly**. The second half is precisely the Phase 100
+/// verification-photo shape — bytes written under one key and read back under
+/// another — reached through the Kotlin rather than through the port.
+/// [_uploadAttachment] resolves through [ResourceFiles], the same helper and
+/// the same `docId` the writer used, and looks the row up by its **local** id,
+/// which is what `outbox.itemId` holds.
+///
+/// **3. The payload must not drift between sweeps.** Kotlin serializes at send
+/// time and so may write `System.currentTimeMillis()` freely; the port stores
+/// the payload in `outbox` at enqueue time and re-serializes on every sweep. A
+/// field that moves makes the request differ from the one already recorded
+/// against this row, so [OutboxRepository.enqueue]'s memo can never match and
+/// a document the server refused is POSTed again on every sweep — a fresh
+/// duplicate each time. [serialize] takes its timestamps as an argument for
+/// that reason, and [queuePending] passes the row's own `createdDate`. Same
+/// fix, same reasoning, as `PersonalsUploader.queuePending`'s `uploadedAt`.
+class ResourcesUploader {
+  ResourcesUploader(this._api, this._resources, this._outbox, this._identity);
+
+  /// The `uploadType` these operations carry in the outbox.
+  static const String type = 'resources';
+
+  final PlanetApi _api;
+  final ResourcesRepository _resources;
+  final OutboxRepository _outbox;
+  final DeviceIdentitySource _identity;
+
+  /// Credential-free: this string is persisted in `outbox.endpoint`. The PIN
+  /// travels as the `Authorization` header at send time instead.
+  static String endpointFor(ServerConfig config) =>
+      '${UrlUtils.credentialFreeDbUrl(config)}/resources';
+
+  /// Port of `MyLibrary.serialize(personal, user)` (`MyLibrary.kt:154-189`).
+  ///
+  /// This is the **create** payload and is deliberately not
+  /// [ResourcesRepository.serializeResource] (the port of `serializeResource`
+  /// at `MyLibrary.kt:81`), which describes a fully synced resource and carries
+  /// `_id`, `_rev` and `_attachments`. Nothing here carries an id: the document
+  /// is new, and CouchDB assigns one.
+  ///
+  /// Field-for-field against the Kotlin, including its quirks:
+  ///
+  /// * `author`, `publisher` and `linkToLicense` coalesce a null to `''`,
+  ///   while `medium`, `description`, `year`, `language`, `resourceType` and
+  ///   `openWith` are sent as JSON `null`. That asymmetry is Kotlin's, and it
+  ///   is reproduced rather than tidied: which keys Planet sees is the
+  ///   contract, and Phase 103 is the standing reminder that a payload the
+  ///   server cannot parse is not a cosmetic defect. `Gson.addProperty(String,
+  ///   String?)` writes `JsonNull` for a null, so those keys really are
+  ///   present-with-null on the wire, not omitted.
+  /// * `mediaType` defaults to `'other'`.
+  /// * `addedBy` is the **user's id**, not the row's `addedBy` column — which
+  ///   holds the user's *name*, because `saveLocalResource` puts `user?.name`
+  ///   there (`add_resource_screen`, matching `AddResourceActivity`). The
+  ///   column is not read here at all.
+  /// * `filename` is the basename of `resourceLocalAddress`, `''` when the
+  ///   column is null — and this is **not** a line-for-line copy, because
+  ///   Kotlin derives the same field twice, differently. The document gets
+  ///   `FileUtils.getFileNameFromUrl` (`MyLibrary.kt:159`), which parses the
+  ///   value as a `Uri` and `URLDecoder.decode`s the last segment, while the
+  ///   attachment PUT names the file with `getFileNameFromLocalAddress`
+  ///   (`FileUploader.kt:38`), a plain `substringAfterLast('/')`. Those
+  ///   disagree for any name the first one transforms: `a+b.pdf` becomes
+  ///   `a b.pdf`, `50%.pdf` throws inside `URLDecoder` and yields `''`, and
+  ///   `notes#1.pdf` truncates at the fragment delimiter to `notes`. A
+  ///   document whose `filename` does not match its attachment's name is a
+  ///   resource Planet cannot resolve, so the two are unified here on the
+  ///   plain basename — the attachment side, since that one names bytes that
+  ///   really exist. [_uploadAttachment] derives it the same way.
+  ///
+  ///   One consequence, stated rather than hidden: for those names the port's
+  ///   document carries a different `filename` string than Kotlin's would.
+  ///   That is the point — Kotlin's is the one the attachment contradicts.
+  /// * `privateFor` is a nested object `{'teams': …}`, and **only present**
+  ///   when the resource is private *and* has a team. Both halves of that
+  ///   condition are Kotlin's.
+  /// * `isDownloadable` is a literal boolean `true`.
+  /// * `sourcePlanet` and `resideOn` both carry the user's planet code.
+  /// * Kotlin writes `createdDate` twice (`:157` and `:186`) with the same
+  ///   expression, so one key here is not a loss.
+  ///
+  /// [uploadedAt] supplies both `uploadDate` and `updatedDate`, which Kotlin
+  /// reads from the clock at send time. See the class doc for why a caller has
+  /// to pass a stable value instead.
+  static Map<String, dynamic> serialize(
+    MyLibraryRow row, {
+    required int uploadedAt,
+    String? addedById,
+    String? planetCode,
+  }) {
+    final localAddress = row.resourceLocalAddress;
+    return {
+      'title': row.title,
+      'uploadDate': uploadedAt,
+      'createdDate': row.createdDate,
+      'filename': (localAddress == null || localAddress.isEmpty)
+          ? ''
+          : p.basename(localAddress.replaceAll(r'\', '/')),
+      'author': row.author ?? '',
+      'addedBy': addedById,
+      'medium': row.medium,
+      'description': row.description,
+      'year': row.year,
+      'language': row.language,
+      'publisher': row.publisher ?? '',
+      'linkToLicense': row.linkToLicense ?? '',
+      'subject': row.subject,
+      'level': row.level,
+      'resourceType': row.resourceType,
+      'openWith': row.openWith,
+      'mediaType': row.mediaType ?? 'other',
+      'resourceFor': row.resourceFor,
+      'private': row.isPrivate,
+      if (row.isPrivate && row.privateFor != null)
+        'privateFor': {'teams': row.privateFor},
+      'isDownloadable': true,
+      'sourcePlanet': planetCode,
+      'resideOn': planetCode,
+      'updatedDate': uploadedAt,
+    };
+  }
+
+  /// Queues every resource this device authored that has not reached the
+  /// server.
+  ///
+  /// Safe to call repeatedly: [OutboxRepository.enqueue] keys on
+  /// `(uploadType, itemId)`, so a resource already queued has its payload
+  /// refreshed rather than being POSTed twice. That refresh is what carries a
+  /// later [ResourcesRepository.updateLocalResource] edit onto the wire — see
+  /// [queueOne].
+  ///
+  /// [user] is the signed-in account, and it is a parameter rather than a
+  /// dependency because Kotlin resolves it the same way, once per upload pass
+  /// (`UploadManager.uploadResource:169` — `userRepository.getUserModel()`).
+  /// A null user costs `addedBy`, `sourcePlanet` and `resideOn`; it does not
+  /// stop the resource being sent, matching Kotlin's `user?.id` /
+  /// `user?.planetCode`.
+  Future<int> queuePending({
+    required ServerConfig config,
+    UserRow? user,
+  }) async {
+    final pending = await _resources.pendingUploads();
+    if (pending.isEmpty) return 0;
+    final endpoint = endpointFor(config);
+    final identity = await _identity.read();
+    for (final row in pending) {
+      await _enqueue(row, endpoint, identity, user);
+    }
+    return pending.length;
+  }
+
+  Future<void> _enqueue(
+    MyLibraryRow row,
+    String endpoint,
+    DeviceIdentity identity,
+    UserRow? user,
+  ) => _outbox.enqueue(
+    uploadType: type,
+    itemId: row.id,
+    endpoint: endpoint,
+    payload: {
+      ...serialize(
+        row,
+        // Deterministic, and the row's creation date is the honest value: the
+        // moment of the POST is what Kotlin sends, and this app cannot know it
+        // at enqueue time because the drain may be days later. See the class
+        // doc for what a drifting field costs here.
+        uploadedAt: row.createdDate,
+        addedById: user?.id,
+        planetCode: user?.planetCode,
+      ),
+      // `MyLibrary.serialize` carries `addDocumentOrigin()` plus both device
+      // names (`:187-189`), which is exactly [DeviceIdentity.documentFields].
+      // Layered at queue time rather than stored on the row, so a resource
+      // created under one device name and drained under another reports the
+      // current one — the Phase 44 convention.
+      ...identity.documentFields,
+    },
+    userId: user?.id,
+  );
+
+  /// The [OutboxHandler] for [type].
+  ///
+  /// Port of `UploadConfigs.getResourcesConfig`'s `markUploaded` followed by
+  /// `UploadManager.uploadResource`'s per-item `uploadAttachment` call. The
+  /// ordering is Kotlin's: the document is marked uploaded first, and the
+  /// attachment is attempted afterwards and best-effort.
+  ///
+  /// **Marking and sending are one step here, which closes a Kotlin hole.**
+  /// `RetryQueueWorker.processOperationInternal` re-POSTs a queued resource
+  /// document and calls only `retryQueue.markCompleted`
+  /// (`RetryQueueWorker.kt:231`) — never `markResourceUploaded` — so the local
+  /// row keeps `_rev = NULL`, stays inside `getPendingUploads()`, and the next
+  /// `uploadResource` POSTs it a second time. The same happens whenever
+  /// Kotlin's `markUploaded` reports a local failure: the document is filed and
+  /// the row is still pending. In this handler the mark is part of the send, so
+  /// a delivered document is always recorded as delivered.
+  ///
+  /// A 2xx whose body carries no usable `id`/`rev` is reported as a failure so
+  /// the row is not deleted while `_id` stays null — otherwise the next sweep
+  /// would find the resource pending again and POST a duplicate on every
+  /// drain, forever. [OutboxRepository] classifies that as
+  /// [OutboxRefusal.indeterminate] and does not retry it, which is the right
+  /// bound: this is an append with a server-assigned id, so a duplicate would
+  /// be undetectable afterwards and the transport already said the write
+  /// landed.
+  OutboxHandler get handler => (row, payload, authHeader) async {
+    final result = await _api.postJsonObject(
+      row.endpoint,
+      payload,
+      authHeader: authHeader,
+    );
+
+    if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
+      final couchId = data['id'];
+      final rev = data['rev'];
+      if (couchId is! String || rev is! String) {
+        return const NetworkError<Map<String, dynamic>>(
+          null,
+          'Upload response carried no id/rev',
+        );
+      }
+      // Port of `ResourcesRepositoryImpl.markResourceUploaded:803-806`. Its
+      // false return means the local row vanished between the POST and now,
+      // which Kotlin surfaces as a failed item via `markUploaded`'s
+      // `results.filter { !markResourceUploaded(…) }`. Here the document is
+      // already filed and there is no row left to attach bytes to or to
+      // re-POST, so the operation is finished: reporting failure would only
+      // keep an un-actionable row in the outbox.
+      final marked = await _resources.markResourceUploaded(
+        row.itemId,
+        couchId,
+        rev,
+      );
+      if (!marked) {
+        log('Resource ${row.itemId} disappeared before its id could be stored');
+        return result;
+      }
+      await _uploadAttachment(row, couchId, rev, authHeader);
+    }
+    return result;
+  };
+
+  /// PUTs the picked file to `resources/<id>/<name>` once the document POST
+  /// lands — the port of `FileUploader.uploadAttachment(id, rev, personal:
+  /// MyLibrary)`, with its path bug fixed.
+  ///
+  /// **The one key.** The bytes were written by
+  /// [ResourcesRepository.saveLocalResource] through
+  /// [ResourceFiles.fileFor] under the row's **local** id, and they are read
+  /// back here through [ResourceFiles.existingFileFor] under
+  /// `row.itemId` — which *is* that local id, because
+  /// [OutboxRepository.enqueue] is keyed on `MyLibraryRow.id`. One derivation,
+  /// one helper, both sides. Phase 100's verification photo is what happens
+  /// when the two sides each pick their own key, and
+  /// `resource_upload_round_trip_test.dart` drives the writer and this method
+  /// together rather than trusting either half's own fixture.
+  ///
+  /// A row with **no file** is a no-op, not an error, and that case is real
+  /// here rather than defensive: Kotlin refuses to save a resource without one
+  /// (`ResourcesRepositoryImpl.kt:235-238`) while the port's form does not, so
+  /// a metadata-only row can exist and its document is still worth filing.
+  /// Kotlin reaches the same outcome by accident — its `File(basename)` never
+  /// exists either, so every attachment took this branch.
+  Future<void> _uploadAttachment(
+    OutboxRow row,
+    String couchId,
+    String rev,
+    String? authHeader,
+  ) async {
+    final localAddress = (await _resources.getLibraryItemById(
+      row.itemId,
+    ))?.resourceLocalAddress;
+    if (localAddress == null || localAddress.isEmpty) return;
+
+    // No second `filename.isEmpty` guard, because there was one and mutation
+    // testing showed it could not fail: [ResourceFiles.existingFileFor]
+    // already returns null for an empty filename, so it — not this method —
+    // is what guarantees the no-op. The early return above is an optimisation
+    // that skips a pointless disk lookup, not the guarantee, and writing it as
+    // though it were the guarantee invites the next reader to stop checking.
+    final filename = p.basename(localAddress.replaceAll(r'\', '/'));
+
+    final file = await ResourceFiles.existingFileFor(
+      docId: row.itemId,
+      filename: filename,
+    );
+    if (file == null) return;
+
+    late final List<int> bytes;
+    try {
+      bytes = await file.readAsBytes();
+    } on Exception catch (e, stack) {
+      log('Could not read local resource file', error: e, stackTrace: stack);
+      return;
+    }
+
+    // `row.endpoint` is already `<db>/resources`, so the document id and the
+    // attachment name append directly — the same construction
+    // `SubmitPhotosUploader` uses, and the same
+    // `String.format("%s/resources/%s/%s", url, id, name)` Kotlin builds.
+    final attachmentUrl =
+        '${row.endpoint}/${Uri.encodeComponent(couchId)}'
+        '/${Uri.encodeComponent(filename)}';
+    final contentType = lookupMimeType(filename) ?? 'application/octet-stream';
+
+    final attachResult = await _api.uploadAttachment(
+      attachmentUrl,
+      bytes: bytes,
+      authHeader: authHeader,
+      // Kotlin passes the rev from the POST response as `If-Match`
+      // (`FileUploader.getHeaderMap:85`), which is how CouchDB accepts an
+      // attachment onto an existing document.
+      ifMatch: rev,
+      contentType: contentType,
+    );
+    if (attachResult case NetworkSuccess<Map<String, dynamic>>(:final data)) {
+      // CouchDB bumped the revision to accept these bytes. Kotlin discards
+      // that response, which leaves the local row a revision behind and makes
+      // the next sync ask the user to re-download their own file; see
+      // [MyLibraryDao.adoptAttachmentRev].
+      final newRev = data['rev'];
+      if (newRev is String && newRev.isNotEmpty) {
+        await _resources.adoptAttachmentRev(row.itemId, newRev);
+      }
+    } else {
+      log('Resource attachment upload failed: $attachResult');
+    }
+  }
+
+  static String authHeaderFor(ServerConfig config) =>
+      UrlUtils.authHeader(config);
+}
+
+/// The safety net, and **it is not wired up** — see the note below.
+///
+/// Kotlin's `uploadResource` has exactly the unconditional-sweep property
+/// Phase 134 was about: three callers with no precondition on how the row got
+/// there (`AutoSyncWorker.kt:129`, `UserDataWorker.kt:84`,
+/// `TeamsRepositoryImpl.kt:928`). The port has **one** enqueue site, in
+/// `add_resource_screen._save`, so a resource whose enqueue never ran has
+/// nothing to deliver it.
+///
+/// That window is narrower than the submissions one Phase 134 closed, because
+/// the write site calls [ResourcesUploader.queuePending] — an *unscoped* sweep
+/// — rather than enqueuing the one row it just wrote, so saving any resource
+/// rescues every stranded one. It is not closed. A user who creates a resource
+/// with no server configured (`serverConfigProvider` null, which is the whole
+/// offline-first premise), or whose process dies between the row write and the
+/// enqueue, and who never returns to that screen, never uploads it — and the
+/// row is invisible in Planet for ever, with the reset-app action able to
+/// destroy it in the meantime.
+///
+/// **`lib/background_entrypoint.dart` belongs to another lane this round**, so
+/// the two calls that close it are reported rather than made. They belong
+/// beside the existing voices and submissions sweeps: this one in
+/// `drainOutbox`, for the reason `sweepPendingVoices` documents at length —
+/// `syncSteps` runs only for a due `autoSync` task with auto-sync enabled,
+/// which is precisely not the user most likely to have an undelivered write.
+/// Ordering against the other sweeps is free: no sync step writes `my_library`
+/// rows over a locally authored one ([MyLibraryMapper.fromDoc] keys on the
+/// CouchDB `_id`, and a pending resource has none), and the port's own
+/// `deleteNotIn` already spares a row with no `_rev`.
+///
+/// [userId] is nullable and a null one is not an early return: Kotlin passes
+/// `user?.id` and `user?.planetCode` straight through, so a handset whose
+/// session has gone still sends the resource, minus its attribution. A handset
+/// whose session has gone is exactly the one with a stranded write on it.
+///
+/// Exposed because `executeBackgroundTask` needs a Flutter binding, real
+/// preferences and a WorkManager engine, so a body written inline in that
+/// closure is unreachable from a unit test — the same reason the sweeps it
+/// sits beside are.
+@visibleForTesting
+Future<void> sweepPendingResources(
+  ProviderContainer container, {
+  required ServerConfig config,
+  required String? userId,
+}) async {
+  try {
+    final user = userId == null
+        ? null
+        : await container.read(userDaoProvider).getById(userId);
+    await container
+        .read(resourcesUploaderProvider)
+        .queuePending(config: config, user: user);
+  } catch (_) {
+    // Swallowed for the reason the sweeps beside it are: a throwing
+    // `drainOutbox` adds `outboxDrain` to the runner's `failedSteps` and asks
+    // the OS to retry the whole task, and no Kotlin caller of `uploadResource`
+    // does that — `UserDataWorker` wraps it and still returns
+    // `Result.success()`. Not hypothetical: `queuePending` reads device
+    // identity, which rethrows on an engine with no channel and no primed
+    // cache.
+  }
+}

--- a/flutter/lib/ui/resources/add_resource_screen.dart
+++ b/flutter/lib/ui/resources/add_resource_screen.dart
@@ -181,6 +181,55 @@ class _AddResourceScreenState extends ConsumerState<AddResourceScreen> {
       error = await repo.saveLocalResource(request);
     }
 
+    // Hand the row to the outbox. Until this landed nothing ever uploaded a
+    // resource the user created: `saveLocalResource` was a complete port whose
+    // output went nowhere, so the resource existed on this handset alone.
+    //
+    // `queuePending` rather than a single-row enqueue, for two reasons. The
+    // create path cannot name the row — `saveLocalResource` mints the id
+    // itself and returns only an error — and sweeping every pending resource
+    // is strictly more useful anyway: this is the one screen a user reliably
+    // reaches, so it also rescues a resource whose own enqueue was lost.
+    //
+    // It runs after an **edit** too, and deliberately. Kotlin re-serializes at
+    // upload time and so picks up an edit for free; the port stores the
+    // payload at enqueue time, so without this an edit to a not-yet-uploaded
+    // resource would be saved locally while the *pre-edit* document went to
+    // the server. For a resource that has already synced there is nothing
+    // pending to find and this does nothing — which matches Kotlin, whose only
+    // upload path is that same pending query, so it never sends an edit to an
+    // existing document either.
+    //
+    // Gated on a successful save because a failed one wrote no row, and on a
+    // configured server because the endpoint is built from it.
+    if (error == null) {
+      try {
+        final config = ref.read(serverConfigProvider);
+        if (config != null) {
+          await ref
+              .read(resourcesUploaderProvider)
+              .queuePending(config: config, user: user);
+        }
+      } catch (_) {
+        // The row is already written, so a failed enqueue must not turn a
+        // successful save into the form's error message — the honest outcome
+        // is "saved, not yet sent", which is what an offline-first app does
+        // all the time. `sweepPendingResources` is what then delivers it, and
+        // it swallows for the same reason.
+        //
+        // Not defensive padding: `queuePending` reads device identity, which
+        // rethrows on an engine with no platform channel and no primed cache,
+        // and `serverConfigProvider` itself reads `planetPrefsProvider`. This
+        // is also the Phase 75 harness shape — that transitive read is
+        // `UnimplementedError` in a widget test that has not overridden it —
+        // and swallowing it here would have made the enqueue *silently
+        // absent* from every screen test, which is the green-but-dead trap
+        // this project keeps finding. `add_resource_screen_test` overrides
+        // `serverConfigProvider` and asserts the outbox row exists, so the
+        // catch cannot hide the enqueue.
+      }
+    }
+
     if (!mounted) return;
     setState(() => _saving = false);
 

--- a/flutter/test/providers/pending_resources_sweep_test.dart
+++ b/flutter/test/providers/pending_resources_sweep_test.dart
@@ -1,0 +1,267 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/files/resource_files.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/system/device_identity.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/repository/local_resource_request.dart';
+import 'package:myplanet/repository/resources_uploader.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../repository/device_identity_fixture.dart';
+import '../support/widget_harness.dart';
+
+class _MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The safety-net question, asked of the resource upload direction.
+///
+/// Kotlin reaches the server for a locally created resource from an
+/// **unconditional sweep**: `UploadManager.uploadResource` reads
+/// `getPendingResourceUploads()` — every row with no revision — and
+/// `AutoSyncWorker:129`, `UserDataWorker:84` and `TeamsRepositoryImpl:928`
+/// call it off nothing the resource itself did.
+///
+/// The port enqueues at write time, from `add_resource_screen._save`. Better
+/// when it runs; nothing when it does not. Phase 134 is the standing lesson:
+/// every layer had passing tests and **nothing asked whether the sweep knew
+/// about the write**.
+///
+/// [sweepPendingResources] is the headless half, and these tests drive it
+/// directly because `lib/background_entrypoint.dart` belongs to another lane
+/// this round — so the call it needs is reported in the PR rather than made.
+/// **The feature is incomplete without that wiring**, and these tests are what
+/// make the missing call a one-liner instead of a rediscovery.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  late AppDatabase db;
+  late _MockPlanetApi api;
+  late Directory sandbox;
+  late Directory source;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.memory();
+    api = _MockPlanetApi();
+    sandbox = await Directory.systemTemp.createTemp('res-sweep-docs');
+    source = await Directory.systemTemp.createTemp('res-sweep-pick');
+    ResourceFiles.baseDirectory = () async => sandbox;
+  });
+  tearDown(() async {
+    ResourceFiles.baseDirectory = () async => Directory.systemTemp;
+    await db.close();
+    await sandbox.delete(recursive: true);
+    await source.delete(recursive: true);
+  });
+
+  Future<ProviderContainer> containerFor({
+    DeviceIdentitySource identity = testDeviceIdentity,
+  }) async {
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        planetApiProvider.overrideWithValue(api),
+        planetPrefsProvider.overrideWithValue(
+          PlanetPrefs(await SharedPreferences.getInstance()),
+        ),
+        deviceIdentitySourceProvider.overrideWithValue(identity),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  void acceptPosts() {
+    var posts = 0;
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((_) async {
+      posts++;
+      return NetworkSuccess<Map<String, dynamic>>({
+        'id': 'server-id-$posts',
+        'rev': '$posts-rev',
+      });
+    });
+    when(
+      () => api.uploadAttachment(
+        any(),
+        bytes: any(named: 'bytes'),
+        authHeader: any(named: 'authHeader'),
+        contentType: any(named: 'contentType'),
+        ifMatch: any(named: 'ifMatch'),
+      ),
+    ).thenAnswer(
+      (_) async => const NetworkSuccess<Map<String, dynamic>>({'ok': true}),
+    );
+  }
+
+  /// The reported state: a `my_library` row the user created, with no `_id`
+  /// and **no** outbox row — the resource whose one write-time enqueue never
+  /// ran, which before this lane was every resource ever created.
+  Future<String> seedStrandedResource(ProviderContainer container) async {
+    final picked = File('${source.path}/well.pdf');
+    await picked.writeAsString('water table falling');
+    final error = await container
+        .read(resourcesRepositoryProvider)
+        .saveLocalResource(
+          LocalResourceRequest(
+            title: 'Well survey',
+            userId: 'org.couchdb.user:ada',
+            resourceUrl: picked.path,
+            mediaType: 'pdf',
+          ),
+        );
+    expect(error, isNull);
+    final row = (await db.myLibraryDao.getAll()).single;
+    expect(
+      await db.outboxDao.forItem(ResourcesUploader.type, row.id),
+      isEmpty,
+      reason: 'the fixture must reproduce the stranded state, not assume it',
+    );
+    return row.id;
+  }
+
+  test('the sweep delivers a resource nothing enqueued', () async {
+    final container = await containerFor();
+    final id = await seedStrandedResource(container);
+    acceptPosts();
+
+    await sweepPendingResources(container, config: config, userId: null);
+    await container.read(outboxDrainerProvider).drain();
+
+    final row = await db.myLibraryDao.getById(id);
+    expect(
+      row?.couchId,
+      'server-id-1',
+      reason:
+          'without a sweep this resource is invisible in Planet for ever, '
+          'and reset-app can destroy it in the meantime',
+    );
+    expect(row?.rev, '1-rev');
+  });
+
+  test(
+    'a null session still sends the resource, minus its attribution',
+    () async {
+      // Kotlin passes `user?.id` and `user?.planetCode` straight into the
+      // serializer with no guard (`MyLibrary.kt:161`, `:181-182`), so a handset
+      // whose session has gone still uploads — and that is precisely the handset
+      // most likely to be carrying a stranded write.
+      final container = await containerFor();
+      await seedStrandedResource(container);
+      acceptPosts();
+
+      await sweepPendingResources(container, config: config, userId: null);
+
+      final payload = (await db.outboxDao.due(
+        DateTime.now().millisecondsSinceEpoch,
+      )).single.payload;
+      expect(payload, contains('"addedBy":null'));
+      expect(payload, contains('"sourcePlanet":null'));
+      expect(payload, contains('"title":"Well survey"'));
+    },
+  );
+
+  test('a resolvable session supplies addedBy and the planet code', () async {
+    final container = await containerFor();
+    await db.userDao.upsertAll([
+      buildUserRow(
+        id: 'org.couchdb.user:ada',
+        name: 'ada',
+      ).copyWith(planetCode: const Value('guatemala')).toCompanion(true),
+    ]);
+    await seedStrandedResource(container);
+    acceptPosts();
+
+    await sweepPendingResources(
+      container,
+      config: config,
+      userId: 'org.couchdb.user:ada',
+    );
+
+    final payload = (await db.outboxDao.due(
+      DateTime.now().millisecondsSinceEpoch,
+    )).single.payload;
+    expect(payload, contains('"addedBy":"org.couchdb.user:ada"'));
+    expect(payload, contains('"sourcePlanet":"guatemala"'));
+    expect(payload, contains('"resideOn":"guatemala"'));
+  });
+
+  test('the write-time enqueue and the sweep send one document', () async {
+    // The pair Phase 134 says to test. `OutboxRepository.enqueue` keys on
+    // `(uploadType, itemId)`, so the sweep refreshes the queued row rather
+    // than adding a second; and the pending predicate stops offering a row
+    // once its `_id` is recorded. Two independent protections, which is one
+    // more than Kotlin has — Kotlin relies on the predicate alone, and
+    // `RetryQueueWorker` bypasses the mark that satisfies it.
+    final container = await containerFor();
+    final id = await seedStrandedResource(container);
+    acceptPosts();
+
+    await container
+        .read(resourcesUploaderProvider)
+        .queuePending(config: config, user: null);
+    expect(
+      await db.outboxDao.forItem(ResourcesUploader.type, id),
+      hasLength(1),
+    );
+
+    await sweepPendingResources(container, config: config, userId: null);
+    expect(
+      await db.outboxDao.forItem(ResourcesUploader.type, id),
+      hasLength(1),
+      reason: 'a sweep over an already-queued resource must not add a row',
+    );
+
+    await container.read(outboxDrainerProvider).drain();
+    await sweepPendingResources(container, config: config, userId: null);
+    await container.read(outboxDrainerProvider).drain();
+
+    verify(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).called(1);
+  });
+
+  test('the sweep swallows a device-identity failure', () async {
+    // A throwing `drainOutbox` adds `outboxDrain` to the runner's
+    // `failedSteps` and asks the OS to retry the whole task. No Kotlin caller
+    // of `uploadResource` does that. `queuePending` reads device identity,
+    // which rethrows on a headless engine with no channel and no primed
+    // cache — the concrete way this fires.
+    final container = await containerFor(identity: const _ThrowingIdentity());
+    await seedStrandedResource(container);
+
+    await expectLater(
+      sweepPendingResources(container, config: config, userId: null),
+      completes,
+    );
+  });
+}
+
+class _ThrowingIdentity implements DeviceIdentitySource {
+  const _ThrowingIdentity();
+
+  @override
+  Future<DeviceIdentity> read() async =>
+      throw StateError('no platform channel on this engine');
+}

--- a/flutter/test/repository/resources_uploader_test.dart
+++ b/flutter/test/repository/resources_uploader_test.dart
@@ -15,6 +15,8 @@ import 'package:myplanet/repository/outbox_drainer.dart';
 import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/repository/resources_repository.dart';
 import 'package:myplanet/repository/resources_uploader.dart';
+import 'package:myplanet/repository/teams_repository.dart';
+import 'package:myplanet/repository/teams_uploader.dart';
 
 import 'device_identity_fixture.dart';
 
@@ -36,6 +38,7 @@ void main() {
   late AppDatabase database;
   late MockPlanetApi api;
   late ResourcesRepository resources;
+  late TeamsRepository teams;
   late OutboxRepository outbox;
   late ResourcesUploader uploader;
   late Directory sandbox;
@@ -44,8 +47,11 @@ void main() {
 
   const config = ServerConfig(
     serverUrl: 'https://planet.example.org',
-    pin: '1234',
-    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+    // Deliberately not a digit run: the payload carries 13-digit epoch
+    // timestamps, so `isNot(contains(pin))` against '1234' has a real chance
+    // of matching one by accident and reading as a pass.
+    pin: 'p1n-9x7',
+    couchDbUrl: 'https://satellite:p1n-9x7@planet.example.org:443',
   );
 
   final user = UserRow(
@@ -69,7 +75,19 @@ void main() {
       database.removedLogDao,
     );
     outbox = OutboxRepository(database.outboxDao, now: () => clock);
-    uploader = ResourcesUploader(api, resources, outbox, testDeviceIdentity);
+    teams = TeamsRepository(
+      api,
+      database.teamDao,
+      database.teamLogDao,
+      createId: () => 'link-1',
+    );
+    uploader = ResourcesUploader(
+      api,
+      resources,
+      teams,
+      outbox,
+      testDeviceIdentity,
+    );
     sandbox = await Directory.systemTemp.createTemp('res-upload-docs');
     source = await Directory.systemTemp.createTemp('res-upload-pick');
     ResourceFiles.baseDirectory = () async => sandbox;
@@ -280,6 +298,36 @@ void main() {
       },
     );
 
+    test(
+      'filename uses the attachment spelling, not the URI-decoded one',
+      () async {
+        // The phase's most-argued decision, and it was pinned by nothing:
+        // `well-survey.pdf` and `deep/dir/book.epub` are names on which
+        // `p.basename` and Kotlin's `getFileNameFromUrl` agree, so a future
+        // "make it faithful to `getFileNameFromUrl`" change passed every test.
+        //
+        // Kotlin derives this field twice, differently: the document gets
+        // `getFileNameFromUrl` (`MyLibrary.kt:159`), which URI-parses and
+        // `URLDecoder.decode`s the last segment, while the attachment PUT names
+        // the file with `getFileNameFromLocalAddress` (`FileUploader.kt:38`), a
+        // plain `substringAfterLast('/')`. `a+b.pdf` is where they part —
+        // `URLDecoder` turns `+` into a space — and a document whose `filename`
+        // does not match its attachment's name is a resource Planet cannot
+        // resolve. The attachment spelling wins, because it names bytes that
+        // really exist.
+        await saveLocal(path: (await pickedFile(name: 'a+b.pdf')).path);
+        final plus = await soleRow();
+        expect(plus.resourceLocalAddress, 'a+b.pdf');
+        expect(
+          ResourcesUploader.serialize(plus, uploadedAt: 1)['filename'],
+          'a+b.pdf',
+          reason:
+              "getFileNameFromUrl would give 'a b.pdf' and contradict the "
+              'attachment PUT below',
+        );
+      },
+    );
+
     test('filename is the basename, or empty when there is no file', () async {
       await saveLocal();
       final row = await soleRow();
@@ -483,7 +531,74 @@ void main() {
       );
       // Indeterminate: the transport said the write landed, and a duplicate
       // append with a server-assigned id cannot be detected afterwards.
+      //
+      // `expect(await outbox.due(), isEmpty)` alone **cannot fail** here, and
+      // that is worth saying out loud: a `transient` classification would set
+      // `nextAttemptAt = now + 60s` and, with the clock unmoved, `due()` is
+      // empty either way. So the clock is advanced well past any backoff and
+      // the drain re-run — a regression that made `noUsableResponse` transient
+      // would re-POST this append, which is the whole harm.
       expect(await outbox.due(), isEmpty);
+      clock = clock.add(const Duration(hours: 2));
+      expect(await outbox.due(), isEmpty);
+      await drainer().drain();
+      verify(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).called(1);
+    });
+
+    test('an in-flight resource is not re-enqueued over', () async {
+      // **A resource POST is an append, so a duplicate is undetectable.**
+      // `enqueue` puts an `in_progress` row back to `pending` to preserve a
+      // mid-flight payload edit, and `markCompleted` is `deleteIfInProgress`
+      // — so without the `isInFlight` guard the succeeding send deletes
+      // nothing, the row survives `pending` with the same body, and the next
+      // drain files a **second CouchDB document**. The handler carries no
+      // `_id`, so the server mints a fresh one and `markResourceUploaded`
+      // repoints the local row at the duplicate, leaving the first document an
+      // unidentifiable orphan.
+      //
+      // Reached by a drain claiming the row on a slow link while the user
+      // saves another resource — `_save` sweeps every pending row, this one
+      // included. Driven here by re-entering `queuePending` from inside the
+      // POST, which is that interleaving exactly.
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+      final id = (await soleRow()).id;
+
+      var posts = 0;
+      when(
+        () => api.postJsonObject(
+          any(),
+          any(),
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer((_) async {
+        posts++;
+        // The user's second save, mid-flight.
+        await uploader.queuePending(config: config, user: user);
+        return NetworkSuccess<Map<String, dynamic>>({
+          'id': 'srv-$posts',
+          'rev': '$posts-a',
+        });
+      });
+      stubAttachment();
+
+      await drainer().drain();
+      clock = clock.add(const Duration(hours: 1));
+      await drainer().drain();
+
+      expect(posts, 1, reason: 'a second POST is a second document in Planet');
+      expect((await soleRow()).couchId, 'srv-1');
+      expect(
+        await database.outboxDao.forItem(ResourcesUploader.type, id),
+        isEmpty,
+        reason: 'the completed row must actually be deleted, not resurrected',
+      );
     });
 
     test(
@@ -806,6 +921,122 @@ void main() {
             ifMatch: any(named: 'ifMatch'),
           ),
         );
+      },
+    );
+
+    test(
+      'a private team resource gains its resourceLink, keyed on the CouchDB id',
+      () async {
+        // Port of `markResourceUploaded`'s second half
+        // (`ResourcesRepositoryImpl.kt:808-816`), which this phase first omitted
+        // on the false premise that the port had no `createLocalResourceLink`.
+        // It has `TeamsRepository.addResourceLink`; the search was for the
+        // Kotlin name rather than the behaviour.
+        //
+        // Without it a team leader's private resource uploads its own document
+        // and **no team links to it**: the team's Resources tab is empty on
+        // Planet and on every other member's handset, for bytes already on the
+        // server.
+        await saveLocal(
+          path: (await pickedFile()).path,
+          private: true,
+          teamId: 'team-7',
+        );
+        await uploader.queuePending(config: config, user: user);
+        stubPost(
+          const NetworkSuccess<Map<String, dynamic>>({
+            'id': 'srv-private',
+            'rev': '1-p',
+          }),
+        );
+        stubAttachment();
+
+        expect(await drainer().drain(), [OutboxOutcome.completed]);
+
+        final link = await database.teamDao.getById('link-1');
+        expect(link, isNotNull, reason: 'the resourceLink row must be written');
+        expect(link!.teamId, 'team-7');
+        expect(link.docType, 'resourceLink');
+        expect(link.teamType, 'local');
+        expect(
+          link.resourceId,
+          'srv-private',
+          reason:
+              'the link must name the CouchDB document. `markUploaded` leaves '
+              '`resourceId` at the local uuid, so linking before the POST — as '
+              "`TeamResourceActions.add` does — would name a document that "
+              'does not exist. Kotlin puts this inside markResourceUploaded '
+              'for exactly this reason',
+        );
+
+        // Writing the row alone would leave the link local, so it is enqueued
+        // the way `TeamResourceActions.add` enqueues one. Kotlin needs no
+        // equivalent: its `updated = true` is swept by the team upload pass.
+        final queued = await database.outboxDao.forItem(
+          TeamsUploader.resourceType,
+          'link-1',
+        );
+        expect(queued, hasLength(1));
+        expect(queued.single.endpoint, 'https://planet.example.org/db/teams');
+        expect(queued.single.payload, contains('"resourceId":"srv-private"'));
+      },
+    );
+
+    test('a public resource gets no team link', () async {
+      // Kotlin's condition is `isPrivate && !privateFor.isNullOrBlank()`, so
+      // both halves matter — a public resource created from a team context
+      // must not be linked.
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+      stubPost(
+        const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'srv-a',
+          'rev': '1-a',
+        }),
+      );
+      stubAttachment();
+      await drainer().drain();
+
+      expect(await database.teamDao.getById('link-1'), isNull);
+      expect(
+        await database.outboxDao.forItem(TeamsUploader.resourceType, 'link-1'),
+        isEmpty,
+      );
+    });
+
+    test(
+      'a privateFor with isPrivate false gets no team link either',
+      () async {
+        // Mutation testing found the `isPrivate` half of the gate pinned by
+        // nothing: the public-resource test above has `privateFor` null, so the
+        // team-id clause alone excludes it, and `saveLocalResource` moves the
+        // two columns together so no port writer produces this shape.
+        //
+        // The clause is defence in depth — it is Kotlin's explicit two-part
+        // condition, `isPrivate && !privateFor.isNullOrBlank()`
+        // (`ResourcesRepositoryImpl.kt:809`) — so it gets a hand-built row
+        // rather than a comment claiming it matters. A clause pinned by nothing
+        // reads as coverage.
+        await saveLocal(path: (await pickedFile()).path);
+        final row = await soleRow();
+        await database.myLibraryDao.upsertAll([
+          row
+              .copyWith(isPrivate: false, privateFor: const Value('team-9'))
+              .toCompanion(true),
+        ]);
+
+        await uploader.queuePending(config: config, user: user);
+        stubPost(
+          const NetworkSuccess<Map<String, dynamic>>({
+            'id': 'srv-b',
+            'rev': '1-b',
+          }),
+        );
+        stubAttachment();
+        await drainer().drain();
+
+        expect((await soleRow()).couchId, 'srv-b');
+        expect(await database.teamDao.getById('link-1'), isNull);
       },
     );
 

--- a/flutter/test/repository/resources_uploader_test.dart
+++ b/flutter/test/repository/resources_uploader_test.dart
@@ -1,0 +1,839 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/files/resource_files.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/my_library_mapper.dart';
+import 'package:myplanet/repository/local_resource_request.dart';
+import 'package:myplanet/repository/outbox_drainer.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
+import 'package:myplanet/repository/resources_repository.dart';
+import 'package:myplanet/repository/resources_uploader.dart';
+
+import 'device_identity_fixture.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The resource **upload** direction, which the port did not have at all.
+///
+/// `ResourcesRepository.saveLocalResource` has been a careful port for several
+/// phases and nothing ever sent what it wrote, so a resource the user created
+/// lived on that handset alone. Kotlin runs this direction from three places
+/// (`AutoSyncWorker:129`, `UserDataWorker:84`, `TeamsRepositoryImpl:928`).
+///
+/// The load-bearing test in this file is *the round trip* — it drives
+/// `saveLocalResource` and the uploader's handler together and asserts the
+/// attachment PUT carries the bytes the writer actually put on disk. Every
+/// other test here could pass with the two halves disagreeing about where the
+/// file is, which is exactly how Phase 100 lost the exam verification photo.
+void main() {
+  late AppDatabase database;
+  late MockPlanetApi api;
+  late ResourcesRepository resources;
+  late OutboxRepository outbox;
+  late ResourcesUploader uploader;
+  late Directory sandbox;
+  late Directory source;
+  var clock = DateTime.fromMillisecondsSinceEpoch(1000);
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+
+  final user = UserRow(
+    id: 'org.couchdb.user:ada',
+    name: 'ada',
+    rolesList: const [],
+    userAdmin: false,
+    joinDate: 0,
+    isArchived: false,
+    isUpdated: false,
+    planetCode: 'guatemala',
+  );
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    api = MockPlanetApi();
+    clock = DateTime.fromMillisecondsSinceEpoch(1000);
+    resources = ResourcesRepository(
+      api,
+      database.myLibraryDao,
+      database.removedLogDao,
+    );
+    outbox = OutboxRepository(database.outboxDao, now: () => clock);
+    uploader = ResourcesUploader(api, resources, outbox, testDeviceIdentity);
+    sandbox = await Directory.systemTemp.createTemp('res-upload-docs');
+    source = await Directory.systemTemp.createTemp('res-upload-pick');
+    ResourceFiles.baseDirectory = () async => sandbox;
+  });
+
+  tearDown(() async {
+    ResourceFiles.baseDirectory = getApplicationDocumentsDirectoryFallback;
+    await database.close();
+    await sandbox.delete(recursive: true);
+    await source.delete(recursive: true);
+  });
+
+  void stubPost(NetworkResult<Map<String, dynamic>> result) {
+    when(
+      () => api.postJsonObject(
+        any(),
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void stubAttachment([
+    NetworkResult<Map<String, dynamic>> result =
+        const NetworkSuccess<Map<String, dynamic>>({'ok': true}),
+  ]) {
+    when(
+      () => api.uploadAttachment(
+        any(),
+        bytes: any(named: 'bytes'),
+        authHeader: any(named: 'authHeader'),
+        contentType: any(named: 'contentType'),
+        ifMatch: any(named: 'ifMatch'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  OutboxDrainer drainer() => OutboxDrainer(
+    api,
+    outbox,
+    handlers: {ResourcesUploader.type: uploader.handler},
+  );
+
+  /// Writes a file the picker would have handed the screen.
+  Future<File> pickedFile({
+    String name = 'well-survey.pdf',
+    String contents = 'water table falling',
+  }) async {
+    final file = File('${source.path}/$name');
+    await file.writeAsString(contents);
+    return file;
+  }
+
+  Future<void> saveLocal({
+    String title = 'Well survey notes',
+    String? path,
+    bool private = false,
+    String? teamId,
+  }) async {
+    final error = await resources.saveLocalResource(
+      LocalResourceRequest(
+        title: title,
+        userId: user.id,
+        addedBy: user.name,
+        author: 'Ada Lovelace',
+        year: '2026',
+        description: 'Notes from the district well',
+        publisher: 'OLE',
+        linkToLicense: 'https://cc.example/by',
+        openWith: 'HTML',
+        language: 'English',
+        mediaType: 'pdf',
+        resourceType: 'Reference',
+        subjects: const ['Science'],
+        levels: const ['Primary'],
+        resourceFor: const ['Learners'],
+        resourceUrl: path,
+        isPrivateTeamResource: private,
+        teamId: teamId,
+      ),
+    );
+    expect(error, isNull, reason: 'the fixture should save cleanly');
+  }
+
+  Future<MyLibraryRow> soleRow() async {
+    final rows = await database.myLibraryDao.getAll();
+    return rows.single;
+  }
+
+  // ---------------------------------------------------------------- serializer
+
+  group('serialize (MyLibrary.serialize:154-189)', () {
+    test('sends every field the Kotlin create payload sends', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      final row = await soleRow();
+
+      expect(
+        ResourcesUploader.serialize(
+          row,
+          uploadedAt: 4242,
+          addedById: user.id,
+          planetCode: user.planetCode,
+        ),
+        {
+          'title': 'Well survey notes',
+          'uploadDate': 4242,
+          'createdDate': row.createdDate,
+          'filename': 'well-survey.pdf',
+          'author': 'Ada Lovelace',
+          // The user's **id**, not the row's `addedBy` column, which holds the
+          // display name. Kotlin: `addProperty("addedBy", user?.id)`.
+          'addedBy': 'org.couchdb.user:ada',
+          'medium': null,
+          'description': 'Notes from the district well',
+          'year': '2026',
+          'language': 'English',
+          'publisher': 'OLE',
+          'linkToLicense': 'https://cc.example/by',
+          'subject': ['Science'],
+          'level': ['Primary'],
+          'resourceType': 'Reference',
+          'openWith': 'HTML',
+          'mediaType': 'pdf',
+          'resourceFor': ['Learners'],
+          'private': false,
+          'isDownloadable': true,
+          'sourcePlanet': 'guatemala',
+          'resideOn': 'guatemala',
+          'updatedDate': 4242,
+        },
+        reason:
+            'Phase 103: a payload whose keys Planet does not read is a '
+            'document the server cannot parse, not a cosmetic defect',
+      );
+    });
+
+    test('reproduces the null-vs-empty-string asymmetry', () async {
+      // Kotlin coalesces exactly three fields to '' and leaves the rest as
+      // JSON null. Tidying that up either way would change what Planet sees.
+      await saveLocal();
+      final bare = (await soleRow()).copyWith(
+        author: const Value(null),
+        publisher: const Value(null),
+        linkToLicense: const Value(null),
+        description: const Value(null),
+        year: const Value(null),
+        language: const Value(null),
+        resourceType: const Value(null),
+        openWith: const Value(null),
+        mediaType: const Value(null),
+      );
+
+      final json = ResourcesUploader.serialize(bare, uploadedAt: 1);
+
+      expect(json['author'], '');
+      expect(json['publisher'], '');
+      expect(json['linkToLicense'], '');
+      // `mediaType` has its own default, and it is not ''.
+      expect(json['mediaType'], 'other');
+      for (final key in [
+        'medium',
+        'description',
+        'year',
+        'language',
+        'resourceType',
+        'openWith',
+      ]) {
+        expect(json.containsKey(key), isTrue, reason: '$key must be present');
+        expect(json[key], isNull, reason: '$key must be null, not ""');
+      }
+    });
+
+    test(
+      'privateFor is a nested object, and only for a private team resource',
+      () async {
+        await saveLocal(
+          path: (await pickedFile()).path,
+          private: true,
+          teamId: 'team-7',
+        );
+        final private = await soleRow();
+
+        expect(
+          ResourcesUploader.serialize(private, uploadedAt: 1)['privateFor'],
+          {'teams': 'team-7'},
+        );
+        expect(
+          ResourcesUploader.serialize(private, uploadedAt: 1)['private'],
+          isTrue,
+        );
+
+        // Kotlin's condition is `isPrivate && privateFor != null`, so both a
+        // public resource and a private one with no team omit the key entirely.
+        expect(
+          ResourcesUploader.serialize(
+            private.copyWith(privateFor: const Value(null)),
+            uploadedAt: 1,
+          ).containsKey('privateFor'),
+          isFalse,
+        );
+        expect(
+          ResourcesUploader.serialize(
+            private.copyWith(isPrivate: false),
+            uploadedAt: 1,
+          ).containsKey('privateFor'),
+          isFalse,
+        );
+      },
+    );
+
+    test('filename is the basename, or empty when there is no file', () async {
+      await saveLocal();
+      final row = await soleRow();
+
+      expect(ResourcesUploader.serialize(row, uploadedAt: 1)['filename'], '');
+      expect(
+        ResourcesUploader.serialize(
+          row.copyWith(resourceLocalAddress: const Value('deep/dir/book.epub')),
+          uploadedAt: 1,
+        )['filename'],
+        'book.epub',
+      );
+    });
+
+    test('carries no _id or _rev — this is a create, not an update', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      final json = ResourcesUploader.serialize(await soleRow(), uploadedAt: 1);
+      expect(json.containsKey('_id'), isFalse);
+      expect(json.containsKey('_rev'), isFalse);
+    });
+  });
+
+  // ------------------------------------------------------- pending predicate
+
+  group('pendingUploads', () {
+    test('finds a resource this device authored', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      expect(await resources.pendingUploads(), hasLength(1));
+    });
+
+    test('excludes a course-embedded resource with no _rev', () async {
+      // **The reason this port does not copy Kotlin's predicate.**
+      //
+      // Kotlin's is `WHERE _rev IS NULL` (`MyLibraryDao.kt:94`). `my_library`
+      // has two writers and only one sees a `_rev`: the resources walk pulls
+      // whole documents, the courses walk pulls the thinner copy embedded in a
+      // course step, and a sub-object carries none. Phase 150 made the port
+      // leave `rev` absent in that case — correctly, for reasons at
+      // `MyLibraryMapper._revOrAbsent` — which removed the accidental guard
+      // Kotlin leans on: Kotlin writes `""` there, via `JsonUtils.getString`
+      // on a missing key, and `_rev IS NULL` does not match an empty string.
+      //
+      // Under the literal predicate this row would be POSTed to `resources`,
+      // filing a **second copy of a document that already exists** — one per
+      // course resource, on the first drain after the first courses sync.
+      final embedded = MyLibraryMapper.fromDoc(
+        // A step's `resources` sub-object: an `_id`, no `_rev`.
+        const {'_id': 'srv-course-res', 'title': 'Embedded reader'},
+        couchDbUrl: config.couchDbUrl,
+        stepId: 'course-1:0',
+        courseId: 'course-1',
+      );
+      await database.myLibraryDao.upsertAll([embedded!]);
+
+      final stored = await database.myLibraryDao.getById('srv-course-res');
+      expect(
+        stored?.rev,
+        isNull,
+        reason: 'the fixture must reproduce the null rev, or it proves nothing',
+      );
+      expect(stored?.couchId, 'srv-course-res');
+
+      expect(
+        await resources.pendingUploads(),
+        isEmpty,
+        reason:
+            'a row carrying a server _id cannot have been authored here, '
+            'whatever its _rev says',
+      );
+    });
+
+    test('excludes a resource that has already been uploaded', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      final row = await soleRow();
+      expect(
+        await resources.markResourceUploaded(row.id, 'srv-1', '1-a'),
+        isTrue,
+      );
+      expect(await resources.pendingUploads(), isEmpty);
+    });
+
+    test('excludes a row carrying a _rev but no _id', () async {
+      // Mutation testing found the `_rev IS NULL` half of the predicate pinned
+      // by **nothing**: `markResourceUploaded` writes `_id` and `_rev`
+      // together, so the already-uploaded test above passes on the `_id`
+      // clause alone, and no port writer produces this shape today. That makes
+      // the clause defence in depth rather than dead — it is the half Kotlin
+      // actually relies on — so it gets a row built by hand rather than a
+      // comment claiming it matters. A clause pinned by nothing reads as
+      // coverage.
+      await database.myLibraryDao.upsertAll([
+        MyLibraryTableCompanion.insert(
+          id: 'odd-row',
+          title: const Value('Half-identified'),
+          rev: const Value('1-a'),
+        ),
+      ]);
+      expect(await resources.pendingUploads(), isEmpty);
+    });
+
+    test('markResourceUploaded reports a row that vanished', () async {
+      expect(
+        await resources.markResourceUploaded('gone', 'srv-1', '1-a'),
+        isFalse,
+        reason:
+            'Kotlin returns false from `getById(localId) ?: return false`, '
+            'and `markUploaded` filters on it to report a failed item',
+      );
+    });
+  });
+
+  // ------------------------------------------------------------------- outbox
+
+  group('outbox behaviour', () {
+    test('the endpoint and the queued row carry no credentials', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+
+      expect(
+        ResourcesUploader.endpointFor(config),
+        'https://planet.example.org/db/resources',
+      );
+      final row = (await outbox.due()).single;
+      expect(row.endpoint, isNot(contains(config.pin)));
+      expect(row.payload, isNot(contains(config.pin)));
+      expect(row.endpoint, isNot(contains('@')));
+
+      final payload = jsonDecode(row.payload) as Map<String, dynamic>;
+      for (final field in testDeviceFields.entries) {
+        expect(payload, containsPair(field.key, field.value));
+      }
+    });
+
+    test('queuePending does not double-queue', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      expect(await uploader.queuePending(config: config, user: user), 1);
+      await uploader.queuePending(config: config, user: user);
+      expect(await outbox.due(), hasLength(1));
+    });
+
+    test('the payload is stable across sweeps', () async {
+      // Kotlin serializes at send time and writes `System.currentTimeMillis()`
+      // into `uploadDate` and `updatedDate` freely. The port stores the payload
+      // at enqueue time and re-serializes on every sweep, so a moving field
+      // makes `enqueue`'s memo never match — and a refused document is POSTed
+      // again on every sweep. This resource is an append with a server-minted
+      // id, so each of those is an undetectable duplicate.
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+      final first = (await outbox.due()).single.payload;
+
+      clock = clock.add(const Duration(hours: 3));
+      await uploader.queuePending(config: config, user: user);
+
+      expect((await outbox.due()).single.payload, first);
+    });
+
+    test(
+      'a refused resource is POSTed once, however many sweeps run',
+      () async {
+        await saveLocal(path: (await pickedFile()).path);
+        stubPost(const NetworkError<Map<String, dynamic>>(400, 'bad request'));
+
+        for (var sweep = 0; sweep < 5; sweep++) {
+          await uploader.queuePending(config: config, user: user);
+          await drainer().drain();
+          clock = clock.add(const Duration(hours: 1));
+        }
+
+        verify(
+          () => api.postJsonObject(
+            any(),
+            any(),
+            authHeader: any(named: 'authHeader'),
+          ),
+        ).called(1);
+        final row = await soleRow();
+        expect(
+          await database.outboxDao.forItem(ResourcesUploader.type, row.id),
+          hasLength(1),
+          reason: 'an outbox item owns exactly one row, for ever (Phase 148)',
+        );
+      },
+    );
+
+    test('a 2xx with no id/rev fails rather than dropping the row', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+      stubPost(const NetworkSuccess<Map<String, dynamic>>({'ok': true}));
+
+      await drainer().drain();
+
+      final row = await soleRow();
+      expect(row.couchId, isNull);
+      expect(
+        await database.outboxDao.forItem(ResourcesUploader.type, row.id),
+        isNotEmpty,
+        reason:
+            'reporting success would delete the row while the resource stays '
+            'pending, so the next sweep would POST a duplicate — for ever',
+      );
+      // Indeterminate: the transport said the write landed, and a duplicate
+      // append with a server-assigned id cannot be detected afterwards.
+      expect(await outbox.due(), isEmpty);
+    });
+
+    test(
+      'a transient failure leaves the resource pending, and the retry settles it',
+      () async {
+        await saveLocal(path: (await pickedFile()).path);
+        await uploader.queuePending(config: config, user: user);
+        stubPost(const NetworkError<Map<String, dynamic>>(503, 'unavailable'));
+
+        expect(await drainer().drain(), [OutboxOutcome.retryScheduled]);
+        expect(await resources.pendingUploads(), hasLength(1));
+
+        clock = clock.add(const Duration(minutes: 1));
+        stubPost(
+          const NetworkSuccess<Map<String, dynamic>>({
+            'id': 'srv-1',
+            'rev': '1-a',
+          }),
+        );
+        stubAttachment();
+        expect(await drainer().drain(), [OutboxOutcome.completed]);
+        expect(await resources.pendingUploads(), isEmpty);
+      },
+    );
+
+    test('a successful upload adopts the ids CouchDB assigned', () async {
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+      stubPost(
+        const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'srv-9',
+          'rev': '1-z',
+        }),
+      );
+      stubAttachment();
+
+      expect(await drainer().drain(), [OutboxOutcome.completed]);
+
+      final saved = await soleRow();
+      expect(saved.couchId, 'srv-9');
+      expect(saved.rev, '1-z');
+      expect(await resources.pendingUploads(), isEmpty);
+    });
+
+    test(
+      'an edit re-queues the edited payload, not the pre-edit one',
+      () async {
+        // Kotlin re-serializes at upload time and so picks an edit up for free.
+        // The port's payload is captured at enqueue time, so without a re-queue
+        // the user's edit would be applied locally and the *pre-edit* document
+        // would be the one that reached the server. `add_resource_screen` calls
+        // `queuePending` after an edit for exactly this reason.
+        await saveLocal(path: (await pickedFile()).path);
+        await uploader.queuePending(config: config, user: user);
+        final row = await soleRow();
+        expect(
+          jsonDecode((await outbox.due()).single.payload)['title'],
+          'Well survey notes',
+        );
+
+        await resources.updateLocalResource(
+          resourceId: row.id,
+          title: 'Well survey notes (revised)',
+          author: 'Ada Lovelace',
+        );
+        await uploader.queuePending(config: config, user: user);
+
+        expect(
+          jsonDecode((await outbox.due()).single.payload)['title'],
+          'Well survey notes (revised)',
+        );
+        expect(await outbox.due(), hasLength(1));
+      },
+    );
+  });
+
+  // -------------------------------------------------------------- round trip
+
+  group('the round trip', () {
+    test(
+      'the attachment PUT carries the bytes saveLocalResource wrote',
+      () async {
+        // **Test the pair, not the halves.**
+        //
+        // Nothing above this line would notice if the writer and the uploader
+        // disagreed about where the file is — and that disagreement is the most
+        // expensive defect this project has had. Phase 100: the exam
+        // verification photo was written under the submission id and read back
+        // under the `submit_photos` row id, so the lookup missed on every
+        // capture, the attachment step took its "a missing file is a no-op"
+        // branch, and the document uploaded without the photo the feature exists
+        // to collect. Nothing failed loudly. Each half had a passing test.
+        //
+        // The Kotlin has this defect *right here*:
+        // `FileUploader.uploadAttachment` does `File(personal
+        // .resourceLocalAddress)` on a column holding a **basename**, so its
+        // attachment upload can never find the bytes either.
+        //
+        // So this test writes a real file through the real writer and asserts
+        // the uploader PUTs those exact bytes. No fixture fabricates the join.
+        const contents = 'the well ran dry in March';
+        final picked = await pickedFile(
+          name: 'district-well.pdf',
+          contents: contents,
+        );
+        await saveLocal(path: picked.path);
+        final row = await soleRow();
+
+        // What the writer actually did, established rather than assumed.
+        expect(row.resourceLocalAddress, 'district-well.pdf');
+        expect(row.resourceOffline, isTrue);
+        final onDisk = File('${sandbox.path}/ole/${row.id}/district-well.pdf');
+        expect(await onDisk.exists(), isTrue);
+
+        await uploader.queuePending(config: config, user: user);
+        stubPost(
+          const NetworkSuccess<Map<String, dynamic>>({
+            'id': 'srv-7',
+            'rev': '1-q',
+          }),
+        );
+        stubAttachment();
+
+        expect(await drainer().drain(), [OutboxOutcome.completed]);
+
+        final captured = verify(
+          () => api.uploadAttachment(
+            captureAny(),
+            bytes: captureAny(named: 'bytes'),
+            authHeader: any(named: 'authHeader'),
+            contentType: captureAny(named: 'contentType'),
+            ifMatch: captureAny(named: 'ifMatch'),
+          ),
+        ).captured;
+
+        expect(
+          captured[0],
+          'https://planet.example.org/db/resources/srv-7/district-well.pdf',
+          reason: 'Kotlin: String.format("%s/resources/%s/%s", url, id, name)',
+        );
+        expect(
+          utf8.decode((captured[1] as List<int>)),
+          contents,
+          reason:
+              'the bytes must be the ones the writer copied, resolved through '
+              'the same ResourceFiles helper under the same docId',
+        );
+        expect(captured[2], 'application/pdf');
+        expect(
+          captured[3],
+          '1-q',
+          reason:
+              'CouchDB needs the rev from the POST response as If-Match, or it '
+              'refuses the attachment (FileUploader.getHeaderMap:85)',
+        );
+      },
+    );
+
+    test(
+      'a metadata-only resource uploads its document and no attachment',
+      () async {
+        // Kotlin *requires* a file (`ResourcesRepositoryImpl.kt:235-238`) while
+        // the port's form does not, so this row can exist. Its document is still
+        // worth filing; there are simply no bytes to attach.
+        await saveLocal();
+        final row = await soleRow();
+        expect(row.resourceLocalAddress, isNull);
+        expect(row.resourceOffline, isFalse);
+
+        await uploader.queuePending(config: config, user: user);
+        stubPost(
+          const NetworkSuccess<Map<String, dynamic>>({
+            'id': 'srv-3',
+            'rev': '1-c',
+          }),
+        );
+        stubAttachment();
+
+        expect(await drainer().drain(), [OutboxOutcome.completed]);
+
+        expect((await soleRow()).couchId, 'srv-3');
+        verifyNever(
+          () => api.uploadAttachment(
+            any(),
+            bytes: any(named: 'bytes'),
+            authHeader: any(named: 'authHeader'),
+            contentType: any(named: 'contentType'),
+            ifMatch: any(named: 'ifMatch'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'the bell does not ask to re-download the resource just created',
+      () async {
+        // A defect the upload direction *introduces* if `downloadedRev` is left
+        // behind. `watchResourcesNeedingUpdateCount` counts a shelf row where
+        // `_rev IS NOT downloaded_rev`. Both are null before the upload and
+        // SQLite's `IS NOT` between two nulls is false, so nothing is counted;
+        // writing `_rev` alone flips it true and the user is told to download
+        // the file already sitting under `ole/<id>/`.
+        //
+        // Kotlin writes only the two columns (`ResourcesRepositoryImpl
+        // .kt:804-806`), so this is a deliberate divergence rather than a port.
+        await saveLocal(path: (await pickedFile()).path);
+        final counts = database.myLibraryDao.watchResourcesNeedingUpdateCount(
+          user.id,
+        );
+        expect(await counts.first, 0);
+
+        await uploader.queuePending(config: config, user: user);
+        stubPost(
+          const NetworkSuccess<Map<String, dynamic>>({
+            'id': 'srv-2',
+            'rev': '1-b',
+          }),
+        );
+        stubAttachment();
+        expect(await drainer().drain(), [OutboxOutcome.completed]);
+
+        final saved = await soleRow();
+        expect(saved.rev, isNotNull);
+        expect(saved.downloadedRev, saved.rev);
+        expect(
+          await counts.first,
+          0,
+          reason:
+              'the file on disk is the attachment of the revision just '
+              'recorded — this device authored both',
+        );
+      },
+    );
+
+    test('the revision the attachment PUT returns is adopted', () async {
+      // Kotlin reads only `ok` from that response (`FileUploader.kt:70-78`), so
+      // its row stays a revision behind and the next resources sync pulls the
+      // newer `_rev` over it — leaving `_rev != downloaded_rev` and the bell
+      // asking for a re-download again, one sync later.
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+      stubPost(
+        const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'srv-4',
+          'rev': '1-d',
+        }),
+      );
+      stubAttachment(
+        const NetworkSuccess<Map<String, dynamic>>({
+          'ok': true,
+          'id': 'srv-4',
+          'rev': '2-e',
+        }),
+      );
+
+      expect(await drainer().drain(), [OutboxOutcome.completed]);
+
+      final saved = await soleRow();
+      expect(saved.rev, '2-e');
+      expect(saved.downloadedRev, '2-e');
+    });
+
+    test('a metadata-only row claims nothing was downloaded', () async {
+      // The other half of the `downloadedRev` rule: there are no bytes, so
+      // saying they are current is the `resourceOffline` lie Phase 150 removed.
+      await saveLocal();
+      await uploader.queuePending(config: config, user: user);
+      stubPost(
+        const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'srv-6',
+          'rev': '1-f',
+        }),
+      );
+      stubAttachment();
+      await drainer().drain();
+
+      final saved = await soleRow();
+      expect(saved.rev, '1-f');
+      expect(saved.downloadedRev, isNull);
+    });
+
+    test(
+      'a blank resourceLocalAddress attempts no attachment either',
+      () async {
+        // The metadata-only test covers a *null* address, so the blank case
+        // was unpinned. No port writer produces a blank one —
+        // `saveLocalResource` stores null when the copy is empty — which is
+        // exactly why it needs a hand-built row rather than trust.
+        //
+        // Chasing this down changed the production code rather than confirming
+        // it: mutation testing showed **neither** in-method guard could fail,
+        // because `ResourceFiles.existingFileFor` refuses an empty filename on
+        // its own. The redundant guard is gone and the remaining early return
+        // is labelled an optimisation. This test stays because it pins the
+        // *behaviour*, which is what matters, and would catch a `ResourceFiles`
+        // change that stopped providing it.
+        await saveLocal(path: (await pickedFile()).path);
+        final row = await soleRow();
+        await database.myLibraryDao.upsertAll([
+          row.copyWith(resourceLocalAddress: const Value('')).toCompanion(true),
+        ]);
+
+        await uploader.queuePending(config: config, user: user);
+        stubPost(
+          const NetworkSuccess<Map<String, dynamic>>({
+            'id': 'srv-8',
+            'rev': '1-g',
+          }),
+        );
+        stubAttachment();
+        expect(await drainer().drain(), [OutboxOutcome.completed]);
+
+        expect((await soleRow()).couchId, 'srv-8');
+        verifyNever(
+          () => api.uploadAttachment(
+            any(),
+            bytes: any(named: 'bytes'),
+            authHeader: any(named: 'authHeader'),
+            contentType: any(named: 'contentType'),
+            ifMatch: any(named: 'ifMatch'),
+          ),
+        );
+      },
+    );
+
+    test('an attachment failure does not undo the uploaded document', () async {
+      // Kotlin's ordering: the document is already filed before the bytes are
+      // attempted, and `uploadDoc` swallows the failure. Re-POSTing would file
+      // a second document to fix a missing attachment.
+      await saveLocal(path: (await pickedFile()).path);
+      await uploader.queuePending(config: config, user: user);
+      stubPost(
+        const NetworkSuccess<Map<String, dynamic>>({
+          'id': 'srv-5',
+          'rev': '1-e',
+        }),
+      );
+      stubAttachment(
+        const NetworkError<Map<String, dynamic>>(413, 'too large'),
+      );
+
+      expect(await drainer().drain(), [OutboxOutcome.completed]);
+      expect((await soleRow()).couchId, 'srv-5');
+      expect(await resources.pendingUploads(), isEmpty);
+    });
+  });
+}
+
+/// Restores the seam `setUp` overrode; see the note in
+/// `local_resource_file_copy_test.dart` for why a real fallback beats a
+/// thrower here.
+Future<Directory> getApplicationDocumentsDirectoryFallback() async =>
+    Directory.systemTemp;

--- a/flutter/test/ui/add_resource_screen_test.dart
+++ b/flutter/test/ui/add_resource_screen_test.dart
@@ -3,14 +3,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/repository/local_resource_request.dart';
 import 'package:myplanet/repository/resources_repository.dart';
+import 'package:myplanet/repository/resources_uploader.dart';
 import 'package:myplanet/ui/resources/add_resource_screen.dart';
 
+import '../repository/device_identity_fixture.dart';
 import '../support/widget_harness.dart';
 
 /// First tests for `AddResourceScreen` (Phase 102).
@@ -46,6 +49,7 @@ void main() {
     String? editResourceId,
     UserRow? user,
     LocalResourceError? failWith,
+    ServerConfig? serverConfig = _testServerConfig,
   }) async {
     // The form is one long `SingleChildScrollView`. It builds every child
     // eagerly, so `find.text` locates widgets below the fold but `tap` misses
@@ -81,6 +85,22 @@ void main() {
             return db;
           }),
           sessionProvider.overrideWith(() => _StubSession(user)),
+          // `_save` enqueues the new resource for upload, and
+          // `serverConfigProvider` transitively reads `planetPrefsProvider` —
+          // `UnimplementedError` in this harness (the Phase 75 shape). The
+          // enqueue is wrapped in a catch so that cannot take the screen down,
+          // which means an un-overridden provider here would leave the upload
+          // *silently absent* from every test in this file. Overriding it is
+          // what keeps `enqueues the new resource for upload` below able to
+          // fail.
+          serverConfigProvider.overrideWith(
+            () => _StubServerConfig(serverConfig),
+          ),
+          // The other half of the same problem. `queuePending` reads device
+          // identity to stamp the document, and the production source needs a
+          // platform channel no widget test has — so without this the enqueue
+          // throws into `_save`'s catch and the upload is silently absent.
+          deviceIdentitySourceProvider.overrideWithValue(testDeviceIdentity),
           // `saveLocalResource` can only fail on the title today: the file
           // copy `AddResourceActivity` relies on is still an open gap, so its
           // three other failure modes are unreachable from here. A stub is
@@ -226,6 +246,63 @@ void main() {
     // resource unopenable: the list sorts offline-first and the detail screen
     // hides Download in favour of View, on the strength of this flag.
     expect(row.resourceOffline, isFalse);
+  });
+
+  testWidgets('enqueues the new resource for upload', (tester) async {
+    // Until this lane, `saveLocalResource` was a complete port whose output
+    // went nowhere: the resource lived on that handset alone, invisible in
+    // Planet and on the user's other devices. The write site now hands it to
+    // the outbox.
+    //
+    // This test is also what keeps `_save`'s catch honest. That catch exists
+    // because `queuePending` reads device identity and `serverConfigProvider`
+    // reads `planetPrefsProvider`, either of which can throw — but a catch
+    // around the only enqueue in the app is exactly how a feature ends up
+    // green and dead, so the outbox row is asserted rather than assumed.
+    await pumpScreen(
+      tester,
+      user: buildUserRow(id: 'user-a', name: 'jane'),
+    );
+    await fillValidForm(tester);
+    await tapSubmit(tester, 'Submit');
+
+    final row = await onlyRow();
+    expect(row, isNotNull);
+    final queued = await db.outboxDao.forItem(ResourcesUploader.type, row!.id);
+    expect(queued, hasLength(1));
+    expect(queued.single.endpoint, endsWith('/resources'));
+    expect(
+      queued.single.endpoint,
+      isNot(contains('1234')),
+      reason: 'outbox.endpoint is persisted, so it must carry no PIN',
+    );
+    expect(queued.single.payload, contains('"title":"Kihu"'));
+  });
+
+  testWidgets('with no server configured the save still succeeds', (
+    tester,
+  ) async {
+    // The concrete way a resource is stranded: there is no endpoint to queue
+    // against, so nothing is queued — and the save must still report success,
+    // because the row is written and offline-first is the premise. This is the
+    // state `sweepPendingResources` exists to rescue, and the reason the
+    // feature is not finished until that sweep is wired into the background
+    // entry point.
+    await pumpScreen(
+      tester,
+      user: buildUserRow(id: 'user-a', name: 'jane'),
+      serverConfig: null,
+    );
+    await fillValidForm(tester);
+    await tapSubmit(tester, 'Submit');
+
+    expect(find.text('Added to My Library'), findsOneWidget);
+    final row = await onlyRow();
+    expect(row, isNotNull);
+    expect(
+      await db.outboxDao.forItem(ResourcesUploader.type, row!.id),
+      isEmpty,
+    );
   });
 
   testWidgets('the signed-in user is recorded on the new resource', (
@@ -487,4 +564,19 @@ class _StubSession extends SessionNotifier {
 
   @override
   Future<UserRow?> build() async => user;
+}
+
+const _testServerConfig = ServerConfig(
+  serverUrl: 'https://planet.example.org',
+  pin: '1234',
+  couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+);
+
+class _StubServerConfig extends ServerConfigNotifier {
+  _StubServerConfig(this._config);
+
+  final ServerConfig? _config;
+
+  @override
+  ServerConfig? build() => _config;
 }


### PR DESCRIPTION
Lane 3. Ports the **resource upload direction**, which the port did not have at all.

`ResourcesRepository.saveLocalResource` has been a careful port for several phases — it writes the `my_library` row, copies the picked file to `<base>/ole/<id>/<basename>`, marks the row offline-available and adds it to the user's shelf — and **nothing ever uploaded it**. A resource the user created lived on that handset alone: absent from Planet, absent from their other devices, destroyed outright by the reset-app action. Same reachability class as Phase 119: the local writer was already in place, the direction Kotlin runs was never ported.

Gate: `dart format` clean, `flutter analyze` clean, **2960 tests pass** (baseline 2923 + 37 new).

Three commits. The third is the **second `parity-auditor` pass over this lane's own finished, already-green code**, which found two more data defects — the fourth consecutive round where that pass earned its keep.

---

## Two corrections to the brief, and one would have corrupted server data

**1. Do not copy Kotlin's pending predicate.** The brief said to port `SELECT * FROM my_library WHERE _rev IS NULL` verbatim, with a note to understand why first. Understanding why is what stops you: in *this* codebase it also matches every course-embedded resource.

`my_library` has two writers and only one sees a `_rev`. The `resources` walk pulls whole CouchDB documents; the courses walk pulls the thinner copy embedded in a course step (`CoursesRepository._ingestCourseResources`), and a sub-object carries no revision — so `MyLibraryMapper.fromDoc` leaves `rev` `Value.absent()`. Those rows have a genuinely NULL `_rev`. Under the literal predicate the first drain after the first courses sync POSTs each one to `resources`, **filing a second copy of a document that already exists on the server**, one per course resource.

Kotlin is spared by a quirk, not by design: `MyLibrary.insertMyLibrary` assigns `_rev = JsonUtils.getString("_rev", doc)` and `getString` returns `""` for a missing key, so its course-embedded rows carry an *empty* revision that `_rev IS NULL` does not match. **Phase 150 deliberately fixed that quirk in the port** (for good reasons at `MyLibraryMapper._revOrAbsent`) and in doing so removed the accidental guard the Kotlin predicate leans on. Nothing noticed, because there was no uploader to notice with.

The predicate here is `_rev IS NULL AND (_id IS NULL OR _id = '')`. Every sync writer sets `couchId` from the document's own `_id` and `fromDoc` returns null when that id is empty, so a row without one cannot have come from the server; only `saveLocalResource` leaves it unset. The audit independently enumerated all nine writers of that table and confirmed no row is wrongly included or excluded.

**2. `my_library` *is* in `localAuthorityTables`** — one of the 28, added in Phase 150. The brief said it was not. So a schema bump does not destroy these rows. Reset-app still does, and they never reach Planet regardless.

## There was no working reference implementation

**Kotlin's attachment upload is dead code, twice over.** I found the second reason; the ground-truth audit found the first, and it is worse.

- `uploadResource` maps its succeeded items back with `getLibraryItemsByIds(localIds)` → `WHERE _id IN (:ids)` (`MyLibraryDao.kt:40`), while `localId` is `config.idExtractor` = the **local** primary key (`UploadConfigs.kt:278`). And by then `markResourceUploaded` has already overwritten `_id` with the CouchDB id, before `uploadRoom` returns. So `libMap` is empty, `uploadAttachment` is **never invoked** — and `notifyListener(…, "Uploaded N resources successfully")` fires anyway (`UploadManager.kt:187`). The map is built on `it.id` while the query is on `_id` (`:178`), which is the tell.
- And the file handle would be wrong if reached: `File(personal.resourceLocalAddress)` (`FileUploader.kt:37`) on a column holding a **basename**, resolved against the process working directory.

Either way the document lands with no `_attachments`, the bytes stay on the handset, the row is no longer pending so nothing retries, and **nothing fails loudly**. The second half is exactly the Phase 100 verification-photo shape, reached through the Kotlin rather than the port.

## What changed

| File | Change |
|---|---|
| `lib/repository/resources_uploader.dart` *(new)* | `ResourcesUploader`: create POST, private-team `resourceLink`, best-effort attachment PUT — all through the outbox, following `PersonalsUploader`/`SubmitPhotosUploader`. Plus top-level `sweepPendingResources`. |
| `lib/data/local/app_database.dart` | `MyLibraryDao.pendingUploads`, `.markUploaded`, `.adoptAttachmentRev` — appended at the end of the DAO. **No schema change**; `couchId`/`rev` already exist. `schemaVersion` untouched at 49. |
| `lib/repository/resources_repository.dart` | `pendingUploads`, `markResourceUploaded`, `adoptAttachmentRev`, `getLibraryItemById`. |
| `lib/ui/resources/add_resource_screen.dart` | The enqueue in `_save`, after both create and edit. |
| `lib/providers/app_providers.dart` | `resourcesUploaderProvider` + one handler-map entry. **Append-only** — no existing provider modified, re-ordered, or re-signed. |

### Deliberate divergences, each because copying would be wrong

- **The attachment resolves through `ResourceFiles` under the row's local id** — the same helper and the same `docId` the writer used. `outbox.itemId` *is* that id, and the audit confirmed nothing can make the two derivations diverge.
- **`filename` is unified on the plain basename.** Kotlin derives it twice, differently: `getFileNameFromUrl` for the document (URI-parse + `URLDecoder.decode`) and `getFileNameFromLocalAddress` for the attachment name (plain `substringAfterLast('/')`). They disagree for `a+b.pdf` → `a b.pdf`, `50%.pdf` → `''`, `notes#1.pdf` → `notes`. A document whose `filename` contradicts its attachment is a resource Planet cannot resolve.
- **The payload's timestamps are deterministic.** Kotlin serializes at send time and reads the clock freely; the port stores the payload at enqueue time and re-serializes every sweep, so a moving field defeats `enqueue`'s memo and re-POSTs a refused document every sweep — each an undetectable duplicate append. Same fix as `PersonalsUploader`'s `uploadedAt`.
- **`downloadedRev` moves with `rev` when there are bytes on disk.** A defect the direction *introduces* at parity: `watchResourcesNeedingUpdateCount` counts a shelf row where `_rev IS NOT downloaded_rev`; both are null before upload and SQLite's `IS NOT` between nulls is false, so writing `_rev` alone makes the bell ask the user to **download the resource they just created**. Kotlin writes only the two columns (`ResourcesRepositoryImpl.kt:804-806`). The attachment PUT's rev is adopted too, which Kotlin discards (`FileUploader.kt:70-78` reads only `ok`). The audit confirmed that stream is the port's **only** consumer of `downloadedRev`, so nothing else is affected — and that under Kotlin's own `isResourceOffline()` this write is the honest state where Kotlin's is not.
- **Marking and sending are one step**, closing a Kotlin hole: `RetryQueueWorker.processOperationInternal` re-POSTs a queued resource and calls only `retryQueue.markCompleted` (`:231`), never `markResourceUploaded`, so the row stays pending and the next `uploadResource` POSTs it again.

---

## What the second audit pass found in my own green code

**A resource POST could file a second CouchDB document.** `queuePending` enqueued unconditionally, where the three sibling *append* uploaders (submissions, voices, adopted surveys) each ask `isInFlight` first. `enqueue` deliberately returns an `in_progress` row to `pending` so a mid-flight payload edit is not lost with the row `markCompleted` deletes — and `markCompleted` is `deleteIfInProgress`, so the send that succeeds moments later deletes nothing, the row survives with the same body, and the next drain POSTs again. The handler carries no `_id`, so the server mints a fresh document and `markResourceUploaded` repoints the local row at the duplicate, leaving the first an unidentifiable orphan. No exotic timing: a drain claims the row on a slow link while the user saves a second resource, whose `_save` sweeps every pending row. Fixed, and pinned by a test that re-enters `queuePending` from inside the POST.

**A private team resource never reached its team, and I asserted a false reason.** Two doc comments said `TeamsRepository.createLocalResourceLink` "does not exist anywhere in the port". It does — as `TeamsRepository.addResourceLink`, a field-for-field match for `TeamsRepositoryImpl.kt:719-740` plus a duplicate check Kotlin lacks — and the search that missed it was for the Kotlin **name** rather than the behaviour, the same mistake as matching a test filename instead of grepping for the symbol. So a team leader's private resource uploaded its own document and no team linked to it: the Resources tab empty on Planet and on every other member's handset, for bytes already on the server. Now ported, in the handler after the POST, because the link must carry the CouchDB id — `markUploaded` leaves `resourceId` at the local uuid, so linking earlier would name a document that does not exist, which is why Kotlin has it inside `markResourceUploaded` too.

The pass also confirmed the serializer is at parity field for field (all 24 keys, `serializeNulls` included), the attachment key holds on every path, and the outbox classification is correct end to end.

---

## The sweep call I need Lane 1 to make

**The feature is not complete without it.** Kotlin's `uploadResource` has exactly the unconditional-sweep property Phase 134 was about: three callers with no precondition on how the row got there. The port has **one** enqueue site.

The audit corrected my framing twice, and both corrections matter. **Two sweep sites are missing, not one** — the headless path *and* the foreground manual sync. And **this is the widest such window the port has had**, not a narrow one: every resource created on any previous build has a `my_library` row with no `_id` and no outbox row, and `my_library` is preserved so no schema bump clears them. Today they upload only if the user happens to open the add-resource screen and save something.

`sweepPendingResources` is written and covered by 5 tests in my own files. **`lib/background_entrypoint.dart` and `lib/providers/dashboard_sync_provider.dart` are Lane 1's, so the calls are reported rather than made.**

```dart
// lib/background_entrypoint.dart — in drainOutbox, after sweepPendingSubmissions(...)
// and BEFORE drainer.drain(...), so swept rows go out in the same invocation
await sweepPendingResources(
  container,
  config: config,
  userId: prefs.loggedInUserId,
);
```
with `import 'repository/resources_uploader.dart';`.

`drainOutbox` rather than `syncSteps`, for the reason `sweepPendingVoices` documents: the step list runs only for a due `autoSync` task with auto-sync enabled, and `BackgroundWorkCoordinator` cancels that job outright for a user who turns auto-sync off — precisely the user most likely to have an undelivered write. Ordering against the other sweeps is free.

The foreground analogue belongs in `DashboardSyncNotifier` (`dashboard_sync_provider.dart:370-390`, which sweeps `adoptedSurveys` and `submissions` and not resources), same placement — with the shelf push, ahead of the pulls.

The third Kotlin caller (`TeamsRepositoryImpl:928`, via `saveLocalResource`'s `teamId != null` tail) needs **no** port counterpart: the screen enqueues on every save, not only for a team, so the port is strictly broader there.

## Does `updateLocalResource` need the PUT direction? No — Kotlin only ever creates.

Definitive, on four independent grounds:

1. `getResourcesConfig` sets no `dbIdExtractor`, so `preparedItem.dbId` is always null and `UploadCoordinator.kt:138-149` can only POST. Contrast `Rating` (`dbIdExtractor = { it._id }`, commented *"Enables POST/PUT logic"*) and `Submissions`/`ExamResults`, which can PUT. Resources cannot.
2. The pending predicate structurally excludes every row that has a `_rev`.
3. `ResourcesRepositoryImpl.updateLocalResource` (`:136-160`) is local-only: nine metadata fields and an upsert. It does **not** clear `_rev`, set a dirty flag, or enqueue anything. Editing an already-synced resource changes only the handset, and the next sync overwrites it from the server document.
4. None of the three callers has an update variant.

`serialize` carries no `_id` and no `_rev`, which is *why* the verb is POST.

**But an edit of a not-yet-uploaded row does need re-queuing**, which is why `_save` calls `queuePending` after an edit too. Kotlin re-serializes at upload time and picks the edit up for free; the port captures the payload at enqueue time, so without it the edit would be applied locally while the *pre-edit* document reached the server. A changed payload is also what Phase 148's policy says re-arms a refused row, so this doubles as the corrected-create retry path.

## Mutation testing

**23 mutations across two rounds, all killed.** Four survivors along the way, each resolved rather than explained.

| Mutation | Result |
|---|---|
| pending predicate = Kotlin's literal `_rev IS NULL` | killed |
| pending predicate drops `_rev IS NULL` | survived → hand-built row → killed |
| `addedBy` = the row column (display name) not the user id | killed |
| payload timestamp drifts between sweeps | killed |
| `mediaType` loses its `'other'` default | killed |
| `author` loses its `''` coalesce | killed |
| `privateFor` emitted unconditionally | killed |
| **attachment resolved under the CouchDB id (Phase 100 shape)** | killed |
| 2xx with no id/rev reported as success | killed |
| `downloadedRev` left behind (Kotlin parity) | killed |
| `downloadedRev` set on a metadata-only row | killed |
| attachment rev discarded (Kotlin behaviour) | killed |
| `markUploaded` always reports success | killed |
| `If-Match` dropped from the attachment PUT | killed |
| ids never adopted (Kotlin's `RetryQueueWorker` hole) | killed |
| blank `resourceLocalAddress` still attempts an attachment | survived → **production simplified** |
| **`isInFlight` guard removed** | killed |
| **team link never created** | killed |
| **link keyed on the local uuid** | killed |
| **link written but never enqueued** | killed |
| **`isPrivate` half of the link gate dropped** | survived → hand-built row → killed |
| **`filename` URI-decoded like `getFileNameFromUrl`** | killed |
| **null status code → transient instead of indeterminate** | killed |

Three findings worth keeping:

**A defect mutation testing found in my own work** before it was even mutation-tested: the `downloadedRev` prompt above. Writing `_rev` at Kotlin parity would have shipped a bell notification asking the user to re-download their own file.

**One survivor changed the production code rather than confirming it.** Neither in-method empty-filename guard could fail — `ResourceFiles.existingFileFor` refuses an empty filename on its own, so removing *both* still left the test green. The redundant guard is gone and the remaining early return is labelled an optimisation, not the guarantee.

**One survivor was my own mutation on the wrong function.** `classifyStatus` is not what maps a null status code to a refusal — the drainer is (`outbox_drainer.dart:468-470`). Re-mutated at the real site: killed. Worth recording, because a mutation that survives for that reason reads exactly like a test that cannot fail.

**Two tests the audit showed could not fail, both fixed.** The 2xx-with-no-id/rev test asserted an empty `due()` with the clock unmoved, which a `transient` misclassification also satisfies — it now advances past the backoff and verifies one POST. And the `filename` divergence, this phase's most-argued decision, used names on which both Kotlin helpers agree; it now uses `a+b.pdf`. Also: the fixture PIN stopped being a digit run, because `isNot(contains('1234'))` against a payload carrying three 13-digit epochs can pass by accident.

---

## Reported, not fixed

Precise enough to be a target. Ordered by consequence.

1. **Enabling this direction makes the locally authored row prunable, and the next resources sync detaches the user from their own resource.** Before this phase a local row had `rev = NULL` and `deleteNotIn`'s `_rev IS NOT NULL AND _rev != ''` guard spared it for ever. `markUploaded` writes `rev`, which makes it eligible — while `deleteNotIn`'s keep set is document `_id`s and the row's primary key is still its local uuid. So the first sync after a successful upload inserts a **second** row keyed on the CouchDB id, with an empty shelf and `resourceOffline` at its default, and prunes the original. Net: the resource is in the catalog, **not** in the user's My Library, shows as not-downloaded, and `ole/<uuid>/well.pdf` is orphaned for ever. **Kotlin reaches the identical outcome** (`deleteStalePublicNotIn` matches `resourceId`, which `saveLocalResource` also sets to the same uuid and `markResourceUploaded` does not update), so this is inherited rather than introduced — but it is not benign, and nothing recorded it before this PR. Note the trap in the obvious repair: `markUploaded` also setting `resourceId = couchId` would spare the row under **Kotlin's** predicate but not the port's, which matches on `id` — and the standing comment at `app_database.dart:1641-1647` saying the column choice is immaterial would stop being true.

2. **`TeamsRepository.addResourceLink` accepts `planetCode` and ignores it.** Kotlin stamps both `sourcePlanet` and `teamPlanetCode` from it, falling back to `sharedPrefManager.getPlanetCode()` when blank (`TeamsRepositoryImpl.kt:726-735`). The value is passed correctly from here so the call is right the moment that lands; `teams_repository.dart` is outside this lane's set.

3. **An attachment PUT that fails leaves the bytes unreachable with nothing queued to retry them.** `adoptAttachmentRev` keeps `rev == downloadedRev` on success, and `markUploaded` keeps them equal when the attachment is skipped — so nothing prompts, and the document sits on the server with no `_attachments`. Kotlin has the same hole (its attachment step is fire-and-forget and unreachable anyway). Closing it means a second outbox row for the attachment, keyed separately — a design decision, not a patch.

4. **Process death between a successful POST and `markCompleted` duplicates any append, port-wide.** `recoverStuck` returns the `in_progress` row to `pending` and the replay POSTs again. No handler in the port guards it, `submissions_uploader.dart` included, so this is not a finding against this lane. Noted because the cheap fix lands naturally here: this handler already reads the library row, so an up-front "skip the POST if `couchId` is already set, attach only" would make resources the one idempotent append in the port.

5. **`resourceId` stays at the local uuid after upload, in both apps.** Kotlin's `markResourceUploaded` writes only `_id`/`_rev`. This is what makes item 1 bite, and `getLibraryItemByResourceId`, the shelf push (`shelf_repository.dart:179-185`, which sends `r.resourceId ?? r.id`) and storage management all read it. Worth a look by whoever next touches resource identity; not changed here because it is parity and changing it alters which rows the prune spares.

6. **`getPendingUploads`' empty-`_rev` hole exists in Kotlin and is unreachable — for now.** Kotlin's pending predicate is `_rev IS NULL` while its prune spares `_rev IS NULL OR _rev = ''`, so a row with `_rev = ''` would be neither pending nor prunable. It cannot arise today because only `insertMyLibrary` writes `''` and it always writes an `_id` too. Recorded because two predicates disagreeing is the kind of thing a future writer walks into.

7. **`mediaType ?: 'other'` is dead on the Kotlin path.** `AddResourceActivity` sends `""` for an unselected spinner, not null — same for `author`/`publisher`/`linkToLicense`. Kept and tested here because it is the serializer's contract, but nobody should read it as live behaviour.

8. **`UploadManager.uploadResource` calls its listener more than once per run**, and the summary races the per-attachment callbacks (`uploadDoc` is `scope.launch`, not awaited). No port counterpart, so nothing to do — but it is why the Kotlin's "Uploaded N resources successfully" is not evidence anything was attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmC6znXbiFFbNVSfpe59fW