### PR TITLE
all: smoother base class view binding (fixes #16999)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseBindingBottomSheetFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseBindingBottomSheetFragment.kt
@@ -1,0 +1,25 @@
+package org.ole.planet.myplanet.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+abstract class BaseBindingBottomSheetFragment<VB : ViewBinding>(
+    inflateBinding: (LayoutInflater, ViewGroup?, Boolean) -> VB
+) : BottomSheetDialogFragment() {
+    private val bindingDelegate = FragmentViewBindingDelegate(inflateBinding)
+    protected val binding: VB get() = bindingDelegate.value
+    protected val _binding: VB? get() = bindingDelegate.bindingOrNull
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return bindingDelegate.inflate(inflater, container)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        bindingDelegate.clear()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseBindingDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseBindingDialogFragment.kt
@@ -1,0 +1,25 @@
+package org.ole.planet.myplanet.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.viewbinding.ViewBinding
+
+abstract class BaseBindingDialogFragment<VB : ViewBinding>(
+    inflateBinding: (LayoutInflater, ViewGroup?, Boolean) -> VB
+) : DialogFragment() {
+    private val bindingDelegate = FragmentViewBindingDelegate(inflateBinding)
+    protected val binding: VB get() = bindingDelegate.value
+    protected val _binding: VB? get() = bindingDelegate.bindingOrNull
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return bindingDelegate.inflate(inflater, container)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        bindingDelegate.clear()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseBindingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseBindingFragment.kt
@@ -1,0 +1,25 @@
+package org.ole.planet.myplanet.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.viewbinding.ViewBinding
+
+abstract class BaseBindingFragment<VB : ViewBinding>(
+    inflateBinding: (LayoutInflater, ViewGroup?, Boolean) -> VB
+) : Fragment() {
+    private val bindingDelegate = FragmentViewBindingDelegate(inflateBinding)
+    protected val binding: VB get() = bindingDelegate.value
+    protected val _binding: VB? get() = bindingDelegate.bindingOrNull
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return bindingDelegate.inflate(inflater, container)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        bindingDelegate.clear()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/base/FragmentViewBindingDelegate.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/FragmentViewBindingDelegate.kt
@@ -1,0 +1,25 @@
+package org.ole.planet.myplanet.base
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
+
+internal class FragmentViewBindingDelegate<VB : ViewBinding>(
+    private val inflateBinding: (LayoutInflater, ViewGroup?, Boolean) -> VB
+) {
+    private var binding: VB? = null
+
+    val value: VB get() = binding!!
+    val bindingOrNull: VB? get() = binding
+
+    fun inflate(inflater: LayoutInflater, container: ViewGroup?): View {
+        val created = inflateBinding(inflater, container, false)
+        binding = created
+        return created.root
+    }
+
+    fun clear() {
+        binding = null
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/calendar/CalendarFragment.kt
@@ -5,30 +5,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import java.util.Calendar
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentCalendarBinding
 
-class CalendarFragment : Fragment() {
-    private var _binding: FragmentCalendarBinding? = null
-    private val binding get() = _binding!!
+class CalendarFragment : BaseBindingFragment<FragmentCalendarBinding>(FragmentCalendarBinding::inflate) {
     var listener: OnHomeItemClickListener? = null
-    
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is OnHomeItemClickListener) listener = context
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentCalendarBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         val calendar = Calendar.getInstance()
         binding.calendarView.setDate(calendar.time)
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
+        return view
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -20,7 +20,6 @@ import android.widget.LinearLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.view.isNotEmpty
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -35,6 +34,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.isPrimaryServerReachable
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatMessage
@@ -51,9 +51,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class ChatDetailFragment : Fragment() {
-    private var _binding: FragmentChatDetailBinding? = null
-    private val binding get() = _binding!!
+class ChatDetailFragment : BaseBindingFragment<FragmentChatDetailBinding>(FragmentChatDetailBinding::inflate) {
     private lateinit var mAdapter: ChatAdapter
     private val sharedViewModel: ChatViewModel by activityViewModels()
     private lateinit var messageTextWatcher: TextWatcher
@@ -116,9 +114,9 @@ class ChatDetailFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentChatDetailBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-        return binding.root
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -699,7 +697,6 @@ class ChatDetailFragment : Fragment() {
         cachedRawModelsString = null
         cachedModelsMap = null
 
-        _binding = null
         super.onDestroyView()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.ui.chat
 import android.content.res.ColorStateList
 import android.content.res.Resources
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
@@ -33,8 +32,6 @@ import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
-
-private data class Quartet<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
 @AndroidEntryPoint
 class ChatHistoryFragment : BaseBindingFragment<FragmentChatHistoryBinding>(FragmentChatHistoryBinding::inflate) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
@@ -21,6 +20,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnChatHistoryItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentChatHistoryBinding
@@ -37,9 +37,7 @@ import org.ole.planet.myplanet.utils.textChanges
 private data class Quartet<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
 @AndroidEntryPoint
-class ChatHistoryFragment : Fragment() {
-    private var _binding: FragmentChatHistoryBinding? = null
-    private val binding get() = _binding!!
+class ChatHistoryFragment : BaseBindingFragment<FragmentChatHistoryBinding>(FragmentChatHistoryBinding::inflate) {
     private val sharedViewModel: ChatViewModel by activityViewModels()
     var user: UserEntity? = null
     private var isFullSearch: Boolean = false
@@ -55,11 +53,6 @@ class ChatHistoryFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentChatHistoryBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -241,7 +234,6 @@ class ChatHistoryFragment : Fragment() {
         sharedNewsMessages = emptyList()
         shareTargets = ChatShareTargets(null, emptyList(), emptyList())
         user = null
-        _binding = null
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.tabs.TabLayoutMediator
@@ -12,18 +11,12 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 
 @AndroidEntryPoint
-class CommunityTabFragment : Fragment() {
-    private var _binding: FragmentTeamDetailBinding? = null
-    private val binding get() = _binding!!
+class CommunityTabFragment : BaseBindingFragment<FragmentTeamDetailBinding>(FragmentTeamDetailBinding::inflate) {
     private val viewModel: CommunityTabViewModel by viewModels()
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -37,10 +30,5 @@ class CommunityTabFragment : Fragment() {
             binding.subtitle.text = state.planetType
             binding.llActionButtons.visibility = View.GONE
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -9,28 +9,21 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingBottomSheetFragment
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 
 @AndroidEntryPoint
-class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
-    private var _binding: FragmentTeamDetailBinding? = null
-    private val binding get() = _binding!!
+class HomeCommunityDialogFragment : BaseBindingBottomSheetFragment<FragmentTeamDetailBinding>(FragmentTeamDetailBinding::inflate) {
     private val viewModel: CommunityTabViewModel by viewModels()
     private var bottomSheetBehavior: BottomSheetBehavior<View>? = null
     private var bottomSheetCallback: BottomSheetBehavior.BottomSheetCallback? = null
     private var tabLayoutMediator: TabLayoutMediator? = null
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -106,12 +99,11 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         bottomSheetCallback?.let { bottomSheetBehavior?.removeBottomSheetCallback(it) }
         bottomSheetCallback = null
         tabLayoutMediator?.detach()
         tabLayoutMediator = null
         binding.viewPager2.adapter = null
-        _binding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressFragment.kt
@@ -1,27 +1,18 @@
 package org.ole.planet.myplanet.ui.courses
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentCoursesProgressBinding
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class CoursesProgressFragment : Fragment() {
-    private var _binding: FragmentCoursesProgressBinding? = null
-    private val binding get() = _binding!!
+class CoursesProgressFragment : BaseBindingFragment<FragmentCoursesProgressBinding>(FragmentCoursesProgressBinding::inflate) {
     private val progressViewModel: ProgressViewModel by viewModels()
     private lateinit var progressAdapter: CoursesProgressAdapter
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentCoursesProgressBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -36,10 +27,5 @@ class CoursesProgressFragment : Fragment() {
         collectWhenStarted(progressViewModel.courseData) { courseData ->
             progressAdapter.submitList(courseData)
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -2,14 +2,11 @@ package org.ole.planet.myplanet.ui.courses
 
 import android.content.DialogInterface
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager.widget.ViewPager
@@ -21,6 +18,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentTakeCourseBinding
 import org.ole.planet.myplanet.model.CourseStep
 import org.ole.planet.myplanet.model.MyCourse
@@ -33,11 +31,9 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
-class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnClickListener {
+class TakeCourseFragment : BaseBindingFragment<FragmentTakeCourseBinding>(FragmentTakeCourseBinding::inflate), ViewPager.OnPageChangeListener, View.OnClickListener {
     private var isNextStepLocked = false
     private var lockedStepMessage = ""
-    private var _binding: FragmentTakeCourseBinding? = null
-    private val binding get() = _binding!!
     @Inject
     lateinit var userSessionManager: UserSessionManager
     private val viewModel: TakeCourseViewModel by viewModels()
@@ -64,11 +60,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
                 position = requireArguments().getInt("position")
             }
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentTakeCourseBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -480,7 +471,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         lifecycleScope.coroutineContext.cancelChildren()
         joinDialog?.dismiss()
         joinDialog = null
-        _binding = null
         coursesPagerAdapter = null
         super.onDestroyView()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/AboutFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/AboutFragment.kt
@@ -6,25 +6,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.text.HtmlCompat
-import androidx.fragment.app.Fragment
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentAboutBinding
 
-class AboutFragment : Fragment() {
-    private var _binding: FragmentAboutBinding? = null
-    private val binding get() = _binding!!
+class AboutFragment : BaseBindingFragment<FragmentAboutBinding>(FragmentAboutBinding::inflate) {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentAboutBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         val versionString = getString(R.string.version, resources.getText(R.string.app_version))
         val aboutText = getString(R.string.about)
 
         val newAboutText: String = aboutText.replace("<h3>MyPlanet</h3>", "<h3>MyPlanet</h3>\n<h4>$versionString</h4>")
         binding.tvDisclaimer.text = Html.fromHtml(newAboutText, HtmlCompat.FROM_HTML_MODE_LEGACY)
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
+        return view
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
@@ -1,11 +1,8 @@
 package org.ole.planet.myplanet.ui.dashboard
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.content.res.ResourcesCompat
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.BarData
@@ -18,24 +15,18 @@ import java.util.Calendar
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentActivitiesBinding
 import org.ole.planet.myplanet.model.OfflineActivity
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
-class ActivitiesFragment : Fragment() {
-    private var _binding: FragmentActivitiesBinding? = null
-    private val binding get() = _binding!!
+class ActivitiesFragment : BaseBindingFragment<FragmentActivitiesBinding>(FragmentActivitiesBinding::inflate) {
     private val months = DateFormatSymbols().months
     private val viewModel: ActivitiesViewModel by viewModels()
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentActivitiesBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -118,10 +109,5 @@ class ActivitiesFragment : Fragment() {
 
     internal fun getMonth(month: Int): String {
         return months[month]
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DisclaimerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DisclaimerFragment.kt
@@ -2,31 +2,16 @@ package org.ole.planet.myplanet.ui.dashboard
 
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.text.HtmlCompat
-import androidx.fragment.app.Fragment
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentDisclaimerBinding
 
-class DisclaimerFragment : Fragment() {
-    private var _binding: FragmentDisclaimerBinding? = null
-    private val binding get() = _binding!!
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentDisclaimerBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
+class DisclaimerFragment : BaseBindingFragment<FragmentDisclaimerBinding>(FragmentDisclaimerBinding::inflate) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.tvDisclaimer.text = HtmlCompat.fromHtml(getString(R.string.disclaimer), HtmlCompat.FROM_HTML_MODE_LEGACY)
         binding.tvDisclaimer.movementMethod = LinkMovementMethod.getInstance()
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/InactiveDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/InactiveDashboardFragment.kt
@@ -4,23 +4,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentInActiveDashboardBinding
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 
-class InactiveDashboardFragment : Fragment() {
-    private var _binding: FragmentInActiveDashboardBinding? = null
-    private val binding get() = _binding!!
+class InactiveDashboardFragment : BaseBindingFragment<FragmentInActiveDashboardBinding>(FragmentInActiveDashboardBinding::inflate) {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentInActiveDashboardBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         binding.btnFeedback.setOnClickListener {
             FeedbackFragment().show(childFragmentManager, "")
         }
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
+        return view
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
@@ -11,7 +11,6 @@ import android.widget.ListView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -20,6 +19,7 @@ import java.util.Calendar
 import java.util.HashMap
 import java.util.Locale
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.AddMeetupBinding
 import org.ole.planet.myplanet.databinding.FragmentEventsDetailBinding
 import org.ole.planet.myplanet.model.Meetup
@@ -31,9 +31,7 @@ import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class EventsDetailFragment : Fragment(), View.OnClickListener {
-    private var _binding: FragmentEventsDetailBinding? = null
-    private val binding get() = _binding!!
+class EventsDetailFragment : BaseBindingFragment<FragmentEventsDetailBinding>(FragmentEventsDetailBinding::inflate), View.OnClickListener {
     private val viewModel: EventsDetailViewModel by viewModels()
     private var meetUpId: String? = null
     private var listUsers: ListView? = null
@@ -53,7 +51,7 @@ class EventsDetailFragment : Fragment(), View.OnClickListener {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentEventsDetailBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         listDesc = binding.root.findViewById(R.id.list_desc)
         listUsers = binding.root.findViewById(R.id.list_users)
         tvJoined = binding.root.findViewById(R.id.tv_joined)
@@ -62,7 +60,7 @@ class EventsDetailFragment : Fragment(), View.OnClickListener {
         binding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
         binding.btnLeave.setOnClickListener(this)
         binding.btnEdit.setOnClickListener { showEditDialog() }
-        return binding.root
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -234,11 +232,6 @@ class EventsDetailFragment : Fragment(), View.OnClickListener {
         val isJoined = !meetup?.userId.isNullOrEmpty()
         binding.btnLeave.setText(if (isJoined) R.string.leave else R.string.join)
         binding.btnLeave.isEnabled = user?.id?.isNotBlank() == true && isEventActive
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -6,20 +6,17 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioButton
 import androidx.core.widget.doAfterTextChanged
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingDialogFragment
 import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackBinding
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
-class FeedbackFragment : DialogFragment(), View.OnClickListener {
-    private var _binding: FragmentFeedbackBinding? = null
-    private val binding get() = _binding!!
-
+class FeedbackFragment : BaseBindingDialogFragment<FragmentFeedbackBinding>(FragmentFeedbackBinding::inflate), View.OnClickListener {
     private val viewModel: FeedbackComposerViewModel by viewModels()
 
     private var mListener: OnChangedListener? = null
@@ -33,11 +30,11 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentFeedbackBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         binding.btnSubmit.setOnClickListener(this)
         binding.btnCancel.setOnClickListener(this)
         setupFormValidation()
-        return binding.root
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -77,11 +74,6 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
         binding.rgType.setOnCheckedChangeListener { _, _ ->
             binding.tlType.error = null
         }
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 
     override fun onClick(view: View) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -4,12 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackListBinding
@@ -21,10 +21,8 @@ import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class FeedbackListFragment : Fragment(), OnChangedListener, RealtimeSyncMixin {
+class FeedbackListFragment : BaseBindingFragment<FragmentFeedbackListBinding>(FragmentFeedbackListBinding::inflate), OnChangedListener, RealtimeSyncMixin {
 
-    private var _binding: FragmentFeedbackListBinding? = null
-    private val binding get() = _binding!!
     private val viewModel: FeedbackListViewModel by viewModels()
 
     @Inject
@@ -38,7 +36,7 @@ class FeedbackListFragment : Fragment(), OnChangedListener, RealtimeSyncMixin {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentFeedbackListBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         binding.fab.setOnClickListener {
             val feedbackFragment = FeedbackFragment()
             feedbackFragment.setOnFeedbackSubmittedListener(this)
@@ -47,7 +45,7 @@ class FeedbackListFragment : Fragment(), OnChangedListener, RealtimeSyncMixin {
             }
         }
         setupRealtimeSync()
-        return binding.root
+        return view
     }
 
     private fun setupRealtimeSync() {
@@ -71,11 +69,6 @@ class FeedbackListFragment : Fragment(), OnChangedListener, RealtimeSyncMixin {
         collectWhenStarted(viewModel.feedbackList) { feedbackList ->
             updatedFeedbackList(feedbackList)
         }
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 
     override fun onChanged() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -13,7 +13,6 @@ import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -31,6 +30,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.AlertHealthListBinding
 import org.ole.planet.myplanet.databinding.AlertMyPersonalBinding
 import org.ole.planet.myplanet.databinding.FragmentVitalSignBinding
@@ -47,7 +47,7 @@ import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
 @OptIn(FlowPreview::class)
-class MyHealthFragment : Fragment() {
+class MyHealthFragment : BaseBindingFragment<FragmentVitalSignBinding>(FragmentVitalSignBinding::inflate) {
 
     private val viewModel: HealthViewModel by viewModels()
 
@@ -60,8 +60,6 @@ class MyHealthFragment : Fragment() {
     lateinit var realtimeSyncManager: RealtimeSyncManager
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
-    private var _binding: FragmentVitalSignBinding? = null
-    private val binding get() = _binding!!
     private lateinit var alertMyPersonalBinding: AlertMyPersonalBinding
     private var alertHealthListBinding: AlertHealthListBinding? = null
     var userId: String? = null
@@ -76,11 +74,6 @@ class MyHealthFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentVitalSignBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     private fun refreshHealthData() {
@@ -354,7 +347,6 @@ class MyHealthFragment : Fragment() {
         searchJob?.cancel()
         searchJob = null
 
-        _binding = null
         super.onDestroyView()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -19,6 +18,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.R.array.status_options
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.callback.OnNotificationsListener
 import org.ole.planet.myplanet.databinding.FragmentNotificationsBinding
@@ -34,12 +34,10 @@ import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class NotificationsFragment : Fragment() {
+class NotificationsFragment : BaseBindingFragment<FragmentNotificationsBinding>(FragmentNotificationsBinding::inflate) {
     @Inject
     lateinit var timeProvider: TimeProvider
 
-    private var _binding: FragmentNotificationsBinding? = null
-    private val binding get() = _binding!!
     private val viewModel: NotificationsViewModel by viewModels()
     private lateinit var adapter: NotificationsAdapter
     private lateinit var userId: String
@@ -52,7 +50,7 @@ class NotificationsFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentNotificationsBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         userId = arguments?.getString("userId") ?: ""
         isAdmin = arguments?.getBoolean("isAdmin", false) ?: false
 
@@ -115,7 +113,7 @@ class NotificationsFragment : Fragment() {
             binding.tvSelectedCount.text = getString(R.string.selected_count, count)
         }
 
-        return binding.root
+        return view
     }
 
     private fun handleNotificationClick(notification: Notification) {
@@ -172,10 +170,5 @@ class NotificationsFragment : Fragment() {
             currentFilter = binding.status.selectedItem.toString().lowercase(Locale.ROOT)
             viewModel.loadNotifications(userId, currentFilter, isAdmin)
         }
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
@@ -5,11 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.callback.OnPersonalSelectedListener
 import org.ole.planet.myplanet.databinding.AlertMyPersonalBinding
 import org.ole.planet.myplanet.databinding.FragmentMyPersonalsBinding
@@ -21,9 +21,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
-class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
-    private var _binding: FragmentMyPersonalsBinding? = null
-    private val binding get() = _binding!!
+class PersonalsFragment : BaseBindingFragment<FragmentMyPersonalsBinding>(FragmentMyPersonalsBinding::inflate), OnPersonalSelectedListener {
     private lateinit var pg: DialogUtils.CustomProgressDialog
     private var addResourceFragment: AddResourceFragment? = null
     private var personalAdapter: PersonalsAdapter? = null
@@ -31,7 +29,7 @@ class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
     private val viewModel: PersonalsViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentMyPersonalsBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         pg = DialogUtils.getCustomProgressDialog(requireContext())
         binding.rvMypersonal.layoutManager = LinearLayoutManager(activity)
         binding.addMyPersonal.setOnClickListener {
@@ -41,7 +39,7 @@ class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
             addResourceFragment?.arguments = b
             addResourceFragment?.show(childFragmentManager, getString(R.string.add_resource))
         }
-        return binding.root
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -89,11 +87,6 @@ class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
         } else {
             binding.tvNodata.visibility = View.GONE
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     override fun onUpload(personal: Personal?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/ratings/RatingsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/ratings/RatingsFragment.kt
@@ -8,19 +8,17 @@ import android.view.ViewGroup
 import android.widget.RatingBar
 import android.widget.RatingBar.OnRatingBarChangeListener
 import androidx.core.view.isVisible
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingDialogFragment
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.FragmentRatingBinding
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class RatingsFragment : DialogFragment() {
-    private var _binding: FragmentRatingBinding? = null
-    private val binding get() = _binding!!
+class RatingsFragment : BaseBindingDialogFragment<FragmentRatingBinding>(FragmentRatingBinding::inflate) {
     private val viewModel: RatingsViewModel by viewModels()
     var id: String? = ""
     var type: String? = ""
@@ -50,11 +48,6 @@ class RatingsFragment : DialogFragment() {
             type = requireArguments().getString("type")
             title = requireArguments().getString("title")
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentRatingBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -135,11 +128,6 @@ class RatingsFragment : DialogFragment() {
         val t = type ?: return
         val i = id ?: return
         viewModel.loadRatingData(t, i)
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 
     private fun submitRating() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/references/ReferencesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/references/ReferencesFragment.kt
@@ -5,16 +5,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentReferenceBinding
 import org.ole.planet.myplanet.model.Reference
 
-class ReferencesFragment : Fragment() {
-    private var _binding: FragmentReferenceBinding? = null
-    private val binding get() = _binding!!
+class ReferencesFragment : BaseBindingFragment<FragmentReferenceBinding>(FragmentReferenceBinding::inflate) {
     private var homeItemClickListener: OnHomeItemClickListener? = null
 
     override fun onAttach(context: Context) {
@@ -23,7 +21,7 @@ class ReferencesFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentReferenceBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         val list = listOf(
             Reference(getString(R.string.maps), android.R.drawable.ic_dialog_map),
             Reference(getString(R.string.english_dictionary), R.drawable.ic_dictionary)
@@ -31,15 +29,10 @@ class ReferencesFragment : Fragment() {
         binding.rvReferences.layoutManager = GridLayoutManager(activity, 3)
         binding.rvReferences.adapter = ReferencesAdapter()
         setRecyclerAdapter(list)
-        return binding.root
+        return view
     }
 
     private fun setRecyclerAdapter(list: List<Reference>) {
         (binding.rvReferences.adapter as ReferencesAdapter).submitList(list)
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -29,7 +29,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.UUID
@@ -37,6 +36,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingBottomSheetFragment
 import org.ole.planet.myplanet.callback.OnAudioRecordListener
 import org.ole.planet.myplanet.databinding.AlertSoundRecorderBinding
 import org.ole.planet.myplanet.databinding.FragmentAddResourceBinding
@@ -48,9 +48,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class AddResourceFragment : BottomSheetDialogFragment() {
-    private var _binding: FragmentAddResourceBinding? = null
-    private val binding get() = _binding!!
+class AddResourceFragment : BaseBindingBottomSheetFragment<FragmentAddResourceBinding>(FragmentAddResourceBinding::inflate) {
     var tvTime: TextView? = null
     var floatingActionButton: FloatingActionButton? = null
     private var audioRecorder: AudioRecorder? = null
@@ -134,17 +132,12 @@ class AddResourceFragment : BottomSheetDialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentAddResourceBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         binding.llRecordVideo.setOnClickListener { dispatchTakeVideoIntent() }
         binding.llRecordAudio.setOnClickListener { showAudioRecordAlert() }
         binding.llCaptureImage.setOnClickListener { takePhoto() }
         binding.llDraft.setOnClickListener { openFolderLauncher.launch("*/*") }
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
+        return view
     }
 
     private fun showAudioRecordAlert() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,6 +16,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingDialogFragment
 import org.ole.planet.myplanet.callback.OnTagClickListener
 import org.ole.planet.myplanet.databinding.FragmentCollectionsBinding
 import org.ole.planet.myplanet.model.TagData
@@ -27,10 +27,7 @@ import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
-class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton.OnCheckedChangeListener {
-    private var _binding: FragmentCollectionsBinding? = null
-    private val binding get() = _binding!!
-
+class CollectionsFragment : BaseBindingDialogFragment<FragmentCollectionsBinding>(FragmentCollectionsBinding::inflate), OnTagClickListener, CompoundButton.OnCheckedChangeListener {
     private val viewModel: CollectionsViewModel by viewModels()
 
     private var list: List<TagEntity> = emptyList()
@@ -48,9 +45,9 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentCollectionsBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         KeyboardUtils.hideSoftKeyboard(requireActivity())
-        return binding.root
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -178,11 +175,6 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         currentTagDataList = buildTagDataList(list)
         adapter.submitList(currentTagDataList)
         binding.btnOk.visibility = if (b) View.VISIBLE else View.GONE
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragment.kt
@@ -18,16 +18,14 @@ import androidx.core.view.isGone
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import java.util.Locale
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingBottomSheetFragment
 import org.ole.planet.myplanet.callback.OnFilterListener
 import org.ole.planet.myplanet.databinding.FragmentLibraryFilterBinding
 
-class ResourcesFilterFragment : BottomSheetDialogFragment(), AdapterView.OnItemClickListener {
-    private var _binding: FragmentLibraryFilterBinding? = null
-    private val binding get() = _binding!!
+class ResourcesFilterFragment : BaseBindingBottomSheetFragment<FragmentLibraryFilterBinding>(FragmentLibraryFilterBinding::inflate), AdapterView.OnItemClickListener {
     var languages: Set<String>? = null
     var subjects: Set<String>? = null
     var mediums: Set<String>? = null
@@ -47,7 +45,7 @@ class ResourcesFilterFragment : BottomSheetDialogFragment(), AdapterView.OnItemC
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentLibraryFilterBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         binding.listMedium.onItemClickListener = this
         binding.listLang.onItemClickListener = this
         binding.listLevel.onItemClickListener = this
@@ -92,12 +90,7 @@ class ResourcesFilterFragment : BottomSheetDialogFragment(), AdapterView.OnItemC
         binding.btnConfirmFilters.setOnClickListener {
             dismiss()
         }
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesSortFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesSortFragment.kt
@@ -7,17 +7,15 @@ import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingBottomSheetFragment
 import org.ole.planet.myplanet.databinding.FragmentResourcesSortBinding
 
-class ResourcesSortFragment : BottomSheetDialogFragment() {
+class ResourcesSortFragment : BaseBindingBottomSheetFragment<FragmentResourcesSortBinding>(FragmentResourcesSortBinding::inflate) {
     fun interface SortSelectionListener {
         fun onSortSelected(mode: ResourcesViewModel.SortMode)
     }
 
-    private var _binding: FragmentResourcesSortBinding? = null
-    private val binding get() = _binding!!
     private var listener: SortSelectionListener? = null
     private var currentMode: ResourcesViewModel.SortMode = ResourcesViewModel.SortMode.NONE
     private var isDateAscending: Boolean = true
@@ -43,11 +41,6 @@ class ResourcesSortFragment : BottomSheetDialogFragment() {
             skipCollapsed = true
         }
         return dialog
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentResourcesSortBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -79,8 +72,4 @@ class ResourcesSortFragment : BottomSheetDialogFragment() {
         binding.sortOrderByTitle.text = "${getString(R.string.order_by_title)} $titleArrow"
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
@@ -14,7 +14,6 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import javax.inject.Inject
@@ -23,6 +22,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingBottomSheetFragment
 import org.ole.planet.myplanet.databinding.FragmentStorageBreakdownBinding
 import org.ole.planet.myplanet.databinding.ItemStorageCategoryBinding
 import org.ole.planet.myplanet.services.FreeSpaceWorker
@@ -33,10 +33,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class StorageBreakdownFragment : BottomSheetDialogFragment() {
-
-    private var _binding: FragmentStorageBreakdownBinding? = null
-    private val binding get() = _binding!!
+class StorageBreakdownFragment : BaseBindingBottomSheetFragment<FragmentStorageBreakdownBinding>(FragmentStorageBreakdownBinding::inflate) {
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
@@ -62,11 +59,6 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
             skipCollapsed = true
         }
         return dialog
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentStorageBreakdownBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -270,7 +262,6 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
         super.onDestroyView()
         progressDialog?.dismiss()
         progressDialog = null
-        _binding = null
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
@@ -12,9 +12,9 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingBottomSheetFragment
 import org.ole.planet.myplanet.databinding.FragmentStorageCategoryDetailBinding
 import org.ole.planet.myplanet.databinding.ItemDownloadedResourceBinding
 import org.ole.planet.myplanet.model.OfflineResourceItem
@@ -23,10 +23,7 @@ import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
-    private var _binding: FragmentStorageCategoryDetailBinding? = null
-    private val binding get() = _binding!!
-
+class StorageCategoryDetailFragment : BaseBindingBottomSheetFragment<FragmentStorageCategoryDetailBinding>(FragmentStorageCategoryDetailBinding::inflate) {
     private val viewModel: StorageCategoryViewModel by viewModels()
 
     private var categoryLabel: String = ""
@@ -61,11 +58,6 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
             skipCollapsed = true
         }
         return dialog
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentStorageCategoryDetailBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -213,10 +205,5 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
                 super.onBindViewHolder(holder, position, payloads)
             }
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionDetailFragment.kt
@@ -4,24 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentSubmissionDetailBinding
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class SubmissionDetailFragment : Fragment() {
-    private var _binding: FragmentSubmissionDetailBinding? = null
-    private val binding get() = _binding!!
+class SubmissionDetailFragment : BaseBindingFragment<FragmentSubmissionDetailBinding>(FragmentSubmissionDetailBinding::inflate) {
     private val viewModel: SubmissionDetailViewModel by viewModels()
     private lateinit var adapter: QuestionAnswerAdapter
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentSubmissionDetailBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -52,10 +45,5 @@ class SubmissionDetailFragment : Fragment() {
             binding.tvSubmissionDate.text = uiState.date
             binding.tvSubmittedBy.text = uiState.submittedBy
         }
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListFragment.kt
@@ -5,20 +5,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentSubmissionListBinding
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class SubmissionListFragment : Fragment() {
-    private var _binding: FragmentSubmissionListBinding? = null
-    private val binding get() = _binding!!
+class SubmissionListFragment : BaseBindingFragment<FragmentSubmissionListBinding>(FragmentSubmissionListBinding::inflate) {
     private val viewModel: SubmissionListViewModel by viewModels()
     private var parentId: String? = null
     private var examTitle: String? = null
@@ -32,11 +30,6 @@ class SubmissionListFragment : Fragment() {
             examTitle = it.getString("examTitle")
             userId = it.getString("userId")
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentSubmissionListBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -103,10 +96,5 @@ class SubmissionListFragment : Fragment() {
 
     private fun generateReport(submissionIds: List<String>) {
         viewModel.generateMultipleSubmissionsPdf(submissionIds, examTitle ?: "Submissions")
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
@@ -23,9 +24,7 @@ import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
 @OptIn(kotlinx.coroutines.FlowPreview::class)
-class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
-    private var _binding: FragmentMySubmissionBinding? = null
-    private val binding get() = _binding!!
+class SubmissionsFragment : BaseBindingFragment<FragmentMySubmissionBinding>(FragmentMySubmissionBinding::inflate), CompoundButton.OnCheckedChangeListener {
     private val viewModel: SubmissionViewModel by viewModels()
 
     private lateinit var adapter: SubmissionsAdapter
@@ -34,11 +33,6 @@ class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) type = requireArguments().getString("type")
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentMySubmissionBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -125,7 +119,6 @@ class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
     override fun onDestroyView() {
         binding.rbExam.setOnCheckedChangeListener(null)
         binding.rbSurvey.setOnCheckedChangeListener(null)
-        _binding = null
         super.onDestroyView()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -23,6 +22,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
 import org.ole.planet.myplanet.databinding.FragmentTeamBinding
 import org.ole.planet.myplanet.model.TeamDetails
@@ -36,9 +36,7 @@ import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
-class TeamFragment : Fragment() {
-    private var _binding: FragmentTeamBinding? = null
-    private val binding get() = _binding!!
+class TeamFragment : BaseBindingFragment<FragmentTeamBinding>(FragmentTeamBinding::inflate) {
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     @Inject
     lateinit var userSessionManager: UserSessionManager
@@ -63,7 +61,7 @@ class TeamFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentTeamBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         binding.addTeam.setOnClickListener { createTeamAlert(null) }
         binding.tvFragmentInfo.text = if (TextUtils.equals(type, "enterprise")) {
             getString(R.string.enterprises)
@@ -72,7 +70,7 @@ class TeamFragment : Fragment() {
         } else {
             getString(R.string.team)
         }
-        return binding.root
+        return view
     }
 
     fun createTeamAlert(team: TeamDetails?) {
@@ -361,7 +359,6 @@ class TeamFragment : Fragment() {
 
     override fun onDestroyView() {
         binding.rvTeamList.adapter = null
-        _binding = null
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersDetailFragment.kt
@@ -1,25 +1,15 @@
 package org.ole.planet.myplanet.ui.teams.members
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.fragment.app.Fragment
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.FragmentMemberDetailBinding
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.ImageUtils
 
-class MembersDetailFragment : Fragment() {
-    private var _binding: FragmentMemberDetailBinding? = null
-    private val binding get() = _binding!!
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentMemberDetailBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
+class MembersDetailFragment : BaseBindingFragment<FragmentMemberDetailBinding>(FragmentMemberDetailBinding::inflate) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -47,11 +37,6 @@ class MembersDetailFragment : Fragment() {
         binding.btnClose.setOnClickListener {
             activity?.supportFragmentManager?.let { FragmentNavigator.popBackStack(it) }
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun setFieldOrHide(view: View, value: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
@@ -22,7 +22,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -51,6 +50,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.R.array.language
 import org.ole.planet.myplanet.R.array.subject_level
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.databinding.DialogPhotoPickerBinding
 import org.ole.planet.myplanet.databinding.EditProfileDialogBinding
 import org.ole.planet.myplanet.databinding.FragmentUserProfileBinding
@@ -65,9 +65,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class UserProfileFragment : Fragment() {
-    private var _binding: FragmentUserProfileBinding? = null
-    private val binding get() = _binding!!
+class UserProfileFragment : BaseBindingFragment<FragmentUserProfileBinding>(FragmentUserProfileBinding::inflate) {
     private val viewModel: UserProfileViewModel by viewModels()
     @Inject
     lateinit var userSessionManager: UserSessionManager
@@ -173,12 +171,6 @@ class UserProfileFragment : Fragment() {
                 setupStatsRecycler()
             }
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentUserProfileBinding.inflate(inflater, container, false)
-
-        return binding.root
     }
 
     private fun initializeDependencies() {
@@ -553,7 +545,6 @@ class UserProfileFragment : Fragment() {
     override fun onDestroyView() {
         editProfileDialog?.dismiss()
         editProfileDialog = null
-        _binding = null
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
@@ -11,7 +11,6 @@ import android.os.Bundle
 import android.os.ParcelFileDescriptor
 import android.text.TextUtils
 import android.util.Rational
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -30,7 +29,6 @@ import androidx.core.graphics.createBitmap
 import androidx.core.net.toUri
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -61,6 +59,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseBindingFragment
 import org.ole.planet.myplanet.callback.OnAudioRecordListener
 import org.ole.planet.myplanet.data.auth.AuthSessionUpdater
 import org.ole.planet.myplanet.databinding.FragmentResourceViewerBinding
@@ -76,14 +75,12 @@ import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 
 @AndroidEntryPoint
-class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
+class ResourceViewerFragment : BaseBindingFragment<FragmentResourceViewerBinding>(FragmentResourceViewerBinding::inflate), AuthSessionUpdater.AuthCallback {
 
     enum class ResourceType {
         VIDEO, AUDIO, PDF, IMAGE, TEXT, MARKDOWN, CSV, UNKNOWN
     }
 
-    private var _binding: FragmentResourceViewerBinding? = null
-    private val binding get() = _binding!!
     private var resourceId: String? = null
     private var filePath: String? = null
     private var title: String? = null
@@ -157,11 +154,6 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
             isFullPath = it.getBoolean(ARG_IS_FULL_PATH, false)
             auth = it.getString(ARG_AUTH) ?: ""
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentResourceViewerBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     private var lastSavedPositionMs: Long = -1L
@@ -696,7 +688,6 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
             noisyReceiverRegistered = false
         }
         super.onDestroyView()
-        _binding = null
     }
 
     companion object {


### PR DESCRIPTION
fixes #16999
Add shared base classes and a binding delegate for fragments, dialog fragments, and bottom sheets, then migrate existing screens to use them. This removes repeated `_binding` setup/cleanup code, centralizes view binding lifecycle handling, and keeps fragment-specific teardown only where extra cleanup is still needed.