### PR TITLE
life: smoother health user view modelling (fixes #17014)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationAdapter.kt
@@ -31,7 +31,8 @@ class HealthExaminationAdapter(
     private var mh: HealthExamination,
     private var userModel: UserEntity?,
     private var userMap: Map<String, UserEntity>,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val onEditClick: ((Intent) -> Unit)? = null
 ) : ListAdapter<HealthExaminationAdapter.HealthExaminationItem, HealthExaminationViewHolder>(DIFF_CALLBACK) {
 
     data class HealthExaminationItem(
@@ -149,9 +150,14 @@ class HealthExaminationAdapter(
         dialog.window?.setBackgroundDrawable(colorMultiSelectGrey.toDrawable())
 
         dialog.setButton(DialogInterface.BUTTON_NEUTRAL, context.getString(R.string.edit)) { _: DialogInterface?, _: Int ->
-            context.startActivity(Intent(context, HealthExaminationActivity::class.java)
+            val intent = Intent(context, HealthExaminationActivity::class.java)
                 .putExtra("id", realmExamination._id)
-                .putExtra("userId", mh._id))
+                .putExtra("userId", mh._id)
+            if (onEditClick != null) {
+                onEditClick.invoke(intent)
+            } else {
+                context.startActivity(intent)
+            }
         }
 
         dialog.show()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
@@ -100,13 +100,16 @@ class HealthViewModel @Inject constructor(
             ?: _loggedInUser.value?.effectiveId?.trim()
         if (!targetId.isNullOrEmpty()) {
             fetchPatientData(targetId)
+        } else {
+            loadInitialPatient()
         }
     }
 
     private fun fetchPatientData(userId: String) {
         currentPatientId = userId
         selectPatientJob?.cancel()
-        selectPatientJob = viewModelScope.launch {
+        var job: Job? = null
+        job = viewModelScope.launch {
             _isLoading.value = true
             try {
                 val user = healthRepository.getPatientById(userId)
@@ -123,9 +126,12 @@ class HealthViewModel @Inject constructor(
                 _patientDetailState.value = PatientDetailState(null, null)
                 throw e
             } finally {
-                _isLoading.value = false
+                if (selectPatientJob === job) {
+                    _isLoading.value = false
+                }
             }
         }
+        selectPatientJob = job
     }
 
     fun loadHealthData(userId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -52,6 +53,7 @@ class HealthViewModel @Inject constructor(
 
     private var searchJob: Job? = null
     private var selectPatientJob: Job? = null
+    private var currentPatientId: String? = null
 
     fun loadPatients(sortBy: String = "joinDate", descending: Boolean = true) {
         viewModelScope.launch {
@@ -86,17 +88,43 @@ class HealthViewModel @Inject constructor(
     }
 
     fun selectPatient(userId: String) {
+        if (userId == currentPatientId && (selectPatientJob?.isActive == true || _patientDetailState.value.user != null)) {
+            return
+        }
+        fetchPatientData(userId)
+    }
+
+    fun refreshSelectedPatient(userId: String? = null) {
+        val targetId = userId?.trim()?.ifEmpty { null }
+            ?: currentPatientId
+            ?: _loggedInUser.value?.effectiveId?.trim()
+        if (!targetId.isNullOrEmpty()) {
+            fetchPatientData(targetId)
+        }
+    }
+
+    private fun fetchPatientData(userId: String) {
+        currentPatientId = userId
         selectPatientJob?.cancel()
         selectPatientJob = viewModelScope.launch {
             _isLoading.value = true
-            val user = healthRepository.getPatientById(userId)
-            if (user != null) {
-                val record = healthRepository.getPatientHealthRecords(userId, user)
-                _patientDetailState.value = PatientDetailState(user, record)
-            } else {
+            try {
+                val user = healthRepository.getPatientById(userId)
+                if (user != null) {
+                    val record = healthRepository.getPatientHealthRecords(userId, user)
+                    _patientDetailState.value = PatientDetailState(user, record)
+                } else {
+                    currentPatientId = null
+                    _patientDetailState.value = PatientDetailState(null, null)
+                }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                currentPatientId = null
                 _patientDetailState.value = PatientDetailState(null, null)
+                throw e
+            } finally {
+                _isLoading.value = false
             }
-            _isLoading.value = false
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
@@ -124,7 +124,6 @@ class HealthViewModel @Inject constructor(
                 if (e is CancellationException) throw e
                 currentPatientId = null
                 _patientDetailState.value = PatientDetailState(null, null)
-                throw e
             } finally {
                 if (selectPatientJob === job) {
                     _isLoading.value = false

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -10,6 +10,7 @@ import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.Button
 import android.widget.EditText
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.content.ContextCompat
@@ -55,6 +56,9 @@ class MyHealthFragment : Fragment() {
         const val SEARCH_DEBOUNCE_MS = 300L
     }
 
+    private val editHealthLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        viewModel.refreshSelectedPatient()
+    }
 
     @Inject
     lateinit var realtimeSyncManager: RealtimeSyncManager
@@ -85,7 +89,7 @@ class MyHealthFragment : Fragment() {
 
     private fun refreshHealthData() {
         if (!isAdded || requireActivity().isFinishing) return
-        viewModel.loadInitialPatient()
+        viewModel.refreshSelectedPatient()
     }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -191,7 +195,9 @@ class MyHealthFragment : Fragment() {
                     binding.tvDataPlaceholder.visibility = View.VISIBLE
 
                     if (!::healthAdapter.isInitialized) {
-                        healthAdapter = HealthExaminationAdapter(requireActivity(), mh, currentUser, userMap, dispatcherProvider)
+                        healthAdapter = HealthExaminationAdapter(requireActivity(), mh, currentUser, userMap, dispatcherProvider) { intent ->
+                            editHealthLauncher.launch(intent)
+                        }
                     }
                     healthAdapter.updateData(mh, currentUser, userMap, list)
                     binding.rvRecords.apply {
@@ -251,11 +257,11 @@ class MyHealthFragment : Fragment() {
         binding.updateHealth.visibility = View.VISIBLE
 
         binding.addNewRecord.setOnClickListener {
-            startActivity(Intent(activity, HealthExaminationActivity::class.java).putExtra("userId", userId))
+            editHealthLauncher.launch(Intent(activity, HealthExaminationActivity::class.java).putExtra("userId", userId))
         }
 
         binding.updateHealth.setOnClickListener {
-            startActivity(Intent(activity, AddHealthActivity::class.java).putExtra("userId", userId))
+            editHealthLauncher.launch(Intent(activity, AddHealthActivity::class.java).putExtra("userId", userId))
         }
 
         binding.txtDob.text = if (userModel?.dob.isNullOrEmpty()) getString(R.string.birth_date) else TimeUtils.formatDateToDDMMYYYY(userModel?.dob)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
@@ -153,6 +153,19 @@ class HealthViewModelTest {
     }
 
     @Test
+    fun `selectPatient handles non-cancellation exception gracefully leaving state empty`() = runTest {
+        coEvery { healthRepository.getPatientById("1") } throws RuntimeException("Database error")
+
+        viewModel.selectPatient("1")
+        advanceUntilIdle()
+
+        val state = viewModel.patientDetailState.first()
+        assertNull(state.user)
+        assertNull(state.healthRecord)
+        assertEquals(false, viewModel.isLoading.first())
+    }
+
+    @Test
     fun `selectPatient resets tracked ID on failure so retry works`() = runTest {
         val user = UserEntity().apply { id = "1"; name = "Test Patient" }
         val record = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())

--- a/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
@@ -67,6 +67,51 @@ class HealthViewModelTest {
     }
 
     @Test
+    fun `selectPatient superseding load keeps isLoading true while second load is in flight`() = runTest {
+        val user1 = UserEntity().apply { id = "1"; name = "Patient 1" }
+        val user2 = UserEntity().apply { id = "2"; name = "Patient 2" }
+        val record2 = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())
+
+        coEvery { healthRepository.getPatientById("1") } coAnswers {
+            kotlinx.coroutines.delay(1000)
+            user1
+        }
+        coEvery { healthRepository.getPatientById("2") } coAnswers {
+            kotlinx.coroutines.delay(1000)
+            user2
+        }
+        coEvery { healthRepository.getPatientHealthRecords("2", user2) } returns record2
+
+        viewModel.selectPatient("1")
+        testScheduler.advanceTimeBy(100)
+        assertEquals(true, viewModel.isLoading.value)
+
+        viewModel.selectPatient("2")
+        testScheduler.advanceTimeBy(100)
+
+        assertEquals(true, viewModel.isLoading.value)
+
+        advanceUntilIdle()
+        assertEquals(false, viewModel.isLoading.value)
+        assertEquals(user2, viewModel.patientDetailState.first().user)
+    }
+
+    @Test
+    fun `refreshSelectedPatient on cold start falls back to loadInitialPatient`() = runTest {
+        val currentUser = UserEntity().apply { id = "user1"; name = "Logged In User" }
+        val record = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())
+
+        coEvery { userRepository.getUserModel() } returns currentUser
+        coEvery { healthRepository.getPatientById("user1") } returns currentUser
+        coEvery { healthRepository.getPatientHealthRecords("user1", currentUser) } returns record
+
+        viewModel.refreshSelectedPatient()
+        advanceUntilIdle()
+
+        assertEquals(currentUser, viewModel.patientDetailState.first().user)
+    }
+
+    @Test
     fun `refreshSelectedPatient forces re-query for current patient`() = runTest {
         val user = UserEntity().apply { id = "1"; name = "Test Patient" }
         val record = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())

--- a/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
@@ -1,12 +1,14 @@
 package org.ole.planet.myplanet.ui.health
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.ole.planet.myplanet.model.HealthRecord
 import org.ole.planet.myplanet.model.UserEntity
@@ -33,7 +35,7 @@ class HealthViewModelTest {
     @Test
     fun `selectPatient updates patientDetailState`() = runTest {
         val user = UserEntity().apply { id = "1"; name = "Test Patient" }
-        val record = org.ole.planet.myplanet.model.HealthRecord(
+        val record = HealthRecord(
             mockk(), mockk(), emptyList(), emptyMap()
         )
         coEvery { healthRepository.getPatientById("1") } returns user
@@ -46,6 +48,85 @@ class HealthViewModelTest {
         assertEquals(user, state.user)
         assertEquals(record, state.healthRecord)
         assertEquals(false, viewModel.isLoading.first())
+    }
+
+    @Test
+    fun `selectPatient called repeatedly for same patient returns early and does not re-query`() = runTest {
+        val user = UserEntity().apply { id = "1"; name = "Test Patient" }
+        val record = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())
+        coEvery { healthRepository.getPatientById("1") } returns user
+        coEvery { healthRepository.getPatientHealthRecords("1", user) } returns record
+
+        viewModel.selectPatient("1")
+        advanceUntilIdle()
+
+        viewModel.selectPatient("1")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { healthRepository.getPatientById("1") }
+    }
+
+    @Test
+    fun `refreshSelectedPatient forces re-query for current patient`() = runTest {
+        val user = UserEntity().apply { id = "1"; name = "Test Patient" }
+        val record = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())
+        coEvery { healthRepository.getPatientById("1") } returns user
+        coEvery { healthRepository.getPatientHealthRecords("1", user) } returns record
+
+        viewModel.selectPatient("1")
+        advanceUntilIdle()
+
+        viewModel.refreshSelectedPatient()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { healthRepository.getPatientById("1") }
+    }
+
+    @Test
+    fun `selectPatient with different patient ID loads new patient`() = runTest {
+        val user1 = UserEntity().apply { id = "1"; name = "Test Patient 1" }
+        val user2 = UserEntity().apply { id = "2"; name = "Test Patient 2" }
+        val record1 = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())
+        val record2 = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())
+
+        coEvery { healthRepository.getPatientById("1") } returns user1
+        coEvery { healthRepository.getPatientHealthRecords("1", user1) } returns record1
+        coEvery { healthRepository.getPatientById("2") } returns user2
+        coEvery { healthRepository.getPatientHealthRecords("2", user2) } returns record2
+
+        viewModel.selectPatient("1")
+        advanceUntilIdle()
+
+        viewModel.selectPatient("2")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { healthRepository.getPatientById("1") }
+        coVerify(exactly = 1) { healthRepository.getPatientById("2") }
+
+        val state = viewModel.patientDetailState.first()
+        assertEquals(user2, state.user)
+    }
+
+    @Test
+    fun `selectPatient resets tracked ID on failure so retry works`() = runTest {
+        val user = UserEntity().apply { id = "1"; name = "Test Patient" }
+        val record = HealthRecord(mockk(), mockk(), emptyList(), emptyMap())
+
+        coEvery { healthRepository.getPatientById("1") } returns null
+
+        viewModel.selectPatient("1")
+        advanceUntilIdle()
+
+        assertNull(viewModel.patientDetailState.first().user)
+
+        coEvery { healthRepository.getPatientById("1") } returns user
+        coEvery { healthRepository.getPatientHealthRecords("1", user) } returns record
+
+        viewModel.selectPatient("1")
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { healthRepository.getPatientById("1") }
+        assertEquals(user, viewModel.patientDetailState.first().user)
     }
 
     @Test


### PR DESCRIPTION
This change prevents MyHealthFragment from re-querying and re-decrypting patient records on screen resume if the patient is already loaded or in-flight in HealthViewModel.

Key changes:
- Track currentPatientId in HealthViewModel.
- Early return from selectPatient(userId) when userId == currentPatientId and the load job is active or _patientDetailState holds that patient.
- Reset currentPatientId on load failures to allow retries.
- Re-throw CancellationException in coroutine exception handling to prevent reset on cancellation.
- Add refreshSelectedPatient() to force re-queries for realtime-sync and post-edit paths.
- Update MyHealthFragment and HealthExaminationAdapter to use ActivityResultLauncher when editing records, invoking refreshSelectedPatient() upon return.
- Add unit tests in HealthViewModelTest.

Fixes #17014

---
*PR created automatically by Jules for task [8725985001149550536](https://jules.google.com/task/8725985001149550536) started by @dogi*