### PR TITLE
teams: smoother activities repository voices member visiting (fixes #17023)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7066
-        versionName = "0.70.66"
+        versionCode = 7067
+        versionName = "0.70.67"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -14,8 +14,14 @@ data class ProfileActivityStats(
     val resourceOpenCount: Long
 )
 
+data class MemberVisitStats(
+    val offlineVisitCount: Int,
+    val lastVisit: Long?
+)
+
 interface ActivitiesRepository {
     suspend fun getOfflineVisitCount(userId: String): Int
+    suspend fun getMemberVisitStats(userId: String?, userName: String?): MemberVisitStats
     suspend fun getOfflineLoginCount(userName: String): Int
     fun getOfflineLogins(userName: String): Flow<List<OfflineActivity>>
     suspend fun markResourceAdded(userId: String?, resourceId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -62,6 +62,12 @@ class ActivitiesRepositoryImpl @Inject constructor(
         return offlineActivityDao.countByUserIdAndType(userId, UserSessionManager.KEY_LOGIN)
     }
 
+    override suspend fun getMemberVisitStats(userId: String?, userName: String?): MemberVisitStats {
+        val count = if (!userId.isNullOrEmpty()) getOfflineVisitCount(userId) else 0
+        val lastVisit = if (!userName.isNullOrEmpty()) getLastVisit(userName) else null
+        return MemberVisitStats(count, lastVisit)
+    }
+
     override suspend fun getOfflineLoginCount(userName: String): Int {
         return offlineActivityDao.countByUserNameAndType(userName, UserSessionManager.KEY_LOGIN)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesActions.kt
@@ -214,14 +214,15 @@ object VoicesActions {
     ): MembersDetailFragment? {
         if (userModel == null) return null
         val userName = "${userModel.firstName} ${userModel.lastName}".trim().ifBlank { userModel.name }
+        val visitStats = activitiesRepository.getMemberVisitStats(userModel.id, userModel.name)
         val fragment = MembersDetailFragment.newInstance(
             userName.toString(),
             userModel.email.toString(),
             userModel.dob.toString().substringBefore("T"),
             userModel.language.toString(),
             userModel.phoneNumber.toString(),
-            (userModel.id?.let { activitiesRepository.getOfflineVisitCount(it) } ?: 0).toString(),
-            (activitiesRepository.getLastVisit(userModel.name ?: "")?.let { dateFormatter.get()?.format(Date(it)) } ?: "No logout record found"),
+            visitStats.offlineVisitCount.toString(),
+            (visitStats.lastVisit?.let { dateFormatter.get()?.format(Date(it)) } ?: "No logout record found"),
             "${userModel.firstName} ${userModel.lastName}",
             userModel.level.toString(),
             userModel.userImage

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
@@ -131,6 +131,28 @@ class ActivitiesRepositoryImplTest {
     }
 
     @Test
+    fun `getMemberVisitStats returns correct count and last visit`() = runTest {
+        coEvery { offlineActivityDao.countByUserIdAndType("user1", UserSessionManager.KEY_LOGIN) } returns 5
+        coEvery { offlineActivityDao.getLastVisit("john") } returns 2000L
+
+        val result = repository.getMemberVisitStats("user1", "john")
+
+        assertEquals(5, result.offlineVisitCount)
+        assertEquals(2000L, result.lastVisit)
+    }
+
+    @Test
+    fun `getMemberVisitStats handles null or empty inputs`() = runTest {
+        val resultNull = repository.getMemberVisitStats(null, null)
+        assertEquals(0, resultNull.offlineVisitCount)
+        assertNull(resultNull.lastVisit)
+
+        val resultEmpty = repository.getMemberVisitStats("", "")
+        assertEquals(0, resultEmpty.offlineVisitCount)
+        assertNull(resultEmpty.lastVisit)
+    }
+
+    @Test
     fun `getOfflineLoginCount returns correct count`() = runTest {
         coEvery { offlineActivityDao.countByUserNameAndType("john", UserSessionManager.KEY_LOGIN) } returns 3
         val result = repository.getOfflineLoginCount("john")

--- a/app/src/test/java/org/ole/planet/myplanet/ui/voices/VoicesActionsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/voices/VoicesActionsTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -14,7 +15,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnNewsItemClickListener
+import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.repository.MemberVisitStats
 import org.ole.planet.myplanet.repository.VoicesEditActions
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -74,5 +77,37 @@ class VoicesActionsTest {
         val activitiesRepository: ActivitiesRepository = mockk()
         val result = VoicesActions.showMemberDetails(null, activitiesRepository)
         assertEquals(null, result)
+    }
+
+    @Test
+    fun `showMemberDetails calls getMemberVisitStats once and constructs fragment`() = runTest {
+        val activitiesRepository: ActivitiesRepository = mockk()
+        val user = UserEntity().apply {
+            id = "user123"
+            name = "john_doe"
+            firstName = "John"
+            lastName = "Doe"
+            email = "john@example.com"
+            dob = "2000-01-01T00:00:00"
+            language = "en"
+            phoneNumber = "1234567890"
+            level = "Level 1"
+            userImage = "image_url"
+        }
+
+        coEvery { activitiesRepository.getMemberVisitStats("user123", "john_doe") } returns MemberVisitStats(
+            offlineVisitCount = 4,
+            lastVisit = null
+        )
+
+        val fragment = VoicesActions.showMemberDetails(user, activitiesRepository)
+
+        assertNotNull(fragment)
+        assertEquals("4", fragment?.arguments?.getString("number_of_visits"))
+        assertEquals("No logout record found", fragment?.arguments?.getString("last_login"))
+
+        coVerify(exactly = 1) { activitiesRepository.getMemberVisitStats("user123", "john_doe") }
+        coVerify(exactly = 0) { activitiesRepository.getOfflineVisitCount(any()) }
+        coVerify(exactly = 0) { activitiesRepository.getLastVisit(any()) }
     }
 }


### PR DESCRIPTION
Add MemberVisitStats data class and getMemberVisitStats method to ActivitiesRepository and consume it in VoicesActions.showMemberDetails to consolidate two queries into a single call.

Fixes #17023

---
*PR created automatically by Jules for task [10007386820824880333](https://jules.google.com/task/10007386820824880333) started by @dogi*