### PR TITLE
login: smoother server config shared preferences managing (fixes #17047)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
@@ -201,6 +201,73 @@ class SharedPrefManager @Inject constructor(
         UrlUtils.invalidateCaches()
     }
 
+    fun saveServerConfig(
+        serverPin: String,
+        urlScheme: String,
+        urlHost: String,
+        serverUrl: String,
+        couchdbUrl: String,
+        urlUser: String,
+        urlPwd: String
+    ) {
+        pref.edit {
+            putString(SERVER_PIN, serverPin)
+            putString(URL_SCHEME, urlScheme)
+            putString(URL_HOST, urlHost)
+            putString(SERVER_URL, serverUrl)
+            putString(COUCHDB_URL, couchdbUrl)
+            putString(URL_USER, urlUser)
+            putString(URL_PWD, urlPwd)
+        }
+        UrlUtils.invalidateCaches()
+    }
+
+    fun saveAlternativeServerConfig(
+        serverPin: String,
+        urlUser: String,
+        urlPwd: String,
+        urlScheme: String,
+        urlHost: String,
+        alternativeUrl: String,
+        processedAlternativeUrl: String,
+        isAlternativeUrl: Boolean = true
+    ) {
+        pref.edit {
+            putString(SERVER_PIN, serverPin)
+            putString(URL_USER, urlUser)
+            putString(URL_PWD, urlPwd)
+            putString(URL_SCHEME, urlScheme)
+            putString(URL_HOST, urlHost)
+            putString(ALTERNATIVE_URL, alternativeUrl)
+            putString(PROCESSED_ALTERNATIVE_URL, processedAlternativeUrl)
+            putBoolean(IS_ALTERNATIVE_URL, isAlternativeUrl)
+        }
+        UrlUtils.invalidateCaches()
+    }
+
+    fun saveUserInfo(
+        userId: String,
+        userName: String,
+        firstName: String?,
+        lastName: String?,
+        middleName: String?,
+        isUserAdmin: Boolean?,
+        lastLogin: Long
+    ) {
+        pref.edit {
+            putString(USER_ID, userId)
+            putString(USER_NAME, userName)
+            remove("password")
+            putString("firstName", firstName)
+            putString("lastName", lastName)
+            putString("middleName", middleName)
+            if (isUserAdmin != null) {
+                putBoolean("isUserAdmin", isUserAdmin)
+            }
+            putLong("lastLogin", lastLogin)
+        }
+    }
+
     fun getPinnedServerUrl(): String? = pref.getString(PINNED_SERVER_URL, null)
     fun setPinnedServerUrl(url: String) = pref.edit { putString(PINNED_SERVER_URL, url) }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -33,17 +33,15 @@ class UserSessionManager @Inject constructor(
         withContext(dispatcherProvider.io) {
             SecurePrefs.saveCredentials(context, sharedPrefManager.rawPreferences, user?.name, password)
         }
-        sharedPrefManager.setUserId(user?.id ?: "")
-        sharedPrefManager.setUserName(user?.name ?: "")
-        sharedPrefManager.rawPreferences.edit().apply {
-            remove("password")
-            putString("firstName", user?.firstName)
-            putString("lastName", user?.lastName)
-            putString("middleName", user?.middleName)
-            user?.userAdmin?.let { putBoolean("isUserAdmin", it) }
-            putLong("lastLogin", timeProvider.now())
-            apply()
-        }
+        sharedPrefManager.saveUserInfo(
+            userId = user?.id ?: "",
+            userName = user?.name ?: "",
+            firstName = user?.firstName,
+            lastName = user?.lastName,
+            middleName = user?.middleName,
+            isUserAdmin = user?.userAdmin,
+            lastLogin = timeProvider.now()
+        )
     }
 
     fun onLogin() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -138,13 +138,15 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
             couchdbURL = "${uri.scheme}://$urlUser:$urlPwd@${uri.host}:$port"
         }
 
-        prefData.setServerPin(password)
-        prefData.setUrlScheme(uri.scheme ?: "")
-        prefData.setUrlHost(uri.host ?: "")
-        prefData.setServerUrl(url)
-        prefData.setCouchdbUrl(couchdbURL)
-        prefData.setUrlUser(urlUser)
-        prefData.setUrlPwd(urlPwd)
+        prefData.saveServerConfig(
+            serverPin = password,
+            urlScheme = uri.scheme ?: "",
+            urlHost = uri.host ?: "",
+            serverUrl = url,
+            couchdbUrl = couchdbURL,
+            urlUser = urlUser,
+            urlPwd = urlPwd
+        )
 
         return UrlUtils.dbUrl(couchdbURL)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ServerConfigUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ServerConfigUtils.kt
