### PR TITLE
teams: smoother resources view modelling (fixes #17010)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7074
-        versionName = "0.70.74"
+        versionCode = 7075
+        versionName = "0.70.75"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
@@ -69,9 +69,13 @@ class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResource
         llImage?.removeAllViews()
     }
 
-    private fun showLibraryList() {
+    private fun showLibraryList(force: Boolean = false) {
         if (!isAdded || activity == null) return
-        viewModel.loadResources(teamId, user?.id)
+        if (force) {
+            viewModel.reload(teamId, user?.id)
+        } else {
+            viewModel.loadResources(teamId, user?.id)
+        }
     }
 
     private fun renderResources(state: TeamResourcesUiState) {
@@ -123,7 +127,7 @@ class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResource
                         }
                     viewLifecycleOwner.lifecycleScope.launch {
                         viewModel.addResources(teamId, selectedResources, user?.id)
-                        showLibraryList()
+                        showLibraryList(force = true)
                     }
                 }
                 .setNeutralButton(R.string.create_new_resource) { _: DialogInterface?, _: Int ->
@@ -147,7 +151,7 @@ class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResource
             override fun onFragmentDetached(fm: FragmentManager, f: Fragment) {
                 if (f === fragment) {
                     fm.unregisterFragmentLifecycleCallbacks(this)
-                    showLibraryList()
+                    showLibraryList(force = true)
                 }
             }
         }, false)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesViewModel.kt
@@ -1,10 +1,10 @@
 package org.ole.planet.myplanet.ui.teams.resources
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,8 +28,18 @@ class TeamResourcesViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<TeamResourcesUiState?>(null)
     val uiState: StateFlow<TeamResourcesUiState?> = _uiState.asStateFlow()
 
