### PR TITLE
all: smoother version utils lookup caching (fixes #17065)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/VersionUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/VersionUtils.kt
@@ -14,15 +14,24 @@ object VersionUtils {
     @Volatile
     private var cachedAndroidId: String? = null
 
+    @Volatile
+    private var cachedVersionCode: Int? = null
+
+    @Volatile
+    private var cachedVersionName: String? = null
+
     fun getVersionCode(context: Context): Int {
+        cachedVersionCode?.let { return it }
         try {
             val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                return getLongVersionCode(pInfo).toInt()
+            val code = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                getLongVersionCode(pInfo).toInt()
             } else {
                 @Suppress("DEPRECATION")
-                return pInfo.versionCode
+                pInfo.versionCode
             }
+            cachedVersionCode = code
+            return code
         } catch (e: PackageManager.NameNotFoundException) {
             Log.w(TAG, "Failed to get version code", e)
         }
@@ -30,9 +39,12 @@ object VersionUtils {
     }
 
     fun getVersionName(context: Context): String? {
+        cachedVersionName?.let { return it }
         try {
             val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            return pInfo.versionName
+            val name = pInfo.versionName
+            cachedVersionName = name
+            return name
         } catch (e: PackageManager.NameNotFoundException) {
             Log.w(TAG, "Failed to get version name", e)
         }
@@ -49,8 +61,15 @@ object VersionUtils {
     }
 
     @VisibleForTesting
-    internal fun resetAndroidIdCacheForTesting() {
+    internal fun reset() {
         cachedAndroidId = null
+        cachedVersionCode = null
+        cachedVersionName = null
+    }
+
+    @VisibleForTesting
+    internal fun resetAndroidIdCacheForTesting() {
+        reset()
     }
 
     fun isVersionAllowed(currentVersion: String, minApkVersion: String): Boolean {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/VersionUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/VersionUtilsTest.kt
@@ -9,6 +9,7 @@ import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -23,7 +24,123 @@ class VersionUtilsTest {
 
     @Before
     fun setUp() {
-        VersionUtils.resetAndroidIdCacheForTesting()
+        VersionUtils.reset()
+    }
+
+    @Test
+    fun getVersionCode_caches_successful_result_and_resets() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        val mockPackageInfo = PackageInfo()
+        @Suppress("DEPRECATION")
+        mockPackageInfo.versionCode = 100
+
+        every { mockContext.packageName } returns "org.ole.planet.myplanet"
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) } returns mockPackageInfo
+
+        // First call populates cache
+        val firstCallCode = VersionUtils.getVersionCode(mockContext)
+        assertEquals(100, firstCallCode)
+
+        // Second call should return cached value without invoking packageManager again
+        val secondCallCode = VersionUtils.getVersionCode(mockContext)
+        assertEquals(100, secondCallCode)
+
+        verify(exactly = 1) { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) }
+
+        // Reset clears the cache
+        VersionUtils.reset()
+
+        val thirdCallCode = VersionUtils.getVersionCode(mockContext)
+        assertEquals(100, thirdCallCode)
+
+        verify(exactly = 2) { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) }
+    }
+
+    @Test
+    fun getVersionCode_does_not_cache_NameNotFoundException() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        val mockPackageInfo = PackageInfo()
+        @Suppress("DEPRECATION")
+        mockPackageInfo.versionCode = 200
+
+        every { mockContext.packageName } returns "org.ole.planet.myplanet"
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) } throws
+                PackageManager.NameNotFoundException() andThen mockPackageInfo
+
+        // First call fails with NameNotFoundException -> returns 0 and is not cached
+        val firstCallCode = VersionUtils.getVersionCode(mockContext)
+        assertEquals(0, firstCallCode)
+
+        // Second call succeeds -> fetches package info and caches result
+        val secondCallCode = VersionUtils.getVersionCode(mockContext)
+        assertEquals(200, secondCallCode)
+
+        // Third call uses cached result
+        val thirdCallCode = VersionUtils.getVersionCode(mockContext)
+        assertEquals(200, thirdCallCode)
+
+        verify(exactly = 2) { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) }
+    }
+
+    @Test
+    fun getVersionName_caches_successful_result_and_resets() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        val mockPackageInfo = PackageInfo()
+        mockPackageInfo.versionName = "1.0.0"
+
+        every { mockContext.packageName } returns "org.ole.planet.myplanet"
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) } returns mockPackageInfo
+
+        // First call populates cache
+        val firstCallName = VersionUtils.getVersionName(mockContext)
+        assertEquals("1.0.0", firstCallName)
+
+        // Second call uses cached result
+        val secondCallName = VersionUtils.getVersionName(mockContext)
+        assertEquals("1.0.0", secondCallName)
+
+        verify(exactly = 1) { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) }
+
+        // Reset clears cache
+        VersionUtils.reset()
+
+        val thirdCallName = VersionUtils.getVersionName(mockContext)
+        assertEquals("1.0.0", thirdCallName)
+
+        verify(exactly = 2) { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) }
+    }
+
+    @Test
+    fun getVersionName_does_not_cache_NameNotFoundException() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        val mockPackageInfo = PackageInfo()
+        mockPackageInfo.versionName = "2.0.0"
+
+        every { mockContext.packageName } returns "org.ole.planet.myplanet"
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) } throws
+                PackageManager.NameNotFoundException() andThen mockPackageInfo
+
+        // First call fails with NameNotFoundException -> returns "" and is not cached
+        val firstCallName = VersionUtils.getVersionName(mockContext)
+        assertEquals("", firstCallName)
+
+        // Second call succeeds -> fetches package info and caches result
+        val secondCallName = VersionUtils.getVersionName(mockContext)
+        assertEquals("2.0.0", secondCallName)
+
+        // Third call uses cached result
+        val thirdCallName = VersionUtils.getVersionName(mockContext)
+        assertEquals("2.0.0", thirdCallName)
+
+        verify(exactly = 2) { mockPackageManager.getPackageInfo("org.ole.planet.myplanet", 0) }
     }
 
     @Test


### PR DESCRIPTION
Caches version code and version name in VersionUtils to prevent unnecessary PackageManager IPC calls. Successful values are cached while NameNotFoundException calls remain uncached. Adds a reset method for testing.

Fixes #17065

---
*PR created automatically by Jules for task [6407221315336607302](https://jules.google.com/task/6407221315336607302) started by @dogi*