### PR TITLE
life: smoother dictionary file reader mapping (fixes #17060)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -19,6 +19,8 @@ import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.repository.CoursesRepositoryImpl
 import org.ole.planet.myplanet.repository.DiagnosticsRepository
 import org.ole.planet.myplanet.repository.DiagnosticsRepositoryImpl
+import org.ole.planet.myplanet.repository.DictionaryAssetDataSource
+import org.ole.planet.myplanet.repository.DictionaryAssetDataSourceImpl
 import org.ole.planet.myplanet.repository.DictionaryRepository
 import org.ole.planet.myplanet.repository.DictionaryRepositoryImpl
 import org.ole.planet.myplanet.repository.DownloadRepository
@@ -80,6 +82,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindDiagnosticsRepository(impl: DiagnosticsRepositoryImpl): DiagnosticsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDictionaryAssetDataSource(impl: DictionaryAssetDataSourceImpl): DictionaryAssetDataSource
 
     @Binds
     @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DictionaryAssetDataSource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DictionaryAssetDataSource.kt
@@ -1,0 +1,26 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import org.ole.planet.myplanet.utils.Constants
+import org.ole.planet.myplanet.utils.FileUtils
+
+interface DictionaryAssetDataSource {
+    fun isDictionaryAssetPresent(): Boolean
+    fun readDictionaryAssetText(): String?
+}
+
+class DictionaryAssetDataSourceImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : DictionaryAssetDataSource {
+
+    override fun isDictionaryAssetPresent(): Boolean {
+        return FileUtils.checkFileExist(context, Constants.DICTIONARY_URL)
+    }
+
+    override fun readDictionaryAssetText(): String? {
+        val path = FileUtils.getSDPathFromUrl(context, Constants.DICTIONARY_URL)
+        return FileUtils.getStringFromFile(path)
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DictionaryMapper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DictionaryMapper.kt
@@ -1,0 +1,25 @@
+package org.ole.planet.myplanet.repository
+
+import com.google.gson.JsonArray
+import java.util.UUID
+import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
+import org.ole.planet.myplanet.utils.JsonUtils
+
+object DictionaryMapper {
+    fun mapJsonArrayToEntities(json: JsonArray): List<DictionaryEntity> {
+        return json.map { js ->
+            val doc = js.asJsonObject
+            DictionaryEntity(
+                id = UUID.randomUUID().toString(),
+                code = JsonUtils.getString("code", doc),
+                language = JsonUtils.getString("language", doc),
+                advanceCode = JsonUtils.getString("advance_code", doc),
+                word = JsonUtils.getString("word", doc),
+                meaning = JsonUtils.getString("meaning", doc),
+                definition = JsonUtils.getString("definition", doc),
+                synonym = JsonUtils.getString("synonym", doc),
+                antonym = JsonUtils.getString("antonoym", doc)
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DictionaryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DictionaryRepositoryImpl.kt
@@ -1,24 +1,18 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
 import com.google.gson.JsonArray
-import dagger.hilt.android.qualifiers.ApplicationContext
-import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
-import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
-import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DispatcherProvider
-import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 
 class DictionaryRepositoryImpl @Inject constructor(
     private val dictionaryDao: DictionaryDao,
     private val dispatcherProvider: DispatcherProvider,
-    @ApplicationContext private val context: Context
+    private val dictionaryAssetDataSource: DictionaryAssetDataSource
 ) : DictionaryRepository {
 
     private val seedMutex = Mutex()
@@ -40,7 +34,7 @@ class DictionaryRepositoryImpl @Inject constructor(
 
     override suspend fun insertDictionaryData(): DictionaryLoad {
         return withContext(dispatcherProvider.io) {
-            if (!FileUtils.checkFileExist(context, Constants.DICTIONARY_URL)) {
+            if (!dictionaryAssetDataSource.isDictionaryAssetPresent()) {
                 return@withContext DictionaryLoad.FileMissing
             }
 
@@ -50,25 +44,10 @@ class DictionaryRepositoryImpl @Inject constructor(
                 }
 
                 try {
-                    val data = FileUtils.getStringFromFile(
-                        FileUtils.getSDPathFromUrl(context, Constants.DICTIONARY_URL)
-                    )
-                    val json = JsonUtils.gson.fromJson(data, JsonArray::class.java)
+                    val data = dictionaryAssetDataSource.readDictionaryAssetText()
+                    val json = data?.let { JsonUtils.gson.fromJson(it, JsonArray::class.java) }
                     if (json != null) {
-                        val entities = json.map { js ->
-                            val doc = js.asJsonObject
-                            DictionaryEntity(
-                                id = UUID.randomUUID().toString(),
-                                code = JsonUtils.getString("code", doc),
-                                language = JsonUtils.getString("language", doc),
-                                advanceCode = JsonUtils.getString("advance_code", doc),
-                                word = JsonUtils.getString("word", doc),
-                                meaning = JsonUtils.getString("meaning", doc),
-                                definition = JsonUtils.getString("definition", doc),
-                                synonym = JsonUtils.getString("synonym", doc),
-                                antonym = JsonUtils.getString("antonoym", doc)
-                            )
-                        }
+                        val entities = DictionaryMapper.mapJsonArrayToEntities(json)
                         dictionaryDao.insertAll(entities)
                         DictionaryLoad.Inserted
                     } else {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/DictionaryMapperTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/DictionaryMapperTest.kt
@@ -1,0 +1,86 @@
+package org.ole.planet.myplanet.repository
+
+import com.google.gson.JsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ole.planet.myplanet.utils.JsonUtils
+
+class DictionaryMapperTest {
+
+    @Test
+    fun `mapJsonArrayToEntities maps valid json fields correctly including advance_code and antonoym`() {
+        val jsonString = """
+            [
+                {
+                    "code": "en_1",
+                    "language": "en",
+                    "advance_code": "adv_100",
+                    "word": "abundant",
+                    "meaning": "existing or available in large quantities",
+                    "definition": "Plentiful",
+                    "synonym": "plentiful",
+                    "antonoym": "scarce"
+                }
+            ]
+        """.trimIndent()
+
+        val jsonArray = JsonUtils.gson.fromJson(jsonString, JsonArray::class.java)
+        val entities = DictionaryMapper.mapJsonArrayToEntities(jsonArray)
+
+        assertEquals(1, entities.size)
+        val entity = entities[0]
+        assertTrue(entity.id.isNotEmpty())
+        assertEquals("en_1", entity.code)
+        assertEquals("en", entity.language)
+        assertEquals("adv_100", entity.advanceCode)
+        assertEquals("abundant", entity.word)
+        assertEquals("existing or available in large quantities", entity.meaning)
+        assertEquals("Plentiful", entity.definition)
+        assertEquals("plentiful", entity.synonym)
+        assertEquals("scarce", entity.antonym)
+    }
+
+    @Test
+    fun `mapJsonArrayToEntities assigns unique IDs to each entity`() {
+        val jsonString = """
+            [
+                {"word": "a"},
+                {"word": "b"}
+            ]
+        """.trimIndent()
+
+        val jsonArray = JsonUtils.gson.fromJson(jsonString, JsonArray::class.java)
+        val entities = DictionaryMapper.mapJsonArrayToEntities(jsonArray)
+
+        assertEquals(2, entities.size)
+        assertNotEquals(entities[0].id, entities[1].id)
+    }
+
+    @Test
+    fun `mapJsonArrayToEntities handles empty json array`() {
+        val jsonArray = JsonArray()
+        val entities = DictionaryMapper.mapJsonArrayToEntities(jsonArray)
+
+        assertTrue(entities.isEmpty())
+    }
+
+    @Test
+    fun `mapJsonArrayToEntities handles missing fields with default empty strings`() {
+        val jsonString = """[{}]"""
+        val jsonArray = JsonUtils.gson.fromJson(jsonString, JsonArray::class.java)
+        val entities = DictionaryMapper.mapJsonArrayToEntities(jsonArray)
+
+        assertEquals(1, entities.size)
+        val entity = entities[0]
+        assertEquals("", entity.code)
+        assertEquals("", entity.language)
+        assertEquals("", entity.advanceCode)
+        assertEquals("", entity.word)
+        assertEquals("", entity.meaning)
+        assertEquals("", entity.definition)
+        assertEquals("", entity.synonym)
+        assertEquals("", entity.antonym)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/DictionaryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/DictionaryRepositoryImplTest.kt
@@ -1,11 +1,9 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -14,7 +12,6 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -22,15 +19,13 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
-import org.ole.planet.myplanet.utils.Constants
-import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
 @ExperimentalCoroutinesApi
 class DictionaryRepositoryImplTest {
 
     private lateinit var dictionaryDao: DictionaryDao
-    private lateinit var context: Context
+    private lateinit var dictionaryAssetDataSource: DictionaryAssetDataSource
     private lateinit var dispatcherProvider: TestDispatcherProvider
     private lateinit var dictionaryRepository: DictionaryRepositoryImpl
     private val testScheduler = TestCoroutineScheduler()
@@ -39,21 +34,14 @@ class DictionaryRepositoryImplTest {
     @Before
     fun setup() {
         dictionaryDao = mockk(relaxed = true)
-        context = mockk(relaxed = true)
+        dictionaryAssetDataSource = mockk(relaxed = true)
         dispatcherProvider = TestDispatcherProvider(testDispatcher)
-        dictionaryRepository = DictionaryRepositoryImpl(dictionaryDao, dispatcherProvider, context)
-
-        mockkObject(FileUtils)
-    }
-
-    @After
-    fun teardown() {
-        io.mockk.unmockkObject(FileUtils)
+        dictionaryRepository = DictionaryRepositoryImpl(dictionaryDao, dispatcherProvider, dictionaryAssetDataSource)
     }
 
     @Test
     fun `insertDictionaryData returns FileMissing if file does not exist`() = runTest(testDispatcher) {
-        every { FileUtils.checkFileExist(context, Constants.DICTIONARY_URL) } returns false
+        every { dictionaryAssetDataSource.isDictionaryAssetPresent() } returns false
 
         val result = dictionaryRepository.insertDictionaryData()
 
@@ -63,7 +51,7 @@ class DictionaryRepositoryImplTest {
 
     @Test
     fun `insertDictionaryData returns AlreadyPopulated if data is already populated`() = runTest(testDispatcher) {
-        every { FileUtils.checkFileExist(context, Constants.DICTIONARY_URL) } returns true
+        every { dictionaryAssetDataSource.isDictionaryAssetPresent() } returns true
         coEvery { dictionaryDao.count() } returns 100L
 
         val result = dictionaryRepository.insertDictionaryData()
@@ -74,9 +62,9 @@ class DictionaryRepositoryImplTest {
 
     @Test
     fun `insertDictionaryData returns Failed if json parsing fails`() = runTest(testDispatcher) {
-        every { FileUtils.checkFileExist(context, Constants.DICTIONARY_URL) } returns true
+        every { dictionaryAssetDataSource.isDictionaryAssetPresent() } returns true
         coEvery { dictionaryDao.count() } returns 0L
-        every { FileUtils.getSDPathFromUrl(context, Constants.DICTIONARY_URL) } throws Exception("Forced exception for testing")
+        every { dictionaryAssetDataSource.readDictionaryAssetText() } throws Exception("Forced exception for testing")
 
         val result = dictionaryRepository.insertDictionaryData()
 
@@ -86,12 +74,11 @@ class DictionaryRepositoryImplTest {
 
     @Test
     fun `insertDictionaryData returns Inserted and inserts entities on success`() = runTest(testDispatcher) {
-        every { FileUtils.checkFileExist(context, Constants.DICTIONARY_URL) } returns true
+        every { dictionaryAssetDataSource.isDictionaryAssetPresent() } returns true
         coEvery { dictionaryDao.count() } returns 0L
-        every { FileUtils.getSDPathFromUrl(context, Constants.DICTIONARY_URL) } returns mockk()
 
         val validJson = """[{"code": "1", "language": "en", "advance_code": "2", "word": "hello", "meaning": "greeting", "definition": "A greeting", "synonym": "hi", "antonoym": "bye"}]"""
-        every { FileUtils.getStringFromFile(any()) } returns validJson
+        every { dictionaryAssetDataSource.readDictionaryAssetText() } returns validJson
 
         val result = dictionaryRepository.insertDictionaryData()
 
@@ -101,16 +88,15 @@ class DictionaryRepositoryImplTest {
 
     @Test
     fun `concurrent insertDictionaryData calls only insert once`() = runTest(testScheduler) {
-        every { FileUtils.checkFileExist(context, Constants.DICTIONARY_URL) } returns true
-        every { FileUtils.getSDPathFromUrl(context, Constants.DICTIONARY_URL) } returns mockk()
+        every { dictionaryAssetDataSource.isDictionaryAssetPresent() } returns true
         val validJson = """[{"code": "1", "language": "en", "advance_code": "2", "word": "hello", "meaning": "greeting", "definition": "A greeting", "synonym": "hi", "antonoym": "bye"}]"""
-        every { FileUtils.getStringFromFile(any()) } returns validJson
+        every { dictionaryAssetDataSource.readDictionaryAssetText() } returns validJson
 
         val concurrentDispatcher = StandardTestDispatcher(testScheduler)
         val concurrentRepository = DictionaryRepositoryImpl(
             dictionaryDao,
             TestDispatcherProvider(concurrentDispatcher),
-            context
+            dictionaryAssetDataSource
         )
 
         val inserted = AtomicBoolean(false)


### PR DESCRIPTION
Split file I/O from pure JSON parsing in the dictionary seed path by extracting DictionaryAssetDataSource and DictionaryMapper.

Fixes #17060

---
*PR created automatically by Jules for task [18042583460098643194](https://jules.google.com/task/18042583460098643194) started by @dogi*