### PR TITLE
courses: smoother tags repositories link querying (fixes #16907)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7062
-        versionName = "0.70.62"
+        versionCode = 7063
+        versionName = "0.70.63"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -289,7 +289,7 @@ class CoursesRepositoryImpl @Inject constructor(
         tagNames: List<String>
     ): List<MyCourse> {
         val courseIdsWithTags = if (tagNames.isNotEmpty()) {
-            tagsRepository.getLinkIdsForTagNames("courses", tagNames).toSet()
+            tagsRepository.getCourseLinkIds(tagNames)
         } else {
             null
         }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -11,6 +11,5 @@ interface TagsRepository {
     suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<TagEntity>>
     suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<TagEntity>>
     suspend fun insert(documentList: List<JsonObject>)
-    suspend fun getLinkIdsForTagNames(dbType: String, tagNames: List<String>): List<String>
     suspend fun getCourseLinkIds(tagNames: List<String>): Set<String>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -12,4 +12,5 @@ interface TagsRepository {
     suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<TagEntity>>
     suspend fun insert(documentList: List<JsonObject>)
     suspend fun getLinkIdsForTagNames(dbType: String, tagNames: List<String>): List<String>
+    suspend fun getCourseLinkIds(tagNames: List<String>): Set<String>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -151,4 +151,7 @@ class TagsRepositoryImpl @Inject constructor(
         tag.isAttached = attachedTo.isNotEmpty()
         return tag
     }
+
+    override suspend fun getCourseLinkIds(tagNames: List<String>): Set<String> =
+        getLinkIdsForTagNames("courses", tagNames).toSet()
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -54,7 +54,7 @@ class TagsRepositoryImpl @Inject constructor(
         return getLinkedTagsBulk("courses", courseIds)
     }
 
-    override suspend fun getLinkIdsForTagNames(dbType: String, tagNames: List<String>): List<String> {
+    private suspend fun getLinkIdsForTagNames(dbType: String, tagNames: List<String>): List<String> {
         val matchingTags = tagDao.getByNames(tagNames)
         if (matchingTags.isEmpty()) {
             return emptyList()

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -173,7 +173,7 @@ class CoursesRepositoryImplTest {
             MyCourse(id = "3", courseId = "3", courseTitle = "cherry", courseTitleNormal = "cherry")
         )
         coEvery { courseStepDao.getByCourseIds(any()) } returns emptyList()
-        coEvery { tagsRepository.getLinkIdsForTagNames(any(), any()) } returns emptyList()
+        coEvery { tagsRepository.getCourseLinkIds(any()) } returns emptySet()
 
         val result = repository.filterCourses("", "", "", emptyList())
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TagsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TagsRepositoryImplTest.kt
@@ -266,7 +266,7 @@ class TagsRepositoryImplTest {
     }
 
     @Test
-    fun `getLinkIdsForTagNames returns linkIds for matching tags`() = runTest {
+    fun `getCourseLinkIds returns linkIds for matching tags`() = runTest {
         val tagNames = listOf("Tag 1", "Tag 2")
         val tag1 = TagEntity().apply { id = "tag1"; name = "Tag 1" }
         val tag2 = TagEntity().apply { id = "tag2"; name = "Tag 2" }
@@ -275,9 +275,9 @@ class TagsRepositoryImplTest {
         val linkTag2 = TagEntity().apply { linkId = "link2"; tagId = "tag2" }
 
         coEvery { tagDao.getByNames(tagNames) } returns listOf(tag1, tag2)
-        coEvery { tagDao.getByDbAndTagIds("resources", listOf("tag1", "tag2")) } returns listOf(linkTag1, linkTag2)
+        coEvery { tagDao.getByDbAndTagIds("courses", listOf("tag1", "tag2")) } returns listOf(linkTag1, linkTag2)
 
-        val result = repository.getLinkIdsForTagNames("resources", tagNames)
+        val result = repository.getCourseLinkIds(tagNames)
 
         assertEquals(2, result.size)
         assertTrue(result.contains("link1"))
@@ -285,27 +285,27 @@ class TagsRepositoryImplTest {
     }
 
     @Test
-    fun `getLinkIdsForTagNames returns empty list when no matching tags`() = runTest {
+    fun `getCourseLinkIds returns empty set when no matching tags`() = runTest {
         val tagNames = listOf("NonExistent Tag")
         coEvery { tagDao.getByNames(tagNames) } returns emptyList()
 
-        val result = repository.getLinkIdsForTagNames("resources", tagNames)
+        val result = repository.getCourseLinkIds(tagNames)
 
         assertTrue(result.isEmpty())
         coVerify(exactly = 0) { tagDao.getByDbAndTagIds(any(), any()) }
     }
 
     @Test
-    fun `getLinkIdsForTagNames ignores tags without linkId`() = runTest {
+    fun `getCourseLinkIds ignores tags without linkId`() = runTest {
         val tagNames = listOf("Tag 1")
         val tag1 = TagEntity().apply { id = "tag1"; name = "Tag 1" }
 
         val linkTagWithoutId = TagEntity().apply { linkId = null; tagId = "tag1" }
 
         coEvery { tagDao.getByNames(tagNames) } returns listOf(tag1)
-        coEvery { tagDao.getByDbAndTagIds("resources", listOf("tag1")) } returns listOf(linkTagWithoutId)
+        coEvery { tagDao.getByDbAndTagIds("courses", listOf("tag1")) } returns listOf(linkTagWithoutId)
 
-        val result = repository.getLinkIdsForTagNames("resources", tagNames)
+        val result = repository.getCourseLinkIds(tagNames)
 
         assertTrue(result.isEmpty())
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TagsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TagsRepositoryImplTest.kt
@@ -377,4 +377,23 @@ class TagsRepositoryImplTest {
 
         coVerify(exactly = 0) { tagDao.upsertAll(any()) }
     }
+
+    @Test
+    fun `getCourseLinkIds delegates to getLinkIdsForTagNames with courses and returns deduplicated set`() = runTest {
+        val tagNames = listOf("Tag 1", "Tag 2")
+        val tag1 = TagEntity().apply { id = "tag1"; name = "Tag 1" }
+        val tag2 = TagEntity().apply { id = "tag2"; name = "Tag 2" }
+
+        val linkTag1 = TagEntity().apply { linkId = "course1"; tagId = "tag1" }
+        val linkTag2 = TagEntity().apply { linkId = "course2"; tagId = "tag2" }
+        val linkTag3 = TagEntity().apply { linkId = "course1"; tagId = "tag2" }
+
+        coEvery { tagDao.getByNames(tagNames) } returns listOf(tag1, tag2)
+        coEvery { tagDao.getByDbAndTagIds("courses", listOf("tag1", "tag2")) } returns listOf(linkTag1, linkTag2, linkTag3)
+
+        val result = repository.getCourseLinkIds(tagNames)
+
+        assertEquals(setOf("course1", "course2"), result)
+        coVerify { tagDao.getByDbAndTagIds("courses", listOf("tag1", "tag2")) }
+    }
 }


### PR DESCRIPTION
Narrows the course-link API in `TagsRepository` by adding `getCourseLinkIds(tagNames: List<String>): Set<String>`. Updates `CoursesRepositoryImpl` to use `tagsRepository.getCourseLinkIds(tagNames)` and adds unit test coverage in `TagsRepositoryImplTest`.

Fixes #16907

---
*PR created automatically by Jules for task [6107245853913768021](https://jules.google.com/task/6107245853913768021) started by @dogi*