@@ -110,14 +110,16 @@ object ServerConfigUtils {
             Triple(user, password, dbUrl)
         }
 
-        sharedPrefManager.setServerPin(password)
-        sharedPrefManager.setUrlUser(urlUser)
-        sharedPrefManager.setUrlPwd(urlPwd)
-        sharedPrefManager.setUrlScheme(uri.scheme ?: "")
-        sharedPrefManager.setUrlHost(uri.host ?: "")
-        sharedPrefManager.setAlternativeUrl(url)
-        sharedPrefManager.setProcessedAlternativeUrl(couchdbURL)
-        sharedPrefManager.setIsAlternativeUrl(true)
+        sharedPrefManager.saveAlternativeServerConfig(
+            serverPin = password,
+            urlUser = urlUser,
+            urlPwd = urlPwd,
+            urlScheme = uri.scheme ?: "",
+            urlHost = uri.host ?: "",
+            alternativeUrl = url,
+            processedAlternativeUrl = couchdbURL,
+            isAlternativeUrl = true
+        )
 
         return couchdbURL
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -270,4 +270,88 @@ class SharedPrefManagerTest {
         unmockkObject(org.ole.planet.myplanet.utils.UrlUtils)
     }
 
+    @Test
+    fun testSaveServerConfig() {
+        mockkObject(org.ole.planet.myplanet.utils.UrlUtils)
+        every { org.ole.planet.myplanet.utils.UrlUtils.invalidateCaches() } just Runs
+
+        sharedPrefManager.saveServerConfig(
+            serverPin = "1234",
+            urlScheme = "http",
+            urlHost = "host.com",
+            serverUrl = "http://host.com",
+            couchdbUrl = "http://satellite:1234@host.com:80",
+            urlUser = "satellite",
+            urlPwd = "1234"
+        )
+
+        verify(exactly = 1) { mockSharedPreferences.edit() }
+        verify { mockEditor.putString("serverPin", "1234") }
+        verify { mockEditor.putString("url_Scheme", "http") }
+        verify { mockEditor.putString("url_Host", "host.com") }
+        verify { mockEditor.putString("serverURL", "http://host.com") }
+        verify { mockEditor.putString("couchdbURL", "http://satellite:1234@host.com:80") }
+        verify { mockEditor.putString("url_user", "satellite") }
+        verify { mockEditor.putString("url_pwd", "1234") }
+        verify { mockEditor.apply() }
+        verify(exactly = 1) { org.ole.planet.myplanet.utils.UrlUtils.invalidateCaches() }
+
+        unmockkObject(org.ole.planet.myplanet.utils.UrlUtils)
+    }
+
+    @Test
+    fun testSaveAlternativeServerConfig() {
+        mockkObject(org.ole.planet.myplanet.utils.UrlUtils)
+        every { org.ole.planet.myplanet.utils.UrlUtils.invalidateCaches() } just Runs
+
+        sharedPrefManager.saveAlternativeServerConfig(
+            serverPin = "5678",
+            urlUser = "admin",
+            urlPwd = "pass",
+            urlScheme = "https",
+            urlHost = "alt.com",
+            alternativeUrl = "https://alt.com",
+            processedAlternativeUrl = "https://admin:pass@alt.com:443",
+            isAlternativeUrl = true
+        )
+
+        verify(exactly = 1) { mockSharedPreferences.edit() }
+        verify { mockEditor.putString("serverPin", "5678") }
+        verify { mockEditor.putString("url_user", "admin") }
+        verify { mockEditor.putString("url_pwd", "pass") }
+        verify { mockEditor.putString("url_Scheme", "https") }
+        verify { mockEditor.putString("url_Host", "alt.com") }
+        verify { mockEditor.putString("alternativeUrl", "https://alt.com") }
+        verify { mockEditor.putString("processedAlternativeUrl", "https://admin:pass@alt.com:443") }
+        verify { mockEditor.putBoolean("isAlternativeUrl", true) }
+        verify { mockEditor.apply() }
+        verify(exactly = 1) { org.ole.planet.myplanet.utils.UrlUtils.invalidateCaches() }
+
+        unmockkObject(org.ole.planet.myplanet.utils.UrlUtils)
+    }
+
+    @Test
+    fun testSaveUserInfo() {
+        sharedPrefManager.saveUserInfo(
+            userId = "usr123",
+            userName = "john_doe",
+            firstName = "John",
+            lastName = "Doe",
+            middleName = "M",
+            isUserAdmin = true,
+            lastLogin = 1000L
+        )
+
+        verify(exactly = 1) { mockSharedPreferences.edit() }
+        verify { mockEditor.putString("userId", "usr123") }
+        verify { mockEditor.putString("name", "john_doe") }
+        verify { mockEditor.remove("password") }
+        verify { mockEditor.putString("firstName", "John") }
+        verify { mockEditor.putString("lastName", "Doe") }
+        verify { mockEditor.putString("middleName", "M") }
+        verify { mockEditor.putBoolean("isUserAdmin", true) }
+        verify { mockEditor.putLong("lastLogin", 1000L) }
+        verify { mockEditor.apply() }
+    }
+
 }

