### PR TITLE
resources: smoother repository view modelling (fixes #17034)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7076
-        versionName = "0.70.76"
+        versionCode = 7077
+        versionName = "0.70.77"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -50,6 +50,7 @@ interface ResourcesRepository {
     suspend fun countLibrariesNeedingUpdate(userId: String?): Int
     suspend fun resourceTitleExists(title: String): Boolean
     suspend fun resolveLibraryItem(id: String): MyLibrary?
+    suspend fun resolveLibraryItemByResourceId(resourceId: String): MyLibrary?
     suspend fun saveLocalResource(request: LocalResourceRequest): Result<Unit>
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): MyLibrary?
     suspend fun setUserLibrary(resourceId: String, add: Boolean): MyLibrary?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -49,8 +49,8 @@ interface ResourcesRepository {
     fun getPendingDownloads(userId: String): Flow<List<String>>
     suspend fun countLibrariesNeedingUpdate(userId: String?): Int
     suspend fun resourceTitleExists(title: String): Boolean
+    suspend fun resolveLibraryItem(id: String): MyLibrary?
     suspend fun saveLocalResource(request: LocalResourceRequest): Result<Unit>
-    suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): MyLibrary?
     suspend fun setUserLibrary(resourceId: String, add: Boolean): MyLibrary?
     suspend fun updateLibraryItem(id: String, updater: (MyLibrary) -> Unit)
@@ -92,7 +92,6 @@ interface ResourcesRepository {
     suspend fun removeResourceFromShelf(resourceId: String, userId: String)
     suspend fun removeResourcesFromShelf(resourceIds: List<String>, userId: String): Result<Unit>
     suspend fun getHtmlResourceDownloadUrls(resourceId: String): ResourceUrlsResponse
-    suspend fun getFilterFacets(libraries: List<MyLibrary>): Map<String, Set<String>>
     suspend fun batchInsertResources(documents: List<JsonObject>): List<String>
     suspend fun batchInsertMyLibrary(shelfId: String?, documents: List<JsonObject>): Int
     suspend fun getResourceListModels(isMyCourseLib: Boolean, modelId: String?): List<ResourceListModel>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -162,6 +162,10 @@ class ResourcesRepositoryImpl @Inject constructor(
         return getLibraryItemById(id) ?: getLibraryItemByResourceId(id)
     }
 
+    override suspend fun resolveLibraryItemByResourceId(resourceId: String): MyLibrary? {
+        return getLibraryItemByResourceId(resourceId) ?: getLibraryItemById(resourceId)
+    }
+
     override suspend fun getLibraryItemById(id: String): MyLibrary? {
         return myLibraryDao.getById(id)
     }
@@ -314,7 +318,7 @@ class ResourcesRepositoryImpl @Inject constructor(
 
     override suspend fun setUserLibrary(resourceId: String, add: Boolean): MyLibrary? {
         val userId = userRepository.getUserModel()?.id ?: return null
-        val library = resolveLibraryItem(resourceId)
+        val library = resolveLibraryItemByResourceId(resourceId)
         if (library != null) {
             val contains = library.userId?.contains(userId) == true
             if (add && contains) return library
@@ -343,7 +347,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         } else {
             activitiesRepository.markResourceRemoved(userId, resourceId)
         }
-        return resolveLibraryItem(resourceId)
+        return resolveLibraryItemByResourceId(resourceId)
     }
 
     override suspend fun updateLibraryItem(id: String, updater: (MyLibrary) -> Unit) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -158,6 +158,10 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun resolveLibraryItem(id: String): MyLibrary? {
+        return getLibraryItemById(id) ?: getLibraryItemByResourceId(id)
+    }
+
     override suspend fun getLibraryItemById(id: String): MyLibrary? {
         return myLibraryDao.getById(id)
     }
@@ -304,13 +308,13 @@ class ResourcesRepositoryImpl @Inject constructor(
         return Result.success(Unit)
     }
 
-    override suspend fun markResourceAdded(userId: String?, resourceId: String) {
+    private suspend fun markResourceAdded(userId: String?, resourceId: String) {
         activitiesRepository.markResourceAdded(userId, resourceId)
     }
 
     override suspend fun setUserLibrary(resourceId: String, add: Boolean): MyLibrary? {
         val userId = userRepository.getUserModel()?.id ?: return null
-        val library = getLibraryItemByResourceId(resourceId) ?: getLibraryItemById(resourceId)
+        val library = resolveLibraryItem(resourceId)
         if (library != null) {
             val contains = library.userId?.contains(userId) == true
             if (add && contains) return library
@@ -339,8 +343,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         } else {
             activitiesRepository.markResourceRemoved(userId, resourceId)
         }
-        return getLibraryItemByResourceId(resourceId)
-            ?: getLibraryItemById(resourceId)
+        return resolveLibraryItem(resourceId)
     }
 
     override suspend fun updateLibraryItem(id: String, updater: (MyLibrary) -> Unit) {
@@ -607,27 +610,6 @@ class ResourcesRepositoryImpl @Inject constructor(
         } else {
             ResourceUrlsResponse.Error
         }
-    }
-
-    override suspend fun getFilterFacets(libraries: List<MyLibrary>): Map<String, Set<String>> {
-        val languages = mutableSetOf<String>()
-        val subjects = mutableSetOf<String>()
-        val mediums = mutableSetOf<String>()
-        val levels = mutableSetOf<String>()
-
-        libraries.forEach { library ->
-            library.language?.takeIf { it.isNotBlank() }?.let { languages.add(it) }
-            library.subject?.let { subjects.addAll(it) }
-            library.mediaType?.takeIf { it.isNotBlank() }?.let { mediums.add(it) }
-            library.level?.let { levels.addAll(it) }
-        }
-
-        return mapOf(
-            "languages" to languages,
-            "subjects" to subjects,
-            "mediums" to mediums,
-            "levels" to levels
-        )
     }
 
     override suspend fun batchInsertMyLibrary(shelfId: String?, documents: List<JsonObject>): Int {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -35,10 +35,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     private var lastKnownRating: RatingSummary? = null
     private lateinit var library: MyLibrary
     var userModel: UserEntity? = null
-    private suspend fun fetchLibrary(libraryId: String): MyLibrary? {
-        return resourcesRepository.getLibraryItemById(libraryId)
-            ?: resourcesRepository.getLibraryItemByResourceId(libraryId)
-    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
@@ -92,7 +89,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
                 return@launch
             }
 
-            val fetchedLibrary = fetchLibrary(id)
+            val fetchedLibrary = resourcesRepository.resolveLibraryItem(id)
 
             if (fetchedLibrary == null) {
                 handleLibraryNotFound()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
@@ -118,7 +118,24 @@ class ResourcesViewModel @Inject constructor(
     }
 
     suspend fun getFilterFacets(libraries: List<MyLibrary>): Map<String, Set<String>> = withContext(dispatcherProvider.default) {
-        resourcesRepository.getFilterFacets(libraries)
+        val languages = mutableSetOf<String>()
+        val subjects = mutableSetOf<String>()
+        val mediums = mutableSetOf<String>()
+        val levels = mutableSetOf<String>()
+
+        libraries.forEach { library ->
+            library.language?.takeIf { it.isNotBlank() }?.let { languages.add(it) }
+            library.subject?.let { subjects.addAll(it) }
+            library.mediaType?.takeIf { it.isNotBlank() }?.let { mediums.add(it) }
+            library.level?.let { levels.addAll(it) }
+        }
+
+        mapOf(
+            "languages" to languages,
+            "subjects" to subjects,
+            "mediums" to mediums,
+            "levels" to levels
+        )
     }
 
     private val listFilter = ResourcesListFilter()

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -123,6 +123,7 @@ class ResourcesRepositoryImplTest {
             id = "res-id"
             userId = listOf("user-123")
         }
+        coEvery { myLibraryDao.getById("res-id") } returns null
         coEvery { myLibraryDao.getByResourceId("res-id") } returns mockLibrary
 
         val result = repository.setUserLibrary("res-id", true)
@@ -140,6 +141,7 @@ class ResourcesRepositoryImplTest {
             id = "res-id"
             userId = emptyList()
         }
+        coEvery { myLibraryDao.getById("res-id") } returns null
         coEvery { myLibraryDao.getByResourceId("res-id") } returns mockLibrary
 
         val result = repository.setUserLibrary("res-id", false)
@@ -310,6 +312,22 @@ class ResourcesRepositoryImplTest {
 
         assertEquals(1, result.size)
         assertEquals("Test Library", result[0].title)
+    }
+
+    @Test
+    fun `resolveLibraryItem resolves by id or falls back to resourceId`() = runTest {
+        val libById = MyLibrary().apply { id = "id1"; title = "By ID" }
+        val libByResId = MyLibrary().apply { id = "id2"; resourceId = "res2"; title = "By Res ID" }
+
+        coEvery { myLibraryDao.getById("id1") } returns libById
+        coEvery { myLibraryDao.getById("res2") } returns null
+        coEvery { myLibraryDao.getByResourceId("res2") } returns libByResId
+
+        val resultById = repository.resolveLibraryItem("id1")
+        val resultByResId = repository.resolveLibraryItem("res2")
+
+        assertEquals("By ID", resultById?.title)
+        assertEquals("By Res ID", resultByResId?.title)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -315,19 +315,29 @@ class ResourcesRepositoryImplTest {
     }
 
     @Test
-    fun `resolveLibraryItem resolves by id or falls back to resourceId`() = runTest {
-        val libById = MyLibrary().apply { id = "id1"; title = "By ID" }
-        val libByResId = MyLibrary().apply { id = "id2"; resourceId = "res2"; title = "By Res ID" }
+    fun `resolveLibraryItem resolves by id first and falls back to resourceId`() = runTest {
+        val libById = MyLibrary().apply { id = "collisionKey"; resourceId = "other1"; title = "By ID" }
+        val libByResId = MyLibrary().apply { id = "other2"; resourceId = "collisionKey"; title = "By Res ID" }
 
-        coEvery { myLibraryDao.getById("id1") } returns libById
-        coEvery { myLibraryDao.getById("res2") } returns null
-        coEvery { myLibraryDao.getByResourceId("res2") } returns libByResId
+        coEvery { myLibraryDao.getById("collisionKey") } returns libById
+        coEvery { myLibraryDao.getByResourceId("collisionKey") } returns libByResId
 
-        val resultById = repository.resolveLibraryItem("id1")
-        val resultByResId = repository.resolveLibraryItem("res2")
+        val result = repository.resolveLibraryItem("collisionKey")
 
-        assertEquals("By ID", resultById?.title)
-        assertEquals("By Res ID", resultByResId?.title)
+        assertEquals("By ID", result?.title)
+    }
+
+    @Test
+    fun `resolveLibraryItemByResourceId resolves by resourceId first and falls back to id`() = runTest {
+        val libById = MyLibrary().apply { id = "collisionKey"; resourceId = "other1"; title = "By ID" }
+        val libByResId = MyLibrary().apply { id = "other2"; resourceId = "collisionKey"; title = "By Res ID" }
+
+        coEvery { myLibraryDao.getById("collisionKey") } returns libById
+        coEvery { myLibraryDao.getByResourceId("collisionKey") } returns libByResId
+
+        val result = repository.resolveLibraryItemByResourceId("collisionKey")
+
+        assertEquals("By Res ID", result?.title)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModelTest.kt
@@ -200,6 +200,29 @@ class ResourcesViewModelTest {
     }
 
     @Test
+    fun `getFilterFacets extracts languages, subjects, mediums, and levels correctly`() = runTest {
+        val lib1 = MyLibrary().apply {
+            language = "English"
+            subject = listOf("Math", "Science")
+            mediaType = "PDF"
+            level = listOf("Primary")
+        }
+        val lib2 = MyLibrary().apply {
+            language = "Spanish"
+            subject = listOf("Science", "History")
+            mediaType = "Video"
+            level = listOf("Secondary")
+        }
+
+        val facets = viewModel.getFilterFacets(listOf(lib1, lib2))
+
+        assertEquals(setOf("English", "Spanish"), facets["languages"])
+        assertEquals(setOf("Math", "Science", "History"), facets["subjects"])
+        assertEquals(setOf("PDF", "Video"), facets["mediums"])
+        assertEquals(setOf("Primary", "Secondary"), facets["levels"])
+    }
+
+    @Test
     fun `filterIfChanged memoizes the criteria in the view model until resetFilter`() = runTest {
         val models = listOf(createResourceModel("a", 1), createResourceModel("b", 2))
         val notDownloaded = ResourcesFilterCriteria(


### PR DESCRIPTION
Tightens the ResourcesRepository interface boundary by removing pass-through markResourceAdded, moving the pure in-memory filter facet fold to ResourcesViewModel.getFilterFacets, and introducing a unified resolveLibraryItem(id) method across repository and UI callers.

Fixes #17034

---
*PR created automatically by Jules for task [8244862689796070174](https://jules.google.com/task/8244862689796070174) started by @dogi*