### PR TITLE
all: smoother user information view modelling (fixes #17055)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -13,6 +13,7 @@ import android.widget.ArrayAdapter
 import android.widget.RadioButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,22 +27,18 @@ import org.ole.planet.myplanet.base.BaseDialogFragment
 import org.ole.planet.myplanet.databinding.FragmentUserInformationBinding
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.model.UserSurveyProfile
-import org.ole.planet.myplanet.repository.SubmissionsRepository
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.SubmissionsUploader
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
     private lateinit var fragmentUserInformationBinding: FragmentUserInformationBinding
     var dob: String? = ""
-    @Inject
-    lateinit var submissionsRepository: SubmissionsRepository
-    @Inject
-    lateinit var userRepository: UserRepository
+    private val viewModel: UserInformationViewModel by viewModels()
     @Inject
     lateinit var userSessionManager: UserSessionManager
     var userModel: UserEntity? = null
@@ -79,6 +76,40 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         super.onViewCreated(view, savedInstanceState)
         viewLifecycleOwner.lifecycleScope.launch {
             userModel = userSessionManager.getUserModel()
+        }
+        collectWhenStarted(viewModel.resultEvent) { result ->
+            when (result) {
+                is UserInformationResult.UpdateProfileSuccess -> {
+                    Utilities.toast(MainApplication.context, getString(R.string.user_profile_updated))
+                    if (isAdded) dialog?.dismiss()
+                }
+                is UserInformationResult.UpdateProfileError -> {
+                    Utilities.toast(MainApplication.context, getString(R.string.unable_to_update_user))
+                    if (isAdded) dialog?.dismiss()
+                }
+                is UserInformationResult.MarkSubmissionSuccess -> {
+                    Log.d("UserInformationFragment", "Submission marked complete, about to dismiss dialog")
+                    Utilities.toast(
+                        MainApplication.context,
+                        getString(R.string.thank_you_for_taking_this_survey)
+                    )
+                    if (isAdded) {
+                        Log.d("UserInformationFragment", "Dismissing dialog, this will trigger onDismiss()")
+                        dialog?.dismiss()
+                    }
+                }
+                is UserInformationResult.MarkSubmissionError -> {
+                    if (result.message == "no ID provided") {
+                        Utilities.toast(
+                            MainApplication.context,
+                            "Error: Unable to save submission - no ID provided"
+                        )
+                    } else {
+                        Utilities.toast(MainApplication.context, "Error saving submission: ${result.message}")
+                    }
+                    if (isAdded) dialog?.dismiss()
+                }
+            }
         }
     }
 
@@ -158,16 +189,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
             saveSubmission(user)
         } else if (TextUtils.isEmpty(id)) {
             val userId = userModel?.id
-            viewLifecycleOwner.lifecycleScope.launch {
-                try {
-                    userRepository.updateProfileFields(userId, user)
-                    Utilities.toast(MainApplication.context, getString(R.string.user_profile_updated))
-                    if (isAdded) dialog?.dismiss()
-                } catch (_: Exception) {
-                    Utilities.toast(MainApplication.context, getString(R.string.unable_to_update_user))
-                    if (isAdded) dialog?.dismiss()
-                }
-            }
+            viewModel.updateProfile(userId, user)
         } else {
             saveSubmission(user)
         }
