### PR TITLE
courses: smoother steps progressing (fixes #17026)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7075
-        versionName = "0.70.75"
+        versionCode = 7076
+        versionName = "0.70.76"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -18,6 +18,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
@@ -54,6 +55,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     private var courseDetailContentReady = false
     private var coursesPagerAdapter: CoursesPagerAdapter? = null
     private var pageChangeCallback: ViewPager2.OnPageChangeCallback? = null
+    private var progressJob: Job? = null
     private val stepFormatPattern by lazy { "${getString(R.string.step)} %d/%d" }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -199,7 +201,8 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         binding.nextStep.text = if (position == 0) getString(R.string.start) else getString(R.string.next)
         binding.courseStepProgressBar.max = steps.size
         binding.courseStepProgressBar.progress = position
-        viewLifecycleOwner.lifecycleScope.launch {
+        progressJob?.cancel()
+        progressJob = viewLifecycleOwner.lifecycleScope.launch {
             val currentProgress = viewModel.getCurrentProgress(steps, userModel?.id, courseId)
             currentCourseProgress = currentProgress
             if (currentProgress < steps.size) {
@@ -478,6 +481,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         pageChangeCallback?.let { binding.viewPager2.unregisterOnPageChangeCallback(it) }
         pageChangeCallback = null
         lifecycleScope.coroutineContext.cancelChildren()
+        progressJob = null
         joinDialog?.dismiss()
         joinDialog = null
         _binding = null


### PR DESCRIPTION
Cancels any active progress query Job before launching a new query in TakeCourseFragment.updateStepDisplay to fix fast-swiping progress display race conditions, and clears the job reference in onDestroyView.

Fixes #17026

---
*PR created automatically by Jules for task [319120447496011515](https://jules.google.com/task/319120447496011515) started by @dogi*