### PR TITLE
sync: smoother repository elapsed time providing (fixes #17048)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -74,6 +74,14 @@ object ServiceModule {
 
     @Provides
     @Singleton
+    fun provideUserDataUploadScheduler(
+        @ApplicationContext context: Context
+    ): org.ole.planet.myplanet.services.sync.UserDataUploadScheduler {
+        return org.ole.planet.myplanet.services.sync.UserDataUploadSchedulerImpl(context)
+    }
+
+    @Provides
+    @Singleton
     fun provideTransactionSyncManager(
         apiInterface: ApiInterface,
         @ApplicationContext context: Context,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SyncRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SyncRepositoryImpl.kt
@@ -1,16 +1,8 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
-import android.os.SystemClock
 import android.util.Log
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkInfo
-import androidx.work.WorkManager
-import androidx.work.workDataOf
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.async
@@ -18,7 +10,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.api.ApiClient
 import org.ole.planet.myplanet.data.api.ApiInterface
@@ -26,6 +17,7 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserDataWorker
 import org.ole.planet.myplanet.services.sync.AdaptiveBatchProcessor
 import org.ole.planet.myplanet.services.sync.TransactionSyncManager
+import org.ole.planet.myplanet.services.sync.UserDataUploadScheduler
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils.getJsonArray
@@ -37,7 +29,6 @@ import org.ole.planet.myplanet.utils.UrlUtils
 
 @Singleton
 class SyncRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val apiInterface: ApiInterface,
     private val dispatcherProvider: DispatcherProvider,
     private val resourcesRepository: ResourcesRepository,
@@ -47,7 +38,8 @@ class SyncRepositoryImpl @Inject constructor(
     private val transactionSyncManager: dagger.Lazy<TransactionSyncManager>,
     private val syncTimeLogger: SyncTimeLogger,
     private val sharedPrefManager: SharedPrefManager,
-    private val timeProvider: TimeProvider
+    private val timeProvider: TimeProvider,
+    private val userDataUploadScheduler: UserDataUploadScheduler
 ) : SyncRepository {
 
     private val shelfDispatchMap: Map<String, suspend (String?, List<JsonObject>) -> Int> by lazy {
@@ -58,39 +50,12 @@ class SyncRepositoryImpl @Inject constructor(
             "teams" to { _, docs -> teamsSyncRepository.batchInsertMyTeams(docs) }
         )
     }
+
     override fun uploadLoginData(): Flow<SyncUiState> =
-        enqueueUserDataUpload("UploadUserData_Login", UserDataWorker.UPLOAD_TYPE_LOGIN)
+        userDataUploadScheduler.enqueueUserDataUpload("UploadUserData_Login", UserDataWorker.UPLOAD_TYPE_LOGIN)
 
     override fun uploadBulkData(): Flow<SyncUiState> =
-        enqueueUserDataUpload("UploadUserData_Bulk", UserDataWorker.UPLOAD_TYPE_BULK)
-
-    private fun enqueueUserDataUpload(uniqueWorkName: String, uploadType: String): Flow<SyncUiState> {
-        val workRequest = OneTimeWorkRequest.Builder(UserDataWorker::class.java)
-            .setInputData(workDataOf(UserDataWorker.KEY_UPLOAD_TYPE to uploadType))
-            .build()
-        val workManager = WorkManager.getInstance(context)
-        workManager.enqueueUniqueWork(
-            uniqueWorkName,
-            ExistingWorkPolicy.REPLACE,
-            workRequest
-        )
-        return workManager.getWorkInfoByIdFlow(workRequest.id).map { workInfo ->
-            mapWorkInfoToState(workInfo)
-        }
-    }
-
-    private fun mapWorkInfoToState(workInfo: WorkInfo?): SyncUiState {
-        return when (workInfo?.state) {
-            WorkInfo.State.SUCCEEDED -> {
-                val message = workInfo.outputData.getString(UserDataWorker.KEY_SUCCESS_MESSAGE)
-                SyncUiState.Success(message)
-            }
-            WorkInfo.State.FAILED -> SyncUiState.Error("Upload failed")
-            WorkInfo.State.CANCELLED -> SyncUiState.Error("Upload cancelled")
-            WorkInfo.State.RUNNING -> SyncUiState.Loading
-            else -> SyncUiState.Idle
-        }
-    }
+        userDataUploadScheduler.enqueueUserDataUpload("UploadUserData_Bulk", UserDataWorker.UPLOAD_TYPE_BULK)
 
     override suspend fun processShelfParallel(shelfId: String): Int {
         var processedItems = 0
@@ -156,7 +121,7 @@ class SyncRepositoryImpl @Inject constructor(
 
             while (i < validIds.size) {
                 batchNum++
-                val batchStartTime = SystemClock.elapsedRealtime()
+                val batchStartTime = timeProvider.elapsedRealtime()
 
                 val end = minOf(i + batchSizer.currentSize, validIds.size)
                 val batch = validIds.subList(i, end)
@@ -166,14 +131,14 @@ class SyncRepositoryImpl @Inject constructor(
                 keysObject.add("keys", gson.toJsonTree(batch))
 
                 // API call
-                val apiStartTime = SystemClock.elapsedRealtime()
+                val apiStartTime = timeProvider.elapsedRealtime()
                 var response: JsonObject? = null
                 ApiClient.executeWithRetryAndWrap {
                     apiInterface.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject)
                 }?.let {
                     response = it.body()
                 }
-                val apiDuration = SystemClock.elapsedRealtime() - apiStartTime
+                val apiDuration = timeProvider.elapsedRealtime() - apiStartTime
 
                 if (response == null) {
                     batchSizer.recordFailure()
@@ -197,16 +162,16 @@ class SyncRepositoryImpl @Inject constructor(
                 }
 
                 if (documentsToProcess.isNotEmpty()) {
-                    val realmStartTime = SystemClock.elapsedRealtime()
+                    val realmStartTime = timeProvider.elapsedRealtime()
                     val handler = shelfDispatchMap[shelfData.type]
                     if (handler != null) {
                         processedCount += handler(shelfId, documentsToProcess)
                     }
-                    val realmDuration = SystemClock.elapsedRealtime() - realmStartTime
+                    val realmDuration = timeProvider.elapsedRealtime() - realmStartTime
                     logger.logDbOperation("shelf_insert", shelfData.type, realmDuration, documentsToProcess.size)
                 }
 
-                val batchDuration = SystemClock.elapsedRealtime() - batchStartTime
+                val batchDuration = timeProvider.elapsedRealtime() - batchStartTime
                 if (batchDuration > 1000) {
                     logger.logDetail("shelf_sync", "Shelf $shelfId ${shelfData.type} batch $batchNum ($end/${validIds.size} ids): ${batchDuration}ms for ${documentsToProcess.size} docs")
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/UserDataUploadScheduler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/UserDataUploadScheduler.kt
@@ -1,0 +1,53 @@
+package org.ole.planet.myplanet.services.sync
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.ole.planet.myplanet.repository.SyncUiState
+import org.ole.planet.myplanet.services.UserDataWorker
+
+interface UserDataUploadScheduler {
+    fun enqueueUserDataUpload(uniqueWorkName: String, uploadType: String): Flow<SyncUiState>
+}
+
+@Singleton
+class UserDataUploadSchedulerImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : UserDataUploadScheduler {
+
+    override fun enqueueUserDataUpload(uniqueWorkName: String, uploadType: String): Flow<SyncUiState> {
+        val workRequest = OneTimeWorkRequest.Builder(UserDataWorker::class.java)
+            .setInputData(workDataOf(UserDataWorker.KEY_UPLOAD_TYPE to uploadType))
+            .build()
+        val workManager = WorkManager.getInstance(context)
+        workManager.enqueueUniqueWork(
+            uniqueWorkName,
+            ExistingWorkPolicy.REPLACE,
+            workRequest
+        )
+        return workManager.getWorkInfoByIdFlow(workRequest.id).map { workInfo ->
+            mapWorkInfoToState(workInfo)
+        }
+    }
+
+    private fun mapWorkInfoToState(workInfo: WorkInfo?): SyncUiState {
+        return when (workInfo?.state) {
+            WorkInfo.State.SUCCEEDED -> {
+                val message = workInfo.outputData.getString(UserDataWorker.KEY_SUCCESS_MESSAGE)
+                SyncUiState.Success(message)
+            }
+            WorkInfo.State.FAILED -> SyncUiState.Error("Upload failed")
+            WorkInfo.State.CANCELLED -> SyncUiState.Error("Upload cancelled")
+            WorkInfo.State.RUNNING -> SyncUiState.Loading
+            else -> SyncUiState.Idle
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/utils/TimeProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/TimeProvider.kt
@@ -8,8 +8,11 @@ package org.ole.planet.myplanet.utils
  * elapsed durations within a single process, use android.os.SystemClock.elapsedRealtime()
  * directly instead — it is monotonic and immune to wall-clock jumps.
  */
+import android.os.SystemClock
+
 interface TimeProvider {
     fun now(): Long
+    fun elapsedRealtime(): Long
     fun sleep(millis: Long) {
         Thread.sleep(millis)
     }
@@ -17,6 +20,7 @@ interface TimeProvider {
 
 class SystemTimeProvider : TimeProvider {
     override fun now(): Long = System.currentTimeMillis()
+    override fun elapsedRealtime(): Long = SystemClock.elapsedRealtime()
     override fun sleep(millis: Long) {
         Thread.sleep(millis)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SyncRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SyncRepositoryImplTest.kt
@@ -1,7 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
-import android.os.SystemClock
 import android.util.Log
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -12,7 +10,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -22,11 +22,14 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.services.UserDataWorker
 import org.ole.planet.myplanet.services.sync.TransactionSyncManager
+import org.ole.planet.myplanet.services.sync.UserDataUploadScheduler
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.SyncTimeLogger
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import retrofit2.Response
@@ -34,7 +37,6 @@ import retrofit2.Response
 @OptIn(ExperimentalCoroutinesApi::class)
 class SyncRepositoryImplTest {
 
-    private val context: Context = mockk(relaxed = true)
     private val apiInterface: ApiInterface = mockk(relaxed = true)
     private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
     private val dispatcherProvider: DispatcherProvider = TestDispatcherProvider(testDispatcher)
@@ -44,6 +46,7 @@ class SyncRepositoryImplTest {
     private val teamsSyncRepository: TeamsSyncRepository = mockk(relaxed = true)
     private val transactionSyncManager: dagger.Lazy<TransactionSyncManager> = mockk(relaxed = true)
     private val syncTimeLogger: SyncTimeLogger = mockk(relaxed = true)
+    private val userDataUploadScheduler: UserDataUploadScheduler = mockk(relaxed = true)
 
     private lateinit var sharedPrefManager: SharedPrefManager
     private lateinit var timeProvider: TimeProvider
@@ -61,11 +64,8 @@ class SyncRepositoryImplTest {
         every { Log.d(any(), any()) } returns 0
         every { Log.i(any(), any()) } returns 0
 
-        mockkStatic(SystemClock::class)
-        every { SystemClock.elapsedRealtime() } returns 1000L
-
         sharedPrefManager = mockk(relaxed = true)
-        timeProvider = mockk(relaxed = true)
+        timeProvider = TestTimeProvider(1000L)
 
         storedStringMap.clear()
         storedLongMap.clear()
@@ -97,7 +97,6 @@ class SyncRepositoryImplTest {
         UrlUtils.init(sharedPrefManager)
 
         syncRepository = SyncRepositoryImpl(
-            context = context,
             apiInterface = apiInterface,
             dispatcherProvider = dispatcherProvider,
             resourcesRepository = resourcesRepository,
@@ -107,7 +106,8 @@ class SyncRepositoryImplTest {
             transactionSyncManager = transactionSyncManager,
             syncTimeLogger = syncTimeLogger,
             sharedPrefManager = sharedPrefManager,
-            timeProvider = timeProvider
+            timeProvider = timeProvider,
+            userDataUploadScheduler = userDataUploadScheduler
         )
     }
 
@@ -115,6 +115,36 @@ class SyncRepositoryImplTest {
     fun tearDown() {
         UrlUtils.resetForTesting()
         unmockkAll()
+    }
+
+    @Test
+    fun `uploadLoginData delegates to UserDataUploadScheduler`() {
+        val expectedFlow = flowOf(SyncUiState.Loading)
+        every {
+            userDataUploadScheduler.enqueueUserDataUpload("UploadUserData_Login", UserDataWorker.UPLOAD_TYPE_LOGIN)
+        } returns expectedFlow
+
+        val result = syncRepository.uploadLoginData()
+
+        assertEquals(expectedFlow, result)
+        verify(exactly = 1) {
+            userDataUploadScheduler.enqueueUserDataUpload("UploadUserData_Login", UserDataWorker.UPLOAD_TYPE_LOGIN)
+        }
+    }
+
+    @Test
+    fun `uploadBulkData delegates to UserDataUploadScheduler`() {
+        val expectedFlow = flowOf(SyncUiState.Loading)
+        every {
+            userDataUploadScheduler.enqueueUserDataUpload("UploadUserData_Bulk", UserDataWorker.UPLOAD_TYPE_BULK)
+        } returns expectedFlow
+
+        val result = syncRepository.uploadBulkData()
+
+        assertEquals(expectedFlow, result)
+        verify(exactly = 1) {
+            userDataUploadScheduler.enqueueUserDataUpload("UploadUserData_Bulk", UserDataWorker.UPLOAD_TYPE_BULK)
+        }
     }
 
     @Test
@@ -214,7 +244,7 @@ class SyncRepositoryImplTest {
     fun `getCachedShelvesWithData returns stored list when cache is within 6 hours`() {
         val now = 1000000000000L
         val cacheTime = now - (5 * 60 * 60 * 1000L) // 5 hours ago
-        every { timeProvider.now() } returns now
+        (timeProvider as TestTimeProvider).currentTime = now
 
         storedLongMap["shelves_cache_time"] = cacheTime
         storedStringMap["shelves_with_data"] = "shelf1,shelf2,shelf3"
@@ -228,7 +258,7 @@ class SyncRepositoryImplTest {
     fun `getCachedShelvesWithData returns empty list when cache is older than 6 hours`() {
         val now = 1000000000000L
         val cacheTime = now - (6 * 60 * 60 * 1000L + 1L) // 6 hours and 1 millisecond ago
-        every { timeProvider.now() } returns now
+        (timeProvider as TestTimeProvider).currentTime = now
 
         storedLongMap["shelves_cache_time"] = cacheTime
         storedStringMap["shelves_with_data"] = "shelf1,shelf2,shelf3"
@@ -241,7 +271,7 @@ class SyncRepositoryImplTest {
     @Test
     fun `getCachedShelvesWithData returns empty list when cache time is not set`() {
         val now = 1000000000000L
-        every { timeProvider.now() } returns now
+        (timeProvider as TestTimeProvider).currentTime = now
 
         val result = syncRepository.getCachedShelvesWithData()
 
@@ -251,7 +281,7 @@ class SyncRepositoryImplTest {
     @Test
     fun `cacheShelvesWithData stores comma joined string and current timestamp`() {
         val now = 1000000000000L
-        every { timeProvider.now() } returns now
+        (timeProvider as TestTimeProvider).currentTime = now
 
         val shelves = listOf("shelf_a", "shelf_b", "shelf_c")
         syncRepository.cacheShelvesWithData(shelves)
@@ -263,7 +293,7 @@ class SyncRepositoryImplTest {
     @Test
     fun `roundtrip caching and retrieving preserves shelf list`() {
         val now = 1000000000000L
-        every { timeProvider.now() } returns now
+        (timeProvider as TestTimeProvider).currentTime = now
 
         val inputShelves = listOf("shelf_1", "shelf_2", "shelf_3")
         syncRepository.cacheShelvesWithData(inputShelves)

--- a/app/src/test/java/org/ole/planet/myplanet/utils/TestTimeProvider.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/TestTimeProvider.kt
@@ -4,6 +4,8 @@ package org.ole.planet.myplanet.utils
 class TestTimeProvider(var currentTime: Long = 0L) : TimeProvider {
     override fun now(): Long = currentTime
 
+    override fun elapsedRealtime(): Long = currentTime
+
     override fun sleep(millis: Long) {
         advanceBy(millis)
     }


### PR DESCRIPTION
Peeled WorkManager, Context, and SystemClock out of SyncRepositoryImpl.

- Added `elapsedRealtime(): Long` to `TimeProvider`, `SystemTimeProvider` (calling `SystemClock.elapsedRealtime()`), and `TestTimeProvider` (returning deterministic `currentTime`).
- Replaced all `SystemClock.elapsedRealtime()` calls in `SyncRepositoryImpl` with `timeProvider.elapsedRealtime()`.
- Created `UserDataUploadScheduler` interface and `UserDataUploadSchedulerImpl` to handle WorkManager enqueueing and WorkInfo state mapping.
- Injected `UserDataUploadScheduler` into `SyncRepositoryImpl` and registered `UserDataUploadSchedulerImpl` in Hilt `ServiceModule`.
- Updated `SyncRepositoryImplTest` to verify flow delegation and passing unit tests without needing Android Context or WorkManager mocks.

Fixes #17048

---
*PR created automatically by Jules for task [14081529859136055422](https://jules.google.com/task/14081529859136055422) started by @dogi*