### PR TITLE
courses: smoother glide cover thumbnail loading (fixes #17025)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7078
-        versionName = "0.70.78"
+        versionCode = 7079
+        versionName = "0.70.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -30,6 +30,7 @@ import org.ole.planet.myplanet.model.MyCourse
 import org.ole.planet.myplanet.utils.CourseSubject
 import org.ole.planet.myplanet.utils.CourseSubjectClassifier
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.GridSpanCalculator
 import org.ole.planet.myplanet.utils.ListViewMode
 import org.ole.planet.myplanet.utils.SelectionUtils
 import org.ole.planet.myplanet.utils.StableIdGenerator
@@ -317,7 +318,10 @@ class CoursesAdapter(
             coverContainer.width > 0 -> coverContainer.width
             coverContainer.layoutParams?.width != null && coverContainer.layoutParams.width > 0 -> coverContainer.layoutParams.width
             else -> if (viewMode == ListViewMode.GRID) {
-                (context.resources.displayMetrics.widthPixels / 2).coerceAtLeast(fallbackHeight)
+                val displayMetrics = context.resources.displayMetrics
+                val widthDp = (displayMetrics.widthPixels / displayMetrics.density).toInt()
+                val cols = GridSpanCalculator.columnCount(widthDp)
+                (displayMetrics.widthPixels / cols).coerceAtLeast(fallbackHeight)
             } else {
                 fallbackHeight
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -307,17 +307,26 @@ class CoursesAdapter(
         ivSubjectIcon.visibility = View.GONE
         ivCover.visibility = View.VISIBLE
 
-        val density = context.resources.displayMetrics.density
+        val fallbackHeight = if (viewMode == ListViewMode.GRID) {
+            context.resources.getDimensionPixelSize(R.dimen.course_grid_cover_height)
+        } else {
+            context.resources.getDimensionPixelSize(R.dimen.course_list_cover_size)
+        }
+
         val targetWidth = when {
             coverContainer.width > 0 -> coverContainer.width
             coverContainer.layoutParams?.width != null && coverContainer.layoutParams.width > 0 -> coverContainer.layoutParams.width
-            else -> (context.resources.displayMetrics.widthPixels / 2).coerceAtLeast((160 * density).toInt())
+            else -> if (viewMode == ListViewMode.GRID) {
+                (context.resources.displayMetrics.widthPixels / 2).coerceAtLeast(fallbackHeight)
+            } else {
+                fallbackHeight
+            }
         }.coerceAtLeast(1)
 
         val targetHeight = when {
             coverContainer.height > 0 -> coverContainer.height
             coverContainer.layoutParams?.height != null && coverContainer.layoutParams.height > 0 -> coverContainer.layoutParams.height
-            else -> (84 * density).toInt()
+            else -> fallbackHeight
         }.coerceAtLeast(1)
 
         Glide.with(context)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -306,10 +306,25 @@ class CoursesAdapter(
         }
         ivSubjectIcon.visibility = View.GONE
         ivCover.visibility = View.VISIBLE
+
+        val density = context.resources.displayMetrics.density
+        val targetWidth = when {
+            coverContainer.width > 0 -> coverContainer.width
+            coverContainer.layoutParams?.width != null && coverContainer.layoutParams.width > 0 -> coverContainer.layoutParams.width
+            else -> (context.resources.displayMetrics.widthPixels / 2).coerceAtLeast((160 * density).toInt())
+        }.coerceAtLeast(1)
+
+        val targetHeight = when {
+            coverContainer.height > 0 -> coverContainer.height
+            coverContainer.layoutParams?.height != null && coverContainer.layoutParams.height > 0 -> coverContainer.layoutParams.height
+            else -> (84 * density).toInt()
+        }.coerceAtLeast(1)
+
         Glide.with(context)
             .load(model)
             .diskCacheStrategy(DiskCacheStrategy.ALL)
             .signature(ObjectKey(course.courseRev.orEmpty()))
+            .override(targetWidth, targetHeight)
             .centerCrop()
             .error(R.drawable.ole_logo)
             .into(ivCover)

--- a/app/src/main/res/layout/item_course_grid.xml
+++ b/app/src/main/res/layout/item_course_grid.xml
@@ -19,7 +19,7 @@
         <FrameLayout
             android:id="@+id/cover_container"
             android:layout_width="match_parent"
-            android:layout_height="84dp"
+            android:layout_height="@dimen/course_grid_cover_height"
             android:background="@drawable/bg_cover_top_rounded"
             android:clipToOutline="true">
 

--- a/app/src/main/res/layout/item_course_list.xml
+++ b/app/src/main/res/layout/item_course_list.xml
@@ -30,8 +30,8 @@
             android:scaleY="0.85" />
         <FrameLayout
             android:id="@+id/cover_container"
-            android:layout_width="44dp"
-            android:layout_height="44dp"
+            android:layout_width="@dimen/course_list_cover_size"
+            android:layout_height="@dimen/course_list_cover_size"
             android:layout_marginStart="4dp"
             android:background="@drawable/bg_rounded_thumbnail"
             android:clipToOutline="true">

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -116,4 +116,7 @@
     <dimen name="dashboard_tile_color_block_width">72dp</dimen>
     <dimen name="dashboard_chip_width">92dp</dimen>
     <dimen name="dashboard_rail_width">182dp</dimen>
+
+    <dimen name="course_grid_cover_height">84dp</dimen>
+    <dimen name="course_list_cover_size">44dp</dimen>
 </resources>


### PR DESCRIPTION
Added `.override(targetWidth, targetHeight)` to Glide in `CoursesAdapter.kt` to decode course covers at thumbnail resolution rather than full image resolution.

Fixes #17025

---
*PR created automatically by Jules for task [4872324890950524367](https://jules.google.com/task/4872324890950524367) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course cover image sizing in grid and list views for more consistent display.
  * Adjusted image loading to match the available cover container dimensions, helping reduce scaling issues.
  * Standardized cover dimensions across course layouts for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->