### PR TITLE
courses: smoother inline resources preview image loading (fixes #17033)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7079
-        versionName = "0.70.79"
+        versionCode = 7080
+        versionName = "0.70.80"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -222,9 +222,11 @@ class InlineResourceAdapter(
         binding.videoThumbnailContainer.visibility = View.VISIBLE
         val exists = withContext(dispatcherProvider.io) { file.exists() }
         if (exists) {
+            val (widthPx, heightPx) = getPreviewDimensions(context)
             Glide.with(context)
                 .load(file)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .override(widthPx, heightPx)
                 .centerCrop()
                 .into(binding.ivVideoThumbnail)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -205,12 +205,12 @@ class InlineResourceAdapter(
     private suspend fun showImagePreview(binding: ItemInlineResourceBinding, context: Context, file: File) {
         val exists = withContext(dispatcherProvider.io) { file.exists() }
         if (exists) {
-            val previewSizePx = getPreviewDecodeSizePx(context)
+            val (widthPx, heightPx) = getPreviewDimensions(context)
             binding.ivResourcePreview.visibility = View.VISIBLE
             Glide.with(context)
                 .load(file)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
-                .override(previewSizePx)
+                .override(widthPx, heightPx)
                 .centerCrop()
                 .placeholder(R.drawable.ole_logo)
                 .error(R.drawable.ole_logo)
@@ -222,11 +222,9 @@ class InlineResourceAdapter(
         binding.videoThumbnailContainer.visibility = View.VISIBLE
         val exists = withContext(dispatcherProvider.io) { file.exists() }
         if (exists) {
-            val previewSizePx = getPreviewDecodeSizePx(context)
             Glide.with(context)
                 .load(file)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
-                .override(previewSizePx)
                 .centerCrop()
                 .into(binding.ivVideoThumbnail)
         }
@@ -256,12 +254,12 @@ class InlineResourceAdapter(
             }
         }
         if (coverImage != null) {
-            val previewSizePx = getPreviewDecodeSizePx(context)
+            val (widthPx, heightPx) = getPreviewDimensions(context)
             binding.ivResourcePreview.visibility = View.VISIBLE
             Glide.with(context)
                 .load(coverImage)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
-                .override(previewSizePx)
+                .override(widthPx, heightPx)
                 .centerCrop()
                 .placeholder(R.drawable.ole_logo)
                 .error(R.drawable.ole_logo)
@@ -319,9 +317,10 @@ class InlineResourceAdapter(
 
     private fun getCacheKey(file: File): String = "${file.absolutePath}_${file.lastModified()}_${file.length()}"
 
-    private fun getPreviewDecodeSizePx(context: Context): Int {
-        val density = context.resources.displayMetrics.density
-        return (PREVIEW_DECODE_SIZE_DP * density).toInt()
+    private fun getPreviewDimensions(context: Context): Pair<Int, Int> {
+        val widthPx = context.resources.displayMetrics.widthPixels
+        val heightPx = context.resources.getDimensionPixelSize(R.dimen.inline_resource_preview_height)
+        return Pair(widthPx, heightPx)
     }
 
     companion object {
@@ -329,6 +328,5 @@ class InlineResourceAdapter(
         const val PAYLOAD_ADDRESS = "PAYLOAD_ADDRESS"
         const val PAYLOAD_STATUS = "PAYLOAD_STATUS"
         private const val PDF_PREVIEW_WIDTH_DP = 240
-        private const val PREVIEW_DECODE_SIZE_DP = 360
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -205,10 +205,12 @@ class InlineResourceAdapter(
     private suspend fun showImagePreview(binding: ItemInlineResourceBinding, context: Context, file: File) {
         val exists = withContext(dispatcherProvider.io) { file.exists() }
         if (exists) {
+            val previewSizePx = getPreviewDecodeSizePx(context)
             binding.ivResourcePreview.visibility = View.VISIBLE
             Glide.with(context)
                 .load(file)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .override(previewSizePx)
                 .centerCrop()
                 .placeholder(R.drawable.ole_logo)
                 .error(R.drawable.ole_logo)
@@ -220,9 +222,11 @@ class InlineResourceAdapter(
         binding.videoThumbnailContainer.visibility = View.VISIBLE
         val exists = withContext(dispatcherProvider.io) { file.exists() }
         if (exists) {
+            val previewSizePx = getPreviewDecodeSizePx(context)
             Glide.with(context)
                 .load(file)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .override(previewSizePx)
                 .centerCrop()
                 .into(binding.ivVideoThumbnail)
         }
@@ -252,10 +256,12 @@ class InlineResourceAdapter(
             }
         }
         if (coverImage != null) {
+            val previewSizePx = getPreviewDecodeSizePx(context)
             binding.ivResourcePreview.visibility = View.VISIBLE
             Glide.with(context)
                 .load(coverImage)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .override(previewSizePx)
                 .centerCrop()
                 .placeholder(R.drawable.ole_logo)
                 .error(R.drawable.ole_logo)
@@ -313,10 +319,16 @@ class InlineResourceAdapter(
 
     private fun getCacheKey(file: File): String = "${file.absolutePath}_${file.lastModified()}_${file.length()}"
 
+    private fun getPreviewDecodeSizePx(context: Context): Int {
+        val density = context.resources.displayMetrics.density
+        return (PREVIEW_DECODE_SIZE_DP * density).toInt()
+    }
+
     companion object {
         const val PAYLOAD_TITLE = "PAYLOAD_TITLE"
         const val PAYLOAD_ADDRESS = "PAYLOAD_ADDRESS"
         const val PAYLOAD_STATUS = "PAYLOAD_STATUS"
         private const val PDF_PREVIEW_WIDTH_DP = 240
+        private const val PREVIEW_DECODE_SIZE_DP = 360
     }
 }

--- a/app/src/main/res/layout/item_inline_resource.xml
+++ b/app/src/main/res/layout/item_inline_resource.xml
@@ -20,13 +20,13 @@
         <ImageView
             android:id="@+id/iv_resource_preview"
             android:layout_width="match_parent"
-            android:layout_height="180dp"
+            android:layout_height="@dimen/inline_resource_preview_height"
             android:scaleType="centerCrop"
             android:visibility="gone" />
         <FrameLayout
             android:id="@+id/video_thumbnail_container"
             android:layout_width="match_parent"
-            android:layout_height="180dp"
+            android:layout_height="@dimen/inline_resource_preview_height"
             android:visibility="gone">
 
             <ImageView

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <resources>
+    <dimen name="inline_resource_preview_height">180dp</dimen>
     <dimen name="menu_item_icon_size">24dp</dimen>
     <dimen name="user_image_size">150dp</dimen>
     <dimen name="padding_normal">8dp</dimen>


### PR DESCRIPTION
Size Glide previews in InlineResourceAdapter to reduce memory footprint when decoding image, video, and HTML cover thumbnails.

Fixes #17033

---
*PR created automatically by Jules for task [15628710347172281435](https://jules.google.com/task/15628710347172281435) started by @dogi*