### PR TITLE
all: smoother network utils system service caching (fixes #17066)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
@@ -220,16 +220,14 @@ object NetworkUtils {
 
     fun getCurrentNetworkId(context: Context): Int {
         var networkId = -1
-        val connManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val network = connManager.activeNetwork
-        val capabilities = connManager.getNetworkCapabilities(network)
+        val network = connectivityManager.activeNetwork
+        val capabilities = connectivityManager.getNetworkCapabilities(network)
         if (capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) {
             val connectionInfo: WifiInfo? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 capabilities.transportInfo as? WifiInfo
             } else {
-                val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager?
                 @Suppress("DEPRECATION")
-                wifiManager?.connectionInfo
+                wifiManager.connectionInfo
             }
 
             if (connectionInfo != null && !connectionInfo.ssid.isNullOrEmpty()) {


### PR DESCRIPTION
Reused the cached `connectivityManager` and `wifiManager` properties in `NetworkUtils.getCurrentNetworkId` instead of re-resolving system services via `context.getSystemService(...)`. Note that callers continue to pass application-scoped context, ensuring identical system service resolution behavior across pre-S and S+ branches.

Fixes #17066

---
*PR created automatically by Jules for task [17590180526593375918](https://jules.google.com/task/17590180526593375918) started by @dogi*