### PR TITLE
teams: smoother voices json images caching (fixes #17037)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/News.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/News.kt
@@ -74,19 +74,21 @@ open class News {
     @Ignore
     var rawImageUrls: List<String>? = null
     @Ignore
-    var rawImages: String? = null
-    @Ignore
-    var parsedImagesArray: JsonArray? = null
-    @Ignore
     var parsedSharedTeamName: String? = null
+
+    private data class ImagesCache(val raw: String?, val parsed: JsonArray)
+
+    @Ignore
+    @Volatile
+    private var imagesCache: ImagesCache? = null
 
     @get:Ignore
     val imagesArray: JsonArray
         get() {
             val currentImages = images
-            val cached = parsedImagesArray
-            if (cached != null && rawImages == currentImages) {
-                return cached
+            val cache = imagesCache
+            if (cache != null && cache.raw == currentImages) {
+                return cache.parsed.deepCopy()
             }
             val parsed = if (currentImages == null) {
                 JsonArray()
@@ -97,9 +99,8 @@ open class News {
                     JsonArray()
                 }
             }
-            rawImages = currentImages
-            parsedImagesArray = parsed
-            return parsed
+            imagesCache = ImagesCache(currentImages, parsed)
+            return parsed.deepCopy()
         }
 
     @get:Ignore

--- a/app/src/main/java/org/ole/planet/myplanet/model/News.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/News.kt
@@ -82,7 +82,25 @@ open class News {
 
     @get:Ignore
     val imagesArray: JsonArray
-        get() = if (images == null) JsonArray() else JsonUtils.gson.fromJson(images, JsonArray::class.java)
+        get() {
+            val currentImages = images
+            val cached = parsedImagesArray
+            if (cached != null && rawImages == currentImages) {
+                return cached
+            }
+            val parsed = if (currentImages == null) {
+                JsonArray()
+            } else {
+                try {
+                    JsonUtils.gson.fromJson(currentImages, JsonArray::class.java) ?: JsonArray()
+                } catch (e: Exception) {
+                    JsonArray()
+                }
+            }
+            rawImages = currentImages
+            parsedImagesArray = parsed
+            return parsed
+        }
 
     @get:Ignore
     val labelsArray: JsonArray
@@ -111,16 +129,22 @@ open class News {
     @get:Ignore
     val isCommunityNews: Boolean
         get() {
-            val array = JsonUtils.gson.fromJson(viewIn, JsonArray::class.java)
-            var isCommunity = false
-            for (e in array) {
-                val `object` = e.asJsonObject
-                if (`object`.has("section") && `object`["section"].asString.equals("community", ignoreCase = true)) {
-                    isCommunity = true
-                    break
+            try {
+                val array = parsedViewIn ?: if (!viewIn.isNullOrEmpty()) {
+                    JsonUtils.gson.fromJson(viewIn, JsonArray::class.java)
+                } else null
+                if (array != null) {
+                    for (e in array) {
+                        val `object` = e.asJsonObject
+                        if (`object`.has("section") && `object`["section"].asString.equals("community", ignoreCase = true)) {
+                            return true
+                        }
+                    }
                 }
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
-            return isCommunity
+            return false
         }
 
     fun calculateSortDate(): Long {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -636,11 +636,6 @@ class VoicesAdapter(
                         it.rawImageUrls = null
                     }
                 }
-                if (it.parsedImagesArray == null || it.rawImages != it.images) {
-                    it.parsedImagesArray = it.imagesArray
-                    it.rawImages = it.images
-                }
-
                 it.parsedSharedTeamName = JsonUtils.extractSharedTeamName(it)
             } catch (e: Exception) {
                 // Catch any parsing exceptions so one bad row doesn't break submitList
@@ -871,7 +866,7 @@ class VoicesAdapter(
             }
         }
 
-        val imagesToLoad = news?.parsedImagesArray ?: news?.imagesArray
+        val imagesToLoad = news?.imagesArray
         imagesToLoad?.let { imagesArray ->
             val size = imagesArray.size()
             if (!imagesArray.isEmpty()) {

--- a/app/src/test/java/org/ole/planet/myplanet/model/NewsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/NewsTest.kt
@@ -6,7 +6,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -107,7 +106,7 @@ class NewsTest {
     }
 
     @Test
-    fun `imagesArray memoizes parsedImagesArray and rawImages when called multiple times`() {
+    fun `imagesArray memoizes parsed JsonArray when called multiple times`() {
         val news = News()
         val jsonString = """[{"resourceId":"res123"}]"""
         news.images = jsonString
@@ -117,29 +116,41 @@ class NewsTest {
         assertEquals(1, firstCall.size())
         assertEquals("res123", firstCall[0].asJsonObject.get("resourceId").asString)
 
-        assertEquals(jsonString, news.rawImages)
-        assertSame(firstCall, news.parsedImagesArray)
-
         val secondCall = news.imagesArray
-        assertSame(firstCall, secondCall)
+        assertEquals(firstCall, secondCall)
     }
 
     @Test
-    fun `imagesArray invalidates cache and re-parses when images is updated`() {
+    fun `imagesArray defensive copy prevents mutating cached instance`() {
+        val news = News()
+        news.images = """[{"resourceId":"res123"}]"""
+
+        val firstCall = news.imagesArray
+        firstCall.add(JsonObject().apply { addProperty("resourceId", "mutated") })
+        assertEquals(2, firstCall.size())
+
+        val secondCall = news.imagesArray
+        assertEquals(1, secondCall.size())
+        assertEquals("res123", secondCall[0].asJsonObject.get("resourceId").asString)
+    }
+
+    @Test
+    fun `imagesArray invalidates cache and re-parses when images is reassigned`() {
         val news = News()
         news.images = """[{"resourceId":"res123"}]"""
 
         val firstCall = news.imagesArray
         assertEquals("res123", firstCall[0].asJsonObject.get("resourceId").asString)
 
-        val newJsonString = """[{"resourceId":"res456"}]"""
-        news.images = newJsonString
+        news.images = """[{"resourceId":"res456"}]"""
 
         val secondCall = news.imagesArray
         assertEquals(1, secondCall.size())
         assertEquals("res456", secondCall[0].asJsonObject.get("resourceId").asString)
-        assertEquals(newJsonString, news.rawImages)
-        assertSame(secondCall, news.parsedImagesArray)
+
+        news.images = null
+        val thirdCall = news.imagesArray
+        assertTrue(thirdCall.isEmpty)
     }
 
     @Test
@@ -150,8 +161,6 @@ class NewsTest {
         val result = news.imagesArray
         assertNotNull(result)
         assertTrue(result.isEmpty)
-        assertEquals(null, news.rawImages)
-        assertSame(result, news.parsedImagesArray)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/model/NewsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/NewsTest.kt
@@ -1,8 +1,12 @@
 package org.ole.planet.myplanet.model
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -81,7 +85,6 @@ class NewsTest {
     fun testCreateNewsWithNewsKeyAndConversations() {
         val map = HashMap<String?, String>()
         map["message"] = "News message"
-        val conversationsJson = "[{'_id':'1','query':'Q1','response':'R1'}]"
         map["news"] = "{'_id':'news_123','conversations':'[{\"query\":\"Q1\",\"response\":\"R1\"}]'}"
 
         val news = News.createNews(map, null, null)
@@ -94,10 +97,6 @@ class NewsTest {
 
     @Test
     fun testCreateNewsWithNullNewsKey() {
-        val map = HashMap<String?, String>()
-        map["message"] = "News message"
-        map["news"] = null.toString() // Or map directly with key having null value if using map that allows null values
-
         val mapWithNull = HashMap<String?, String?>()
         mapWithNull["message"] = "Test"
         @Suppress("UNCHECKED_CAST")
@@ -105,5 +104,93 @@ class NewsTest {
 
         assertNull(news.newsId)
         assertNull(news.newsRev)
+    }
+
+    @Test
+    fun `imagesArray memoizes parsedImagesArray and rawImages when called multiple times`() {
+        val news = News()
+        val jsonString = """[{"resourceId":"res123"}]"""
+        news.images = jsonString
+
+        val firstCall = news.imagesArray
+        assertNotNull(firstCall)
+        assertEquals(1, firstCall.size())
+        assertEquals("res123", firstCall[0].asJsonObject.get("resourceId").asString)
+
+        assertEquals(jsonString, news.rawImages)
+        assertSame(firstCall, news.parsedImagesArray)
+
+        val secondCall = news.imagesArray
+        assertSame(firstCall, secondCall)
+    }
+
+    @Test
+    fun `imagesArray invalidates cache and re-parses when images is updated`() {
+        val news = News()
+        news.images = """[{"resourceId":"res123"}]"""
+
+        val firstCall = news.imagesArray
+        assertEquals("res123", firstCall[0].asJsonObject.get("resourceId").asString)
+
+        val newJsonString = """[{"resourceId":"res456"}]"""
+        news.images = newJsonString
+
+        val secondCall = news.imagesArray
+        assertEquals(1, secondCall.size())
+        assertEquals("res456", secondCall[0].asJsonObject.get("resourceId").asString)
+        assertEquals(newJsonString, news.rawImages)
+        assertSame(secondCall, news.parsedImagesArray)
+    }
+
+    @Test
+    fun `imagesArray returns empty JsonArray for null images string`() {
+        val news = News()
+        news.images = null
+
+        val result = news.imagesArray
+        assertNotNull(result)
+        assertTrue(result.isEmpty)
+        assertEquals(null, news.rawImages)
+        assertSame(result, news.parsedImagesArray)
+    }
+
+    @Test
+    fun `isCommunityNews uses parsedViewIn if present even when viewIn is null or empty`() {
+        val news = News()
+        val communityArray = JsonArray().apply {
+            add(JsonObject().apply {
+                addProperty("section", "community")
+            })
+        }
+        news.parsedViewIn = communityArray
+        news.viewIn = null
+
+        assertTrue(news.isCommunityNews)
+
+        news.viewIn = """[{"section":"other"}]"""
+        assertTrue(news.isCommunityNews)
+    }
+
+    @Test
+    fun `isCommunityNews falls back to viewIn parsing when parsedViewIn is null`() {
+        val news = News()
+        news.parsedViewIn = null
+        news.viewIn = """[{"section":"community"}]"""
+
+        assertTrue(news.isCommunityNews)
+
+        news.viewIn = """[{"section":"my_courses"}]"""
+        assertFalse(news.isCommunityNews)
+    }
+
+    @Test
+    fun `isCommunityNews handles null or invalid viewIn gracefully`() {
+        val news = News()
+        news.viewIn = null
+        news.parsedViewIn = null
+        assertFalse(news.isCommunityNews)
+
+        news.viewIn = "not a valid json"
+        assertFalse(news.isCommunityNews)
     }
 }


### PR DESCRIPTION
Memoize imagesArray and isCommunityNews JSON getters in News model using existing @Ignore cache fields.

Fixes #17037

---
*PR created automatically by Jules for task [6497726261439308549](https://jules.google.com/task/6497726261439308549) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved news image handling for faster, safer access and more reliable behavior with missing or invalid image data.
  * Community news detection now handles missing or malformed metadata without errors and correctly prioritizes available information.

* **Tests**
  * Added coverage for image caching, defensive copies, cache updates, null values, and community-news detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->