### PR TITLE
all: smoother confirmation dialog utils handling (fixes #17001)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7067
-        versionName = "0.70.67"
+        versionCode = 7068
+        versionName = "0.70.68"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/AudioRecorder.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/AudioRecorder.kt
@@ -14,7 +14,6 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale
 import androidx.core.content.ContextCompat
 import java.io.File
@@ -23,6 +22,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnAudioRecordListener
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.Utilities
 
 class AudioRecorder {
@@ -117,18 +117,18 @@ class AudioRecorder {
                 else {
                     val activity = context as? Activity
                     if (activity != null && !shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)) {
-                        AlertDialog.Builder(activity, R.style.AlertDialogTheme)
-                            .setTitle(R.string.permission_required)
-                            .setMessage(R.string.microphone_permission_required)
-                            .setPositiveButton(R.string.settings) { dialog, _ ->
-                                dialog.dismiss()
+                        activity.confirmDialog(
+                            title = activity.getString(R.string.permission_required),
+                            message = activity.getString(R.string.microphone_permission_required),
+                            positiveText = activity.getString(R.string.settings),
+                            onPositive = {
                                 val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
                                 val uri: Uri = Uri.fromParts("package", context.packageName, null)
                                 intent.data = uri
                                 context.startActivity(intent)
-                            }
-                            .setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }
-                            .show()
+                            },
+                            negativeText = activity.getString(R.string.cancel)
+                        )
                     } else {
                         Utilities.toast(context, "Microphone permission is required to record audio.")
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseSelectionController.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseSelectionController.kt
@@ -1,13 +1,11 @@
 package org.ole.planet.myplanet.ui.courses
 
-import android.app.AlertDialog
-import android.content.DialogInterface
 import android.view.View
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.TextView
-import androidx.appcompat.view.ContextThemeWrapper
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 
 class CourseSelectionController(
     private val rootView: View,
@@ -128,10 +126,10 @@ class CourseSelectionController(
     }
 
     private fun showConfirmDialog(messageRes: Int, onConfirmed: () -> Unit) {
-        AlertDialog.Builder(ContextThemeWrapper(rootView.context, R.style.CustomAlertDialog))
-            .setMessage(messageRes)
-            .setPositiveButton(R.string.yes) { _: DialogInterface, _: Int -> onConfirmed() }
-            .setNegativeButton(R.string.no, null)
-            .show()
+        rootView.context.confirmDialog(
+            message = rootView.context.getString(messageRes),
+            styleRes = R.style.CustomAlertDialog,
+            onPositive = onConfirmed
+        )
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
@@ -32,6 +32,7 @@ import org.ole.planet.myplanet.databinding.DialogAddReportBinding
 import org.ole.planet.myplanet.databinding.FragmentReportsBinding
 import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.model.News
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
@@ -292,14 +293,13 @@ class EnterprisesReportsFragment : BaseTeamFragment() {
 
     private fun showDeleteReportDialog(report: MyTeam) {
         report._id?.let { reportId ->
-            val builder = AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-            builder.setTitle(getString(R.string.delete_report))
-                .setMessage(R.string.delete_record)
-                .setPositiveButton(R.string.ok) { _, _ ->
-                    viewModel.archiveReport(reportId = reportId)
-                }
-                .setNegativeButton("Cancel", null)
-                .show()
+            requireContext().confirmDialog(
+                title = getString(R.string.delete_report),
+                message = getString(R.string.delete_record),
+                positiveText = getString(R.string.ok),
+                onPositive = { viewModel.archiveReport(reportId = reportId) },
+                negativeText = "Cancel"
+            )
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
@@ -18,7 +18,6 @@ import android.widget.CompoundButton
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
@@ -43,6 +42,7 @@ import org.ole.planet.myplanet.repository.SurveysRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.CameraUtils.ImageCaptureCallback
 import org.ole.planet.myplanet.utils.CameraUtils.capturePhoto
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getString
@@ -755,13 +755,15 @@ class ExamTakingFragment : BaseExamFragment(), View.OnClickListener, CompoundBut
     }
 
     private suspend fun askResumeOrRestart(): Boolean = suspendCancellableCoroutine { cont ->
-        val dialog = AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-            .setTitle(R.string.resume_survey)
-            .setMessage(R.string.resume_survey_message)
-            .setPositiveButton(R.string.continuation) { _, _ -> if (cont.isActive) cont.resume(true) }
-            .setNegativeButton(R.string.start_over) { _, _ -> if (cont.isActive) cont.resume(false) }
-            .setCancelable(false)
-            .show()
+        val dialog = requireContext().confirmDialog(
+            title = getString(R.string.resume_survey),
+            message = getString(R.string.resume_survey_message),
+            cancelable = false,
+            positiveText = getString(R.string.continuation),
+            onPositive = { if (cont.isActive) cont.resume(true) },
+            negativeText = getString(R.string.start_over),
+            onNegative = { if (cont.isActive) cont.resume(false) }
+        )
         cont.invokeOnCancellation { dialog.dismiss() }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.ui.health
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.ContextThemeWrapper
 import android.view.MenuItem
@@ -8,7 +7,6 @@ import android.view.View
 import android.widget.CheckBox
 import android.widget.CompoundButton
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.widget.doOnTextChanged
@@ -30,6 +28,7 @@ import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.encrypt
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateIv
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateKey
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.DimenUtils.dpToPx
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.JsonUtils
@@ -396,11 +395,12 @@ class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedC
     }
 
     override fun finish() {
-        val alertDialogBuilder = AlertDialog.Builder(this, R.style.AlertDialogTheme)
-        alertDialogBuilder.setMessage(R.string.cancel_adding_examination)
-        alertDialogBuilder.setPositiveButton(getString(R.string.yes_i_want_to_exit)) { _: DialogInterface?, _: Int -> super.finish() }
-            .setNegativeButton(getString(R.string.cancel), null)
-        alertDialogBuilder.show()
+        confirmDialog(
+            message = getString(R.string.cancel_adding_examination),
+            positiveText = getString(R.string.yes_i_want_to_exit),
+            onPositive = { super.finish() },
+            negativeText = getString(R.string.cancel)
+        )
     }
 
     override fun onCheckedChanged(compoundButton: CompoundButton, b: Boolean) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
@@ -17,6 +17,7 @@ import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.repository.PersonalUpdate
 import org.ole.planet.myplanet.ui.resources.AddResourceFragment
 import org.ole.planet.myplanet.utils.DialogUtils
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
@@ -134,15 +135,16 @@ class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
     }
 
     override fun onDeletePersonal(personal: Personal) {
-        AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-            .setMessage(R.string.delete_record)
-            .setPositiveButton(R.string.ok) { _, _ ->
+        requireContext().confirmDialog(
+            message = getString(R.string.delete_record),
+            positiveText = getString(R.string.ok),
+            onPositive = {
                 val id = personal.id ?: personal._id
                 if (id != null) {
                     viewModel.deletePersonalResource(id)
                 }
-            }
-            .setNegativeButton(R.string.cancel, null)
-            .show()
+            },
+            negativeText = getString(R.string.cancel)
+        )
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.repository.LocalResourceRequest
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.ui.components.CheckboxAdapter
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.Utilities.toast
@@ -282,12 +283,10 @@ class AddResourceActivity : AppCompatActivity() {
     }
 
     private fun showExitConfirmationDialog() {
-        AlertDialog.Builder(this,R.style.AlertDialogTheme)
-            .setMessage(R.string.are_you_sure_you_want_to_exit_your_data_will_be_lost)
-            .setPositiveButton(R.string.yes_i_want_to_exit) { _, _ ->
-                finish()
-            }
-            .setNegativeButton(R.string.no, null)
-            .show()
+        confirmDialog(
+            message = getString(R.string.are_you_sure_you_want_to_exit_your_data_will_be_lost),
+            positiveText = getString(R.string.yes_i_want_to_exit),
+            onPositive = ::finish
+        )
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -42,6 +42,7 @@ import org.ole.planet.myplanet.databinding.AlertSoundRecorderBinding
 import org.ole.planet.myplanet.databinding.FragmentAddResourceBinding
 import org.ole.planet.myplanet.services.AudioRecorder
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.Utilities
@@ -104,18 +105,18 @@ class AddResourceFragment : BottomSheetDialogFragment() {
                 takePhoto()
             } else {
                 if (!shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)) {
-                    AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-                        .setTitle(R.string.permission_required)
-                        .setMessage(R.string.camera_permission_required)
-                        .setPositiveButton(R.string.settings) { dialog, _ ->
-                            dialog.dismiss()
+                    requireContext().confirmDialog(
+                        title = getString(R.string.permission_required),
+                        message = getString(R.string.camera_permission_required),
+                        positiveText = getString(R.string.settings),
+                        onPositive = {
                             val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
                             val uri: Uri = Uri.fromParts("package", requireContext().packageName, null)
                             intent.data = uri
                             startActivity(intent)
-                        }
-                        .setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }
-                        .show()
+                        },
+                        negativeText = getString(R.string.cancel)
+                    )
                 } else {
                     Utilities.toast(requireContext(), "camera permission is required.")
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -54,6 +54,7 @@ import org.ole.planet.myplanet.ui.components.ViewModeToggleController
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.Utilities
@@ -362,12 +363,10 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
 
     private fun setupDeleteListener() {
         tvDelete?.setOnClickListener {
-            AlertDialog.Builder(this.context, R.style.AlertDialogTheme)
-                .setMessage(R.string.confirm_removal)
-                .setPositiveButton(R.string.yes) { _, _ ->
-                    deleteSelected(true)
-                }
-                .setNegativeButton(R.string.no, null).show()
+            requireContext().confirmDialog(
+                message = getString(R.string.confirm_removal),
+                onPositive = { deleteSelected(true) }
+            )
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
@@ -27,6 +26,7 @@ import org.ole.planet.myplanet.databinding.FragmentStorageBreakdownBinding
 import org.ole.planet.myplanet.databinding.ItemStorageCategoryBinding
 import org.ole.planet.myplanet.services.FreeSpaceWorker
 import org.ole.planet.myplanet.utils.DialogUtils
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.Utilities
@@ -82,12 +82,11 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
         }
 
         binding.freeUpSpaceButton.setOnClickListener {
-            AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-                .setTitle(R.string.are_you_sure)
-                .setMessage(R.string.are_you_sure_want_to_delete_all_the_files)
-                .setPositiveButton(R.string.yes) { _, _ -> freeUpSpace() }
-                .setNegativeButton(R.string.no, null)
-                .show()
+            requireContext().confirmDialog(
+                title = getString(R.string.are_you_sure),
+                message = getString(R.string.are_you_sure_want_to_delete_all_the_files),
+                onPositive = ::freeUpSpace
+            )
         }
 
         loadStorage()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
@@ -19,6 +18,7 @@ import org.ole.planet.myplanet.databinding.FragmentStorageCategoryDetailBinding
 import org.ole.planet.myplanet.databinding.ItemDownloadedResourceBinding
 import org.ole.planet.myplanet.model.OfflineResourceItem
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
@@ -162,12 +162,11 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
     }
 
     private fun confirmDelete(count: Int, message: String, onConfirm: () -> Unit) {
-        AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-            .setTitle(R.string.are_you_sure)
-            .setMessage(message)
-            .setPositiveButton(R.string.yes) { _, _ -> onConfirm() }
-            .setNegativeButton(R.string.no, null)
-            .show()
+        requireContext().confirmDialog(
+            title = getString(R.string.are_you_sure),
+            message = message,
+            onPositive = onConfirm
+        )
     }
 
     private val DIFF_CALLBACK = DiffUtils.itemCallback<OfflineResourceItem>(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
@@ -21,6 +20,7 @@ import org.ole.planet.myplanet.databinding.FragmentCombinedMembersBinding
 import org.ole.planet.myplanet.model.JoinedMemberData
 import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
@@ -104,9 +104,9 @@ class MembersFragment : BaseTeamFragment() {
     }
 
     private fun handleLeaveTeam() {
-        AlertDialog.Builder(requireContext())
-            .setMessage(R.string.confirm_exit)
-            .setPositiveButton(R.string.yes) { _, _ ->
+        requireContext().confirmDialog(
+            message = getString(R.string.confirm_exit),
+            onPositive = {
                 viewLifecycleOwner.lifecycleScope.launch {
                     try {
                         val nextLeader = teamsRepository.getNextLeaderCandidate(teamId, user?.id)
@@ -120,8 +120,7 @@ class MembersFragment : BaseTeamFragment() {
                     }
                 }
             }
-            .setNegativeButton(R.string.no, null)
-            .show()
+        )
     }
 
     private fun handleRemoveMember(member: JoinedMemberData) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.ui.voices
 import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
-import android.content.DialogInterface
 import android.os.Build
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -11,7 +10,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AlertDialog
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toDrawable
@@ -37,6 +35,7 @@ import org.ole.planet.myplanet.repository.VoicesEditActions
 import org.ole.planet.myplanet.services.VoicesLabelManager
 import org.ole.planet.myplanet.ui.chat.ChatAdapter
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.ImageUtils
 import org.ole.planet.myplanet.utils.JsonUtils
@@ -473,15 +472,16 @@ class VoicesAdapter(
                 val pos = holder.bindingAdapterPosition
                 val snapshotList = currentList.toMutableList()
                 val newsToDelete = snapshotList.getOrNull(pos)
-                AlertDialog.Builder(context, R.style.AlertDialogTheme)
-                    .setMessage(R.string.delete_record)
-                    .setPositiveButton(R.string.ok) { _: DialogInterface?, _: Int ->
+                context.confirmDialog(
+                    message = context.getString(R.string.delete_record),
+                    positiveText = context.getString(R.string.ok),
+                    onPositive = {
                         newsToDelete?.id?.let { id ->
                             deletePostFn(id)
                         }
-                    }
-                    .setNegativeButton(R.string.cancel, null)
-                    .show()
+                    },
+                    negativeText = context.getString(R.string.cancel)
+                )
             }
         }
 
@@ -791,21 +791,21 @@ class VoicesAdapter(
         viewHolder.binding.btnShare.setVisibility(canShare(news))
 
         viewHolder.binding.btnShare.setOnClickListener {
-            AlertDialog.Builder(context, R.style.AlertDialogTheme)
-                .setTitle(R.string.share_with_community)
-                .setMessage(R.string.confirm_share_community)
-                .setPositiveButton(R.string.yes) { _, _ ->
-                     val newsId = news?.id
-                     val userId = currentUser?.id
-                     val planetCode = currentUser?.planetCode ?: ""
-                     val parentCode = currentUser?.parentCode ?: ""
+            context.confirmDialog(
+                title = context.getString(R.string.share_with_community),
+                message = context.getString(R.string.confirm_share_community),
+                onPositive = {
+                    val newsId = news?.id
+                    val userId = currentUser?.id
+                    val planetCode = currentUser?.planetCode ?: ""
+                    val parentCode = currentUser?.parentCode ?: ""
 
-                     if (newsId != null && userId != null) {
-                         shareNewsFn(newsId, userId, planetCode, parentCode, teamName)
-                     }
-                }
-                .setNegativeButton(R.string.cancel, null)
-                .show()
+                    if (newsId != null && userId != null) {
+                        shareNewsFn(newsId, userId, planetCode, parentCode, teamName)
+                    }
+                },
+                negativeText = context.getString(R.string.cancel)
+            )
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utils/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DialogUtils.kt
@@ -9,6 +9,7 @@ import android.provider.Settings
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
+import androidx.annotation.StyleRes
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
@@ -59,6 +60,43 @@ object DialogUtils {
         cancel.setOnClickListener {
             dialog.dismiss()
         }
+    }
+
+    fun Context.confirmDialog(
+        message: CharSequence,
+        title: CharSequence? = null,
+        @StyleRes styleRes: Int = R.style.AlertDialogTheme,
+        cancelable: Boolean = true,
+        positiveText: CharSequence = getString(R.string.yes),
+        positiveContentDescription: CharSequence = positiveText,
+        onPositive: (() -> Unit)? = null,
+        negativeText: CharSequence = getString(R.string.no),
+        negativeContentDescription: CharSequence = negativeText,
+        onNegative: (() -> Unit)? = null
+    ): AlertDialog {
+        val builder = AlertDialog.Builder(this, styleRes)
+        title?.let { builder.setTitle(it) }
+        builder.setMessage(message)
+        builder.setCancelable(cancelable)
+        builder.setPositiveButton(positiveText, null)
+        builder.setNegativeButton(negativeText, null)
+
+        val dialog = builder.show()
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).apply {
+            contentDescription = positiveContentDescription
+            setOnClickListener {
+                dialog.dismiss()
+                onPositive?.invoke()
+            }
+        }
+        dialog.getButton(AlertDialog.BUTTON_NEGATIVE).apply {
+            contentDescription = negativeContentDescription
+            setOnClickListener {
+                dialog.dismiss()
+                onNegative?.invoke()
+            }
+        }
+        return dialog
     }
 
     fun showError(prgDialog: CustomProgressDialog?, message: String?) {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/DialogUtilsConfirmDialogTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/DialogUtilsConfirmDialogTest.kt
@@ -1,0 +1,94 @@
+package org.ole.planet.myplanet.utils
+
+import android.app.Activity
+import android.app.Application
+import androidx.appcompat.app.AlertDialog
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.utils.DialogUtils.confirmDialog
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class DialogUtilsConfirmDialogTest {
+
+    private lateinit var activity: Activity
+
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    }
+
+    @Test
+    fun `defaults positive and negative button text to yes and no`() {
+        val dialog = activity.confirmDialog(message = "Are you sure?")
+
+        assertEquals(activity.getString(R.string.yes), dialog.getButton(AlertDialog.BUTTON_POSITIVE).text)
+        assertEquals(activity.getString(R.string.no), dialog.getButton(AlertDialog.BUTTON_NEGATIVE).text)
+    }
+
+    @Test
+    fun `uses custom button text when provided`() {
+        val dialog = activity.confirmDialog(message = "Leave team?", positiveText = "Leave", negativeText = "Stay")
+
+        assertEquals("Leave", dialog.getButton(AlertDialog.BUTTON_POSITIVE).text)
+        assertEquals("Stay", dialog.getButton(AlertDialog.BUTTON_NEGATIVE).text)
+    }
+
+    @Test
+    fun `content description defaults to the button label`() {
+        val dialog = activity.confirmDialog(message = "Are you sure?", positiveText = "Delete", negativeText = "Keep")
+
+        assertEquals("Delete", dialog.getButton(AlertDialog.BUTTON_POSITIVE).contentDescription)
+        assertEquals("Keep", dialog.getButton(AlertDialog.BUTTON_NEGATIVE).contentDescription)
+    }
+
+    @Test
+    fun `content description can be overridden independently of the label`() {
+        val dialog = activity.confirmDialog(
+            message = "Are you sure?",
+            positiveText = "Yes",
+            positiveContentDescription = "Confirm removal",
+            negativeText = "No",
+            negativeContentDescription = "Keep item"
+        )
+
+        assertEquals("Confirm removal", dialog.getButton(AlertDialog.BUTTON_POSITIVE).contentDescription)
+        assertEquals("Keep item", dialog.getButton(AlertDialog.BUTTON_NEGATIVE).contentDescription)
+    }
+
+    @Test
+    fun `tapping positive button dismisses the dialog and invokes onPositive`() {
+        var invoked = false
+        val dialog = activity.confirmDialog(message = "Are you sure?", onPositive = { invoked = true })
+
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick()
+
+        assertTrue(invoked)
+        assertFalse(dialog.isShowing)
+    }
+
+    @Test
+    fun `tapping negative button dismisses the dialog and invokes onNegative without invoking onPositive`() {
+        var positiveInvoked = false
+        var negativeInvoked = false
+        val dialog = activity.confirmDialog(
+            message = "Are you sure?",
+            onPositive = { positiveInvoked = true },
+            onNegative = { negativeInvoked = true }
+        )
+
+        dialog.getButton(AlertDialog.BUTTON_NEGATIVE).performClick()
+
+        assertTrue(negativeInvoked)
+        assertFalse(positiveInvoked)
+        assertFalse(dialog.isShowing)
+    }
+}


### PR DESCRIPTION
fixes #17001
Replace repeated AlertDialog setup across audio, resources, exams, teams, and other screens with DialogUtils.confirmDialog. The new helper standardizes styling, default button labels, dismiss behavior, and button content descriptions, and adds Robolectric coverage for the shared dialog behavior.