### PR TITLE
courses: smoother repository step exam bulk querying (fixes #17007)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7072
-        versionName = "0.70.72"
+        versionCode = 7073
+        versionName = "0.70.73"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -138,12 +138,26 @@ class CoursesRepositoryImpl @Inject constructor(
             val downloadedResources = getCourseOfflineResources(courseId)
             val rawSteps = getCourseSteps(courseId)
 
+            val stepIds = rawSteps.mapNotNull { it.id }
+            val questionCountsByStepId = if (stepIds.isEmpty()) {
+                emptyMap()
+            } else {
+                val exams = examDao.getByStepIds(stepIds)
+                val countsMap = mutableMapOf<String, Int>()
+                exams.forEach { exam ->
+                    val sId = exam.stepId
+                    if (sId != null && !countsMap.containsKey(sId)) {
+                        countsMap[sId] = exam.noOfQuestions
+                    }
+                }
+                countsMap
+            }
+
             val steps = rawSteps.map { step ->
-                val count = step.id.let { submissionsRepository.getExamQuestionCount(it) }
                 StepItem(
                     id = step.id,
                     stepTitle = step.stepTitle,
-                    questionCount = count
+                    questionCount = questionCountsByStepId[step.id] ?: 0
                 )
             }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -23,7 +23,6 @@ interface SubmissionsRepository {
     suspend fun getSubmissionById(id: String): Submission?
     suspend fun getSubmissionsByIds(ids: List<String>): List<Submission>
     suspend fun getExamMap(submissions: List<Submission>): Map<String?, StepExam>
-    suspend fun getExamQuestionCount(stepId: String): Int
     suspend fun hasSubmission(
         stepExamId: String?,
         courseId: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -159,10 +159,6 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         }.toMap()
     }
 
-    override suspend fun getExamQuestionCount(stepId: String): Int {
-        return examDao.getFirstByStepId(stepId)?.noOfQuestions ?: 0
-    }
-
     override suspend fun getSubmissionById(id: String): Submission? {
         return hydrateSubmission(submissionDao.getByIdOrRemoteId(id))
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -375,7 +375,7 @@ class CoursesRepositoryImplTest {
         coEvery { myLibraryDao.getCourseResources("course_id", false) } returns emptyList()
         coEvery { myLibraryDao.getCourseResources("course_id", true) } returns emptyList()
         coEvery { courseStepDao.getByCourseId("course_id") } returns listOf(org.ole.planet.myplanet.model.CourseStep().apply { id = "step_1"; stepTitle = "Title" })
-        coEvery { submissionsRepository.getExamQuestionCount("step_1") } returns 3
+        coEvery { examDao.getByStepIds(listOf("step_1")) } returns listOf(org.ole.planet.myplanet.model.StepExam().apply { stepId = "step_1"; noOfQuestions = 3 })
 
         coEvery { ratingsRepository.getRatingSummary("course", "course_id", "user_1") } returns RatingSummary(
             existingRating = null,


### PR DESCRIPTION
Replaces single LIMIT 1 per-step exam question count queries in CoursesRepositoryImpl with a single bulk lookup via examDao.getByStepIds, and removes getExamQuestionCount from SubmissionsRepository and SubmissionsRepositoryImpl.

Fixes #17007

---
*PR created automatically by Jules for task [16634147295499682935](https://jules.google.com/task/16634147295499682935) started by @dogi*