### PR TITLE
enterprises: smoother finances transactions view modelling (fixes #17013)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7073
-        versionName = "0.70.73"
+        versionCode = 7074
+        versionName = "0.70.74"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModel.kt
@@ -66,6 +66,14 @@ class EnterprisesFinancesViewModel @Inject constructor(
     private val _transactionCreated = MutableSharedFlow<Result<Unit>>(extraBufferCapacity = 1)
     val transactionCreated: SharedFlow<Result<Unit>> = _transactionCreated.asSharedFlow()
 
+    private data class TransactionQuery(
+        val teamId: String,
+        val sortAscending: Boolean,
+        val startDate: Long?,
+        val endDate: Long?
+    )
+
+    private var lastQuery: TransactionQuery? = null
     private var transactionsJob: Job? = null
 
     fun getTeamTransactions(
@@ -74,6 +82,11 @@ class EnterprisesFinancesViewModel @Inject constructor(
         startDate: Long?,
         endDate: Long?
     ) {
+        val query = TransactionQuery(teamId, sortAscending, startDate, endDate)
+        if (lastQuery == query && transactionsJob?.isActive == true) {
+            return
+        }
+        lastQuery = query
         transactionsJob?.cancel()
         transactionsJob = viewModelScope.launch {
             teamsRepository.getTeamTransactionsWithBalance(

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.enterprises
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -150,6 +151,74 @@ class EnterprisesFinancesViewModelTest {
 
         val actualTransactions = viewModel.transactions.first()
         assertEquals(mockTransactions, actualTransactions)
+    }
+
+    @Test
+    fun `getTeamTransactions duplicate call while active does not re-query repository`() = runTest {
+        val mockTransactions = listOf(Transaction("1", 0L, "desc", "type", 100, 100))
+        val teamId = "test_team_id"
+        val sortAscending = true
+        val startDate = 1000L
+        val endDate = 2000L
+
+        coEvery {
+            teamsRepository.getTeamTransactionsWithBalance(
+                teamId = teamId,
+                startDate = startDate,
+                endDate = endDate,
+                sortAscending = sortAscending
+            )
+        } returns flowOf(mockTransactions)
+
+        viewModel.getTeamTransactions(teamId, sortAscending, startDate, endDate)
+        viewModel.getTeamTransactions(teamId, sortAscending, startDate, endDate)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            teamsRepository.getTeamTransactionsWithBalance(
+                teamId = teamId,
+                startDate = startDate,
+                endDate = endDate,
+                sortAscending = sortAscending
+            )
+        }
+    }
+
+    @Test
+    fun `getTeamTransactions call with different arguments re-queries repository`() = runTest {
+        val mockTransactions = listOf(Transaction("1", 0L, "desc", "type", 100, 100))
+        val teamId = "test_team_id"
+
+        coEvery {
+            teamsRepository.getTeamTransactionsWithBalance(
+                teamId = teamId,
+                startDate = null,
+                endDate = null,
+                sortAscending = any()
+            )
+        } returns flowOf(mockTransactions)
+
+        viewModel.getTeamTransactions(teamId, sortAscending = false, startDate = null, endDate = null)
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.getTeamTransactions(teamId, sortAscending = true, startDate = null, endDate = null)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            teamsRepository.getTeamTransactionsWithBalance(
+                teamId = teamId,
+                startDate = null,
+                endDate = null,
+                sortAscending = false
+            )
+        }
+        coVerify(exactly = 1) {
+            teamsRepository.getTeamTransactionsWithBalance(
+                teamId = teamId,
+                startDate = null,
+                endDate = null,
+                sortAscending = true
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Prevents EnterprisesFinancesViewModel from cancelling and restarting an active transaction query when identical query arguments are provided (such as when entering EnterprisesFinancesFragment where observeTransactions is invoked in both onViewCreated and onResume).

Fixes #17013

---
*PR created automatically by Jules for task [11203593152205880366](https://jules.google.com/task/11203593152205880366) started by @dogi*