### PR TITLE
resources: smoother list tag hash filtering (fixes #17075)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesListFilter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesListFilter.kt
@@ -55,8 +55,9 @@ class ResourcesListFilter {
     private fun filterBySearchAndTags(models: List<ResourceListModel>, searchQuery: String, tags: List<TagEntity>): List<ResourceListModel> {
         var filteredList = ResourcesSearchUtils.searchLocalModels(models, searchQuery)
         if (tags.isNotEmpty()) {
+            val searchTagIds = tags.mapTo(HashSet()) { it.id }
             filteredList = filteredList.filter { model ->
-                tags.any { searchTag -> model.tags.any { it.id == searchTag.id } }
+                model.tags.any { it.id in searchTagIds }
             }
         }
         return filteredList

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesListFilterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesListFilterTest.kt
@@ -63,7 +63,8 @@ class ResourcesListFilterTest {
     fun `apply filters by selected tag`() {
         val models = listOf(
             model(id = "1", title = "A", tags = listOf(TagItem(id = "t1", name = "Math"))),
-            model(id = "2", title = "B", tags = listOf(TagItem(id = "t2", name = "Science")))
+            model(id = "2", title = "B", tags = listOf(TagItem(id = "t2", name = "Science"))),
+            model(id = "3", title = "C", tags = listOf(TagItem(id = "t3", name = "History"), TagItem(id = "t2", name = "Science")))
         )
         val filter = ResourcesListFilter()
 
@@ -71,6 +72,10 @@ class ResourcesListFilterTest {
 
         assertEquals(1, result.size)
         assertEquals("1", result[0].item.id)
+
+        val multiTagResult = filter.apply(models, noFilters.copy(searchTags = listOf(TagEntity().apply { id = "t1" }, TagEntity().apply { id = "t3" })), emptySet())
+        assertEquals(2, multiTagResult.size)
+        assertEquals(setOf("1", "3"), multiTagResult.map { it.item.id }.toSet())
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.api.tasks.Delete
 buildscript {
     repositories {
         google()
-        maven("https://maven-central.storage-download.googleapis.com/maven2/")
         mavenCentral()
     }
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.tasks.Delete
 buildscript {
     repositories {
         google()
+        maven("https://maven-central.storage-download.googleapis.com/maven2/")
         mavenCentral()
     }
     dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         google()
+        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -11,6 +12,7 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         google()
+        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         maven { url = uri('https://jitpack.io') }
         maven { url = uri('https://oss.sonatype.org/content/repositories/snapshots') }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
     repositories {
         google()
-        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -12,7 +11,6 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         google()
-        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         maven { url = uri('https://jitpack.io') }
         maven { url = uri('https://oss.sonatype.org/content/repositories/snapshots') }


### PR DESCRIPTION
Optimized tag filtering in `ResourcesListFilter` by precomputing `searchTagIds` into a `HashSet` once when `tags` is non-empty. This reduces complexity from $O(\text{models} \times \text{searchTags} \times \text{modelTags})$ to $O(1)$ set membership checks per model tag while preserving any-of matching semantics. Added unit test coverage for multi-tag filtering.

Fixes #17075

---
*PR created automatically by Jules for task [642254986216207117](https://jules.google.com/task/642254986216207117) started by @dogi*