### PR TITLE
teams: smoother notifications repository counting (fixes #17011)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7065
-        versionName = "0.70.65"
+        versionCode = 7066
+        versionName = "0.70.66"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -9,6 +9,9 @@ import java.util.LinkedHashSet
 import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.ole.planet.myplanet.data.room.dao.NotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
@@ -312,9 +315,10 @@ class NotificationsRepositoryImpl @Inject constructor(
             }
         }
 
-        val chatCountsById = mutableMapOf<String, Long>()
-        for (teamId in notificationsById.keys) {
-            chatCountsById[teamId] = voicesRepository.countTopLevelByTeam(teamId)
+        val chatCountsById = coroutineScope {
+            notificationsById.keys.map { teamId ->
+                async { teamId to voicesRepository.countTopLevelByTeam(teamId) }
+            }.awaitAll().toMap()
         }
 
         val current = timeProvider.now()

--- a/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
@@ -766,6 +766,44 @@ class NotificationsRepositoryImplTest {
     }
 
     @Test
+    fun `getTeamNotifications returns empty map when teamIds is empty`() = runTest {
+        val result = repository.getTeamNotifications(emptyList(), "user1")
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { teamNotificationDao.getByTypeAndParentIds(any(), any()) }
+        coVerify(exactly = 0) { voicesRepository.countTopLevelByTeam(any()) }
+    }
+
+    @Test
+    fun `getTeamNotifications fetches chat counts concurrently for multiple tracked teams`() = runTest {
+        val team1 = "team1"
+        val team2 = "team2"
+        val team3 = "team3"
+        val teamIds = listOf(team1, team2, team3)
+        val userId = "user1"
+
+        val notif1 = TeamNotification().apply { parentId = team1; type = "chat"; lastCount = 2 }
+        val notif2 = TeamNotification().apply { parentId = team2; type = "chat"; lastCount = 5 }
+        val notif3 = TeamNotification().apply { parentId = team3; type = "chat"; lastCount = 10 }
+
+        coEvery { teamNotificationDao.getByTypeAndParentIds("chat", teamIds) } returns listOf(notif1, notif2, notif3)
+        coEvery { voicesRepository.countTopLevelByTeam(team1) } returns 5L
+        coEvery { voicesRepository.countTopLevelByTeam(team2) } returns 3L
+        coEvery { voicesRepository.countTopLevelByTeam(team3) } returns 10L
+        coEvery { teamTaskDao.getTasksForUserBetween(eq(userId), any(), any()) } returns emptyList()
+
+        val result = repository.getTeamNotifications(teamIds, userId)
+
+        coVerify(exactly = 1) { voicesRepository.countTopLevelByTeam(team1) }
+        coVerify(exactly = 1) { voicesRepository.countTopLevelByTeam(team2) }
+        coVerify(exactly = 1) { voicesRepository.countTopLevelByTeam(team3) }
+
+        assertEquals(3, result.size)
+        assertTrue(result[team1]?.hasChat == true)   // 2 < 5
+        assertFalse(result[team2]?.hasChat == true)  // 5 >= 3
+        assertFalse(result[team3]?.hasChat == true)  // 10 >= 10
+    }
+
+    @Test
     fun `resolveType falls back to message sniffing for unknown types`() {
         assertEquals("task", repository.resolveType("other", "Report is due tomorrow", null))
         assertEquals("storage", repository.resolveType("other", "Low storage", null))


### PR DESCRIPTION
Replaced the sequential per-team chat count loop in `NotificationsRepositoryImpl.getTeamNotifications` with a concurrent fetch using `coroutineScope`, `async`, and `awaitAll`. Updated `NotificationsRepositoryImplTest` to cover concurrent fetching across multiple teams.

Fixes #17011

---
*PR created automatically by Jules for task [17398082137068262596](https://jules.google.com/task/17398082137068262596) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Team notification updates now retrieve chat activity counts in parallel, improving responsiveness when monitoring multiple teams.

- **Bug Fixes**
  - Empty team selections now return cleanly without unnecessary data requests.
  - Chat indicators now accurately reflect whether new activity is available compared with the latest notification count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->