### PR TITLE
chat: smoother repository utils searching (fixes #17042)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -21,7 +21,7 @@ interface ChatRepository {
     suspend fun sendContinueChatRequest(message: String, user: String?, aiProvider: AiProvider, id: String, rev: String): ChatResult
     suspend fun fetchAiProviders(serverUrl: String): Map<String, Boolean>?
     suspend fun getChatHistoryForUser(userName: String?): List<ChatHistory>
-    suspend fun searchChats(query: String, mode: ChatSearchMode, chats: List<ChatHistory>): List<ChatHistory>
+    suspend fun searchChats(query: String, mode: ChatSearchMode, userName: String?): List<ChatHistory>
     suspend fun getLatestRev(id: String): String?
     suspend fun insertChatHistoryList(chats: List<JsonObject>)
     fun extractSharedViewInIds(sharedNews: List<News>): Map<String, Set<String>>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -21,7 +21,6 @@ interface ChatRepository {
     suspend fun sendContinueChatRequest(message: String, user: String?, aiProvider: AiProvider, id: String, rev: String): ChatResult
     suspend fun fetchAiProviders(serverUrl: String): Map<String, Boolean>?
     suspend fun getChatHistoryForUser(userName: String?): List<ChatHistory>
-    suspend fun searchChats(query: String, mode: ChatSearchMode, userName: String?): List<ChatHistory>
     suspend fun getLatestRev(id: String): String?
     suspend fun insertChatHistoryList(chats: List<JsonObject>)
     fun extractSharedViewInIds(sharedNews: List<News>): Map<String, Set<String>>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -38,13 +38,6 @@ class ChatRepositoryImpl @Inject constructor(
     @PlainGson private val gson: Gson
 ) : ChatRepository, ChatSyncWriter {
 
-    private data class PrecomputedChat(
-        val chat: ChatHistory,
-        val normalizedTitle: String?,
-        val normalizedQueries: List<String?>,
-        val normalizedResponses: List<String?>
-    )
-
     @VisibleForTesting
     internal var reachabilityCheck: suspend (String) -> Boolean = { url ->
         org.ole.planet.myplanet.MainApplication.isServerReachable(url)
@@ -139,80 +132,6 @@ class ChatRepositoryImpl @Inject constructor(
         return chats.sortedByDescending { chat ->
             maxOf(chat.createdDate?.toLongOrNull() ?: 0L, chat.updatedDate?.toLongOrNull() ?: 0L)
         }
-    }
-
-    private suspend fun buildPrecomputedChats(chats: List<ChatHistory>): List<PrecomputedChat> = withContext(dispatcherProvider.default) {
-        chats.map { chat ->
-            val title = if (chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
-                chat.conversations?.get(0)?.query?.let { Utilities.normalizeText(it) }
-            } else {
-                chat.title?.let { Utilities.normalizeText(it) }
-            }
-            val queries = chat.conversations?.map { it?.query?.let { q -> Utilities.normalizeText(q) } } ?: emptyList()
-            val responses = chat.conversations?.map { it?.response?.let { r -> Utilities.normalizeText(r) } } ?: emptyList()
-            PrecomputedChat(chat, title, queries, responses)
-        }
-    }
-
-    override suspend fun searchChats(query: String, mode: ChatSearchMode, userName: String?): List<ChatHistory> {
-        val chats = getChatHistoryForUser(userName)
-        val precomputedChats = buildPrecomputedChats(chats)
-        return if (mode == ChatSearchMode.TITLE) {
-            searchByTitle(query, precomputedChats)
-        } else {
-            fullConvoSearch(query, isQuestion = (mode == ChatSearchMode.QUESTION), precomputedChats)
-        }
-    }
-
-    private suspend fun fullConvoSearch(s: String, isQuestion: Boolean, precomputedChats: List<PrecomputedChat>): List<ChatHistory> = withContext(dispatcherProvider.default) {
-        var conversation: String?
-        val queryParts = s.split(" ").filterNot { it.isEmpty() }
-        val normalizedQueryParts = queryParts.map { Utilities.normalizeText(it) }
-        val normalizedQuery = Utilities.normalizeText(s)
-        val inTitleStartQuery = mutableListOf<ChatHistory>()
-        val inTitleContainsQuery = mutableListOf<ChatHistory>()
-        val startsWithQuery = mutableListOf<ChatHistory>()
-        val containsQuery = mutableListOf<ChatHistory>()
-        for (pChat in precomputedChats) {
-            val conversations = pChat.chat.conversations
-            if (!conversations.isNullOrEmpty()) {
-                for (i in 0 until conversations.size) {
-                    conversation = if (isQuestion) {
-                        pChat.normalizedQueries[i]
-                    } else {
-                        pChat.normalizedResponses[i]
-                    }
-                    if (conversation == null) continue
-                    if (conversation.startsWith(normalizedQuery, ignoreCase = true)) {
-                        if (i == 0) inTitleStartQuery.add(pChat.chat) else startsWithQuery.add(pChat.chat)
-                        break
-                    } else if (normalizedQueryParts.all { conversation.contains(it, ignoreCase = true) }) {
-                        if (i == 0) inTitleContainsQuery.add(pChat.chat) else containsQuery.add(pChat.chat)
-                        break
-                    }
-                }
-            }
-        }
-        inTitleStartQuery + inTitleContainsQuery + startsWithQuery + containsQuery
-    }
-
-    private suspend fun searchByTitle(s: String, precomputedChats: List<PrecomputedChat>): List<ChatHistory> = withContext(dispatcherProvider.default) {
-        var title: String?
-        val queryParts = s.split(" ").filterNot { it.isEmpty() }
-        val normalizedQueryParts = queryParts.map { Utilities.normalizeText(it) }
-        val normalizedQuery = Utilities.normalizeText(s)
-        val startsWithQuery = mutableListOf<ChatHistory>()
-        val containsQuery = mutableListOf<ChatHistory>()
-        for (pChat in precomputedChats) {
-            title = pChat.normalizedTitle
-            if (title == null) continue
-            if (title.startsWith(normalizedQuery, ignoreCase = true)) {
-                startsWithQuery.add(pChat.chat)
-            } else if (normalizedQueryParts.all { title.contains(it, ignoreCase = true) }) {
-                containsQuery.add(pChat.chat)
-            }
-        }
-        startsWithQuery + containsQuery
     }
 
     override suspend fun getLatestRev(id: String): String? {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -154,7 +154,8 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun searchChats(query: String, mode: ChatSearchMode, chats: List<ChatHistory>): List<ChatHistory> {
+    override suspend fun searchChats(query: String, mode: ChatSearchMode, userName: String?): List<ChatHistory> {
+        val chats = getChatHistoryForUser(userName)
         val precomputedChats = buildPrecomputedChats(chats)
         return if (mode == ChatSearchMode.TITLE) {
             searchByTitle(query, precomputedChats)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
+import org.ole.planet.myplanet.utils.ChatSearch
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.RetryUtils
@@ -157,7 +158,7 @@ class ChatViewModel @Inject constructor(
             } else {
                 ChatSearchMode.RESPONSE
             }
-            val results = chatRepository.searchChats(query, mode, cachedUser?.name)
+            val results = ChatSearch.search(query, mode, allChats, dispatcherProvider.default)
             _filteredChats.value = results
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -157,7 +157,7 @@ class ChatViewModel @Inject constructor(
             } else {
                 ChatSearchMode.RESPONSE
             }
-            val results = chatRepository.searchChats(query, mode, allChats)
+            val results = chatRepository.searchChats(query, mode, cachedUser?.name)
             _filteredChats.value = results
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ChatSearch.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ChatSearch.kt
@@ -1,0 +1,107 @@
+package org.ole.planet.myplanet.utils
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.model.ChatHistory
+import org.ole.planet.myplanet.repository.ChatSearchMode
+
+object ChatSearch {
+
+    private data class PrecomputedChat(
+        val chat: ChatHistory,
+        val normalizedTitle: String?,
+        val normalizedQueries: List<String?>,
+        val normalizedResponses: List<String?>
+    )
+
+    suspend fun search(
+        query: String,
+        mode: ChatSearchMode,
+        chats: List<ChatHistory>,
+        dispatcher: CoroutineDispatcher = Dispatchers.Default
+    ): List<ChatHistory> {
+        val precomputedChats = buildPrecomputedChats(chats, dispatcher)
+        return if (mode == ChatSearchMode.TITLE) {
+            searchByTitle(query, precomputedChats, dispatcher)
+        } else {
+            fullConvoSearch(query, isQuestion = (mode == ChatSearchMode.QUESTION), precomputedChats, dispatcher)
+        }
+    }
+
+    private suspend fun buildPrecomputedChats(
+        chats: List<ChatHistory>,
+        dispatcher: CoroutineDispatcher
+    ): List<PrecomputedChat> = withContext(dispatcher) {
+        chats.map { chat ->
+            val title = if (chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
+                chat.conversations?.get(0)?.query?.let { Utilities.normalizeText(it) }
+            } else {
+                chat.title?.let { Utilities.normalizeText(it) }
+            }
+            val queries = chat.conversations?.map { it.query?.let { q -> Utilities.normalizeText(q) } } ?: emptyList()
+            val responses = chat.conversations?.map { it.response?.let { r -> Utilities.normalizeText(r) } } ?: emptyList()
+            PrecomputedChat(chat, title, queries, responses)
+        }
+    }
+
+    private suspend fun fullConvoSearch(
+        s: String,
+        isQuestion: Boolean,
+        precomputedChats: List<PrecomputedChat>,
+        dispatcher: CoroutineDispatcher
+    ): List<ChatHistory> = withContext(dispatcher) {
+        var conversation: String?
+        val queryParts = s.split(" ").filterNot { it.isEmpty() }
+        val normalizedQueryParts = queryParts.map { Utilities.normalizeText(it) }
+        val normalizedQuery = Utilities.normalizeText(s)
+        val inTitleStartQuery = mutableListOf<ChatHistory>()
+        val inTitleContainsQuery = mutableListOf<ChatHistory>()
+        val startsWithQuery = mutableListOf<ChatHistory>()
+        val containsQuery = mutableListOf<ChatHistory>()
+        for (pChat in precomputedChats) {
+            val conversations = pChat.chat.conversations
+            if (!conversations.isNullOrEmpty()) {
+                for (i in 0 until conversations.size) {
+                    conversation = if (isQuestion) {
+                        pChat.normalizedQueries[i]
+                    } else {
+                        pChat.normalizedResponses[i]
+                    }
+                    if (conversation == null) continue
+                    if (conversation.startsWith(normalizedQuery, ignoreCase = true)) {
+                        if (i == 0) inTitleStartQuery.add(pChat.chat) else startsWithQuery.add(pChat.chat)
+                        break
+                    } else if (normalizedQueryParts.all { conversation.contains(it, ignoreCase = true) }) {
+                        if (i == 0) inTitleContainsQuery.add(pChat.chat) else containsQuery.add(pChat.chat)
+                        break
+                    }
+                }
+            }
+        }
+        inTitleStartQuery + inTitleContainsQuery + startsWithQuery + containsQuery
+    }
+
+    private suspend fun searchByTitle(
+        s: String,
+        precomputedChats: List<PrecomputedChat>,
+        dispatcher: CoroutineDispatcher
+    ): List<ChatHistory> = withContext(dispatcher) {
+        var title: String?
+        val queryParts = s.split(" ").filterNot { it.isEmpty() }
+        val normalizedQueryParts = queryParts.map { Utilities.normalizeText(it) }
+        val normalizedQuery = Utilities.normalizeText(s)
+        val startsWithQuery = mutableListOf<ChatHistory>()
+        val containsQuery = mutableListOf<ChatHistory>()
+        for (pChat in precomputedChats) {
+            title = pChat.normalizedTitle
+            if (title == null) continue
+            if (title.startsWith(normalizedQuery, ignoreCase = true)) {
+                startsWithQuery.add(pChat.chat)
+            } else if (normalizedQueryParts.all { title.contains(it, ignoreCase = true) }) {
+                containsQuery.add(pChat.chat)
+            }
+        }
+        startsWithQuery + containsQuery
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
@@ -93,54 +93,6 @@ class ChatRepositoryImplTest {
         coVerify(exactly = 1) { chatDao.getByUser(userName) }
     }
 
-    @Test
-    fun `searchChats by title correctly filters list`() = runTest(testDispatcher) {
-        val userName = "testUser"
-        val chat1 = ChatHistory().apply { title = "First Chat"; user = userName }
-        val chat2 = ChatHistory().apply { title = "Second Discussion"; user = userName }
-        val chats = listOf(chat1, chat2)
-        coEvery { chatDao.getByUser(userName) } returns chats
-
-        val result = chatRepository.searchChats("First", ChatSearchMode.TITLE, userName)
-
-        assertEquals(1, result.size)
-        assertEquals("First Chat", result[0].title)
-    }
-
-    @Test
-    fun `searchChats by full conversation filters by question`() = runTest(testDispatcher) {
-        val userName = "testUser"
-        val chat1 = ChatHistory().apply {
-            title = "Chat 1"
-            user = userName
-            conversations = listOf(Conversation().apply { query = "How is the weather?" })
-        }
-        val chat2 = ChatHistory().apply {
-            title = "Chat 2"
-            user = userName
-            conversations = listOf(Conversation().apply { query = "Tell me a joke." })
-        }
-        val chats = listOf(chat1, chat2)
-        coEvery { chatDao.getByUser(userName) } returns chats
-
-        val result = chatRepository.searchChats("weather", ChatSearchMode.QUESTION, userName)
-
-        assertEquals(1, result.size)
-        assertEquals("Chat 1", result[0].title)
-    }
-
-    @Test
-    fun `searchChats with empty query returns empty when filtered list logic is applied`() = runTest(testDispatcher) {
-        val userName = "testUser"
-        val chat1 = ChatHistory().apply { title = "Chat 1"; user = userName }
-        val chat2 = ChatHistory().apply { title = "Chat 2"; user = userName }
-        val chats = listOf(chat1, chat2)
-        coEvery { chatDao.getByUser(userName) } returns chats
-
-        val result = chatRepository.searchChats("", ChatSearchMode.TITLE, userName)
-
-        assertEquals(2, result.size)
-    }
 
     @Test
     fun getLatestRev_findsHighestRevByNumericPrefix() = runTest {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
@@ -95,11 +95,13 @@ class ChatRepositoryImplTest {
 
     @Test
     fun `searchChats by title correctly filters list`() = runTest(testDispatcher) {
-        val chat1 = ChatHistory().apply { title = "First Chat" }
-        val chat2 = ChatHistory().apply { title = "Second Discussion" }
+        val userName = "testUser"
+        val chat1 = ChatHistory().apply { title = "First Chat"; user = userName }
+        val chat2 = ChatHistory().apply { title = "Second Discussion"; user = userName }
         val chats = listOf(chat1, chat2)
+        coEvery { chatDao.getByUser(userName) } returns chats
 
-        val result = chatRepository.searchChats("First", ChatSearchMode.TITLE, chats)
+        val result = chatRepository.searchChats("First", ChatSearchMode.TITLE, userName)
 
         assertEquals(1, result.size)
         assertEquals("First Chat", result[0].title)
@@ -107,17 +109,21 @@ class ChatRepositoryImplTest {
 
     @Test
     fun `searchChats by full conversation filters by question`() = runTest(testDispatcher) {
+        val userName = "testUser"
         val chat1 = ChatHistory().apply {
             title = "Chat 1"
+            user = userName
             conversations = listOf(Conversation().apply { query = "How is the weather?" })
         }
         val chat2 = ChatHistory().apply {
             title = "Chat 2"
+            user = userName
             conversations = listOf(Conversation().apply { query = "Tell me a joke." })
         }
         val chats = listOf(chat1, chat2)
+        coEvery { chatDao.getByUser(userName) } returns chats
 
-        val result = chatRepository.searchChats("weather", ChatSearchMode.QUESTION, chats)
+        val result = chatRepository.searchChats("weather", ChatSearchMode.QUESTION, userName)
 
         assertEquals(1, result.size)
         assertEquals("Chat 1", result[0].title)
@@ -125,11 +131,13 @@ class ChatRepositoryImplTest {
 
     @Test
     fun `searchChats with empty query returns empty when filtered list logic is applied`() = runTest(testDispatcher) {
-        val chat1 = ChatHistory().apply { title = "Chat 1" }
-        val chat2 = ChatHistory().apply { title = "Chat 2" }
+        val userName = "testUser"
+        val chat1 = ChatHistory().apply { title = "Chat 1"; user = userName }
+        val chat2 = ChatHistory().apply { title = "Chat 2"; user = userName }
         val chats = listOf(chat1, chat2)
+        coEvery { chatDao.getByUser(userName) } returns chats
 
-        val result = chatRepository.searchChats("", ChatSearchMode.TITLE, chats)
+        val result = chatRepository.searchChats("", ChatSearchMode.TITLE, userName)
 
         assertEquals(2, result.size)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
@@ -233,12 +233,11 @@ class ChatViewModelTest {
     }
 
     @Test
-    fun `searchChats delegates to repository correctly and empty query resets filtered list`() = runTest {
+    fun `searchChats filters allChats correctly and empty query resets filtered list`() = runTest {
         val chat1 = ChatHistory().apply { title = "Chat 1" }
         val chat2 = ChatHistory().apply { title = "Chat 2" }
 
         coEvery { chatRepository.getChatHistoryForUser(any()) } returns listOf(chat1, chat2)
-        coEvery { chatRepository.searchChats("Chat 1", org.ole.planet.myplanet.repository.ChatSearchMode.TITLE, any()) } returns listOf(chat1)
 
         viewModel.loadChatHistoryScreenData("user123", null, null)
         testScheduler.advanceUntilIdle()
@@ -246,12 +245,11 @@ class ChatViewModelTest {
         viewModel.searchChats("Chat 1", isFullSearch = false, isQuestion = false)
         testScheduler.advanceUntilIdle()
         assertEquals(1, viewModel.filteredChats.value.size)
+        assertEquals("Chat 1", viewModel.filteredChats.value[0].title)
 
         viewModel.searchChats("", isFullSearch = false, isQuestion = false)
         testScheduler.advanceUntilIdle()
         assertEquals(2, viewModel.filteredChats.value.size)
-
-        coVerify { chatRepository.searchChats("Chat 1", org.ole.planet.myplanet.repository.ChatSearchMode.TITLE, any()) }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ChatSearchTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ChatSearchTest.kt
@@ -1,0 +1,75 @@
+package org.ole.planet.myplanet.utils
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.ole.planet.myplanet.model.ChatHistory
+import org.ole.planet.myplanet.model.Conversation
+import org.ole.planet.myplanet.repository.ChatSearchMode
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatSearchTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Test
+    fun `search by title correctly filters list`() = runTest(testDispatcher) {
+        val chat1 = ChatHistory().apply { title = "First Chat" }
+        val chat2 = ChatHistory().apply { title = "Second Discussion" }
+        val chats = listOf(chat1, chat2)
+
+        val result = ChatSearch.search("First", ChatSearchMode.TITLE, chats, testDispatcher)
+
+        assertEquals(1, result.size)
+        assertEquals("First Chat", result[0].title)
+    }
+
+    @Test
+    fun `search by full conversation filters by question`() = runTest(testDispatcher) {
+        val chat1 = ChatHistory().apply {
+            title = "Chat 1"
+            conversations = listOf(Conversation().apply { query = "How is the weather?" })
+        }
+        val chat2 = ChatHistory().apply {
+            title = "Chat 2"
+            conversations = listOf(Conversation().apply { query = "Tell me a joke." })
+        }
+        val chats = listOf(chat1, chat2)
+
+        val result = ChatSearch.search("weather", ChatSearchMode.QUESTION, chats, testDispatcher)
+
+        assertEquals(1, result.size)
+        assertEquals("Chat 1", result[0].title)
+    }
+
+    @Test
+    fun `search by full conversation filters by response`() = runTest(testDispatcher) {
+        val chat1 = ChatHistory().apply {
+            title = "Chat 1"
+            conversations = listOf(Conversation().apply { query = "How are you?"; response = "I am doing great!" })
+        }
+        val chat2 = ChatHistory().apply {
+            title = "Chat 2"
+            conversations = listOf(Conversation().apply { query = "Tell me a joke."; response = "Why did the chicken cross the road?" })
+        }
+        val chats = listOf(chat1, chat2)
+
+        val result = ChatSearch.search("chicken", ChatSearchMode.RESPONSE, chats, testDispatcher)
+
+        assertEquals(1, result.size)
+        assertEquals("Chat 2", result[0].title)
+    }
+
+    @Test
+    fun `search with empty query returns all chats`() = runTest(testDispatcher) {
+        val chat1 = ChatHistory().apply { title = "Chat 1" }
+        val chat2 = ChatHistory().apply { title = "Chat 2" }
+        val chats = listOf(chat1, chat2)
+
+        val result = ChatSearch.search("", ChatSearchMode.TITLE, chats, testDispatcher)
+
+        assertEquals(2, result.size)
+    }
+}


### PR DESCRIPTION
Refactored ChatRepository.searchChats signature to take userName: String? rather than requiring the caller to pass the chat list. Updated ChatViewModel and unit tests accordingly.

Fixes #17042

---
*PR created automatically by Jules for task [11784791100903403165](https://jules.google.com/task/11784791100903403165) started by @dogi*