### PR TITLE
chat: smoother repository history dao sorting (fixes #17064)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ChatDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ChatDao.kt
@@ -9,7 +9,9 @@ import org.ole.planet.myplanet.model.ChatHistory
 
 @Dao
 interface ChatDao {
-    @Query("SELECT * FROM chat_history WHERE user = :user ORDER BY id DESC")
+    // Note: ChatRepositoryImpl.sortChats owns ordering for user chats because
+    // createdDate and updatedDate are string-typed, so a SQL ORDER BY would not be numerically correct.
+    @Query("SELECT * FROM chat_history WHERE user = :user")
     suspend fun getByUser(user: String): List<ChatHistory>
 
     @Query("SELECT * FROM chat_history WHERE _id = :docId")

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
@@ -82,14 +82,30 @@ class ChatRepositoryImplTest {
     }
 
     @Test
-    fun getChatHistoryForUser_delegatesToDao() = runTest {
+    fun getChatHistoryForUser_delegatesToDaoAndSortsByRepositoryOrdering() = runTest {
         val userName = "testUser"
-        val mockHistoryList = listOf(ChatHistory().apply { user = userName })
-        coEvery { chatDao.getByUser(userName) } returns mockHistoryList
+        val oldestChat = ChatHistory().apply {
+            user = userName
+            createdDate = "1000"
+            updatedDate = "1000"
+        }
+        val middleChat = ChatHistory().apply {
+            user = userName
+            createdDate = "2000"
+            updatedDate = "1500"
+        }
+        val newestChat = ChatHistory().apply {
+            user = userName
+            createdDate = "1000"
+            updatedDate = "3000"
+        }
+
+        val reversedDaoList = listOf(oldestChat, middleChat, newestChat)
+        coEvery { chatDao.getByUser(userName) } returns reversedDaoList
 
         val result = chatRepository.getChatHistoryForUser(userName)
 
-        assertEquals(mockHistoryList, result)
+        assertEquals(listOf(newestChat, middleChat, oldestChat), result)
         coVerify(exactly = 1) { chatDao.getByUser(userName) }
     }
 


### PR DESCRIPTION
Align ChatDao.getByUser with repository-owned ordering.

- Dropped `ORDER BY id DESC` from `@Query` in `ChatDao.getByUser`.
- Added a comment in `ChatDao` noting that `ChatRepositoryImpl.sortChats` owns ordering due to string-typed `createdDate` / `updatedDate`.
- Updated `ChatRepositoryImplTest` to assert that `getChatHistoryForUser` returns items sorted by `sortChats` even when `ChatDao.getByUser` returns rows in reversed order.

Fixes #17064

---
*PR created automatically by Jules for task [697179163892613755](https://jules.google.com/task/697179163892613755) started by @dogi*