### PR TITLE
teams: smoother surveys repository exam dao querying (fixes #17049)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ExamDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ExamDao.kt
@@ -29,6 +29,7 @@ interface ExamDao {
     @Query("SELECT * FROM exams WHERE type = :type AND (teamId = :teamId OR id IN (:submissionIds))") suspend fun getTeamOwnedSurveys(teamId: String, submissionIds: Collection<String>, type: String = "surveys"): List<StepExam>
     @Query("SELECT * FROM exams WHERE type = :type AND isTeamShareAllowed = 1 AND id NOT IN (:excludedIds)") suspend fun getAdoptableTeamSurveys(excludedIds: Collection<String>, type: String = "surveys"): List<StepExam>
     @Query("SELECT * FROM exams WHERE type = :type AND isTeamShareAllowed = 1") suspend fun getAdoptableTeamSurveys(type: String = "surveys"): List<StepExam>
+    @Query("SELECT * FROM exams WHERE type = :type AND isTeamShareAllowed = 0 AND (teamId IS NULL OR teamId = '')") suspend fun getIndividualSurveys(type: String = "surveys"): List<StepExam>
     @Query("DELETE FROM exams WHERE id = :id") suspend fun deleteById(id: String): Int
     @Upsert suspend fun upsert(item: StepExam)
     @Upsert suspend fun upsertAll(items: List<StepExam>)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -266,8 +266,7 @@ class SurveysRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getIndividualSurveys(): List<StepExam> {
-        return examDao.getByType("surveys")
-            .filter { !it.isTeamShareAllowed && it.teamId.isNullOrEmpty() }
+        return examDao.getIndividualSurveys()
     }
 
     private suspend fun getTeamSubmissionExamIds(teamId: String): Set<String> {

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/ExamDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/ExamDaoTest.kt
@@ -136,4 +136,43 @@ class ExamDaoTest {
         val resultWithoutExclusion = examDao.getAdoptableTeamSurveys()
         assertEquals(listOf("1", "2"), resultWithoutExclusion.map { it.id })
     }
+
+    @Test
+    fun getIndividualSurveys_filtersCorrectly() = runBlocking {
+        val exam1 = StepExam().apply {
+            id = "1"
+            type = "surveys"
+            isTeamShareAllowed = false
+            teamId = null
+        }
+        val exam2 = StepExam().apply {
+            id = "2"
+            type = "surveys"
+            isTeamShareAllowed = true
+            teamId = null
+        }
+        val exam3 = StepExam().apply {
+            id = "3"
+            type = "surveys"
+            isTeamShareAllowed = false
+            teamId = "team1"
+        }
+        val exam4 = StepExam().apply {
+            id = "4"
+            type = "surveys"
+            isTeamShareAllowed = false
+            teamId = ""
+        }
+        val exam5 = StepExam().apply {
+            id = "5"
+            type = "other"
+            isTeamShareAllowed = false
+            teamId = null
+        }
+
+        examDao.upsertAll(listOf(exam1, exam2, exam3, exam4, exam5))
+
+        val result = examDao.getIndividualSurveys()
+        assertEquals(listOf("1", "4"), result.map { it.id })
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
@@ -160,17 +160,16 @@ class SurveysRepositoryImplTest {
     }
 
     @Test
-    fun `getIndividualSurveys filters surveys without team and not shareable`() = runTest {
-        coEvery { examDao.getByType("surveys") } returns listOf(
-            StepExam(id = "survey1", isTeamShareAllowed = false, teamId = null), // Included
-            StepExam(id = "survey2", isTeamShareAllowed = true, teamId = null), // Excluded (shareable)
-            StepExam(id = "survey3", isTeamShareAllowed = false, teamId = "team1"), // Excluded (has teamId)
-            StepExam(id = "survey4", isTeamShareAllowed = false, teamId = "") // Included (empty teamId)
+    fun `getIndividualSurveys delegates to examDao`() = runTest {
+        val expected = listOf(
+            StepExam(id = "survey1", isTeamShareAllowed = false, teamId = null),
+            StepExam(id = "survey4", isTeamShareAllowed = false, teamId = "")
         )
+        coEvery { examDao.getIndividualSurveys() } returns expected
 
         val result = repository.getIndividualSurveys()
 
-        assertEquals(listOf("survey1", "survey4"), result.map { it.id })
+        assertEquals(expected, result)
     }
 
     @Test


### PR DESCRIPTION
This change filters individual surveys in Room instead of fetching all surveys and filtering them in Kotlin in SurveysRepositoryImpl.

- Added `getIndividualSurveys` query to `ExamDao` filtering by `type = :type AND isTeamShareAllowed = 0 AND (teamId IS NULL OR teamId = '')`.
- Updated `SurveysRepositoryImpl.getIndividualSurveys()` to delegate directly to `examDao.getIndividualSurveys()`.
- Updated repository unit tests and added Room DAO query test in `ExamDaoTest`.

Fixes #17049

---
*PR created automatically by Jules for task [9941909336418639181](https://jules.google.com/task/9941909336418639181) started by @dogi*