--- a/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
@@ -314,7 +314,7 @@ class UserSessionManagerTest {
                 lastName = "Doe",
                 middleName = "A",
                 isUserAdmin = false,
-                lastLogin = 1000L
+                lastLogin = 0L
             )
         }
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
@@ -2,11 +2,15 @@ package org.ole.planet.myplanet.services
 
 import android.content.Context
 import android.util.Log
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -281,5 +285,39 @@ class UserSessionManagerTest {
         advanceUntilIdle()
 
         verify { Log.e("UserSessionManager", "Error in setResourceOpenCount", any()) }
+    }
+
+    @Test
+    fun `saveUserInfoPref saves credentials and updates user info via SharedPrefManager`() = testScope.runTest {
+        mockkObject(org.ole.planet.myplanet.utils.SecurePrefs)
+        every { org.ole.planet.myplanet.utils.SecurePrefs.saveCredentials(any(), any(), any(), any()) } just Runs
+
+        val user = UserEntity(
+            id = "u123",
+            name = "johndoe",
+            firstName = "John",
+            lastName = "Doe",
+            middleName = "A",
+            userAdmin = false
+        )
+
+        userSessionManager.saveUserInfoPref("secret", user)
+
+        coVerify {
+            org.ole.planet.myplanet.utils.SecurePrefs.saveCredentials(context, sharedPrefManager.rawPreferences, "johndoe", "secret")
+        }
+        verify {
+            sharedPrefManager.saveUserInfo(
+                userId = "u123",
+                userName = "johndoe",
+                firstName = "John",
+                lastName = "Doe",
+                middleName = "A",
+                isUserAdmin = false,
+                lastLogin = 1000L
+            )
+        }
+
+        unmockkObject(org.ole.planet.myplanet.utils.SecurePrefs)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
@@ -156,7 +156,7 @@ class ServerConfigUtilsTest {
                 urlScheme = "",
                 urlHost = "",
                 alternativeUrl = url,
-                processedAlternativeUrl = "://satellite:testPassword@:443",
+                processedAlternativeUrl = "null://satellite:testPassword@null:443",
                 isAlternativeUrl = true
             )
         }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
@@ -32,14 +32,18 @@ class ServerConfigUtilsTest {
         val expectedDbUrl = "http://satellite:testPassword@demo.ole.org:80"
         assertEquals(expectedDbUrl, result)
 
-        verify { mockSharedPrefManager.setServerPin(password) }
-        verify { mockSharedPrefManager.setUrlUser("satellite") }
-        verify { mockSharedPrefManager.setUrlPwd(password) }
-        verify { mockSharedPrefManager.setUrlScheme("http") }
-        verify { mockSharedPrefManager.setUrlHost("demo.ole.org") }
-        verify { mockSharedPrefManager.setAlternativeUrl(url) }
-        verify { mockSharedPrefManager.setProcessedAlternativeUrl(expectedDbUrl) }
-        verify { mockSharedPrefManager.setIsAlternativeUrl(true) }
+        verify {
+            mockSharedPrefManager.saveAlternativeServerConfig(
+                serverPin = password,
+                urlUser = "satellite",
+                urlPwd = password,
+                urlScheme = "http",
+                urlHost = "demo.ole.org",
+                alternativeUrl = url,
+                processedAlternativeUrl = expectedDbUrl,
+                isAlternativeUrl = true
+            )
+        }
     }
 
     @Test
