### PR TITLE
life: less view model application context is more (fixes #17054)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
@@ -83,7 +83,7 @@ class LifeFragment : BaseRecyclerFragment<MyLife?>(), OnStartDragListener {
         collectWhenStarted(viewModel.myLifeList) { list ->
             lifeAdapter.submitList(list)
         }
-        viewModel.loadMyLifeList()
+        viewModel.loadMyLifeList(requireContext()::getString)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeViewModel.kt
@@ -1,10 +1,8 @@
 package org.ole.planet.myplanet.ui.life
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +16,6 @@ import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class LifeViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val lifeRepository: LifeRepository,
     private val userRepository: UserRepository,
     private val dispatcherProvider: DispatcherProvider
@@ -33,11 +30,11 @@ class LifeViewModel @Inject constructor(
         return raw.takeIf { it.isNotBlank() && it != "--" }
     }
 
-    fun loadMyLifeList() {
+    fun loadMyLifeList(resolveLabel: (Int) -> String) {
         viewModelScope.launch {
             val list = withContext(dispatcherProvider.io) {
                 val userId = resolveUserId()
-                lifeRepository.getMyLifeByUserId(userId, MyLife.defaultItems(userId, context::getString))
+                lifeRepository.getMyLifeByUserId(userId, MyLife.defaultItems(userId, resolveLabel))
             }
             _myLifeList.value = list
         }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/life/LifeViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/life/LifeViewModelTest.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.ui.life
 
-import android.content.Context
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -24,22 +23,20 @@ import org.ole.planet.myplanet.utils.TestDispatcherProvider
 @OptIn(ExperimentalCoroutinesApi::class)
 class LifeViewModelTest {
 
-    private lateinit var context: Context
     private lateinit var lifeRepository: LifeRepository
     private lateinit var userRepository: UserRepository
     private lateinit var viewModel: LifeViewModel
     private val testDispatcher = StandardTestDispatcher()
     private val testDispatcherProvider = TestDispatcherProvider(testDispatcher)
+    private val labelResolver: (Int) -> String = { "mock_string_$it" }
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        context = mockk(relaxed = true)
         lifeRepository = mockk(relaxed = true)
         userRepository = mockk(relaxed = true)
 
         viewModel = LifeViewModel(
-            context,
             lifeRepository,
             userRepository,
             testDispatcherProvider
@@ -57,7 +54,7 @@ class LifeViewModelTest {
         val item = MyLife("img1", "user_123", "Item 1")
         coEvery { lifeRepository.getMyLifeByUserId("user_123", any()) } returns listOf(item)
 
-        viewModel.loadMyLifeList()
+        viewModel.loadMyLifeList(labelResolver)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf(item), viewModel.myLifeList.value)
@@ -72,12 +69,12 @@ class LifeViewModelTest {
         val defaults = slot<List<MyLife>>()
         coEvery { lifeRepository.getMyLifeByUserId("user_123", capture(defaults)) } returns listOf(item)
 
-        viewModel.loadMyLifeList()
+        viewModel.loadMyLifeList(labelResolver)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf(item), viewModel.myLifeList.value)
         assertEquals(
-            MyLife.defaultItems("user_123", context::getString).map { it.imageId },
+            MyLife.defaultItems("user_123", labelResolver).map { it.imageId },
             defaults.captured.map { it.imageId }
         )
         coVerify(exactly = 1) { lifeRepository.getMyLifeByUserId("user_123", any()) }
@@ -113,7 +110,7 @@ class LifeViewModelTest {
         val item = MyLife("img1", null, "Item 1")
         coEvery { lifeRepository.getMyLifeByUserId(null, any()) } returns listOf(item)
 
-        viewModel.loadMyLifeList()
+        viewModel.loadMyLifeList(labelResolver)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf(item), viewModel.myLifeList.value)
@@ -127,7 +124,7 @@ class LifeViewModelTest {
         coEvery { userRepository.getUserModel() } returns UserEntity("userFromRepo", name = "Test User")
         coEvery { lifeRepository.getMyLifeByUserId("userFromRepo", any()) } returns listOf(item)
 
-        viewModel.loadMyLifeList()
+        viewModel.loadMyLifeList(labelResolver)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf(item), viewModel.myLifeList.value)
@@ -140,7 +137,7 @@ class LifeViewModelTest {
         coEvery { userRepository.getUserModel() } returns null
         coEvery { lifeRepository.getMyLifeByUserId(null, any()) } returns emptyList()
 
-        viewModel.loadMyLifeList()
+        viewModel.loadMyLifeList(labelResolver)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(emptyList<MyLife>(), viewModel.myLifeList.value)


### PR DESCRIPTION
Removed `@ApplicationContext private val context: Context` from `LifeViewModel` constructor and updated `loadMyLifeList` to accept `resolveLabel: (Int) -> String`. Updated `LifeFragment` to pass `requireContext()::getString` when calling `loadMyLifeList`, and updated `LifeViewModelTest` to reflect these changes.

Fixes #17054

---
*PR created automatically by Jules for task [17471216513270375939](https://jules.google.com/task/17471216513270375939) started by @dogi*