### PR TITLE
courses: smoother progress vew holding (fixes #17006)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7077
-        versionName = "0.70.77"
+        versionCode = 7078
+        versionName = "0.70.78"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
@@ -30,9 +30,6 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
         holder.binding.tvTitle.text = item.courseName
         if (item.progressCurrent != null && item.progressMax != null) {
             holder.binding.tvDescription.text = context.getString(R.string.step_progress, item.progressCurrent, item.progressMax)
-            holder.itemView.setOnClickListener {
-                context.startActivity(Intent(context, CourseProgressActivity::class.java).putExtra("courseId", item.courseId))
-            }
         }
         if (item.mistakes != null) holder.binding.tvTotal.text = item.mistakes.toString()
         else holder.binding.tvTotal.text = context.getString(R.string.message_placeholder, "0")
@@ -100,6 +97,22 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
         val tvTitle = binding.tvTitle
         val tvTotal = binding.tvTotal
         val tvDescription = binding.tvDescription
+
+        init {
+            itemView.setOnClickListener {
+                val position = bindingAdapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    val item = getItem(position)
+                    if (item.progressCurrent != null && item.progressMax != null) {
+                        context.startActivity(
+                            Intent(context, CourseProgressActivity::class.java)
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                .putExtra("courseId", item.courseId)
+                        )
+                    }
+                }
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
@@ -104,13 +104,7 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
                 if (position != RecyclerView.NO_POSITION) {
                     val item = getItem(position)
                     if (item.progressCurrent != null && item.progressMax != null) {
-                        context.startActivity(
-                            Intent(context, CourseProgressActivity::class.java)
-                                // Defensive: allows launching if a non-Activity context is ever passed.
-                                // From an Activity context this flag alone does not start a new task.
-                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                .putExtra("courseId", item.courseId)
-                        )
+                        context.startActivity(Intent(context, CourseProgressActivity::class.java).putExtra("courseId", item.courseId))
                     }
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
@@ -106,6 +106,8 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
                     if (item.progressCurrent != null && item.progressMax != null) {
                         context.startActivity(
                             Intent(context, CourseProgressActivity::class.java)
+                                // Defensive: allows launching if a non-Activity context is ever passed.
+                                // From an Activity context this flag alone does not start a new task.
                                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                                 .putExtra("courseId", item.courseId)
                         )

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
@@ -5,15 +5,19 @@ import android.content.Context
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.CoursesProgressRow
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -27,6 +31,13 @@ class CoursesProgressAdapterTest {
     fun setup() {
         context = ApplicationProvider.getApplicationContext()
         adapter = CoursesProgressAdapter(context)
+    }
+
+    private fun setupRecyclerView(adapter: CoursesProgressAdapter): RecyclerView {
+        val recyclerView = RecyclerView(context)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        recyclerView.adapter = adapter
+        return recyclerView
     }
 
     @Test
@@ -83,6 +94,89 @@ class CoursesProgressAdapterTest {
 
         adapter.onBindViewHolder(holder, 2)
         assertEquals(0, holder.binding.llProgress.childCount)
+    }
+
+    @Test
+    fun `click row with progress launches CourseProgressActivity`() {
+        val withProgressItem = CoursesProgressRow(
+            courseId = "course123",
+            courseName = "Course 1",
+            progressCurrent = 2,
+            progressMax = 5,
+            mistakes = null,
+            stepMistake = null
+        )
+
+        adapter.submitList(listOf(withProgressItem))
+        val recyclerView = setupRecyclerView(adapter)
+        recyclerView.measure(0, 0)
+        recyclerView.layout(0, 0, 1000, 1000)
+
+        val holder = recyclerView.findViewHolderForAdapterPosition(0)
+        assertNotEquals(null, holder)
+        holder!!.itemView.performClick()
+
+        val nextStartedActivity = shadowOf(context as Application).nextStartedActivity
+        assertNotEquals(null, nextStartedActivity)
+        assertEquals(CourseProgressActivity::class.java.name, nextStartedActivity.component?.className)
+        assertEquals("course123", nextStartedActivity.getStringExtra("courseId"))
+    }
+
+    @Test
+    fun `click row without progress does nothing`() {
+        val noProgressItem = CoursesProgressRow(
+            courseId = "course456",
+            courseName = "Course 2",
+            progressCurrent = null,
+            progressMax = null,
+            mistakes = null,
+            stepMistake = null
+        )
+
+        adapter.submitList(listOf(noProgressItem))
+        val recyclerView = setupRecyclerView(adapter)
+        recyclerView.measure(0, 0)
+        recyclerView.layout(0, 0, 1000, 1000)
+
+        val holder = recyclerView.findViewHolderForAdapterPosition(0)
+        assertNotEquals(null, holder)
+        holder!!.itemView.performClick()
+
+        val nextStartedActivity = shadowOf(context as Application).nextStartedActivity
+        assertNull(nextStartedActivity)
+    }
+
+    @Test
+    fun `recycled holder from row with progress to row without progress does nothing on click`() {
+        val withProgressItem = CoursesProgressRow(
+            courseId = "course123",
+            courseName = "Course 1",
+            progressCurrent = 2,
+            progressMax = 5,
+            mistakes = null,
+            stepMistake = null
+        )
+
+        val noProgressItem = CoursesProgressRow(
+            courseId = "course456",
+            courseName = "Course 2",
+            progressCurrent = null,
+            progressMax = null,
+            mistakes = null,
+            stepMistake = null
+        )
+
+        adapter.submitList(listOf(withProgressItem, noProgressItem))
+        val recyclerView = setupRecyclerView(adapter)
+        recyclerView.measure(0, 0)
+        recyclerView.layout(0, 0, 1000, 1000)
+
+        val holder1 = recyclerView.findViewHolderForAdapterPosition(1)
+        assertNotEquals(null, holder1)
+        holder1!!.itemView.performClick()
+
+        val nextStartedActivity = shadowOf(context as Application).nextStartedActivity
+        assertNull(nextStartedActivity)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
@@ -1,13 +1,13 @@
 package org.ole.planet.myplanet.ui.courses
 
+import android.app.Activity
 import android.app.Application
-import android.content.Context
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.CoursesProgressRow
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
@@ -24,18 +25,19 @@ import org.robolectric.annotation.Config
 @Config(application = Application::class)
 class CoursesProgressAdapterTest {
 
-    private lateinit var context: Context
+    private lateinit var activity: Activity
     private lateinit var adapter: CoursesProgressAdapter
 
     @Before
     fun setup() {
-        context = ApplicationProvider.getApplicationContext()
-        adapter = CoursesProgressAdapter(context)
+        activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(com.google.android.material.R.style.Theme_MaterialComponents)
+        adapter = CoursesProgressAdapter(activity)
     }
 
     private fun setupRecyclerView(adapter: CoursesProgressAdapter): RecyclerView {
-        val recyclerView = RecyclerView(context)
-        recyclerView.layoutManager = LinearLayoutManager(context)
+        val recyclerView = RecyclerView(activity)
+        recyclerView.layoutManager = LinearLayoutManager(activity)
         recyclerView.adapter = adapter
         return recyclerView
     }
@@ -71,7 +73,7 @@ class CoursesProgressAdapterTest {
 
         adapter.submitList(listOf(manyStepsItem, fewerStepsItem, noStepsItem))
 
-        val parent = LinearLayout(context)
+        val parent = LinearLayout(activity)
         val holder = adapter.onCreateViewHolder(parent, 0)
 
         adapter.onBindViewHolder(holder, 0)
@@ -116,7 +118,7 @@ class CoursesProgressAdapterTest {
         assertNotEquals(null, holder)
         holder!!.itemView.performClick()
 
-        val nextStartedActivity = shadowOf(context as Application).nextStartedActivity
+        val nextStartedActivity = shadowOf(activity).nextStartedActivity
         assertNotEquals(null, nextStartedActivity)
         assertEquals(CourseProgressActivity::class.java.name, nextStartedActivity.component?.className)
         assertEquals("course123", nextStartedActivity.getStringExtra("courseId"))
@@ -142,7 +144,7 @@ class CoursesProgressAdapterTest {
         assertNotEquals(null, holder)
         holder!!.itemView.performClick()
 
-        val nextStartedActivity = shadowOf(context as Application).nextStartedActivity
+        val nextStartedActivity = shadowOf(activity).nextStartedActivity
         assertNull(nextStartedActivity)
     }
 
@@ -175,7 +177,7 @@ class CoursesProgressAdapterTest {
         assertNotEquals(null, holder1)
         holder1!!.itemView.performClick()
 
-        val nextStartedActivity = shadowOf(context as Application).nextStartedActivity
+        val nextStartedActivity = shadowOf(activity).nextStartedActivity
         assertNull(nextStartedActivity)
     }
 
@@ -192,12 +194,12 @@ class CoursesProgressAdapterTest {
 
         adapter.submitList(listOf(item))
 
-        val parent = LinearLayout(context)
+        val parent = LinearLayout(activity)
         val holder = adapter.onCreateViewHolder(parent, 0)
         adapter.onBindViewHolder(holder, 0)
 
         val row = holder.binding.llProgress.getChildAt(0) as LinearLayout
-        val expectedColor = ContextCompat.getColor(context, R.color.daynight_textColor)
+        val expectedColor = ContextCompat.getColor(activity, R.color.daynight_textColor)
         assertNotEquals(0, expectedColor)
         assertEquals(expectedColor, (row.getChildAt(0) as TextView).currentTextColor)
         assertEquals(expectedColor, (row.getChildAt(1) as TextView).currentTextColor)


### PR DESCRIPTION
Move click listener initialization into CoursesProgressViewHolder.init using bindingAdapterPosition to resolve the item dynamically and check for non-null progress values. This removes per-bind listener allocations and fixes wrong-course navigation caused by recycled ViewHolders retaining previous listeners. Unit tests have been added to verify row clicks.

Fixes #17006

---
*PR created automatically by Jules for task [18317461799797761292](https://jules.google.com/task/18317461799797761292) started by @dogi*