### PR TITLE
sync: smoother time logger managing (fixes #17038)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -74,9 +74,13 @@ class SyncManager @Inject constructor(
     private val syncTimeLogger: SyncTimeLogger
 ) {
     private inline fun syncPerf(message: () -> String) {
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
-            Log.d("SyncPerf", message())
+        if (syncTimeLogger.isVerbose) {
+            Log.d(TAG, message())
         }
+    }
+
+    companion object {
+        private const val TAG = "SyncPerf"
     }
 
     private val timestampFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
@@ -142,11 +146,9 @@ class SyncManager @Inject constructor(
         val syncStartTime = SystemClock.elapsedRealtime()
 
         syncTimeLogger.startLogging()
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            Log.d("SyncPerf", "FULL SYNC STARTED at ${timestampFormat.format(Instant.now())}")
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-        }
+        syncPerf { "═══════════════════════════════════════════════════════════════" }
+        syncPerf { "FULL SYNC STARTED at ${timestampFormat.format(Instant.now())}" }
+        syncPerf { "═══════════════════════════════════════════════════════════════" }
         try {
 
             initializeSync()
@@ -212,21 +214,17 @@ class SyncManager @Inject constructor(
             val totalSyncTime = syncEndTime - syncStartTime
             val minutes = totalSyncTime / 60000
             val seconds = (totalSyncTime % 60000) / 1000
-            if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
-                Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-                Log.d("SyncPerf", "FULL SYNC COMPLETED at ${timestampFormat.format(Instant.now())}")
-                Log.d("SyncPerf", "TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)")
-                Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            }
+            syncPerf { "═══════════════════════════════════════════════════════════════" }
+            syncPerf { "FULL SYNC COMPLETED at ${timestampFormat.format(Instant.now())}" }
+            syncPerf { "TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)" }
+            syncPerf { "═══════════════════════════════════════════════════════════════" }
         } catch (err: Exception) {
             val syncEndTime = SystemClock.elapsedRealtime()
             val totalSyncTime = syncEndTime - syncStartTime
-            if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
-                Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-                Log.d("SyncPerf", "SYNC FAILED after ${totalSyncTime}ms")
-                Log.d("SyncPerf", "Error: ${err.message}")
-                Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            }
+            syncPerf { "═══════════════════════════════════════════════════════════════" }
+            syncPerf { "SYNC FAILED after ${totalSyncTime}ms" }
+            syncPerf { "Error: ${err.message}" }
+            syncPerf { "═══════════════════════════════════════════════════════════════" }
             Log.e("SyncManager", "Full sync failed", err)
             handleException(err.message)
         } finally {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
@@ -42,6 +42,9 @@ class SyncTimeLogger @Inject constructor(
     private val apiCallCounter = AtomicInteger(0)
     private val dbOpCounter = AtomicInteger(0)
 
+    var isVerbose: Boolean = false
+        private set
+
     data class ApiCallLog(
         val endpoint: String,
         val duration: Long,
@@ -61,6 +64,8 @@ class SyncTimeLogger @Inject constructor(
     fun startLogging() {
         startTime = timeProvider.now()
         isLogging = true
+        // Deliberately snapshot loggability once per sync session rather than checking per event
+        isVerbose = Log.isLoggable(TAG, Log.DEBUG)
         processTimes.clear()
         processItemCounts.clear()
         apiCallTimes.clear()
@@ -68,10 +73,10 @@ class SyncTimeLogger @Inject constructor(
         detailedLogs.clear()
         apiCallCounter.set(0)
         dbOpCounter.set(0)
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            Log.d("SyncPerf", "SYNC STARTED at ${formatTimestamp(startTime)}")
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (isVerbose) {
+            Log.d(TAG, "═══════════════════════════════════════════════════════════════")
+            Log.d(TAG, "SYNC STARTED at ${formatTimestamp(startTime)}")
+            Log.d(TAG, "═══════════════════════════════════════════════════════════════")
         }
     }
 
@@ -83,11 +88,11 @@ class SyncTimeLogger @Inject constructor(
         val summary = generateSummary()
         saveSummaryToRoom(summary, uploadManager)
 
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            Log.d("SyncPerf", "SYNC COMPLETED at ${formatTimestamp(endTime)}")
-            Log.d("SyncPerf", "TOTAL DURATION: ${formatTime(endTime - startTime)}")
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (isVerbose) {
+            Log.d(TAG, "═══════════════════════════════════════════════════════════════")
+            Log.d(TAG, "SYNC COMPLETED at ${formatTimestamp(endTime)}")
+            Log.d(TAG, "TOTAL DURATION: ${formatTime(endTime - startTime)}")
+            Log.d(TAG, "═══════════════════════════════════════════════════════════════")
         }
     }
 
@@ -141,12 +146,12 @@ class SyncTimeLogger @Inject constructor(
         processTimes[processName] = duration
         processItemCounts[processName] = itemCount
 
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
+        if (isVerbose) {
             val elapsed = endTime - this.startTime
             if (itemCount > 0) {
-                Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}, $itemCount items")
+                Log.d(TAG, "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}, $itemCount items")
             } else {
-                Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}")
+                Log.d(TAG, "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}")
             }
         }
     }
@@ -161,11 +166,11 @@ class SyncTimeLogger @Inject constructor(
         val log = ApiCallLog(endpoint, duration, timestamp, success, itemsReturned)
         apiCallTimes.getOrPut(processName) { mutableListOf() }.add(log)
 
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
+        if (isVerbose) {
             val elapsed = timestamp - startTime
             val statusIcon = if (success) "✓" else "✗"
             val itemInfo = if (itemsReturned > 0) ", $itemsReturned items" else ""
-            Log.d("SyncPerf", "[${formatElapsed(elapsed)}] $statusIcon API #$callNum: ${shortenEndpoint(endpoint)} - ${formatTime(duration)}$itemInfo")
+            Log.d(TAG, "[${formatElapsed(elapsed)}] $statusIcon API #$callNum: ${shortenEndpoint(endpoint)} - ${formatTime(duration)}$itemInfo")
         }
     }
 
@@ -178,9 +183,9 @@ class SyncTimeLogger @Inject constructor(
         val log = DbOperationLog(operation, model, duration, itemCount, timestamp)
         dbOperationTimes.getOrPut(model) { mutableListOf() }.add(log)
 
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
+        if (isVerbose) {
             val elapsed = timestamp - startTime
-            Log.d("SyncPerf", "[${formatElapsed(elapsed)}] 💾 DB #$opNum: $operation $model - ${formatTime(duration)}, $itemCount items")
+            Log.d(TAG, "[${formatElapsed(elapsed)}] 💾 DB #$opNum: $operation $model - ${formatTime(duration)}, $itemCount items")
         }
     }
 
@@ -189,10 +194,10 @@ class SyncTimeLogger @Inject constructor(
 
         detailedLogs.getOrPut(context) { mutableListOf() }.add(message)
 
-        if (Log.isLoggable("SyncPerf", Log.DEBUG)) {
+        if (isVerbose) {
             val timestamp = timeProvider.now()
             val elapsed = timestamp - startTime
-            Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ℹ $context: $message")
+            Log.d(TAG, "[${formatElapsed(elapsed)}] ℹ $context: $message")
         }
     }
 
@@ -323,6 +328,8 @@ class SyncTimeLogger @Inject constructor(
 
 
     companion object {
+        private const val TAG = "SyncPerf"
+
         internal fun extractProcessName(endpoint: String): String {
             val segments = endpoint.split("/")
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
@@ -146,9 +146,9 @@ class SyncManagerTest {
     }
 
     @Test
-    fun `syncPerf logging is evaluated when isLoggable returns true`() = runTest {
+    fun `syncPerf logging is evaluated when isVerbose returns true`() = runTest {
         io.mockk.mockkStatic(android.util.Log::class)
-        every { android.util.Log.isLoggable("SyncPerf", android.util.Log.DEBUG) } returns true
+        every { syncTimeLogger.isVerbose } returns true
         every { android.util.Log.d(any(), any()) } returns 0
 
         coEvery { transactionSyncManager.authenticate() } returns true
@@ -159,9 +159,9 @@ class SyncManagerTest {
     }
 
     @Test
-    fun `syncPerf logging is skipped when isLoggable returns false`() = runTest {
+    fun `syncPerf logging is skipped when isVerbose returns false`() = runTest {
         io.mockk.mockkStatic(android.util.Log::class)
-        every { android.util.Log.isLoggable("SyncPerf", android.util.Log.DEBUG) } returns false
+        every { syncTimeLogger.isVerbose } returns false
         every { android.util.Log.d(any(), any()) } returns 0
 
         coEvery { transactionSyncManager.authenticate() } returns true

--- a/app/src/test/java/org/ole/planet/myplanet/utils/SyncTimeLoggerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/SyncTimeLoggerTest.kt
@@ -48,6 +48,8 @@ class SyncTimeLoggerTest {
         currentTime = 2000L
         logger.stopLogging()
 
+        assertTrue(logger.isVerbose)
+
         val summary = logger.generateSummary()
 
         assertTrue(summary.contains("Total API calls: 2 (Success: 1, Failed: 1)"))
@@ -100,6 +102,56 @@ class SyncTimeLoggerTest {
         val summary = logger.generateSummary()
         assertTrue(summary.contains("validProcess"))
         assertTrue(!summary.contains("nonExistentProcess"))
+    }
+
+    @Test
+    fun testWhenTagNotLoggableNoPerEventLogOutput() {
+        mockkStatic(Log::class)
+        every { Log.isLoggable("SyncPerf", Log.DEBUG) } returns false
+        every { Log.d(any(), any()) } returns 0
+
+        var currentTime = 1000L
+        val timeProvider = mockk<TimeProvider> {
+            every { now() } answers { currentTime }
+        }
+
+        val testDispatcher = UnconfinedTestDispatcher()
+        val logger = SyncTimeLogger(
+            timeProvider = timeProvider,
+            appScope = CoroutineScope(testDispatcher),
+            dispatcherProvider = TestDispatcherProvider(testDispatcher),
+            sharedPrefManager = mockk(relaxed = true),
+            serverUrlMapper = mockk(relaxed = true),
+            diagnosticsRepository = mockk(relaxed = true),
+            serverReachabilityProvider = mockk(relaxed = true)
+        )
+
+        logger.startLogging()
+
+        assertTrue(!logger.isVerbose)
+
+        currentTime = 1200L
+        logger.startProcess("testProcess")
+
+        currentTime = 1400L
+        logger.logApiCall("http://server/api/v1/courses", duration = 200L, success = true, itemsReturned = 1)
+
+        currentTime = 1600L
+        logger.logDbOperation("INSERT", "CourseModel", duration = 150L, itemCount = 1)
+
+        currentTime = 1800L
+        logger.logDetail("context", "message")
+
+        currentTime = 2000L
+        logger.endProcess("testProcess", itemCount = 1)
+
+        currentTime = 2200L
+        logger.stopLogging()
+
+        io.mockk.verify(exactly = 0) { Log.d("SyncPerf", any()) }
+
+        val summary = logger.generateSummary()
+        assertTrue(summary.contains("Total API calls: 1"))
     }
 
     @Test


### PR DESCRIPTION
Refactored SyncPerf logging evaluation to snapshot loggability once per sync session in `SyncTimeLogger.startLogging()` instead of checking `Log.isLoggable("SyncPerf", Log.DEBUG)` on every API call and database operation. Updated `SyncManager` inline log statements and `syncPerf` helper to gate on `SyncTimeLogger.isVerbose`.

Fixes #17038

---
*PR created automatically by Jules for task [17276266126909069846](https://jules.google.com/task/17276266126909069846) started by @dogi*