### PR TITLE
courses: smoother submissions repository row projecting (fixes #17043)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/SubmissionRowProjection.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/SubmissionRowProjection.kt
@@ -1,0 +1,7 @@
+package org.ole.planet.myplanet.model
+
+data class SubmissionRowProjection(
+    val submission: Submission,
+    val submitterName: String,
+    val submissionCount: Int,
+)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -11,12 +11,20 @@ import org.ole.planet.myplanet.model.StepExam
 import org.ole.planet.myplanet.model.Submission
 import org.ole.planet.myplanet.model.SubmissionDetail
 import org.ole.planet.myplanet.model.SubmissionItem
+import org.ole.planet.myplanet.model.SubmissionRowProjection
 import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.UserEntity
 
 interface SubmissionsRepository {
     fun getPendingSurveysFlow(userId: String?): Flow<List<Submission>>
     fun getSubmissionsFlow(userId: String): Flow<List<Submission>>
+    suspend fun getSubmissionProjections(
+        submissions: List<Submission>,
+        userId: String,
+        type: String,
+        query: String,
+        examMap: Map<String?, StepExam>,
+    ): List<SubmissionRowProjection>
     suspend fun getPendingSurveys(userId: String?): List<Submission>
     suspend fun getUniquePendingSurveys(userId: String?): List<Submission>
     suspend fun getSurveyTitlesFromSubmissions(submissions: List<Submission>): List<String>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -32,6 +32,7 @@ import org.ole.planet.myplanet.model.StepExam
 import org.ole.planet.myplanet.model.Submission
 import org.ole.planet.myplanet.model.SubmissionDetail
 import org.ole.planet.myplanet.model.SubmissionItem
+import org.ole.planet.myplanet.model.SubmissionRowProjection
 import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.TeamReference
 import org.ole.planet.myplanet.model.UserEntity
@@ -44,6 +45,7 @@ import org.ole.planet.myplanet.utils.toSyncDocuments
 
 class SubmissionsRepositoryImpl @Inject internal constructor(
     private val teamsRepositoryProvider: Provider<TeamsRepository>,
+    private val userRepository: UserRepository,
     @ApplicationContext private val context: Context,
     private val sharedPrefManager: SharedPrefManager,
     private val exporter: SubmissionsRepositoryExporter,
@@ -85,6 +87,48 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         return submissionDao.observeByUserId(userId).distinctUntilChanged { old, new ->
             old.size == new.size && old.zip(new).all { (o, n) -> o.id == n.id && o.lastUpdateTime == n.lastUpdateTime }
         }
+    }
+
+    override suspend fun getSubmissionProjections(
+        submissions: List<Submission>,
+        userId: String,
+        type: String,
+        query: String,
+        examMap: Map<String?, StepExam>,
+    ): List<SubmissionRowProjection> {
+        var filtered = when (type) {
+            "survey" -> submissions.filter { it.userId == userId && it.type == "survey" }
+            "survey_submission" -> submissions.filter {
+                it.userId == userId && it.type == "survey" && it.status != "pending"
+            }
+            else -> submissions.filter { it.userId == userId && it.type != "survey" }
+        }.sortedByDescending { it.lastUpdateTime }
+
+        if (query.isNotEmpty()) {
+            val examIds = examMap.mapNotNullTo(HashSet()) { (id, exam) ->
+                if (exam.name?.contains(query, ignoreCase = true) == true) id else null
+            }
+            filtered = filtered.filter { examIds.contains(it.parentId) }
+        }
+
+        val uniqueRawSubmissions = mutableListOf<Submission>()
+        val submissionCountMap = HashMap<String?, Int>()
+        for (group in filtered.groupBy { it.parentId }.values) {
+            val newest = group.maxByOrNull { it.lastUpdateTime } ?: continue
+            uniqueRawSubmissions.add(newest)
+            submissionCountMap[newest.id] = group.size
+        }
+
+        val userIds = uniqueRawSubmissions.mapNotNull { it.userId }.distinct()
+        val fallbackUsersMap = userRepository.getUsersByIds(userIds).associateBy { it.id }
+
+        return uniqueRawSubmissions.map { sub ->
+            val name = getNormalizedSubmitterName(sub)
+            val fallback = sub.userId?.let { fallbackUsersMap[it]?.name }
+            val submitterName = name ?: fallback ?: ""
+            val count = submissionCountMap[sub.id] ?: 1
+            SubmissionRowProjection(sub, submitterName, count)
+        }.sortedByDescending { it.submission.lastUpdateTime }
     }
 
     override suspend fun getPendingSurveys(userId: String?): List<Submission> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModel.kt
@@ -12,12 +12,10 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import org.ole.planet.myplanet.model.StepExam
-import org.ole.planet.myplanet.model.Submission
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -29,11 +27,6 @@ class SubmissionViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
-
-    private data class SubmissionViewData(
-        val submission: Submission,
-        val submitterName: String,
-    )
 
     private val _type = MutableStateFlow("")
     private val _query = MutableStateFlow("")
@@ -49,60 +42,26 @@ class SubmissionViewModel @Inject constructor(
         HashMap(submissionsRepository.getExamMap(subs))
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), hashMapOf())
 
-    private val filteredSubmissionsRaw = combine(allSubmissionsFlow, _type, _query, exams, userIdFlow) { subs, type, query, examMap, uid ->
-        var filtered = when (type) {
-            "survey" -> subs.filter { it.userId == uid && it.type == "survey" }
-            "survey_submission" -> subs.filter {
-                it.userId == uid && it.type == "survey" && it.status != "pending"
-            }
-            else -> subs.filter { it.userId == uid && it.type != "survey" }
-        }.sortedByDescending { it.lastUpdateTime }
-
-        if (query.isNotEmpty()) {
-            val examIds = examMap.mapNotNullTo(HashSet()) { (id, exam) ->
-                if (exam.name?.contains(query, ignoreCase = true) == true) id else null
-            }
-            filtered = filtered.filter { examIds.contains(it.parentId) }
-        }
-
-        val uniqueRawSubmissions = mutableListOf<Submission>()
-        val submissionCountMap = HashMap<String?, Int>()
-        for (group in filtered.groupBy { it.parentId }.values) {
-            val newest = group.maxByOrNull { it.lastUpdateTime } ?: continue
-            uniqueRawSubmissions.add(newest)
-            submissionCountMap[newest.id] = group.size
-        }
-
-        val userIds = uniqueRawSubmissions.mapNotNull { it.userId }.distinct()
-        val fallbackUsersMap = userRepository.getUsersByIds(userIds).associateBy { it.id }
-
-        val uniqueSubmissions = uniqueRawSubmissions.map { sub ->
-            val name = submissionsRepository.getNormalizedSubmitterName(sub)
-            val fallback = sub.userId?.let { fallbackUsersMap[it]?.name }
-            SubmissionViewData(sub, name ?: fallback ?: "")
-        }.sortedByDescending { it.submission.lastUpdateTime }
-
-        Triple(uniqueSubmissions, submissionCountMap, filtered)
+    private val filteredProjections = combine(allSubmissionsFlow, _type, _query, exams, userIdFlow) { subs, type, query, examMap, uid ->
+        submissionsRepository.getSubmissionProjections(subs, uid, type, query, examMap)
     }.flowOn(dispatcherProvider.io).shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
-    val submissions: StateFlow<List<SubmissionUiModel>> = combine(filteredSubmissionsRaw, exams) { (uniqueSubmissions, submissionCountMap), examsMap ->
-        uniqueSubmissions.map { viewData ->
-            val examTitle = examsMap[viewData.submission.parentId]?.name ?: "Submissions"
-            val count = submissionCountMap[viewData.submission.id] ?: 1
+    val submissions: StateFlow<List<SubmissionUiModel>> = combine(filteredProjections, exams) { projections, examsMap ->
+        projections.map { projection ->
+            val examTitle = examsMap[projection.submission.parentId]?.name ?: "Submissions"
             SubmissionUiModel(
-                id = viewData.submission.id,
-                status = viewData.submission.status,
-                startTime = viewData.submission.startTime,
-                lastUpdateTime = viewData.submission.lastUpdateTime,
-                parentId = viewData.submission.parentId,
-                userId = viewData.submission.userId,
-                submitterName = viewData.submitterName,
+                id = projection.submission.id,
+                status = projection.submission.status,
+                startTime = projection.submission.startTime,
+                lastUpdateTime = projection.submission.lastUpdateTime,
+                parentId = projection.submission.parentId,
+                userId = projection.submission.userId,
+                submitterName = projection.submitterName,
                 examTitle = examTitle,
-                submissionCount = count
+                submissionCount = projection.submissionCount
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-
 
     fun setFilter(type: String, query: String) {
         _type.value = type

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -58,6 +58,7 @@ class SubmissionsRepositoryImplTest {
     private val answerDao: AnswerDao = mockk(relaxed = true)
     private val examDao: ExamDao = mockk(relaxed = true)
     private val questionDao: QuestionDao = mockk(relaxed = true)
+    private val userRepository: UserRepository = mockk(relaxed = true)
     private lateinit var repository: SubmissionsRepositoryImpl
 
     @Before
@@ -72,6 +73,7 @@ class SubmissionsRepositoryImplTest {
 
         repository = spyk(SubmissionsRepositoryImpl(
             teamsRepositoryProvider,
+            userRepository,
             context,
             sharedPrefManager,
             exporter,
@@ -889,6 +891,44 @@ class SubmissionsRepositoryImplTest {
         }
         val result = repository.getNormalizedSubmitterName(submission)
         assertNull(result)
+    }
+
+    @Test
+    fun `getSubmissionProjections filters by type, selects newest per group, resolves submitter name and count`() = runTest {
+        val s1 = Submission().apply { id = "1"; parentId = "p1"; type = "survey"; status = "pending"; lastUpdateTime = 100L; userId = "user1" }
+        val s2 = Submission().apply { id = "2"; parentId = "p1"; type = "survey"; status = "complete"; lastUpdateTime = 200L; userId = "user1" }
+        val s3 = Submission().apply { id = "3"; parentId = "p2"; type = "exam"; status = "complete"; lastUpdateTime = 300L; userId = "user1" }
+        val subs = listOf(s1, s2, s3)
+
+        val fallbackUser = UserEntity().apply { id = "user1"; name = "Fallback Name" }
+        coEvery { userRepository.getUsersByIds(listOf("user1")) } returns listOf(fallbackUser)
+
+        // Type "survey" returns s1 and s2, grouped by parentId "p1", newest is s2 with count 2
+        val projections = repository.getSubmissionProjections(subs, "user1", "survey", "", emptyMap())
+
+        assertEquals(1, projections.size)
+        assertEquals("2", projections[0].submission.id)
+        assertEquals(2, projections[0].submissionCount)
+        assertEquals("Fallback Name", projections[0].submitterName)
+    }
+
+    @Test
+    fun `getSubmissionProjections filters by query matching exam name`() = runTest {
+        val s1 = Submission().apply { id = "1"; parentId = "p1"; type = "exam"; status = "complete"; lastUpdateTime = 100L; userId = "user1" }
+        val s2 = Submission().apply { id = "2"; parentId = "p2"; type = "exam"; status = "complete"; lastUpdateTime = 200L; userId = "user1" }
+        val subs = listOf(s1, s2)
+
+        val examMap = mapOf<String?, StepExam>(
+            "p1" to StepExam().apply { name = "Math Quiz" },
+            "p2" to StepExam().apply { name = "Science Test" }
+        )
+
+        coEvery { userRepository.getUsersByIds(any()) } returns emptyList()
+
+        val projections = repository.getSubmissionProjections(subs, "user1", "exam", "Math", examMap)
+
+        assertEquals(1, projections.size)
+        assertEquals("1", projections[0].submission.id)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModelTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -13,10 +14,14 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.ArgumentMatchers.anyMap
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.ole.planet.myplanet.model.StepExam
 import org.ole.planet.myplanet.model.Submission
+import org.ole.planet.myplanet.model.SubmissionRowProjection
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -41,6 +46,50 @@ class SubmissionViewModelTest {
         Dispatchers.setMain(testDispatcher)
         submissionsRepository = mock(SubmissionsRepository::class.java)
         userRepository = mock(UserRepository::class.java)
+
+        runBlocking {
+            `when`(submissionsRepository.getSubmissionProjections(anyList(), anyString(), anyString(), anyString(), anyMap())).thenAnswer { invocation ->
+                val subs = invocation.getArgument<List<Submission>>(0)
+                val uid = invocation.getArgument<String>(1)
+                val type = invocation.getArgument<String>(2)
+                val query = invocation.getArgument<String>(3)
+                val examMap = invocation.getArgument<Map<String?, StepExam>>(4)
+
+                var filtered = when (type) {
+                    "survey" -> subs.filter { it.userId == uid && it.type == "survey" }
+                    "survey_submission" -> subs.filter {
+                        it.userId == uid && it.type == "survey" && it.status != "pending"
+                    }
+                    else -> subs.filter { it.userId == uid && it.type != "survey" }
+                }.sortedByDescending { it.lastUpdateTime }
+
+                if (query.isNotEmpty()) {
+                    val examIds = examMap.mapNotNullTo(HashSet()) { (id, exam) ->
+                        if (exam.name?.contains(query, ignoreCase = true) == true) id else null
+                    }
+                    filtered = filtered.filter { examIds.contains(it.parentId) }
+                }
+
+                val uniqueRawSubmissions = mutableListOf<Submission>()
+                val submissionCountMap = HashMap<String?, Int>()
+                for (group in filtered.groupBy { it.parentId }.values) {
+                    val newest = group.maxByOrNull { it.lastUpdateTime } ?: continue
+                    uniqueRawSubmissions.add(newest)
+                    submissionCountMap[newest.id] = group.size
+                }
+
+                val userIds = uniqueRawSubmissions.mapNotNull { it.userId }.distinct()
+                val fallbackUsersMap = runBlocking { userRepository.getUsersByIds(userIds) }.associateBy { it.id }
+
+                uniqueRawSubmissions.map { sub ->
+                    val name = submissionsRepository.getNormalizedSubmitterName(sub)
+                    val fallback = sub.userId?.let { fallbackUsersMap[it]?.name }
+                    val submitterName = name ?: fallback ?: ""
+                    val count = submissionCountMap[sub.id] ?: 1
+                    SubmissionRowProjection(sub, submitterName, count)
+                }.sortedByDescending { it.submission.lastUpdateTime }
+            }
+        }
     }
 
     @After


### PR DESCRIPTION
Moved submission-list enrichment logic (filtering, grouping by parentId, newest-per-group selection, batch user lookup for submitter names, and count calculation) from SubmissionViewModel into SubmissionsRepository behind a platform-free list-row projection (`SubmissionRowProjection`). Refactored SubmissionViewModel to delegate projection creation to SubmissionsRepository.getSubmissionProjections.

Fixes #17043

---
*PR created automatically by Jules for task [15056084168231445396](https://jules.google.com/task/15056084168231445396) started by @dogi*