### PR TITLE
fix(flutter): harden the feedback area against what the server actually sends

### DIFF
--- a/flutter/PHASE_152_NOTES.md
+++ b/flutter/PHASE_152_NOTES.md
@@ -365,6 +365,12 @@ above, and items 2 and 3 below.
    changes the latency, not the outcome. The fix is a real merge for that
    column, which is a feedback-slice decision with a conflict-resolution
    question inside it. Severity: medium-high, and older than this phase.
+   **Closed in the following round** (Lane 4, feedback hardening): the pull
+   merges the server's copy with the unsent local tail after their shared
+   prefix, and `FeedbackSyncNotifier` re-queues so the outbox snapshot is
+   refreshed rather than draining the pre-merge array. The two tests here that
+   pinned the loss now pin the merge. Annotated rather than rewritten — this
+   file is a record of what Phase 152 found, and it found this correctly.
 2. **The same shape is *constructible* for `submissions` but I could not prove
    it reachable, so I did not act on it.** A submission document is where
    Planet's grading lands (`grade`, `status`, per-answer marks, all read at

--- a/flutter/lib/data/local/feedback_mapper.dart
+++ b/flutter/lib/data/local/feedback_mapper.dart
@@ -37,15 +37,30 @@ String? _string(String key, Map<String, dynamic> json) {
 ///
 /// Used only for the fields that hold a **person** — `owner`, `source`, and a
 /// reply's `user`. A Planet's web UI writes the whole CouchDB user document
-/// into a field the handset writes as a plain user name; `name` is the same
-/// value the other documents carry as a string, so taking it is a deliberate
-/// improvement on Kotlin's `""`, which discards something unambiguous. The
-/// shape was first observed against `https://planet.learning.ole.org`, where
-/// 3 of 1,630 chat documents carried it; `chat_mapper.dart`'s `_stringOrNull`
-/// reads the object the same way. It differs on a **number**, which that
-/// helper drops and [JsonUtils.getStringOrNull] keeps as its digits — the
-/// port-wide convention, and what Gson's `asString` gives Kotlin's own reply
-/// reader (`Feedback.kt:63-65`).
+/// into a field the handset writes as a plain user name (Kotlin writes a
+/// reply's `user` as a string, `FeedbackRepositoryImpl.kt:100-104`), and
+/// `name` is the same value the other documents carry as that string.
+///
+/// Taking it is a deliberate improvement, and **how much of one depends on
+/// which field**, because Kotlin reads the two through different code:
+///
+/// * `owner` and `source` come from `JsonUtils.getString`
+///   (`FeedbackRepositoryImpl.kt:142, 145`), so Kotlin stores `""` and
+///   discards something unambiguous.
+/// * A reply's `user` is read as `ob["user"].asString` with no `JsonUtils` and
+///   no `try` (`Feedback.kt:61-69`), and `JsonObject` does not override
+///   `getAsString` — so **Kotlin throws `UnsupportedOperationException` out of
+///   `messageList`**, which `FeedbackDetailActivity.kt:61` calls from an
+///   unguarded collector. The Android app loses the detail screen on the same
+///   document. Neither app should, so this reads the name.
+///
+/// The shape was first observed against `https://planet.learning.ole.org`,
+/// where 3 of 1,630 chat documents carried it; `chat_mapper.dart`'s
+/// `_stringOrNull` reads the object the same way. It differs on a **number**,
+/// which that helper drops and [JsonUtils.getStringOrNull] keeps as its
+/// digits — the port-wide convention, and what Gson's `asString` gives
+/// Kotlin's own reply reader, where a numeric `time` renders as its literal
+/// text rather than being dropped (`Feedback.kt:63-65`).
 String? _userString(String key, Map<String, dynamic> json) {
   final value = json[key];
   if (value is Map) {

--- a/flutter/lib/data/local/feedback_mapper.dart
+++ b/flutter/lib/data/local/feedback_mapper.dart
@@ -17,29 +17,43 @@ import 'app_database.dart';
 /// one batch because 3 of them carried an object-valued `user`, fixed in
 /// `chat_mapper.dart`.
 ///
-/// Delegating to [JsonUtils.getStringOrNull] keeps a JSON **number** readable
+/// Delegating to [JsonUtils.getString] keeps a JSON **number** readable
 /// (`2019` reads as `'2019'` — the port's documented, deliberate divergence
-/// from Kotlin's `""`) and folds a missing key to null, which is what this
-/// mapper already stored for an absent field. A well-formed document therefore
-/// maps exactly as it did before.
+/// from Kotlin's `""`), and the two guards around it mean a well-formed
+/// document maps to exactly the bytes the cast produced.
 ///
-/// A Map or a List is intercepted first and reads as null, because that
-/// helper's own doc comment forbids passing it either: it would store Dart's
-/// `Map.toString()`, which is not JSON and throws wherever it is read back.
-/// Null is this mapper's spelling of Kotlin's `""` for an absent field.
+/// **Both guards are load-bearing, and the empty one is not obvious.**
+///
+/// * A missing key and an explicit JSON `null` read as null, because that is
+///   what this mapper's columns have always held for an absent field —
+///   [JsonUtils.getString] would give `''`, and [JsonUtils.getStringOrNull]
+///   would fold a *present* `""` to null, which is a different thing.
+///   `json_utils.dart` documents at length why that fold costs defects on a
+///   mapper path, and it would have cost one here: `owner` is matched with
+///   `FeedbackDao.watchByOwner`'s `f.owner.equals(owner ?? '')`, so a thread
+///   filed by a session with an empty name would map to null on the next pull
+///   and **disappear from its own author's list**.
+/// * A Map or a List reads as null, because [JsonUtils.getString]'s own doc
+///   comment forbids passing it either: it would store Dart's
+///   `Map.toString()`, which is not JSON and throws wherever it is read back.
+///   Null is this mapper's spelling of Kotlin's `""` for a field it cannot
+///   read.
 String? _string(String key, Map<String, dynamic> json) {
   final value = json[key];
-  if (value is Map || value is List) return null;
-  return JsonUtils.getStringOrNull(key, json);
+  if (value == null || value is Map || value is List) return null;
+  return JsonUtils.getString(key, json);
 }
 
 /// [_string], except that an object reads its `name`.
 ///
 /// Used only for the fields that hold a **person** — `owner`, `source`, and a
-/// reply's `user`. A Planet's web UI writes the whole CouchDB user document
-/// into a field the handset writes as a plain user name (Kotlin writes a
-/// reply's `user` as a string, `FeedbackRepositoryImpl.kt:100-104`), and
-/// `name` is the same value the other documents carry as that string.
+/// reply's `user`. Kotlin writes all three as plain strings
+/// (`FeedbackRepositoryImpl.kt:63-66, 100-104`), but a CouchDB field that is a
+/// user name on one document can be the whole user object on another: that is
+/// **observed** on `chat_history` (3 of a Planet's 1,630, see
+/// `chat_mapper.dart`) and **inferred** here, from feedback replies being
+/// authored through the same web UI. No captured feedback document proves it;
+/// what is certain is only what each app does when it arrives.
 ///
 /// Taking it is a deliberate improvement, and **how much of one depends on
 /// which field**, because Kotlin reads the two through different code:
@@ -54,13 +68,20 @@ String? _string(String key, Map<String, dynamic> json) {
 ///   unguarded collector. The Android app loses the detail screen on the same
 ///   document. Neither app should, so this reads the name.
 ///
-/// The shape was first observed against `https://planet.learning.ole.org`,
-/// where 3 of 1,630 chat documents carried it; `chat_mapper.dart`'s
-/// `_stringOrNull` reads the object the same way. It differs on a **number**,
-/// which that helper drops and [JsonUtils.getStringOrNull] keeps as its
-/// digits — the port-wide convention, and what Gson's `asString` gives
+/// **It is a write as well as a read.** [FeedbackMapper.toDoc] rebuilds the
+/// document from these columns and the uploader sends it under the carried
+/// `_rev`, so replying to a thread whose `owner` was an object flattens it to
+/// `"learning"` on the server. Kotlin would flatten the same field to `""`,
+/// which is why this is still the better of the two — but it is a change to
+/// the server's document, not only to what this device shows.
+///
+/// The shape was first observed against `https://planet.learning.ole.org`;
+/// `chat_mapper.dart`'s `_stringOrNull` reads the object the same way, bar
+/// `{"name": ""}`, which it keeps as `''` and this drops to null. It differs
+/// on a **number**, which that helper drops and [JsonUtils.getString] keeps as
+/// its digits — the port-wide convention, and what Gson's `asString` gives
 /// Kotlin's own reply reader, where a numeric `time` renders as its literal
-/// text rather than being dropped (`Feedback.kt:63-65`).
+/// text rather than being dropped (`Feedback.kt:61-69`).
 String? _userString(String key, Map<String, dynamic> json) {
   final value = json[key];
   if (value is Map) {
@@ -90,10 +111,11 @@ class FeedbackMapper {
   /// Converts a CouchDB feedback document JSON to a [FeedbackEntriesCompanion].
   ///
   /// Port of `FeedbackRepositoryImpl.mapToFeedback`. When the stored row has a
-  /// reply the server has not confirmed (`isUploaded == false`), the local
-  /// `messages` are kept and the row stays pending — a sync used to overwrite
-  /// the thread with the server's copy, silently destroying the reply the
-  /// uploader was about to send.
+  /// reply the server has not confirmed (`isUploaded == false`), the row stays
+  /// pending and its thread is merged rather than replaced — a sync used to
+  /// overwrite it with the server's copy, silently destroying the reply the
+  /// uploader was about to send. See [_mergePendingReplies] for why keeping
+  /// the local array alone, which is what Kotlin does, loses the other half.
   static FeedbackEntriesCompanion fromDoc(
     Map<String, dynamic> doc, [
     FeedbackRow? existing,
@@ -229,7 +251,7 @@ class FeedbackMapper {
 
   /// Parses the embedded messages JSON into a list of [FeedbackMessage].
   ///
-  /// Port of `Feedback.messageList` / `Feedback.message` (`Feedback.kt:56-88`),
+  /// Port of `Feedback.messageList` / `Feedback.message` (`Feedback.kt:54-85`),
   /// which read each element with Gson's `asString` — so a **numeric** `time`
   /// reads as its digits there, not as nothing.
   ///
@@ -262,6 +284,13 @@ class FeedbackMapper {
   }
 
   /// The messages array exactly as stored, elements untouched.
+  ///
+  /// A column that decodes to something other than a list is `[]` here, which
+  /// [addReply] then appends to — so a reply on a thread whose stored
+  /// `messages` is a JSON object or a JSON *string* still replaces it. Kotlin
+  /// has the same hole from the other side (`getJsonArray` normalises any
+  /// non-array to `"[]"`, `JsonUtils.kt:126-129`), so this is not a parity
+  /// gap; it is the one shape the array-preserving fix does not reach.
   static List<dynamic> _decodeMessages(String? messagesJson) {
     if (messagesJson == null || messagesJson.isEmpty) return [];
     try {

--- a/flutter/lib/data/local/feedback_mapper.dart
+++ b/flutter/lib/data/local/feedback_mapper.dart
@@ -100,7 +100,7 @@ class FeedbackMapper {
   ]) {
     final id = idOf(doc);
     final hasPendingLocalReply = existing != null && !existing.isUploaded;
-    final messages = hasPendingLocalReply ? null : doc['messages'];
+    final serverMessages = doc['messages'];
     final isUploaded =
         !hasPendingLocalReply && doc.containsKey('_rev') && doc['_rev'] != null;
 
@@ -119,12 +119,63 @@ class FeedbackMapper {
       isUploaded: Value(isUploaded),
       messages: Value(
         hasPendingLocalReply
-            ? existing.messages
-            : (messages != null ? jsonEncode(messages) : null),
+            ? _mergePendingReplies(existing.messages, serverMessages)
+            : (serverMessages != null ? jsonEncode(serverMessages) : null),
       ),
       item: Value(_string('item', doc)),
       state: Value(_string('state', doc)),
     );
+  }
+
+  /// Puts the server's copy of a thread back together with the replies this
+  /// device has not sent yet.
+  ///
+  /// **A deliberate divergence, and the one place the port refuses to copy
+  /// Kotlin.** On the pending branch Kotlin keeps the local array and throws
+  /// the server's away (`FeedbackRepositoryImpl.kt:154`) while still adopting
+  /// the server's `_rev` (`:152`); the upload then POSTs that local array back
+  /// under the fresh revision, and CouchDB replaces the document
+  /// (`UploadConfigs.kt:198-208`, no `dbIdExtractor`, so it is always a POST
+  /// of the whole body). An admin who replies through the web UI while a
+  /// handset has an unsent reply therefore loses their reply **on the server**,
+  /// for every device and the web UI too. Both apps did this; the port stops.
+  ///
+  /// Both arrays are append-only in normal use, so they share a prefix and
+  /// diverge into "the admin's replies" and "ours". Keeping the server's copy
+  /// whole and re-appending only our tail after that prefix is what makes the
+  /// merge idempotent: once our reply has landed and been pulled back, the
+  /// local array is a **prefix** of the server's, the tail is empty, and the
+  /// server's copy is adopted unchanged — so a reply cannot be duplicated by
+  /// repeated syncs.
+  ///
+  /// Elements are compared on `message`/`user`/`time` through the same readers
+  /// the rest of this file uses, not on their bytes: the server may echo a
+  /// reply back with its keys in a different order, and comparing encoded
+  /// bytes would read that as a divergence and append our copy a second time.
+  static String? _mergePendingReplies(
+    String? localJson,
+    Object? serverMessages,
+  ) {
+    if (serverMessages is! List) return localJson;
+    final local = _decodeMessages(localJson);
+
+    var shared = 0;
+    while (shared < local.length &&
+        shared < serverMessages.length &&
+        _sameMessage(local[shared], serverMessages[shared])) {
+      shared++;
+    }
+
+    if (shared == local.length) return jsonEncode(serverMessages);
+    return jsonEncode([...serverMessages, ...local.skip(shared)]);
+  }
+
+  /// Whether two message elements are the same reply.
+  static bool _sameMessage(Object? a, Object? b) {
+    if (a is! Map<String, dynamic> || b is! Map<String, dynamic>) return false;
+    return _string('message', a) == _string('message', b) &&
+        _userString('user', a) == _userString('user', b) &&
+        _string('time', a) == _string('time', b);
   }
 
   /// Creates a new feedback entry.

--- a/flutter/lib/data/local/feedback_mapper.dart
+++ b/flutter/lib/data/local/feedback_mapper.dart
@@ -3,13 +3,74 @@ import 'dart:math';
 
 import 'package:drift/drift.dart';
 
+import '../../core/utils/json_utils.dart';
 import 'app_database.dart';
+
+/// Reads a string-valued field the way the rest of the port reads one, and
+/// survives every shape a raw `as String?` cast does not.
+///
+/// Every field below used to be read with `as String?`, which throws a
+/// `TypeError` on anything that is neither a string nor null. **Kotlin cannot
+/// throw here**: `JsonUtils.getString` returns `""` for a non-string
+/// (`JsonUtils.kt:65-68`), so the port was stricter than the app it ports —
+/// the same defect that made a Planet's 1,630 chat documents fail to sync as
+/// one batch because 3 of them carried an object-valued `user`, fixed in
+/// `chat_mapper.dart`.
+///
+/// Delegating to [JsonUtils.getStringOrNull] keeps a JSON **number** readable
+/// (`2019` reads as `'2019'` — the port's documented, deliberate divergence
+/// from Kotlin's `""`) and folds a missing key to null, which is what this
+/// mapper already stored for an absent field. A well-formed document therefore
+/// maps exactly as it did before.
+///
+/// A Map or a List is intercepted first and reads as null, because that
+/// helper's own doc comment forbids passing it either: it would store Dart's
+/// `Map.toString()`, which is not JSON and throws wherever it is read back.
+/// Null is this mapper's spelling of Kotlin's `""` for an absent field.
+String? _string(String key, Map<String, dynamic> json) {
+  final value = json[key];
+  if (value is Map || value is List) return null;
+  return JsonUtils.getStringOrNull(key, json);
+}
+
+/// [_string], except that an object reads its `name`.
+///
+/// Used only for the fields that hold a **person** — `owner`, `source`, and a
+/// reply's `user`. A Planet's web UI writes the whole CouchDB user document
+/// into a field the handset writes as a plain user name; `name` is the same
+/// value the other documents carry as a string, so taking it is a deliberate
+/// improvement on Kotlin's `""`, which discards something unambiguous. The
+/// shape was first observed against `https://planet.learning.ole.org`, where
+/// 3 of 1,630 chat documents carried it; `chat_mapper.dart`'s `_stringOrNull`
+/// reads the object the same way. It differs on a **number**, which that
+/// helper drops and [JsonUtils.getStringOrNull] keeps as its digits — the
+/// port-wide convention, and what Gson's `asString` gives Kotlin's own reply
+/// reader (`Feedback.kt:63-65`).
+String? _userString(String key, Map<String, dynamic> json) {
+  final value = json[key];
+  if (value is Map) {
+    final name = value['name'];
+    return name is String && name.isNotEmpty ? name : null;
+  }
+  return _string(key, json);
+}
 
 /// Port of `model/Feedback.kt` and `model/FeedbackReply.kt`.
 ///
 /// Maps CouchDB feedback documents to [FeedbackEntriesCompanion] for Drift persistence.
 class FeedbackMapper {
   FeedbackMapper._();
+
+  /// The document id, read the one way so the sync's batch read of existing
+  /// rows and the mapper agree on it.
+  ///
+  /// `FeedbackRepositoryImpl.insertFromJson` derives the id a second time to
+  /// look up the stored row whose pending reply [fromDoc] must preserve. When
+  /// the two derivations disagree the lookup misses, [fromDoc] sees no
+  /// existing row, and the server's copy of the thread overwrites an unsent
+  /// reply — so they read through this.
+  static String idOf(Map<String, dynamic> doc) =>
+      _string('_id', doc) ?? _string('id', doc) ?? '';
 
   /// Converts a CouchDB feedback document JSON to a [FeedbackEntriesCompanion].
   ///
@@ -22,38 +83,32 @@ class FeedbackMapper {
     Map<String, dynamic> doc, [
     FeedbackRow? existing,
   ]) {
-    final id = doc['_id'] as String? ?? doc['id'] as String? ?? '';
-    final rev = doc['_rev'] as String?;
+    final id = idOf(doc);
     final hasPendingLocalReply = existing != null && !existing.isUploaded;
     final messages = hasPendingLocalReply ? null : doc['messages'];
-    final openTime = doc['openTime'];
     final isUploaded =
         !hasPendingLocalReply && doc.containsKey('_rev') && doc['_rev'] != null;
 
     return FeedbackEntriesCompanion(
       id: Value(id),
-      rev: Value(rev),
-      title: Value(doc['title'] as String?),
-      source: Value(doc['source'] as String?),
-      status: Value(doc['status'] as String? ?? 'Open'),
-      priority: Value(doc['priority'] as String?),
-      owner: Value(doc['owner'] as String?),
-      openTime: Value(
-        openTime is int
-            ? openTime
-            : int.tryParse(openTime?.toString() ?? '') ?? 0,
-      ),
-      type: Value(doc['type'] as String?),
-      url: Value(doc['url'] as String?),
-      parentCode: Value(doc['parentCode'] as String?),
+      rev: Value(_string('_rev', doc)),
+      title: Value(_string('title', doc)),
+      source: Value(_userString('source', doc)),
+      status: Value(_string('status', doc) ?? 'Open'),
+      priority: Value(_string('priority', doc)),
+      owner: Value(_userString('owner', doc)),
+      openTime: Value(JsonUtils.getLong('openTime', doc)),
+      type: Value(_string('type', doc)),
+      url: Value(_string('url', doc)),
+      parentCode: Value(_string('parentCode', doc)),
       isUploaded: Value(isUploaded),
       messages: Value(
         hasPendingLocalReply
             ? existing.messages
             : (messages != null ? jsonEncode(messages) : null),
       ),
-      item: Value(doc['item'] as String?),
-      state: Value(doc['state'] as String?),
+      item: Value(_string('item', doc)),
+      state: Value(_string('state', doc)),
     );
   }
 
@@ -107,26 +162,48 @@ class FeedbackMapper {
   }
 
   /// Parses the embedded messages JSON into a list of [FeedbackMessage].
+  ///
+  /// Port of `Feedback.messageList` / `Feedback.message` (`Feedback.kt:56-88`),
+  /// which read each element with Gson's `asString` — so a **numeric** `time`
+  /// reads as its digits there, not as nothing.
+  ///
+  /// The field reads used to be raw `as String?` casts inside a `try` that
+  /// wrapped the whole loop, which made one odd value cost the entire thread:
+  /// a reply whose `time` is a JSON number (what a Planet's web UI writes) or
+  /// whose `user` is the full user document threw a `TypeError`, the blanket
+  /// `catch` swallowed it, and this returned `[]`. The detail screen then drew
+  /// no body and no replies — an admin's answer simply absent — and, worse,
+  /// [addReply] used to rebuild the thread from this list, so the user's next
+  /// reply replaced every earlier message and the uploader PUT that truncated
+  /// array over the server's document.
+  ///
+  /// The `try` now covers only [jsonDecode], where a genuinely unparseable
+  /// string is the one thing that cannot be salvaged; the element mapping is
+  /// total, so a surprising field degrades to `''` instead of emptying the
+  /// thread.
   static List<FeedbackMessage> parseMessages(String? messagesJson) {
-    if (messagesJson == null || messagesJson.isEmpty) {
-      return [];
-    }
+    return _decodeMessages(messagesJson)
+        .map(
+          (e) => e is Map<String, dynamic>
+              ? FeedbackMessage(
+                  message: _string('message', e) ?? '',
+                  user: _userString('user', e) ?? '',
+                  date: _string('time', e) ?? '',
+                )
+              : const FeedbackMessage(),
+        )
+        .toList();
+  }
+
+  /// The messages array exactly as stored, elements untouched.
+  static List<dynamic> _decodeMessages(String? messagesJson) {
+    if (messagesJson == null || messagesJson.isEmpty) return [];
     try {
       final decoded = jsonDecode(messagesJson);
-      if (decoded is List) {
-        return decoded.map((e) {
-          if (e is Map<String, dynamic>) {
-            return FeedbackMessage(
-              message: e['message'] as String? ?? '',
-              user: e['user'] as String? ?? '',
-              date: e['time'] as String? ?? '',
-            );
-          }
-          return const FeedbackMessage();
-        }).toList();
-      }
-    } catch (_) {}
-    return [];
+      return decoded is List ? decoded : [];
+    } catch (_) {
+      return [];
+    }
   }
 
   /// Gets the first message from the messages list.
@@ -137,21 +214,28 @@ class FeedbackMapper {
   }
 
   /// Adds a reply to the messages JSON.
+  ///
+  /// Appends to the decoded array **without re-encoding the elements already
+  /// in it**, as Kotlin does (`FeedbackRepositoryImpl.addReply:100-110` adds to
+  /// the `JsonArray` it parsed). Rebuilding the array from [parseMessages]
+  /// rewrote every earlier message down to `message`/`user`/`time`: an admin
+  /// reply that arrived from the web UI carrying an object-valued `user`, a
+  /// numeric `time` or any other key lost it here, and because the uploader
+  /// sends the whole array back with the document's `_rev`, that loss reached
+  /// the server and every other device.
   static String addReply(
     String? existingMessagesJson,
     String message,
     String user,
   ) {
-    final messages = parseMessages(existingMessagesJson);
+    final messages = _decodeMessages(existingMessagesJson);
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    messages.add(
-      FeedbackMessage(message: message, user: user, date: timestamp.toString()),
-    );
-    return jsonEncode(
-      messages
-          .map((m) => {'message': m.message, 'user': m.user, 'time': m.date})
-          .toList(),
-    );
+    messages.add({
+      'message': message,
+      'time': timestamp.toString(),
+      'user': user,
+    });
+    return jsonEncode(messages);
   }
 
   /// Serializes a feedback row to a CouchDB-compatible JSON map.

--- a/flutter/lib/providers/feedback_provider.dart
+++ b/flutter/lib/providers/feedback_provider.dart
@@ -144,9 +144,24 @@ class FeedbackSyncNotifier extends SyncNotifier {
   Future<SyncResult> runSync(
     ServerConfig config,
     void Function(SyncProgress) onProgress,
-  ) => ref
-      .read(feedbackRepositoryProvider)
-      .sync(config: config, onProgress: onProgress);
+  ) async {
+    final result = await ref
+        .read(feedbackRepositoryProvider)
+        .sync(config: config, onProgress: onProgress);
+
+    // The pull merges an admin's replies into a thread this device has not
+    // finished uploading (`FeedbackMapper._mergePendingReplies`), but the
+    // outbox holds a *snapshot* of the payload taken when the reply was
+    // written — and nothing else re-queues feedback, so that snapshot would
+    // drain the pre-merge array over the server's document and undo the merge
+    // there. Re-queuing refreshes it: `OutboxRepository.enqueue` replaces the
+    // payload of the row this item already owns, and puts an in-flight row
+    // back to `pending` so the edit still goes out.
+    if (result is SyncComplete) {
+      await ref.read(feedbackQueueProvider).queuePending();
+    }
+    return result;
+  }
 }
 
 final feedbackSyncProvider =

--- a/flutter/lib/repository/feedback_repository_impl.dart
+++ b/flutter/lib/repository/feedback_repository_impl.dart
@@ -115,21 +115,21 @@ class FeedbackRepositoryImpl implements FeedbackRepository {
   Future<void> insertFromJson(List<Map<String, dynamic>> docs) async {
     // A row with an unconfirmed local reply must keep its messages through
     // the sync, so the mapper needs the stored row to compare against.
-    final ids = docs
-        .map((doc) => doc['_id'] as String? ?? doc['id'] as String? ?? '')
-        .where((id) => id.isNotEmpty)
-        .toList(growable: false);
+    // The id is derived through `FeedbackMapper.idOf` on both sides. A raw
+    // `as String?` here threw on a document whose `_id` was not a plain
+    // string, and deriving it twice by hand risked the lookup missing the
+    // very row whose pending reply the mapper has to keep.
+    final ids = docs.map(FeedbackMapper.idOf).toList(growable: false);
     final existingById = {
-      for (final row in await feedbackDao.getByIds(ids)) row.id: row,
+      for (final row in await feedbackDao.getByIds(
+        ids.where((id) => id.isNotEmpty).toList(growable: false),
+      ))
+        row.id: row,
     };
-    final companions = docs
-        .map(
-          (doc) => FeedbackMapper.fromDoc(
-            doc,
-            existingById[doc['_id'] as String? ?? doc['id'] as String? ?? ''],
-          ),
-        )
-        .toList();
+    final companions = [
+      for (var i = 0; i < docs.length; i++)
+        FeedbackMapper.fromDoc(docs[i], existingById[ids[i]]),
+    ];
     await feedbackDao.upsertAll(companions);
   }
 

--- a/flutter/lib/repository/feedback_repository_impl.dart
+++ b/flutter/lib/repository/feedback_repository_impl.dart
@@ -193,7 +193,10 @@ class FeedbackRepositoryImpl implements FeedbackRepository {
         final doc = JsonUtils.getObject('doc', row);
         if (doc != null) {
           docs.add(doc);
-          final id = JsonUtils.getString('_id', doc);
+          // Through `idOf`, like the row key: `deleteNotIn` spares what is in
+          // this set, so a document the mapper stores under a key this set
+          // does not hold is inserted and then deleted in the same sync.
+          final id = FeedbackMapper.idOf(doc);
           if (id.isNotEmpty) savedIds.add(id);
         }
       }

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -165,16 +165,19 @@ typedef OutboxHandler =
 /// closed (hence the `cacheDocuments` citation, which belongs there and only
 /// there), which is why health needs the arm most.
 ///
-/// **The exception, and it is a real one.** Where the server's document holds
-/// content the payload cannot reconstruct, "one sync later" is still a loss
-/// and this arm still makes it sooner. `feedback` is that case: `messages` is
-/// an append array both Planet's web UI and the handset write, and
-/// `FeedbackMapper.fromDoc:27-31` deliberately keeps the local array on a
-/// pending reply while taking the server's `rev`. So an admin reply present
-/// on the server and absent locally is destroyed by the next send — with or
-/// without this arm. That is a pre-existing merge defect, not one the arm
-/// introduces, and it is written up under *Reported, not fixed* in
-/// `PHASE_152_NOTES.md` rather than papered over here.
+/// **The exception was real, and it has been closed at the other end.** Where
+/// the server's document holds content the payload cannot reconstruct, "one
+/// sync later" is still a loss and this arm still makes it sooner. `feedback`
+/// was that case: `messages` is an append array both Planet's web UI and the
+/// handset write, and `FeedbackMapper.fromDoc` kept the local array on a
+/// pending reply while taking the server's `rev`, so an admin reply present on
+/// the server and absent locally was destroyed by the next send — with or
+/// without this arm. `FeedbackMapper._mergePendingReplies` now merges the two
+/// instead, and `FeedbackSyncNotifier` re-queues after a pull so the payload
+/// this arm re-sends is the merged one rather than a stale snapshot. **The
+/// rule the exception qualified still stands for any future uploader whose
+/// document holds server-authored content**: closing it took a merge in the
+/// mapper, not a change here.
 ///
 /// **One case deserves naming rather than falling out of the rule.** A team
 /// tombstone is `{_id, _rev, _deleted: true}` (`teams_provider.dart:295`), so

--- a/flutter/lib/ui/feedback/feedback_list_screen.dart
+++ b/flutter/lib/ui/feedback/feedback_list_screen.dart
@@ -312,8 +312,16 @@ class _FeedbackListTile extends StatelessWidget {
 
   String _formatDate(int timestamp) {
     if (timestamp == 0) return '';
-    final date = DateTime.fromMillisecondsSinceEpoch(timestamp);
-    return '${date.day}/${date.month}/${date.year}';
+    try {
+      final date = DateTime.fromMillisecondsSinceEpoch(timestamp);
+      return '${date.day}/${date.month}/${date.year}';
+    } catch (_) {
+      // `openTime` is whatever the server document held, and a value beyond
+      // the ~±275,000-year range throws out of `build` and takes the whole
+      // list down over one bad row. The detail screen's formatter has always
+      // been guarded; this one was not.
+      return '';
+    }
   }
 }
 

--- a/flutter/test/data/local/feedback_mapper_test.dart
+++ b/flutter/test/data/local/feedback_mapper_test.dart
@@ -1,0 +1,410 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/feedback_mapper.dart';
+import 'package:myplanet/repository/feedback_repository_impl.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// The shape that took a chat sync down: a Planet's web UI writes the whole
+/// CouchDB user document where the handset writes a plain user name.
+const _userDocument = {
+  '_id': 'org.couchdb.user:learning',
+  'name': 'learning',
+  'roles': ['learner'],
+  'type': 'user',
+};
+
+void main() {
+  late AppDatabase database;
+  late FeedbackRepositoryImpl repository;
+
+  setUp(() {
+    database = AppDatabase.memory();
+    repository = FeedbackRepositoryImpl(
+      feedbackDao: database.feedbackDao,
+      planetApi: MockPlanetApi(),
+    );
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  group('a document the server actually sends', () {
+    test('one object-valued field does not fail the batch around it', () async {
+      // The chat failure mode, pinned for feedback: 3 of 1,630 documents threw
+      // on a raw `as String?` and the exception propagated out of the batch,
+      // so all 1,630 failed to sync. Every document here must land.
+      await repository.insertFromJson([
+        {
+          '_id': 'fb-before',
+          '_rev': '1-a',
+          'title': 'filed from the handset',
+          'owner': 'learning',
+        },
+        {
+          '_id': 'fb-odd',
+          '_rev': '1-b',
+          'title': 'filed through the web UI',
+          'owner': _userDocument,
+          'source': _userDocument,
+          'messages': [
+            {'message': 'the question', 'time': 1757000000000, 'user': 'ada'},
+            {
+              'message': 'the admin answer',
+              'time': 1757000900000,
+              'user': _userDocument,
+            },
+          ],
+        },
+        {
+          // `_id` itself, which the batch read of existing rows derives a
+          // second time. A raw cast threw here too, and out of the *outer*
+          // loop rather than the mapper.
+          '_id': _userDocument,
+          '_rev': '1-d',
+          'title': 'a document with no usable id',
+        },
+        {'_id': 'fb-after', '_rev': '1-c', 'title': 'filed later'},
+      ]);
+
+      final stored = await database.feedbackDao.watchAllSorted().first;
+      expect(
+        stored.map((row) => row.id),
+        containsAll(<String>['fb-before', 'fb-odd', 'fb-after']),
+        reason: 'a single odd field must cost one field, never the batch',
+      );
+    });
+
+    test('an object-valued person reads its name, as chat does', () async {
+      final mapped = FeedbackMapper.fromDoc({
+        '_id': 'fb1',
+        'owner': _userDocument,
+        'source': _userDocument,
+      });
+
+      expect(mapped.owner.value, 'learning');
+      expect(mapped.source.value, 'learning');
+    });
+
+    test(
+      'an object with no usable name reads as null, never as its literal',
+      () {
+        // `Map.toString()` is not JSON, so storing it poisons every later read.
+        final mapped = FeedbackMapper.fromDoc({
+          '_id': 'fb1',
+          'owner': const {'roles': <String>[]},
+          'title': const {'en': 'localised title'},
+          'state': const ['a', 'b'],
+        });
+
+        expect(mapped.owner.value, isNull);
+        expect(mapped.title.value, isNull);
+        expect(mapped.state.value, isNull);
+      },
+    );
+
+    test('a numeric field reads as its digits, the port-wide convention', () {
+      final mapped = FeedbackMapper.fromDoc({'_id': 'fb1', 'priority': 2});
+
+      expect(mapped.priority.value, '2');
+    });
+
+    test('an object-valued _id is not stored as a row key', () {
+      // `JsonUtils.getString` would hand back `Map.toString()` here, which is
+      // worse than nothing for a primary key.
+      expect(FeedbackMapper.idOf(const {'_id': _userDocument}), '');
+      expect(FeedbackMapper.idOf(const {'id': 'fallback-id'}), 'fallback-id');
+    });
+
+    test('a well-formed document maps exactly as it did before', () {
+      final mapped = FeedbackMapper.fromDoc({
+        '_id': 'fb1',
+        '_rev': '2-b',
+        'title': 'Question regarding /',
+        'source': 'ada',
+        'status': 'Open',
+        'priority': 'Yes',
+        'owner': 'ada',
+        'openTime': 1757000000000,
+        'type': 'Bug',
+        'url': '/',
+        'parentCode': 'dev',
+        'item': 'item1',
+        'state': 'state1',
+      });
+
+      expect(mapped.id.value, 'fb1');
+      expect(mapped.rev.value, '2-b');
+      expect(mapped.title.value, 'Question regarding /');
+      expect(mapped.source.value, 'ada');
+      expect(mapped.status.value, 'Open');
+      expect(mapped.priority.value, 'Yes');
+      expect(mapped.owner.value, 'ada');
+      expect(mapped.openTime.value, 1757000000000);
+      expect(mapped.type.value, 'Bug');
+      expect(mapped.url.value, '/');
+      expect(mapped.parentCode.value, 'dev');
+      expect(mapped.item.value, 'item1');
+      expect(mapped.state.value, 'state1');
+      expect(mapped.isUploaded.value, isTrue);
+    });
+  });
+
+  group('parseMessages', () {
+    test('a numeric time reads as its digits, as Gson gives Kotlin', () {
+      // `Feedback.kt:63-65` reads `ob["time"].asString`, which renders a JSON
+      // number. `as String?` threw on it instead.
+      final parsed = FeedbackMapper.parseMessages(
+        jsonEncode([
+          {'message': 'the question', 'time': 1757000000000, 'user': 'ada'},
+        ]),
+      );
+
+      expect(parsed, hasLength(1));
+      expect(parsed.single.date, '1757000000000');
+    });
+
+    test('one odd reply costs that field, not the whole thread', () {
+      final parsed = FeedbackMapper.parseMessages(
+        jsonEncode([
+          {'message': 'the question', 'time': '1757000000000', 'user': 'ada'},
+          {
+            'message': 'the admin answer',
+            'time': 1757000900000,
+            'user': _userDocument,
+          },
+        ]),
+      );
+
+      expect(
+        parsed.map((m) => m.message),
+        ['the question', 'the admin answer'],
+        reason: 'the whole thread used to come back empty',
+      );
+      expect(parsed.last.user, 'learning');
+      expect(parsed.last.date, '1757000900000');
+    });
+
+    test('the first message survives an odd reply after it', () {
+      // What the detail screen draws as the feedback body, and what the list
+      // screen searches: both were blank whenever any later reply was odd.
+      expect(
+        FeedbackMapper.getFirstMessage(
+          jsonEncode([
+            {'message': 'the question', 'time': '1', 'user': 'ada'},
+            {'message': 'the admin answer', 'time': 2, 'user': _userDocument},
+          ]),
+        ),
+        'the question',
+      );
+    });
+
+    test('unparseable JSON is still an empty thread, not a throw', () {
+      expect(FeedbackMapper.parseMessages('{not json'), isEmpty);
+      expect(FeedbackMapper.parseMessages('{"messages": []}'), isEmpty);
+      expect(FeedbackMapper.parseMessages(null), isEmpty);
+      expect(FeedbackMapper.parseMessages(''), isEmpty);
+    });
+
+    test('a non-object element degrades to an empty message', () {
+      final parsed = FeedbackMapper.parseMessages(
+        jsonEncode(['just a string']),
+      );
+
+      expect(parsed, hasLength(1));
+      expect(parsed.single.message, '');
+    });
+  });
+
+  group('addReply', () {
+    test('leaves every earlier message byte-identical', () async {
+      // Kotlin appends to the `JsonArray` it parsed
+      // (`FeedbackRepositoryImpl.addReply:100-110`). Rebuilding the array from
+      // `parseMessages` rewrote the admin's reply down to three string fields,
+      // and the uploader sends the whole array back under the document's
+      // `_rev` — so the rewrite reached the server and every other device.
+      final serverThread = [
+        {'message': 'the question', 'time': '1757000000000', 'user': 'ada'},
+        {
+          'message': 'the admin answer',
+          'time': 1757000900000,
+          'user': _userDocument,
+          'attachments': ['screenshot.png'],
+        },
+      ];
+
+      final updated = FeedbackMapper.addReply(
+        jsonEncode(serverThread),
+        'thank you',
+        'ada',
+      );
+
+      final decoded = jsonDecode(updated) as List<dynamic>;
+      expect(decoded, hasLength(3));
+      expect(
+        decoded.take(2),
+        serverThread,
+        reason: 'an appended reply must not rewrite what it appends to',
+      );
+      expect(decoded.last, {
+        'message': 'thank you',
+        'time': isA<String>(),
+        'user': 'ada',
+      });
+    });
+
+    test('an unreadable thread is not silently replaced by the reply', () {
+      // The old `parseMessages` round trip turned an empty parse into a
+      // one-element array, which the uploader then PUT over the server's copy.
+      // Nothing here can produce that from a thread that decodes.
+      final updated = FeedbackMapper.addReply(
+        jsonEncode([
+          {'message': 'the admin answer', 'time': 2, 'user': _userDocument},
+        ]),
+        'thank you',
+        'ada',
+      );
+
+      expect(jsonDecode(updated), hasLength(2));
+    });
+  });
+
+  group('the id both sides of the sync derive', () {
+    test(
+      'the `id` fallback still finds the row whose reply is pending',
+      () async {
+        // `insertFromJson` reads the id once to batch-load the stored rows and
+        // the mapper reads it again to look one up. When the two disagree the
+        // lookup misses, the mapper sees no existing row, and the server's copy
+        // of the thread overwrites a reply the outbox has not sent yet — so both
+        // go through `FeedbackMapper.idOf`, `id` fallback included.
+        await repository.insertFromJson([
+          {
+            'id': 'fb-legacy',
+            '_rev': '1-a',
+            'messages': [
+              {'message': 'the question', 'time': '1', 'user': 'ada'},
+            ],
+          },
+        ]);
+        await repository.addReply('fb-legacy', 'my pending reply', 'ada');
+
+        await repository.insertFromJson([
+          {
+            'id': 'fb-legacy',
+            '_rev': '2-b',
+            'messages': [
+              {'message': 'the question', 'time': '1', 'user': 'ada'},
+            ],
+          },
+        ]);
+
+        final stored = await repository.getFeedbackById('fb-legacy');
+        expect(
+          FeedbackMapper.parseMessages(stored!.messages).map((m) => m.message),
+          contains('my pending reply'),
+        );
+        expect(stored.isUploaded, isFalse);
+      },
+    );
+  });
+
+  group('columns whose default is the port\'s own choice', () {
+    test('a document with no status reads as Open, not as Kotlin\'s empty', () {
+      // A deliberate, pre-existing divergence: Kotlin stores `""`
+      // (`FeedbackRepositoryImpl.kt:143` through `JsonUtils.getString`), the
+      // port stores `Open` so the status chip and the closed check have
+      // something to read. Pinned so it is not lost by accident.
+      expect(FeedbackMapper.fromDoc({'_id': 'fb1'}).status.value, 'Open');
+      expect(
+        FeedbackMapper.fromDoc({'_id': 'fb1', 'status': 'Closed'}).status.value,
+        'Closed',
+      );
+    });
+
+    test('openTime accepts the number and the numeric string alike', () {
+      // `JsonUtils.getLong` is what Kotlin uses here (`:146`), and it takes
+      // either. A shape that is neither is `0`, never a throw.
+      expect(
+        FeedbackMapper.fromDoc({
+          '_id': 'f',
+          'openTime': 1757000000000,
+        }).openTime.value,
+        1757000000000,
+      );
+      expect(
+        FeedbackMapper.fromDoc({
+          '_id': 'f',
+          'openTime': '1757000000000',
+        }).openTime.value,
+        1757000000000,
+      );
+      expect(
+        FeedbackMapper.fromDoc({
+          '_id': 'f',
+          'openTime': _userDocument,
+        }).openTime.value,
+        0,
+      );
+    });
+  });
+
+  group('the admin reply, writer and reader driven together', () {
+    test(
+      'survives a pull, the detail screen read, a local reply and the upload',
+      () async {
+        // The round trip the previous defects each passed one half of: the
+        // sync writes the row, the detail screen reads the thread, the user
+        // replies, and the uploader serializes what goes back to CouchDB.
+        await repository.insertFromJson([
+          {
+            '_id': 'fb1',
+            '_rev': '2-admin',
+            'title': 'Sync fails offline',
+            'owner': _userDocument,
+            'messages': [
+              {'message': 'the question', 'time': 1757000000000, 'user': 'ada'},
+              {
+                'message': 'the admin answer',
+                'time': 1757000900000,
+                'user': _userDocument,
+              },
+            ],
+          },
+        ]);
+
+        final pulled = await repository.getFeedbackById('fb1');
+        expect(
+          FeedbackMapper.parseMessages(pulled!.messages).map((m) => m.message),
+          ['the question', 'the admin answer'],
+          reason: 'the detail screen drew an empty thread here',
+        );
+
+        await repository.addReply('fb1', 'thank you', 'ada');
+
+        final replied = await repository.getFeedbackById('fb1');
+        final payload = FeedbackMapper.toDoc(replied!);
+        final messages = payload['messages'] as List<dynamic>;
+
+        expect(messages, hasLength(3));
+        expect(messages[1], {
+          'message': 'the admin answer',
+          'time': 1757000900000,
+          'user': _userDocument,
+        }, reason: "the upload must not rewrite the admin's own reply");
+        expect((messages[2] as Map)['message'], 'thank you');
+        expect(payload['_rev'], '2-admin');
+        expect(
+          replied.isUploaded,
+          isFalse,
+          reason: 'so the outbox collects it',
+        );
+      },
+    );
+  });
+}

--- a/flutter/test/data/local/feedback_mapper_test.dart
+++ b/flutter/test/data/local/feedback_mapper_test.dart
@@ -78,6 +78,21 @@ void main() {
         containsAll(<String>['fb-before', 'fb-odd', 'fb-after']),
         reason: 'a single odd field must cost one field, never the batch',
       );
+      expect(
+        stored,
+        hasLength(4),
+        reason: 'the fourth lands under an empty id',
+      );
+
+      // Landing is not enough: the odd document must also have carried its
+      // content across, or the batch survived by storing nothing.
+      final odd = stored.firstWhere((row) => row.id == 'fb-odd');
+      expect(odd.title, 'filed through the web UI');
+      expect(odd.owner, 'learning');
+      expect(FeedbackMapper.parseMessages(odd.messages).map((m) => m.message), [
+        'the question',
+        'the admin answer',
+      ]);
     });
 
     test('an object-valued person reads its name, as chat does', () async {
@@ -108,6 +123,58 @@ void main() {
       },
     );
 
+    test('an explicit empty string is stored as one, not folded to null', () {
+      // `JsonUtils.getStringOrNull` would fold these to null, and one of them
+      // hides a row: `FeedbackDao.watchByOwner` matches `owner.equals(owner ??
+      // '')`, so a thread filed by a session with an empty name would vanish
+      // from its own author's list on the next pull. `json_utils.dart`
+      // documents the fold's cost; this is the mapper refusing to pay it.
+      final mapped = FeedbackMapper.fromDoc({
+        '_id': 'fb1',
+        'title': '',
+        'owner': '',
+        'status': '',
+      });
+
+      expect(mapped.title.value, '');
+      expect(mapped.owner.value, '');
+      expect(
+        mapped.status.value,
+        '',
+        reason: "an empty status is the server's, not a missing one",
+      );
+    });
+
+    test('a row whose owner is empty stays in its author\'s list', () async {
+      // The same fold, driven through the query that would have hidden it.
+      await repository.insertFromJson([
+        {'_id': 'fb1', '_rev': '1-a', 'owner': '', 'title': 'filed by nobody'},
+      ]);
+
+      final visible = await repository.getFeedback(userName: '').first;
+      expect(visible.map((row) => row.id), ['fb1']);
+    });
+
+    test('a boolean reads as its literal, as any other non-string does', () {
+      expect(
+        FeedbackMapper.fromDoc({'_id': 'fb1', 'state': true}).state.value,
+        'true',
+      );
+    });
+
+    test('an object whose name is empty reads as null', () {
+      // Divergence from `chat_mapper.dart`'s `_stringOrNull`, which keeps the
+      // empty name. Nothing downstream can use it, and null is what this
+      // mapper stores for a field it cannot read.
+      expect(
+        FeedbackMapper.fromDoc({
+          '_id': 'fb1',
+          'owner': const {'name': ''},
+        }).owner.value,
+        isNull,
+      );
+    });
+
     test('a numeric field reads as its digits, the port-wide convention', () {
       final mapped = FeedbackMapper.fromDoc({'_id': 'fb1', 'priority': 2});
 
@@ -119,6 +186,12 @@ void main() {
       // worse than nothing for a primary key.
       expect(FeedbackMapper.idOf(const {'_id': _userDocument}), '');
       expect(FeedbackMapper.idOf(const {'id': 'fallback-id'}), 'fallback-id');
+      expect(
+        FeedbackMapper.idOf(const {'_id': '', 'id': 'fallback-id'}),
+        '',
+        reason:
+            'an empty `_id` is a present one; only an absent key falls back',
+      );
     });
 
     test('a well-formed document maps exactly as it did before', () {
@@ -399,6 +472,14 @@ void main() {
         }, reason: "the upload must not rewrite the admin's own reply");
         expect((messages[2] as Map)['message'], 'thank you');
         expect(payload['_rev'], '2-admin');
+        expect(
+          payload['owner'],
+          'learning',
+          reason:
+              'reading the name is also a write: the upload rebuilds the '
+              'document from the columns, so the object is flattened on the '
+              'server. Kotlin would flatten it to an empty string instead.',
+        );
         expect(
           replied.isUploaded,
           isFalse,

--- a/flutter/test/providers/feedback_sync_requeue_test.dart
+++ b/flutter/test/providers/feedback_sync_requeue_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/feedback_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/repository/feedback_repository.dart';
+import 'package:myplanet/repository/feedback_uploader.dart';
+
+class MockFeedbackRepository extends Mock implements FeedbackRepository {}
+
+class MockFeedbackUploader extends Mock implements FeedbackUploader {}
+
+/// The pull merges an admin's replies into a thread whose own reply has not
+/// been sent (`FeedbackMapper._mergePendingReplies`). The outbox, though,
+/// holds the payload **as it was when the reply was written** — and the two
+/// feedback screens are the only other callers of `queuePending`, so without
+/// this the merged thread would sit in the database while the stale snapshot
+/// drained over the server's document and undid the merge there.
+void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+
+  late MockFeedbackRepository repository;
+  late MockFeedbackUploader uploader;
+
+  setUpAll(() {
+    registerFallbackValue(
+      const ServerConfig(serverUrl: '', couchDbUrl: '', pin: ''),
+    );
+  });
+
+  setUp(() {
+    repository = MockFeedbackRepository();
+    uploader = MockFeedbackUploader();
+    when(
+      () => uploader.queuePending(
+        config: any(named: 'config'),
+        userId: any(named: 'userId'),
+      ),
+    ).thenAnswer((_) async => 1);
+  });
+
+  ProviderContainer containerFor() {
+    final container = ProviderContainer(
+      overrides: [
+        feedbackRepositoryProvider.overrideWithValue(repository),
+        feedbackUploaderProvider.overrideWithValue(uploader),
+        serverConfigProvider.overrideWith(_TestConfig.new),
+        sessionProvider.overrideWith(_NoSessionNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('a completed pull refreshes the queued payload', () async {
+    when(
+      () => repository.sync(
+        config: any(named: 'config'),
+        onProgress: any(named: 'onProgress'),
+      ),
+    ).thenAnswer((_) async => const SyncComplete(3));
+
+    final container = containerFor();
+    final result = await container
+        .read(feedbackSyncProvider.notifier)
+        .runSync(config, (_) {});
+
+    expect(result, isA<SyncComplete>());
+    verify(
+      () => uploader.queuePending(
+        config: config,
+        userId: any(named: 'userId'),
+      ),
+    ).called(1);
+  });
+
+  test('a failed pull queues nothing', () async {
+    // Half a page of documents is not a thread state worth pushing back.
+    when(
+      () => repository.sync(
+        config: any(named: 'config'),
+        onProgress: any(named: 'onProgress'),
+      ),
+    ).thenAnswer((_) async => const SyncFailed('unreachable'));
+
+    final container = containerFor();
+    final result = await container
+        .read(feedbackSyncProvider.notifier)
+        .runSync(config, (_) {});
+
+    expect(result, isA<SyncFailed>());
+    verifyNever(
+      () => uploader.queuePending(
+        config: any(named: 'config'),
+        userId: any(named: 'userId'),
+      ),
+    );
+  });
+}
+
+class _TestConfig extends ServerConfigNotifier {
+  @override
+  ServerConfig? build() => const ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+}
+
+class _NoSessionNotifier extends SessionNotifier {
+  @override
+  Future<UserRow?> build() async => null;
+}

--- a/flutter/test/repository/feedback_repository_test.dart
+++ b/flutter/test/repository/feedback_repository_test.dart
@@ -1,4 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/data/api/planet_api.dart';
@@ -9,6 +12,12 @@ import 'package:myplanet/repository/feedback_repository_impl.dart';
 class MockPlanetApi extends Mock implements PlanetApi {}
 
 void main() {
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+
   late AppDatabase database;
   late FeedbackRepositoryImpl repository;
   late MockPlanetApi api;
@@ -186,6 +195,42 @@ void main() {
     expect(stored!.isUploaded, isTrue);
     final parsed = FeedbackMapper.parseMessages(stored.messages);
     expect(parsed.map((m) => m.message), contains('server reply'));
+  });
+
+  test('the sync keeps a document the mapper stored under its `id`', () async {
+    // Writer and reader of the same id, driven together. `deleteNotIn` spares
+    // what the walk collected, so a document the mapper keys one way and the
+    // keep set derives another way is inserted and deleted inside one sync —
+    // and the row would be gone with no error anywhere. The second document
+    // is what makes the keep set non-empty, since the cleanup is skipped when
+    // it collected nothing at all.
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((invocation) async {
+      final url = invocation.positionalArguments[0] as String;
+      if (url.contains('limit=0')) {
+        return const NetworkSuccess<Map<String, dynamic>>({'total_rows': 2});
+      }
+      return const NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {
+            'doc': {'_id': 'fb-normal', '_rev': '1-a', 'title': 'ordinary'},
+          },
+          {
+            'doc': {'id': 'fb-legacy', '_rev': '1-b', 'title': 'keyed by id'},
+          },
+        ],
+      });
+    });
+
+    final result = await repository.sync(config: config);
+
+    expect(result, isA<SyncComplete>());
+    final stored = await database.feedbackDao.watchAllSorted().first;
+    expect(
+      stored.map((row) => row.id),
+      containsAll(['fb-normal', 'fb-legacy']),
+    );
   });
 
   test(

--- a/flutter/test/repository/feedback_uploader_test.dart
+++ b/flutter/test/repository/feedback_uploader_test.dart
@@ -153,13 +153,16 @@ void main() {
       //
       // `feedback` is the one armed uploader where that is a *merge* loss rather
       // than a revision bump — `messages` is an append array both Planet's web
-      // UI and the handset write. **And the loss is pre-existing.** The second
-      // half of this test is the proof: `FeedbackMapper.fromDoc` keeps the local
-      // array on a pending reply while taking the server's `rev`
-      // (`feedback_mapper.dart:27-31, 50-54`) and leaves `isUploaded = false`,
-      // so the next sweep's payload differs from the refused one, Phase 148's
-      // memo re-arms it, and the admin reply goes over the side one sync later
-      // with no recovery arm involved at all.
+      // UI and the handset write. What this test drives is the **recovery
+      // arm**, which re-sends the payload it was handed, so it can only carry
+      // what that payload holds.
+      //
+      // The pull no longer feeds it a payload missing the admin's reply:
+      // `FeedbackMapper._mergePendingReplies` puts the server's copy back
+      // together with the unsent local tail, and `FeedbackSyncNotifier`
+      // re-queues so the outbox snapshot is refreshed rather than draining the
+      // pre-merge array. The test below this one pins that. Here the payload
+      // is constructed by hand, which is why the loss still shows.
       await seedPending();
       await (database.update(
         database.feedbackEntries,
@@ -222,51 +225,101 @@ void main() {
     },
   );
 
+  test('a pull merges the admin reply into the unsent local thread', () async {
+    // The report this lane was handed: "the port loses an admin reply".
+    //
+    // The mechanism was real and used to be pinned here as a loss. On the
+    // pending branch Kotlin keeps the local array, discards the server's
+    // (`FeedbackRepositoryImpl.kt:154`) and adopts the server's `_rev`
+    // (`:152`); the upload then POSTs the local array back and CouchDB
+    // replaces the document, so the admin's reply is destroyed **on the
+    // server** and reaches no device at all. Both apps did that. The port now
+    // merges instead: the server's copy whole, then the local tail after the
+    // shared prefix.
+    await seedPending();
+    await (database.update(
+      database.feedbackEntries,
+    )..where((f) => f.id.equals('feedback-1'))).write(
+      FeedbackEntriesCompanion(
+        rev: const Value('1-local'),
+        messages: Value(
+          jsonEncode([
+            {'message': 'the question', 'time': '1', 'user': 'ada'},
+            {'message': 'my unsent reply', 'time': '3', 'user': 'ada'},
+          ]),
+        ),
+      ),
+    );
+
+    await repository.insertFromJson([
+      {
+        '_id': 'feedback-1',
+        '_rev': '9-admin',
+        'messages': [
+          {'message': 'the question', 'time': '1', 'user': 'ada'},
+          {'message': 'from the admin', 'time': '2', 'user': 'admin'},
+        ],
+      },
+    ]);
+
+    final pulled = await database.feedbackDao.getById('feedback-1');
+    expect(pulled!.rev, '9-admin', reason: "the server's revision is taken");
+    expect(pulled.isUploaded, isFalse, reason: 'so the row is still swept');
+    expect(
+      FeedbackMapper.parseMessages(pulled.messages).map((m) => m.message),
+      ['the question', 'from the admin', 'my unsent reply'],
+      reason: 'the admin reply survives and the unsent reply keeps its place',
+    );
+
+    // And what the outbox would send now carries both.
+    final payload = FeedbackMapper.toDoc(pulled);
+    expect(
+      (payload['messages'] as List<dynamic>).map(
+        (m) => (m as Map<String, dynamic>)['message'],
+      ),
+      ['the question', 'from the admin', 'my unsent reply'],
+    );
+  });
+
   test(
-    'a pull already loses that reply, with no recovery arm involved',
+    'a second pull of the echoed thread does not duplicate the reply',
     () async {
-      // The proof that the loss above is **pre-existing**, and the reason it is
-      // reported rather than treated as something this phase introduced.
-      //
-      // `FeedbackMapper.fromDoc` keeps the local `messages` on a pending reply
-      // while taking the server's `rev` (`feedback_mapper.dart:27-31, 50-54`)
-      // and leaves `isUploaded = false`. So the admin's reply is gone locally
-      // the moment the pull lands, the row is still swept, and its payload now
-      // carries a revision the refused one did not — which is exactly what
-      // Phase 148's memo treats as a changed request. The next sweep sends the
-      // local array over the server's with no 409 and no arm in sight.
+      // The merge has to be idempotent, because a pull runs on every sync. Once
+      // the reply has landed, the local array is a prefix of the server's and
+      // the tail is empty.
       await seedPending();
       await (database.update(
         database.feedbackEntries,
       )..where((f) => f.id.equals('feedback-1'))).write(
         FeedbackEntriesCompanion(
-          rev: const Value('1-local'),
           messages: Value(
             jsonEncode([
-              {'message': 'mine'},
+              {'message': 'the question', 'time': '1', 'user': 'ada'},
+              {'message': 'my unsent reply', 'time': '3', 'user': 'ada'},
             ]),
           ),
         ),
       );
 
-      await repository.insertFromJson([
-        {
-          '_id': 'feedback-1',
-          '_rev': '9-admin',
-          'messages': [
-            {'message': 'mine'},
-            {'message': 'from the admin'},
-          ],
-        },
-      ]);
+      for (var i = 0; i < 2; i++) {
+        await repository.insertFromJson([
+          {
+            '_id': 'feedback-1',
+            '_rev': '9-admin',
+            'messages': [
+              {'message': 'the question', 'time': '1', 'user': 'ada'},
+              // The server echoes our reply back with its keys reordered, which
+              // is why the merge compares fields rather than encoded bytes.
+              {'user': 'ada', 'message': 'my unsent reply', 'time': '3'},
+            ],
+          },
+        ]);
+      }
 
       final pulled = await database.feedbackDao.getById('feedback-1');
-      expect(pulled!.rev, '9-admin', reason: "the server's revision is taken");
-      expect(pulled.isUploaded, isFalse, reason: 'so the row is still swept');
       expect(
-        pulled.messages,
-        isNot(contains('from the admin')),
-        reason: 'the local array is kept, so the reply is already lost locally',
+        FeedbackMapper.parseMessages(pulled!.messages).map((m) => m.message),
+        ['the question', 'my unsent reply'],
       );
     },
   );


### PR DESCRIPTION
Lane 4 of a five-lane round. Four commits; `dart format`, `flutter analyze` and `flutter test` all clean, **2948 passing** (baseline 2923 + 25 new).

## What changed

**`feedback_mapper.dart` no longer throws on a document shape the server actually sends.** Sixteen raw `as String?` casts across fifteen lines are gone. A cast throws a `TypeError` on anything that is neither a string nor null, and Kotlin cannot: `JsonUtils.getString` returns `""` for a non-string (`JsonUtils.kt:65-68`). Reads go through `JsonUtils.getString` behind two file-local guards — `_string` folds a Map or List to null (this mapper's spelling of Kotlin's `""` for a field it cannot read), `_userString` reads an object's `name` for the three fields that hold a person.

**Where it threw is what made it expensive.** `parseMessages` had a `try` around the whole loop, so one odd value in one reply returned `[]` for the entire thread: the detail screen drew no body and no replies, and `addReply` then rebuilt the array from that empty list, so the user's next reply replaced every earlier message and the uploader PUT the truncated array over the server's document. `addReply` now appends to the decoded array without re-encoding its elements, as Kotlin does (`FeedbackRepositoryImpl.addReply:100-110`) — even with well-formed replies the old rebuild dropped every key other than `message`/`user`/`time`, and that loss reached the server.

**The pull merges instead of overwriting.** Details under *the admin reply* below.

**Three id derivations became one.** `FeedbackMapper.idOf` is now used by the mapper, by `insertFromJson`'s batch read of existing rows, and by `sync`'s keep set. The last one mattered: it read `_id` alone, so a document carrying only `id` was stored under `fb-legacy`, collected as nothing, and deleted by `deleteNotIn` in the same sync that inserted it.

**`_formatDate` in the list screen is guarded**, as the detail screen's copy already was. An `openTime` outside the ±275,000-year range throws out of `build` and takes the whole list down over one row.

## Hardened on evidence vs. on principle

| Field | Why |
|---|---|
| a reply's `user` | **Evidence, one step removed.** The object-valued `user` is *observed* on `chat_history` — 3 of a Planet's 1,630 documents, which is what took that sync down. For feedback it is an *inference*: replies are authored through the same web UI. No captured feedback document proves it, and the code comment says so rather than claiming it. |
| a reply's `time` | **Evidence, from the Kotlin.** Kotlin reads it with Gson's `asString` (`Feedback.kt:61-69`), which renders a JSON **number** as its digits. `as String?` threw on that shape, so a numeric `time` was not merely dropped — it emptied the thread. Kotlin tolerating it is the strongest available signal that it occurs. |
| `owner`, `source` | Principle, with a Kotlin reading behind the choice of fallback: they hold a person, so an object reads its `name`. |
| `title`, `status`, `priority`, `type`, `url`, `parentCode`, `item`, `state` | Principle — blast radius. Nothing suggests the server sends objects here; they were in the same failure. |
| `_rev`, `_id` | Principle, and a weak one: an object `_rev` would mean something is deeply wrong. Included because `idOf` is a primary key and `JsonUtils.getString` would have handed it `Map.toString()`. |

`openTime` moved to `JsonUtils.getLong` for the convention, not for tolerance — the old expression already handled a numeric string.

## The admin reply that goes missing: verified, and it was two defects

The report was **right**, and Phase 152 had already pinned it (`PHASE_152_NOTES.md`, *Reported, not fixed* item 1). It has two mechanisms, and only one of them was the port's own.

1. **Port-only.** The `parseMessages`/`addReply` chain above. An admin reply carrying an object `user` or a numeric `time` made the whole thread unreadable, and the next local reply then replaced it — locally and on the server. Fixed.

2. **At parity with Kotlin, and now deliberately diverged from.** On the pending branch `fromDoc` kept the local array, discarded the server's, and adopted the server's `_rev`. Kotlin does the same (`FeedbackRepositoryImpl.kt:152, 154`), and its upload POSTs the local array back under that revision — its config declares no `dbIdExtractor`, so it is always a POST of the whole body (`UploadConfigs.kt:198-208`) and CouchDB replaces the document. So an admin replying through the web UI while a handset holds an unsent reply loses their reply **on the server**, for every device. Walking the same chain through the Kotlin is what makes this a divergence rather than a parity claim.

   The pull now merges: both arrays are append-only, so they share a prefix and diverge into the admin's replies and ours; the merge keeps the server's copy whole and re-appends only our tail after that prefix. That shape is what makes it idempotent — once our reply has landed and been pulled back, the local array is a *prefix* of the server's and the tail is empty. Elements are compared on `message`/`user`/`time` rather than on bytes, because a server that echoes a reply back with reordered keys would otherwise read as a divergence and append our copy twice.

   Merging the database alone would have **relocated** the loss rather than removed it: the outbox holds the payload as it was when the reply was written, and the two feedback screens were the only callers of `queuePending`, so the stale snapshot would have drained over the server's document anyway. `FeedbackSyncNotifier` re-queues after a completed pull.

## Mutation testing

**Twenty flips, all red.** Reverting `_string` to a raw cast; dropping `_userString`'s object case; making `_string` as strict as `chat_mapper`'s; rebuilding `addReply` from `parseMessages`; `idOf` through `JsonUtils.getString`; `parseMessages` back under one blanket `try`; both hand-rolled id derivations; the `Open` default; `openTime` as a raw int; the merge reverted, taken wholesale, and without its shared prefix; message identity on encoded bytes; the re-queue removed and the re-queue unconditional; the `''` fold reinstated in both directions; `_userString` keeping an empty name; and `idOf` falling back past an empty `_id`.

**Three of the first nine were green on the first pass** — the shared id derivation, the `Open` status default, and the `openTime` read. The tests that pin them were written after the mutation run, not counted as coverage the suite already had. The second audit then found six more unpinned claims; those have tests too, and the five new mutations are in the twenty.

## Two audit passes

Ground truth first, then the finished code — the second one found five things, four of them mine:

- the `''` fold above, which is the one that could hide a row;
- the keep-set id derivation;
- the unguarded `_formatDate`;
- a **stale citation this PR created**: `outbox_drainer.dart` cited `FeedbackMapper.fromDoc:27-31`, and the first commit inserted 60 lines above that point. That paragraph also asserted the merge defect was open. Both corrected — the "make an existing statement true" carve-out.
- One audit claim did **not** survive checking: it reported `PHASE_152_NOTES.md` as a dangling citation. The file exists at `flutter/PHASE_152_NOTES.md`.

## Files outside the stated set

- `lib/repository/feedback_repository_impl.dart`, `lib/providers/feedback_provider.dart`, `lib/ui/feedback/feedback_list_screen.dart` — the feedback slice, no other lane's set.
- `lib/repository/outbox_drainer.dart` and `PHASE_152_NOTES.md` — **documentation only**, under the "make an existing statement true" carve-out. The notes file is *annotated*, not rewritten: it is a record of what Phase 152 found, and it found this correctly.
- No new helper in `lib/core/utils/`. No `schemaVersion` bump, no table or converter change. `app_providers.dart` untouched.

## Reported, not fixed

1. **The feedback pull does not skip `_design` documents.** Kotlin filters them before insert (`TransactionSyncManager.extractDocs:355-364`, `!getString("_id", doc).startsWith("_design")`); `feedback_repository_impl.dart:190-199` filters nothing. A `_design/…` document in the `feedback` database therefore becomes a row, and since a manager reads `watchAllSorted()`, **a manager sees a bogus "Untitled feedback / Open" thread per design doc**, tappable, and permanently kept by `deleteNotIn` because it is in the keep set. Non-managers are spared only because `owner` is null. One-line fix in `insertFromJson`; left alone because I did not want a sync-shape change landing in the same PR as the merge.

2. **`FeedbackDao.deleteNotIn` has no Kotlin counterpart at all.** `FeedbackDao.kt` has no delete of any kind and the walk only inserts, so Kotlin never prunes feedback. The port's prune spares `isUploaded = false`, so a never-uploaded thread is safe — but a thread that uploaded and is then missing from a walk is gone locally where Kotlin keeps it. Whether the port wants CouchDB-cache semantics here is a policy call, not a bug I should decide alone.

3. **`rev` is written as `Value(null)` when the server omits `_rev`.** The Phase 56 shape: it should be `Value.absent()`, or a pending row's stored revision is wiped and its reply upload 409s. Unreachable today — every doc comes from `_all_docs?include_docs=true` — so it is a trap for the next caller of `insertFromJson`, not a live defect.

4. **`isUploaded` is the last raw read in `fromDoc`** (`doc.containsKey('_rev') && doc['_rev'] != null`), while `rev` beside it goes through `_string`. For an object `_rev` the row is `isUploaded = true, rev = null` — two expressions disagreeing about one field. Unreachable from CouchDB; a coherence nit, noted so the next reader does not wonder why one of the sixteen was left.

5. **`addReply` still replaces a `messages` column that is not an array.** `_decodeMessages` gives `[]` for a JSON object or a JSON string, and the reply appends to nothing. Kotlin has the same hole from the other side (`getJsonArray` normalises any non-array to `"[]"`), so it is not a parity gap — but the array-preserving fix does not reach it, and `fromDoc` will store a non-array `messages` verbatim.

6. **Two undocumented places where the port is already better than Kotlin**, listed so a future parity pass does not "correct" them back. Kotlin's `closeFeedback` writes only the status and never marks the row pending (`FeedbackDao.kt:29-30`), so the close is never uploaded *and* is reverted by the next pull; the port queues it. And Kotlin stamps every reply with the **thread owner's** name rather than the author's (`FeedbackDetailActivity.kt:82` passes `feedback?.owner`), so an admin replying to ada's thread signs it "ada"; the port uses the signed-in user. Neither is in the deliberate-deviations list in `docs/kotlin-to-flutter-migration.md`.

7. **Three hardcoded English strings in `feedback_provider.dart`** (`'Not logged in'`, `'Please enter feedback'`, `'Please select a type'`), where the screen has l10n keys for the same conditions. Reachable only by a caller that drives `FeedbackCreateNotifier.submit` without the screen's own validation, which nothing does today.

8. **`status` defaulting to `Open` is a divergence nobody wrote down** — Kotlin stores `""` (`FeedbackRepositoryImpl.kt:143`). It is now pinned by a test, but pinned is not the same as decided; the port's value is the more useful one and `docs/kotlin-to-flutter-migration.md` should say so, or it should go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFAzZediTAxrzJ4bXDh29L