### PR TITLE
resources: smoother viewer pdf rendering (fixes #17004)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7070
-        versionName = "0.70.70"
+        versionCode = 7071
+        versionName = "0.70.71"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
@@ -10,6 +10,7 @@ import android.media.AudioManager
 import android.os.Bundle
 import android.os.ParcelFileDescriptor
 import android.text.TextUtils
+import android.util.Log
 import android.util.Rational
 import android.view.LayoutInflater
 import android.view.Menu
@@ -508,14 +509,27 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
 
     private fun renderPdf() {
         val file = File(externalFilesDir, "ole/$filePath")
-        if (file.exists()) {
-            try {
-                val fileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-                val pdfRenderer = PdfRenderer(fileDescriptor)
-                val page = pdfRenderer.openPage(0)
-                val bitmap = createBitmap(page.width, page.height)
-                page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+        if (!file.exists()) return
 
+        viewLifecycleOwner.lifecycleScope.launch {
+            val bitmap = withContext(dispatcherProvider.io) {
+                try {
+                    ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { fileDescriptor ->
+                        PdfRenderer(fileDescriptor).use { pdfRenderer ->
+                            pdfRenderer.openPage(0).use { page ->
+                                val bmp = createBitmap(page.width, page.height)
+                                page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                                bmp
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to render PDF page", e)
+                    null
+                }
+            }
+
+            if (bitmap != null && isAdded) {
                 val pdfPlaceholder = binding.root.findViewById<TextView>(R.id.pdfPlaceholder)
                 pdfPlaceholder.visibility = View.GONE
                 val parent = pdfPlaceholder.parent as ViewGroup
@@ -524,12 +538,6 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
                 imageView.scaleType = ImageView.ScaleType.FIT_CENTER
                 parent.addView(imageView, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0))
                 (imageView.layoutParams as LinearLayout.LayoutParams).weight = 1f
-
-                page.close()
-                pdfRenderer.close()
-                fileDescriptor.close()
-            } catch (e: Exception) {
-                e.printStackTrace()
             }
         }
     }
@@ -700,6 +708,7 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
     }
 
     companion object {
+        private const val TAG = "ResourceViewerFragment"
         private val UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/")
         private const val MIN_PIP_ASPECT_RATIO = 1.0 / 2.39
         private const val MAX_PIP_ASPECT_RATIO = 2.39 / 1.0


### PR DESCRIPTION
Moves PDF rendering off the main thread onto I/O dispatcher using coroutines, safely closes native PDF handles using .use blocks on success or failure, replaces e.printStackTrace() with sanitized tagged logging, and keeps view mutations on the main thread.

Fixes #17004

---
*PR created automatically by Jules for task [16637416671500816998](https://jules.google.com/task/16637416671500816998) started by @dogi*