### PR TITLE
all: smoother crash log store capacity checking (fixes #16871)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
@@ -37,7 +37,9 @@ object CrashLogStore {
         return try {
             val logDir = dir(context)
             if (!logDir.exists() && !logDir.mkdirs()) return null
-            if ((logDir.listFiles()?.asSequence()?.filter { isValidLogFile(it) }?.take(MAX_PENDING_FILES)?.count() ?: 0) >= MAX_PENDING_FILES) return null
+            val pendingFiles = logDir.listFiles().orEmpty()
+            val validCount = pendingFiles.asSequence().filter { isValidLogFile(it) }.take(MAX_PENDING_FILES).count()
+            if (validCount >= MAX_PENDING_FILES) return null
             val file = File(logDir, "${timeProvider.now()}_$type$FILE_EXTENSION")
             file.writeText(error)
             file

--- a/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
@@ -37,7 +37,7 @@ object CrashLogStore {
         return try {
             val logDir = dir(context)
             if (!logDir.exists() && !logDir.mkdirs()) return null
-            if ((logDir.listFiles()?.count { isValidLogFile(it) } ?: 0) >= MAX_PENDING_FILES) return null
+            if ((logDir.listFiles()?.asSequence()?.filter { isValidLogFile(it) }?.take(MAX_PENDING_FILES)?.count() ?: 0) >= MAX_PENDING_FILES) return null
             val file = File(logDir, "${timeProvider.now()}_$type$FILE_EXTENSION")
             file.writeText(error)
             file


### PR DESCRIPTION
Short-circuits the capacity check in CrashLogStore.save by evaluating directory files as a sequence and taking at most MAX_PENDING_FILES valid log files. Retains identical eviction, retention, and formatting logic.

Fixes #16871

---
*PR created automatically by Jules for task [12457252658846363948](https://jules.google.com/task/12457252658846363948) started by @dogi*