@@ -52,14 +56,18 @@ class ServerConfigUtilsTest {
         assertEquals(url, result)
 
         // Note: The pin uses the provided password parameter, while the URL password ("admin123") is extracted for setUrlPwd.
-        verify { mockSharedPrefManager.setServerPin(password) }
-        verify { mockSharedPrefManager.setUrlUser("admin") }
-        verify { mockSharedPrefManager.setUrlPwd("admin123") }
-        verify { mockSharedPrefManager.setUrlScheme("http") }
-        verify { mockSharedPrefManager.setUrlHost("demo.ole.org") }
-        verify { mockSharedPrefManager.setAlternativeUrl(url) }
-        verify { mockSharedPrefManager.setProcessedAlternativeUrl(url) }
-        verify { mockSharedPrefManager.setIsAlternativeUrl(true) }
+        verify {
+            mockSharedPrefManager.saveAlternativeServerConfig(
+                serverPin = password,
+                urlUser = "admin",
+                urlPwd = "admin123",
+                urlScheme = "http",
+                urlHost = "demo.ole.org",
+                alternativeUrl = url,
+                processedAlternativeUrl = url,
+                isAlternativeUrl = true
+            )
+        }
     }
 
     @Test
@@ -72,8 +80,18 @@ class ServerConfigUtilsTest {
         val expectedDbUrl = "https://satellite:testPassword@demo.ole.org:443"
         assertEquals(expectedDbUrl, result)
 
-        verify { mockSharedPrefManager.setUrlScheme("https") }
-        verify { mockSharedPrefManager.setProcessedAlternativeUrl(expectedDbUrl) }
+        verify {
+            mockSharedPrefManager.saveAlternativeServerConfig(
+                serverPin = password,
+                urlUser = "satellite",
+                urlPwd = password,
+                urlScheme = "https",
+                urlHost = "demo.ole.org",
+                alternativeUrl = url,
+                processedAlternativeUrl = expectedDbUrl,
+                isAlternativeUrl = true
+            )
+        }
     }
 
     @Test
@@ -86,8 +104,18 @@ class ServerConfigUtilsTest {
         val expectedDbUrl = "http://satellite:testPassword@demo.ole.org:5984"
         assertEquals(expectedDbUrl, result)
 
-        verify { mockSharedPrefManager.setUrlHost("demo.ole.org") }
-        verify { mockSharedPrefManager.setProcessedAlternativeUrl(expectedDbUrl) }
+        verify {
+            mockSharedPrefManager.saveAlternativeServerConfig(
+                serverPin = password,
+                urlUser = "satellite",
+                urlPwd = password,
+                urlScheme = "http",
+                urlHost = "demo.ole.org",
+                alternativeUrl = url,
+                processedAlternativeUrl = expectedDbUrl,
+                isAlternativeUrl = true
+            )
+        }
     }
 
     @Test
@@ -99,8 +127,18 @@ class ServerConfigUtilsTest {
 
         assertEquals(url, result)
 
-        verify { mockSharedPrefManager.setUrlUser("") }
-        verify { mockSharedPrefManager.setUrlPwd("") }
+        verify {
+            mockSharedPrefManager.saveAlternativeServerConfig(
+                serverPin = password,
+                urlUser = "",
+                urlPwd = "",
+                urlScheme = "http",
+                urlHost = "demo.ole.org",
+                alternativeUrl = url,
+                processedAlternativeUrl = url,
+                isAlternativeUrl = true
+            )
+        }
     }
 
     @Test
@@ -110,8 +148,18 @@ class ServerConfigUtilsTest {
 
         val result = ServerConfigUtils.saveAlternativeUrl(url, password, mockSharedPrefManager)
 
-        verify { mockSharedPrefManager.setUrlScheme("") }
-        verify { mockSharedPrefManager.setUrlHost("") }
+        verify {
+            mockSharedPrefManager.saveAlternativeServerConfig(
+                serverPin = password,
+                urlUser = "satellite",
+                urlPwd = password,
+                urlScheme = "",
+                urlHost = "",
+                alternativeUrl = url,
+                processedAlternativeUrl = "://satellite:testPassword@:443",
+                isAlternativeUrl = true
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Consolidated multiple sequential SharedPreferences commits and cache invalidations in ServerConfigUtils, ProcessUserDataActivity, and UserSessionManager into batched preference setters in SharedPrefManager.

Fixes #17047

---
*PR created automatically by Jules for task [1187281609338770544](https://jules.google.com/task/1187281609338770544) started by @dogi*