### PR TITLE
life: smoother health examination item encrypting (fixes #17003)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7064
-        versionName = "0.70.64"
+        versionCode = 7065
+        versionName = "0.70.65"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationAdapter.kt
@@ -39,7 +39,7 @@ class HealthExaminationAdapter(
         val formattedDate: String,
         val isSelfExamination: Boolean,
         val resolvedName: String,
-        val hasEncryptedData: Boolean
+        val encrypted: JsonObject?
     )
 
     private val colorGrey50 by lazy { ContextCompat.getColor(context, R.color.md_grey_50) }
@@ -77,7 +77,7 @@ class HealthExaminationAdapter(
                     formattedDate = formattedDate,
                     isSelfExamination = isSelfExamination,
                     resolvedName = resolvedName,
-                    hasEncryptedData = encrypted != null
+                    encrypted = encrypted
                 )
             }
         }
@@ -116,8 +116,7 @@ class HealthExaminationAdapter(
         binding.txtVision.text = realmExamination.vision
 
         holder.itemView.setOnClickListener {
-            if (item.hasEncryptedData) {
-                val encrypted = userModel?.let { user -> item.examination.getEncryptedDataAsJson(user) } ?: JsonObject()
+            item.encrypted?.let { encrypted ->
                 showAlert(binding, item, encrypted)
             }
         }


### PR DESCRIPTION
Updated `HealthExaminationItem` to store `encrypted: JsonObject?` computed off the main thread during `submitExaminations`, eliminating synchronous re-decryption and JSON parsing on the main thread when tapping items in `HealthExaminationAdapter`.

Fixes #17003

---
*PR created automatically by Jules for task [4186953270365790712](https://jules.google.com/task/4186953270365790712) started by @dogi*