### PR TITLE
courses: smoother progress chip filter selecting (fixes #16975)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7061
-        versionName = "0.70.61"
+        versionCode = 7062
+        versionName = "0.70.62"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -384,7 +384,11 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
     }
 
     private fun renderCourseChipSelection(chipRow: LinearLayout) {
-        val selected = if (::filterController.isInitialized) filterController.currentState().progressFilter else ""
+        val selected = if (::filterController.isInitialized) {
+            filterController.currentState().progressFilter
+        } else {
+            viewModel.currentFilterState.progressFilter
+        }
         for (i in 0 until chipRow.childCount) {
             val chip = chipRow.getChildAt(i) as? TextView ?: continue
             val isSelected = (chip.tag as? String)?.let { it == selected || (selected.isEmpty() && i == 0) } == true


### PR DESCRIPTION
fixes #16975
Use `viewModel.currentFilterState.progressFilter` as the fallback selected value when `filterController` is not initialized, instead of defaulting to an empty filter. This keeps the course progress chip selection in sync with the current filter state during early render paths.
[Screen_recording_20260910_185355.webm](https://github.com/user-attachments/assets/f3f740bf-2024-49d2-af40-287febec2dab)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the selected course progress filter when the filter controls are still initializing, preventing the selection from appearing blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->