### PR TITLE
teams: less voices label dispatcher provider is more (fixes #17009)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7069
-        versionName = "0.70.69"
+        versionCode = 7070
+        versionName = "0.70.70"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
@@ -25,17 +25,15 @@ import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.repository.toVoicePostingPolicy
 import org.ole.planet.myplanet.ui.voices.DefaultLabelManipulator
 import org.ole.planet.myplanet.ui.voices.LabelManipulator
-import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class TeamsVoicesViewModel @Inject constructor(
     private val voicesRepository: VoicesRepository,
     private val teamsRepository: TeamsRepository,
-    private val dispatcherProvider: DispatcherProvider,
     private val userRepository: UserRepository,
     private val resourcesRepository: ResourcesRepository,
     private val notificationsRepository: NotificationsRepository
-) : ViewModel(), LabelManipulator by DefaultLabelManipulator(voicesRepository, dispatcherProvider) {
+) : ViewModel(), LabelManipulator by DefaultLabelManipulator(voicesRepository) {
 
     private val _teamPolicy = MutableStateFlow<Pair<MyTeam?, VoicePostingPolicy?>?>(null)
     val teamPolicy: StateFlow<Pair<MyTeam?, VoicePostingPolicy?>?> = _teamPolicy.asStateFlow()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/LabelManipulator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/LabelManipulator.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.ui.voices
 
 import org.ole.planet.myplanet.repository.VoicesRepository
-import org.ole.planet.myplanet.utils.DispatcherProvider
 
 interface LabelManipulator {
     suspend fun addLabel(newsId: String, label: String)
@@ -9,8 +8,7 @@ interface LabelManipulator {
 }
 
 class DefaultLabelManipulator(
-    private val voicesRepository: VoicesRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val voicesRepository: VoicesRepository
 ) : LabelManipulator {
     override suspend fun addLabel(newsId: String, label: String) {
         voicesRepository.addLabel(newsId, label)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
@@ -10,12 +10,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class NewsViewModel @Inject constructor(
-    private val resourcesRepository: ResourcesRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val resourcesRepository: ResourcesRepository
 ) : ViewModel() {
 
     private val _privateImageUrls = MutableSharedFlow<List<String>>(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
@@ -36,7 +36,7 @@ class VoicesViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val userRepository: UserRepository,
     private val resourcesRepository: ResourcesRepository
-) : ViewModel(), LabelManipulator by DefaultLabelManipulator(voicesRepository, dispatcherProvider) {
+) : ViewModel(), LabelManipulator by DefaultLabelManipulator(voicesRepository) {
 
     private val _searchQuery = MutableStateFlow("")
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModelTest.kt
@@ -16,7 +16,6 @@ import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.MainDispatcherRule
-import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TeamsVoicesViewModelTest {
@@ -32,11 +31,10 @@ class TeamsVoicesViewModelTest {
     private val userRepository: org.ole.planet.myplanet.repository.UserRepository = mockk(relaxed = true)
     private val resourcesRepository: org.ole.planet.myplanet.repository.ResourcesRepository = mockk(relaxed = true)
     private val notificationsRepository: org.ole.planet.myplanet.repository.NotificationsRepository = mockk(relaxed = true)
-    private val dispatcherProvider = TestDispatcherProvider(testDispatcher)
 
     @Before
     fun setup() {
-        viewModel = TeamsVoicesViewModel(voicesRepository, teamsRepository, dispatcherProvider, userRepository, resourcesRepository, notificationsRepository)
+        viewModel = TeamsVoicesViewModel(voicesRepository, teamsRepository, userRepository, resourcesRepository, notificationsRepository)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/ui/voices/NewsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/voices/NewsViewModelTest.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.voices
 
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -13,7 +12,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -25,18 +23,10 @@ class NewsViewModelTest {
     private lateinit var resourcesRepository: ResourcesRepository
     private lateinit var viewModel: NewsViewModel
 
-    private val testDispatcherProvider = object : DispatcherProvider {
-        override val main: CoroutineDispatcher = UnconfinedTestDispatcher()
-        override val mainImmediate: CoroutineDispatcher = UnconfinedTestDispatcher()
-        override val io: CoroutineDispatcher = UnconfinedTestDispatcher()
-        override val default: CoroutineDispatcher = UnconfinedTestDispatcher()
-        override val unconfined: CoroutineDispatcher = UnconfinedTestDispatcher()
-    }
-
     @Before
     fun setup() {
         resourcesRepository = mockk()
-        viewModel = NewsViewModel(resourcesRepository, testDispatcherProvider)
+        viewModel = NewsViewModel(resourcesRepository)
     }
 
     @Test


### PR DESCRIPTION
Removed the unused DispatcherProvider parameter from DefaultLabelManipulator, TeamsVoicesViewModel, and NewsViewModel, updated delegation calls, and updated the corresponding unit tests.

Fixes #17009

---
*PR created automatically by Jules for task [2561720295050167184](https://jules.google.com/task/2561720295050167184) started by @dogi*