### PR TITLE
enterprises: smoother finances reports file utils caching (fixes #17050)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AttachmentPresenceCache.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AttachmentPresenceCache.kt
@@ -1,0 +1,30 @@
+package org.ole.planet.myplanet.ui.enterprises
+
+import java.io.File
+
+class AttachmentPresenceCache(
+    private val ttlMs: Long = DEFAULT_TTL_MS
+) {
+    private val cache = HashMap<String, Pair<Boolean, Long>>()
+
+    fun clear() {
+        cache.clear()
+    }
+
+    fun exists(file: File?, now: Long): Boolean {
+        if (file == null) return false
+        val path = file.absolutePath
+        val cached = cache[path]
+        return if (cached != null && now - cached.second < ttlMs) {
+            cached.first
+        } else {
+            val freshExists = file.exists()
+            cache[path] = Pair(freshExists, now)
+            freshExists
+        }
+    }
+
+    companion object {
+        const val DEFAULT_TTL_MS = 5000L
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
@@ -30,15 +30,14 @@ class EnterprisesFinancesAdapter(
         areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
     )
 ) {
-    private val attachmentExistsCache = HashMap<String, Pair<Boolean, Long>>()
-    private val cacheTtlMs = 5000L
+    private val attachmentPresenceCache = AttachmentPresenceCache()
 
     override fun onCurrentListChanged(
         previousList: MutableList<Transaction>,
         currentList: MutableList<Transaction>
     ) {
         super.onCurrentListChanged(previousList, currentList)
-        attachmentExistsCache.clear()
+        attachmentPresenceCache.clear()
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FinanceViewHolder {
@@ -71,19 +70,7 @@ class EnterprisesFinancesAdapter(
 
     private fun bindFinanceImage(binding: RowFinanceBinding, item: Transaction) {
         val imageFile = MyTeam.getAttachmentFile(context, item.id, item.imageName)
-        val now = timeProvider.now()
-        val exists = if (imageFile != null) {
-            val cached = attachmentExistsCache[imageFile.absolutePath]
-            if (cached != null && now - cached.second < cacheTtlMs) {
-                cached.first
-            } else {
-                val freshExists = imageFile.exists()
-                attachmentExistsCache[imageFile.absolutePath] = Pair(freshExists, now)
-                freshExists
-            }
-        } else {
-            false
-        }
+        val exists = attachmentPresenceCache.exists(imageFile, timeProvider.now())
 
         if (imageFile != null && exists) {
             binding.financeImage.visibility = View.VISIBLE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsAdapter.kt
@@ -24,15 +24,14 @@ class EnterprisesReportsAdapter(
     private val timeProvider: TimeProvider = SystemTimeProvider(),
 ) : ListAdapter<MyTeam, EnterprisesReportsAdapter.ReportsViewHolder>(diffCallback) {
     private var nonTeamMember = false
-    private val attachmentExistsCache = HashMap<String, Pair<Boolean, Long>>()
-    private val cacheTtlMs = 5000L
+    private val attachmentPresenceCache = AttachmentPresenceCache()
 
     override fun onCurrentListChanged(
         previousList: MutableList<MyTeam>,
         currentList: MutableList<MyTeam>
     ) {
         super.onCurrentListChanged(previousList, currentList)
-        attachmentExistsCache.clear()
+        attachmentPresenceCache.clear()
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReportsViewHolder {
@@ -107,19 +106,7 @@ class EnterprisesReportsAdapter(
 
     private fun bindReportImage(binding: ReportListItemBinding, report: MyTeam) {
         val imageFile = MyTeam.getAttachmentFile(context, report._id, report.imageName)
-        val now = timeProvider.now()
-        val exists = if (imageFile != null) {
-            val cached = attachmentExistsCache[imageFile.absolutePath]
-            if (cached != null && now - cached.second < cacheTtlMs) {
-                cached.first
-            } else {
-                val freshExists = imageFile.exists()
-                attachmentExistsCache[imageFile.absolutePath] = Pair(freshExists, now)
-                freshExists
-            }
-        } else {
-            false
-        }
+        val exists = attachmentPresenceCache.exists(imageFile, timeProvider.now())
 
         if (imageFile != null && exists) {
             binding.reportImage.visibility = View.VISIBLE

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/AttachmentPresenceCacheTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/AttachmentPresenceCacheTest.kt
@@ -1,0 +1,58 @@
+package org.ole.planet.myplanet.ui.enterprises
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class AttachmentPresenceCacheTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var cache: AttachmentPresenceCache
+
+    @Before
+    fun setUp() {
+        cache = AttachmentPresenceCache(ttlMs = 5000L)
+    }
+
+    @Test
+    fun testExists_nullFile_returnsFalse() {
+        assertFalse(cache.exists(null, now = 1000L))
+    }
+
+    @Test
+    fun testExists_cachesResultAndHonorsTtl() {
+        val testFile = tempFolder.newFile("test.txt")
+
+        // First check when file exists -> true
+        assertTrue(cache.exists(testFile, now = 1000L))
+
+        // Delete file on disk
+        testFile.delete()
+
+        // Within TTL (1000L + 4999L < 5000L TTL end at 6000L) -> returns cached true
+        assertTrue(cache.exists(testFile, now = 5999L))
+
+        // After TTL (1000L + 5000L = 6000L) -> re-checks disk and returns false
+        assertFalse(cache.exists(testFile, now = 6000L))
+    }
+
+    @Test
+    fun testClear_invalidatesCache() {
+        val testFile = tempFolder.newFile("test_clear.txt")
+
+        assertTrue(cache.exists(testFile, now = 1000L))
+
+        testFile.delete()
+
+        // Clearing cache forces fresh stat on disk
+        cache.clear()
+
+        assertFalse(cache.exists(testFile, now = 2000L))
+    }
+}


### PR DESCRIPTION
Extract AttachmentPresenceCache to de-duplicate attachment presence caching logic between EnterprisesFinancesAdapter and EnterprisesReportsAdapter.

Fixes #17050

---
*PR created automatically by Jules for task [8550359493043568357](https://jules.google.com/task/8550359493043568357) started by @dogi*