### PR TITLE
teams: smoother events repository meetup dao member joining (fixes #17061)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/MeetupDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/MeetupDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import org.ole.planet.myplanet.model.Meetup
+import org.ole.planet.myplanet.model.UserEntity
 
 @Dao
 interface MeetupDao {
@@ -24,6 +25,15 @@ interface MeetupDao {
         "SELECT DISTINCT userId FROM meetup WHERE meetupId = :meetupId AND userId IS NOT NULL AND userId != ''"
     )
     suspend fun getMemberUserIdsByMeetupId(meetupId: String): List<String>
+
+    @Query(
+        """
+        SELECT DISTINCT u.* FROM users u
+        INNER JOIN meetup m ON (u.id = m.userId OR u._id = m.userId)
+        WHERE m.meetupId = :meetupId AND m.userId IS NOT NULL AND m.userId != ''
+        """
+    )
+    suspend fun getJoinedMembersByMeetupId(meetupId: String): List<UserEntity>
 
     @Query("SELECT * FROM meetup WHERE userId = :userId AND userId != ''")
     suspend fun getByUserId(userId: String): List<Meetup>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
@@ -6,7 +6,6 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
-import org.ole.planet.myplanet.data.room.dao.UserDao
 import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.MeetupCreationParams
 import org.ole.planet.myplanet.model.UserEntity
@@ -17,7 +16,6 @@ import org.ole.planet.myplanet.utils.TimeProvider
 class EventsRepositoryImpl @Inject constructor(
     private val timeProvider: TimeProvider,
     private val meetupDao: MeetupDao,
-    private val userDao: UserDao,
     private val gson: Gson
 ) : EventsRepository, EventsSyncWriter {
 
@@ -67,16 +65,7 @@ class EventsRepositoryImpl @Inject constructor(
         if (meetupId.isBlank()) {
             return emptyList()
         }
-        val memberIds = meetupDao.getMemberUserIdsByMeetupId(meetupId)
-            .mapNotNull { it.takeUnless { id -> id.isBlank() } }
-            .distinct()
-        if (memberIds.isEmpty()) {
-            return emptyList()
-        }
-
-        return memberIds.chunked(400)
-            .flatMap { chunk -> userDao.getUsersByAnyIds(chunk) }
-            .distinctBy { it.id }
+        return meetupDao.getJoinedMembersByMeetupId(meetupId)
     }
 
     override suspend fun toggleAttendance(meetupId: String, userId: String): Meetup? {

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/MeetupDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/MeetupDaoTest.kt
@@ -1,0 +1,105 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.data.room.AppDatabase
+import org.ole.planet.myplanet.model.Meetup
+import org.ole.planet.myplanet.model.UserEntity
+
+@RunWith(AndroidJUnit4::class)
+class MeetupDaoTest {
+
+    private lateinit var database: AppDatabase
+    private lateinit var meetupDao: MeetupDao
+    private lateinit var userDao: UserDao
+
+    @Before
+    fun initDb() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        meetupDao = database.meetupDao()
+        userDao = database.userDao()
+    }
+
+    @After
+    fun closeDb() {
+        database.close()
+    }
+
+    private fun createUser(id: String, _id: String? = null, name: String? = null): UserEntity {
+        return UserEntity().apply {
+            this.id = id
+            this._id = _id
+            this.name = name
+        }
+    }
+
+    private fun createMeetup(id: String, meetupId: String, userId: String?): Meetup {
+        return Meetup().apply {
+            this.id = id
+            this.meetupId = meetupId
+            this.userId = userId
+        }
+    }
+
+    @Test
+    fun getJoinedMembersByMeetupId_matchesUserByIdOr_Id() = runBlocking {
+        userDao.upsert(createUser("user1_local", "user1_remote", "User 1"))
+        userDao.upsert(createUser("user2_local", null, "User 2"))
+
+        meetupDao.upsert(createMeetup("m1", "meetup1", "user1_remote"))
+        meetupDao.upsert(createMeetup("m2", "meetup1", "user2_local"))
+
+        val result = meetupDao.getJoinedMembersByMeetupId("meetup1")
+        assertEquals(2, result.size)
+        assertTrue(result.any { it.id == "user1_local" })
+        assertTrue(result.any { it.id == "user2_local" })
+    }
+
+    @Test
+    fun getJoinedMembersByMeetupId_deduplicatesMembers() = runBlocking {
+        userDao.upsert(createUser("user1_local", "user1_remote", "User 1"))
+
+        meetupDao.upsert(createMeetup("m1", "meetup1", "user1_local"))
+        meetupDao.upsert(createMeetup("m2", "meetup1", "user1_remote"))
+
+        val result = meetupDao.getJoinedMembersByMeetupId("meetup1")
+        assertEquals(1, result.size)
+        assertEquals("user1_local", result[0].id)
+    }
+
+    @Test
+    fun getJoinedMembersByMeetupId_excludesNullOrBlankUserIds() = runBlocking {
+        userDao.upsert(createUser("user1_local", "user1_remote", "User 1"))
+
+        meetupDao.upsert(createMeetup("m1", "meetup1", "user1_local"))
+        meetupDao.upsert(createMeetup("m2", "meetup1", null))
+        meetupDao.upsert(createMeetup("m3", "meetup1", ""))
+
+        val result = meetupDao.getJoinedMembersByMeetupId("meetup1")
+        assertEquals(1, result.size)
+        assertEquals("user1_local", result[0].id)
+    }
+
+    @Test
+    fun getJoinedMembersByMeetupId_returnsEmptyWhenNoMembersOrBlankMeetupId() = runBlocking {
+        userDao.upsert(createUser("user1_local", "user1_remote", "User 1"))
+        meetupDao.upsert(createMeetup("m1", "meetup1", "user1_local"))
+
+        val resultUnknown = meetupDao.getJoinedMembersByMeetupId("unknown_meetup")
+        assertTrue(resultUnknown.isEmpty())
+
+        val resultBlank = meetupDao.getJoinedMembersByMeetupId("")
+        assertTrue(resultBlank.isEmpty())
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
@@ -16,7 +16,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
-import org.ole.planet.myplanet.data.room.dao.UserDao
 import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.MeetupCreationParams
 import org.ole.planet.myplanet.model.UserEntity
@@ -26,7 +25,6 @@ import org.ole.planet.myplanet.utils.SystemTimeProvider
 class EventsRepositoryImplTest {
 
     private lateinit var meetupDao: MeetupDao
-    private lateinit var userDao: UserDao
     private lateinit var repository: EventsRepositoryImpl
 
     class SilentException(message: String) : Exception(message) {
@@ -36,8 +34,7 @@ class EventsRepositoryImplTest {
     @Before
     fun setup() {
         meetupDao = mockk(relaxed = true)
-        userDao = mockk(relaxed = true)
-        repository = EventsRepositoryImpl(SystemTimeProvider(), meetupDao, userDao, Gson())
+        repository = EventsRepositoryImpl(SystemTimeProvider(), meetupDao, Gson())
     }
 
     @Test
@@ -65,10 +62,7 @@ class EventsRepositoryImplTest {
 
     @Test
     fun getJoinedMembers() = runTest {
-        coEvery { meetupDao.getMemberUserIdsByMeetupId("meetup1") } returns listOf(
-            "user1", "user2", "user1"
-        )
-        coEvery { userDao.getUsersByAnyIds(any()) } returns listOf(
+        coEvery { meetupDao.getJoinedMembersByMeetupId("meetup1") } returns listOf(
             UserEntity(id = "user1"),
             UserEntity(id = "user2", _id = "remote-user2")
         )


### PR DESCRIPTION
Refactored `getJoinedMembers` in `EventsRepositoryImpl` to join `meetup` and `users` directly in Room database via `MeetupDao.getJoinedMembersByMeetupId`. Removed Kotlin-side chunking and deduplication as well as the unused `UserDao` injection. Added unit tests in `MeetupDaoTest` and updated `EventsRepositoryImplTest`.

Fixes #17061

---
*PR created automatically by Jules for task [8301623562494912535](https://jules.google.com/task/8301623562494912535) started by @dogi*