@@ -255,39 +277,9 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
 
     private fun saveSubmission(user: JsonObject) {
         Log.d("UserInformationFragment", "saveSubmission called, syncStartTime: $syncStartTime")
-        viewLifecycleOwner.lifecycleScope.launch {
-            try {
-                val submissionId = id
-                if (submissionId.isNullOrEmpty()) {
-                    Utilities.toast(
-                        MainApplication.context,
-                        "Error: Unable to save submission - no ID provided"
-                    )
-                    if (isAdded) dialog?.dismiss()
-                    return@launch
-                }
-
-                Log.d("UserInformationFragment", "Marking submission complete for ID: $submissionId")
-                submissionsRepository.markSubmissionComplete(submissionId, user)
-                Log.d("UserInformationFragment", "Submission marked complete, about to dismiss dialog")
-
-                Utilities.toast(
-                    MainApplication.context,
-                    getString(R.string.thank_you_for_taking_this_survey)
-                )
-                if (isAdded) {
-                    Log.d("UserInformationFragment", "Dismissing dialog, this will trigger onDismiss()")
-                    dialog?.dismiss()
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                Log.e("UserInformationFragment", "Error in saveSubmission", e)
-                Utilities.toast(MainApplication.context, "Error saving submission: ${e.message}")
-                if (isAdded) {
-                    dialog?.dismiss()
-                }
-            }
-        }
+        val submissionId = id
+        Log.d("UserInformationFragment", "Marking submission complete for ID: $submissionId")
+        viewModel.markSubmissionComplete(submissionId, user)
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationViewModel.kt
@@ -1,0 +1,56 @@
+package org.ole.planet.myplanet.ui.exam
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.gson.JsonObject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.repository.SubmissionsRepository
+import org.ole.planet.myplanet.repository.UserRepository
+
+sealed class UserInformationResult {
+    object UpdateProfileSuccess : UserInformationResult()
+    data class UpdateProfileError(val message: String) : UserInformationResult()
+    object MarkSubmissionSuccess : UserInformationResult()
+    data class MarkSubmissionError(val message: String) : UserInformationResult()
+}
+
+@HiltViewModel
+class UserInformationViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val submissionsRepository: SubmissionsRepository
+) : ViewModel() {
+
+    private val _resultEvent = MutableSharedFlow<UserInformationResult>(extraBufferCapacity = 1)
+    val resultEvent: SharedFlow<UserInformationResult> = _resultEvent.asSharedFlow()
+
+    fun updateProfile(userId: String?, user: JsonObject) {
+        viewModelScope.launch {
+            try {
+                userRepository.updateProfileFields(userId, user)
+                _resultEvent.emit(UserInformationResult.UpdateProfileSuccess)
+            } catch (e: Exception) {
+                _resultEvent.emit(UserInformationResult.UpdateProfileError(e.message ?: ""))
+            }
+        }
+    }
+
+    fun markSubmissionComplete(submissionId: String?, user: JsonObject) {
+        viewModelScope.launch {
+            if (submissionId.isNullOrEmpty()) {
+                _resultEvent.emit(UserInformationResult.MarkSubmissionError("no ID provided"))
+                return@launch
+            }
+            try {
+                submissionsRepository.markSubmissionComplete(submissionId, user)
+                _resultEvent.emit(UserInformationResult.MarkSubmissionSuccess)
+            } catch (e: Exception) {
+                _resultEvent.emit(UserInformationResult.MarkSubmissionError(e.message ?: ""))
+            }
+        }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/exam/UserInformationViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/exam/UserInformationViewModelTest.kt
@@ -7,7 +7,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -44,7 +43,6 @@ class UserInformationViewModelTest {
         coEvery { userRepository.updateProfileFields(userId, jsonUser) } returns Unit
 
         viewModel.updateProfile(userId, jsonUser)
-        advanceUntilIdle()
 
         val result = viewModel.resultEvent.first()
         assertEquals(UserInformationResult.UpdateProfileSuccess, result)
@@ -59,7 +57,6 @@ class UserInformationViewModelTest {
         coEvery { userRepository.updateProfileFields(userId, jsonUser) } throws Exception(errorMessage)
 
         viewModel.updateProfile(userId, jsonUser)
-        advanceUntilIdle()
 
         val result = viewModel.resultEvent.first()
         assertTrue(result is UserInformationResult.UpdateProfileError)
@@ -71,7 +68,6 @@ class UserInformationViewModelTest {
         val jsonUser = JsonObject()
 
         viewModel.markSubmissionComplete(null, jsonUser)
-        advanceUntilIdle()
 
         val result = viewModel.resultEvent.first()
         assertTrue(result is UserInformationResult.MarkSubmissionError)
@@ -86,7 +82,6 @@ class UserInformationViewModelTest {
         coEvery { submissionsRepository.markSubmissionComplete(submissionId, jsonUser) } returns Unit
 
         viewModel.markSubmissionComplete(submissionId, jsonUser)
-        advanceUntilIdle()
 
         val result = viewModel.resultEvent.first()
         assertEquals(UserInformationResult.MarkSubmissionSuccess, result)
@@ -101,7 +96,6 @@ class UserInformationViewModelTest {
         coEvery { submissionsRepository.markSubmissionComplete(submissionId, jsonUser) } throws Exception(errorMessage)
 
         viewModel.markSubmissionComplete(submissionId, jsonUser)
-        advanceUntilIdle()
 
         val result = viewModel.resultEvent.first()
         assertTrue(result is UserInformationResult.MarkSubmissionError)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/exam/UserInformationViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/exam/UserInformationViewModelTest.kt
@@ -1,0 +1,110 @@
+package org.ole.planet.myplanet.ui.exam
+
+import com.google.gson.JsonObject
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.ole.planet.myplanet.repository.SubmissionsRepository
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.utils.MainDispatcherRule
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserInformationViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var submissionsRepository: SubmissionsRepository
+    private lateinit var viewModel: UserInformationViewModel
+
+    @Before
+    fun setup() {
+        userRepository = mockk(relaxed = true)
+        submissionsRepository = mockk(relaxed = true)
+        viewModel = UserInformationViewModel(userRepository, submissionsRepository)
+    }
+
+    @Test
+    fun `updateProfile success emits UpdateProfileSuccess`() = runTest {
+        val userId = "user123"
+        val jsonUser = JsonObject()
+        coEvery { userRepository.updateProfileFields(userId, jsonUser) } returns Unit
+
+        viewModel.updateProfile(userId, jsonUser)
+        advanceUntilIdle()
+
+        val result = viewModel.resultEvent.first()
+        assertEquals(UserInformationResult.UpdateProfileSuccess, result)
+        coVerify(exactly = 1) { userRepository.updateProfileFields(userId, jsonUser) }
+    }
+
+    @Test
+    fun `updateProfile exception emits UpdateProfileError`() = runTest {
+        val userId = "user123"
+        val jsonUser = JsonObject()
+        val errorMessage = "Database error"
+        coEvery { userRepository.updateProfileFields(userId, jsonUser) } throws Exception(errorMessage)
+
+        viewModel.updateProfile(userId, jsonUser)
+        advanceUntilIdle()
+
+        val result = viewModel.resultEvent.first()
+        assertTrue(result is UserInformationResult.UpdateProfileError)
+        assertEquals(errorMessage, (result as UserInformationResult.UpdateProfileError).message)
+    }
+
+    @Test
+    fun `markSubmissionComplete with null or empty submissionId emits MarkSubmissionError`() = runTest {
+        val jsonUser = JsonObject()
+
+        viewModel.markSubmissionComplete(null, jsonUser)
+        advanceUntilIdle()
+
+        val result = viewModel.resultEvent.first()
+        assertTrue(result is UserInformationResult.MarkSubmissionError)
+        assertEquals("no ID provided", (result as UserInformationResult.MarkSubmissionError).message)
+        coVerify(exactly = 0) { submissionsRepository.markSubmissionComplete(any(), any()) }
+    }
+
+    @Test
+    fun `markSubmissionComplete success emits MarkSubmissionSuccess`() = runTest {
+        val submissionId = "sub123"
+        val jsonUser = JsonObject()
+        coEvery { submissionsRepository.markSubmissionComplete(submissionId, jsonUser) } returns Unit
+
+        viewModel.markSubmissionComplete(submissionId, jsonUser)
+        advanceUntilIdle()
+
+        val result = viewModel.resultEvent.first()
+        assertEquals(UserInformationResult.MarkSubmissionSuccess, result)
+        coVerify(exactly = 1) { submissionsRepository.markSubmissionComplete(submissionId, jsonUser) }
+    }
+
+    @Test
+    fun `markSubmissionComplete exception emits MarkSubmissionError`() = runTest {
+        val submissionId = "sub123"
+        val jsonUser = JsonObject()
+        val errorMessage = "Failed to mark complete"
+        coEvery { submissionsRepository.markSubmissionComplete(submissionId, jsonUser) } throws Exception(errorMessage)
+
+        viewModel.markSubmissionComplete(submissionId, jsonUser)
+        advanceUntilIdle()
+
+        val result = viewModel.resultEvent.first()
+        assertTrue(result is UserInformationResult.MarkSubmissionError)
+        assertEquals(errorMessage, (result as UserInformationResult.MarkSubmissionError).message)
+    }
+}


### PR DESCRIPTION
Hoisted repository access from UserInformationFragment into UserInformationViewModel so writes survive configuration changes. Updated fragment to observe operation results via SharedFlow. Added unit tests for the ViewModel.

Fixes #17055

---
*PR created automatically by Jules for task [16146362856025865306](https://jules.google.com/task/16146362856025865306) started by @dogi*