-    fun loadResources(teamId: String, userId: String?) {
-        viewModelScope.launch {
+    private var loadJob: Job? = null
+    private var lastTeamId: String? = null
+    private var lastUserId: String? = null
+
+    fun loadResources(teamId: String, userId: String?, force: Boolean = false) {
+        if (!force && loadJob?.isActive == true && teamId == lastTeamId && userId == lastUserId) {
+            return
+        }
+        loadJob?.cancel()
+        lastTeamId = teamId
+        lastUserId = userId
+        loadJob = viewModelScope.launch {
             coroutineScope {
                 val librariesDeferred = async { teamsRepository.getTeamResources(teamId) }
                 val canRemoveDeferred = async { teamsRepository.isTeamLeader(teamId, userId) }
@@ -39,6 +49,10 @@ class TeamResourcesViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun reload(teamId: String, userId: String?) {
+        loadResources(teamId, userId, force = true)
     }
 
     suspend fun addResources(teamId: String, resources: List<TeamResourceDto>, userId: String?) {
@@ -57,10 +71,5 @@ class TeamResourcesViewModel @Inject constructor(
 
     private suspend fun recordActivitySafely() {
         runCatching { teamsRepository.recordTeamActivity() }
-            .onFailure { Log.w(TAG, "Failed to record team activity", it) }
-    }
-
-    private companion object {
-        const val TAG = "TeamResourcesViewModel"
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesViewModelTest.kt
@@ -1,14 +1,11 @@
 package org.ole.planet.myplanet.ui.teams.resources
 
-import android.util.Log
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -34,15 +31,11 @@ class TeamResourcesViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        mockkStatic(Log::class)
-        every { Log.w(any(), any<String>()) } returns 0
-        every { Log.w(any(), any<String>(), any()) } returns 0
         viewModel = TeamResourcesViewModel(teamsRepository)
     }
 
     @After
     fun tearDown() {
-        unmockkStatic(Log::class)
         Dispatchers.resetMain()
     }
 
@@ -151,11 +144,11 @@ class TeamResourcesViewModelTest {
     fun `loadResources executes queries concurrently`() = runTest(testDispatcher) {
         val libraries = listOf(MyLibrary().apply { id = "r1"; title = "Resource 1" })
         coEvery { teamsRepository.getTeamResources("team1") } coAnswers {
-            kotlinx.coroutines.delay(100)
+            delay(100)
             libraries
         }
         coEvery { teamsRepository.isTeamLeader("team1", "user1") } coAnswers {
-            kotlinx.coroutines.delay(100)
+            delay(100)
             true
         }
 
@@ -165,5 +158,84 @@ class TeamResourcesViewModelTest {
         val state = viewModel.uiState.value
         assertEquals(1, state?.resources?.size)
         assertTrue(state?.canRemove == true)
+    }
+
+    @Test
+    fun `loadResources ignores duplicate calls while loadJob is active for same team and user`() = runTest(testDispatcher) {
+        val libraries = listOf(MyLibrary().apply { id = "r1"; title = "Resource 1" })
+        coEvery { teamsRepository.getTeamResources("team1") } coAnswers {
+            delay(100)
+            libraries
+        }
+        coEvery { teamsRepository.isTeamLeader("team1", "user1") } coAnswers {
+            delay(100)
+            true
+        }
+
+        viewModel.loadResources("team1", "user1")
+        viewModel.loadResources("team1", "user1")
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { teamsRepository.getTeamResources("team1") }
+        coVerify(exactly = 1) { teamsRepository.isTeamLeader("team1", "user1") }
+    }
+
+    @Test
+    fun `reload cancels active loadJob and triggers new queries`() = runTest(testDispatcher) {
+        val firstLibraries = listOf(MyLibrary().apply { id = "r1"; title = "Resource 1" })
+        val secondLibraries = listOf(
+            MyLibrary().apply { id = "r1"; title = "Resource 1" },
+            MyLibrary().apply { id = "r2"; title = "Resource 2" }
+        )
+
+        var callCount = 0
+        coEvery { teamsRepository.getTeamResources("team1") } coAnswers {
+            if (callCount++ == 0) firstLibraries else secondLibraries
+        }
+        coEvery { teamsRepository.isTeamLeader("team1", "user1") } returns true
+
+        viewModel.loadResources("team1", "user1")
+        advanceUntilIdle()
+
+        viewModel.reload("team1", "user1")
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { teamsRepository.getTeamResources("team1") }
+        assertEquals(2, viewModel.uiState.value?.resources?.size)
+    }
+
+    @Test
+    fun `loadResources for different team cancels superseded loadJob`() = runTest(testDispatcher) {
+        val team1Libraries = listOf(MyLibrary().apply { id = "r1"; title = "Team 1 Resource" })
+        val team2Libraries = listOf(MyLibrary().apply { id = "r2"; title = "Team 2 Resource" })
+
+        coEvery { teamsRepository.getTeamResources("team1") } coAnswers {
+            delay(200)
+            team1Libraries
+        }
+        coEvery { teamsRepository.isTeamLeader("team1", "user1") } coAnswers {
+            delay(200)
+            true
+        }
+
+        coEvery { teamsRepository.getTeamResources("team2") } coAnswers {
+            delay(50)
+            team2Libraries
+        }
+        coEvery { teamsRepository.isTeamLeader("team2", "user1") } coAnswers {
+            delay(50)
+            false
+        }
+
+        viewModel.loadResources("team1", "user1")
+        viewModel.loadResources("team2", "user1")
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(1, state?.resources?.size)
+        assertEquals("Team 2 Resource", state?.resources?.get(0)?.title)
+        assertTrue(state?.canRemove == false)
     }
 }


### PR DESCRIPTION
Fix double-loading team resources on screen entry by tracking active load jobs, deduplicating identical requests, cancelling superseded jobs, adding reload support for resource mutations, and removing android.* imports from TeamResourcesViewModel.

Fixes #17010

---
*PR created automatically by Jules for task [8507509632764662975](https://jules.google.com/task/8507509632764662975) started by @dogi*