### PR TITLE
all: less personals repository dao is more (fixes #17032)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/PersonalDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/PersonalDao.kt
@@ -4,7 +4,6 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.model.Personal
 
@@ -32,9 +31,6 @@ interface PersonalDao {
 
     @Query("SELECT * FROM my_personal WHERE id = :id LIMIT 1")
     suspend fun findById(id: String): Personal?
-
-    @Update
-    suspend fun update(item: Personal)
 
     @Query("DELETE FROM my_personal WHERE _id = :id OR id = :id")
     suspend fun deleteByIdOrDocId(id: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepository.kt
@@ -19,11 +19,10 @@ interface PersonalsRepository {
         description: String?
     )
 
-    suspend fun getPersonalResources(userId: String?): Flow<List<Personal>>
+    fun getPersonalResources(userId: String?): Flow<List<Personal>>
     suspend fun deletePersonalResource(id: String)
     suspend fun updatePersonalResource(id: String, update: PersonalUpdate)
     suspend fun getPendingPersonalUploads(userId: String): List<Personal>
     suspend fun updatePersonalAfterSync(id: String, newId: String, rev: String)
-    suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>?
     suspend fun uploadPersonal(personal: Personal): String
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
@@ -44,7 +44,7 @@ class PersonalsRepositoryImpl @Inject constructor(
         personalDao.insert(personal)
     }
 
-    override suspend fun getPersonalResources(userId: String?): Flow<List<Personal>> {
+    override fun getPersonalResources(userId: String?): Flow<List<Personal>> {
         if (userId.isNullOrBlank()) {
             return flowOf(emptyList())
         }
@@ -71,7 +71,7 @@ class PersonalsRepositoryImpl @Inject constructor(
         personalDao.updateUploadedStatus(id, newId, rev)
     }
 
-    override suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>? {
+    suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>? {
         val response = uploadRepository.postUpload(
             "${UrlUtils.getUrl()}/resources",
             Personal.serialize(personal, deviceNameProvider.getCustomDeviceName())

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
@@ -71,7 +71,7 @@ class PersonalsRepositoryImpl @Inject constructor(
         personalDao.updateUploadedStatus(id, newId, rev)
     }
 
-    suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>? {
+    internal suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>? {
         val response = uploadRepository.postUpload(
             "${UrlUtils.getUrl()}/resources",
             Personal.serialize(personal, deviceNameProvider.getCustomDeviceName())

--- a/app/src/test/java/org/ole/planet/myplanet/ui/personals/PersonalsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/personals/PersonalsViewModelTest.kt
@@ -2,7 +2,9 @@ package org.ole.planet.myplanet.ui.personals
 
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -44,7 +46,7 @@ class PersonalsViewModelTest {
         val user = UserEntity().apply { id = "user-123" }
         val personal = Personal().apply { id = "p-1"; title = "My Personal" }
         coEvery { userRepository.getUserModel() } returns user
-        coEvery { personalsRepository.getPersonalResources("user-123") } returns flowOf(listOf(personal))
+        every { personalsRepository.getPersonalResources("user-123") } returns flowOf(listOf(personal))
 
         val collected = mutableListOf<List<Personal>>()
         val job = launch { viewModel.personals.collect { collected.add(it) } }
@@ -52,14 +54,14 @@ class PersonalsViewModelTest {
 
         assertTrue(collected.isNotEmpty())
         assertEquals(listOf(personal), collected.last())
-        coVerify { personalsRepository.getPersonalResources("user-123") }
+        verify { personalsRepository.getPersonalResources("user-123") }
         job.cancel()
     }
 
     @Test
     fun `personals flow falls back to empty list when there is no current user`() = runTest {
         coEvery { userRepository.getUserModel() } returns null
-        coEvery { personalsRepository.getPersonalResources(null) } returns flowOf(emptyList())
+        every { personalsRepository.getPersonalResources(null) } returns flowOf(emptyList())
 
         val collected = mutableListOf<List<Personal>>()
         val job = launch { viewModel.personals.collect { collected.add(it) } }
@@ -67,7 +69,7 @@ class PersonalsViewModelTest {
 
         assertTrue(collected.isNotEmpty())
         assertEquals(0, collected.last().size)
-        coVerify { personalsRepository.getPersonalResources(null) }
+        verify { personalsRepository.getPersonalResources(null) }
         job.cancel()
     }
 


### PR DESCRIPTION
Tightens the personals boundary by dropping `suspend` from `getPersonalResources` (Flow accessors should be non-suspend), removing `uploadPersonalDocument` from the interface (as its only caller is `uploadPersonal` inside the implementation), deleting the unused `PersonalDao.update` method and import, and updating unit tests.

Fixes #17032

---
*PR created automatically by Jules for task [6233377538860778290](https://jules.google.com/task/6233377538860778290) started by @dogi*