### PR TITLE
sync: smoother upload attachments managing (fixes #17073)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -38,6 +38,7 @@ import org.ole.planet.myplanet.services.upload.UploadConstants.BATCH_SIZE
 import org.ole.planet.myplanet.services.upload.UploadCoordinator
 import org.ole.planet.myplanet.services.upload.UploadError
 import org.ole.planet.myplanet.services.upload.UploadResult
+import org.ole.planet.myplanet.services.upload.UploadedItem
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getString
@@ -165,6 +166,18 @@ class UploadManager @Inject constructor(
             notifyListener(listener, it)
         }
     }
+    private suspend fun uploadAttachments(items: List<UploadedItem>, listener: OnSuccessListener?) {
+        if (listener == null || items.isEmpty()) return
+        val libraryIds = items.map { it.localId }
+        val libraries = resourcesRepository.getLibraryItemsByIds(libraryIds)
+        val libMap = libraries.associateBy { it.id }
+        items.forEach { item ->
+            libMap[item.localId]?.let { library ->
+                uploadAttachment(item.remoteId, item.remoteRev, library, listener)
+            }
+        }
+    }
+
     suspend fun uploadResource(listener: OnSuccessListener?) {
         try {
             val user = userRepository.getUserModel()
@@ -172,35 +185,11 @@ class UploadManager @Inject constructor(
 
             when (result) {
                 is UploadResult.Success -> {
-                    listener?.let { l ->
-                        val libraryIds = result.items.map { it.localId }
-                        if (libraryIds.isNotEmpty()) {
-                            val libraries = resourcesRepository.getLibraryItemsByIds(libraryIds)
-                            val libMap = libraries.associateBy { it.id }
-
-                            result.items.forEach { item ->
-                                libMap[item.localId]?.let { library ->
-                                    uploadAttachment(item.remoteId, item.remoteRev, library, l)
-                                }
-                            }
-                        }
-                    }
+                    uploadAttachments(result.items, listener)
                     notifyListener(listener, "Uploaded ${result.items.size} resources successfully")
                 }
                 is UploadResult.PartialSuccess -> {
-                    listener?.let { l ->
-                        val libraryIds = result.succeeded.map { it.localId }
-                        if (libraryIds.isNotEmpty()) {
-                            val libraries = resourcesRepository.getLibraryItemsByIds(libraryIds)
-                            val libMap = libraries.associateBy { it.id }
-
-                            result.succeeded.forEach { item ->
-                                libMap[item.localId]?.let { library ->
-                                    uploadAttachment(item.remoteId, item.remoteRev, library, l)
-                                }
-                            }
-                        }
-                    }
+                    uploadAttachments(result.succeeded, listener)
                     notifyListener(listener, "Partial success: ${result.succeeded.size} succeeded, ${result.failed.size} failed")
                 }
                 is UploadResult.Failure -> {

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -389,4 +389,74 @@ class UploadManagerTest {
         coVerify { listener.onSuccess("Resource upload failed: $errorMessage") }
     }
 
+    @Test
+    fun `uploadResource uploads attachments on UploadResult Success`() = testScope.runTest {
+        val uploadedItem = org.ole.planet.myplanet.services.upload.UploadedItem(
+            localId = "lib1",
+            remoteId = "remote1",
+            remoteRev = "rev1",
+            response = JsonObject()
+        )
+        val library = MyLibrary().apply { id = "lib1" }
+        coEvery { uploadCoordinator.uploadRoom<MyLibrary>(any()) } returns UploadResult.Success(1, listOf(uploadedItem))
+        coEvery { resourcesRepository.getLibraryItemsByIds(listOf("lib1")) } returns listOf(library)
+
+        val listener = mockk<OnSuccessListener>(relaxed = true)
+        uploadManager.uploadResource(listener)
+        advanceUntilIdle()
+
+        coVerify { resourcesRepository.getLibraryItemsByIds(listOf("lib1")) }
+        coVerify { listener.onSuccess("Uploaded 1 resources successfully") }
+    }
+
+    @Test
+    fun `uploadResource uploads attachments on UploadResult PartialSuccess`() = testScope.runTest {
+        val uploadedItem = org.ole.planet.myplanet.services.upload.UploadedItem(
+            localId = "lib1",
+            remoteId = "remote1",
+            remoteRev = "rev1",
+            response = JsonObject()
+        )
+        val mockError = UploadError("lib2", Exception("Failed"), false)
+        val library = MyLibrary().apply { id = "lib1" }
+        coEvery { uploadCoordinator.uploadRoom<MyLibrary>(any()) } returns UploadResult.PartialSuccess(
+            succeeded = listOf(uploadedItem),
+            failed = listOf(mockError)
+        )
+        coEvery { resourcesRepository.getLibraryItemsByIds(listOf("lib1")) } returns listOf(library)
+
+        val listener = mockk<OnSuccessListener>(relaxed = true)
+        uploadManager.uploadResource(listener)
+        advanceUntilIdle()
+
+        coVerify { resourcesRepository.getLibraryItemsByIds(listOf("lib1")) }
+        coVerify { listener.onSuccess("Partial success: 1 succeeded, 1 failed") }
+    }
+
+    @Test
+    fun `uploadResource skips fetching libraries when listener is null or items empty`() = testScope.runTest {
+        val uploadedItem = org.ole.planet.myplanet.services.upload.UploadedItem(
+            localId = "lib1",
+            remoteId = "remote1",
+            remoteRev = "rev1",
+            response = JsonObject()
+        )
+        coEvery { uploadCoordinator.uploadRoom<MyLibrary>(any()) } returns UploadResult.Success(1, listOf(uploadedItem))
+
+        // When listener is null
+        uploadManager.uploadResource(null)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { resourcesRepository.getLibraryItemsByIds(any()) }
+
+        // When items list is empty with listener
+        coEvery { uploadCoordinator.uploadRoom<MyLibrary>(any()) } returns UploadResult.Success(0, emptyList())
+        val listener = mockk<OnSuccessListener>(relaxed = true)
+        uploadManager.uploadResource(listener)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { resourcesRepository.getLibraryItemsByIds(any()) }
+        coVerify { listener.onSuccess("Uploaded 0 resources successfully") }
+    }
+
 }


### PR DESCRIPTION
Extracted a private helper function `uploadAttachments` in `UploadManager.kt` that accepts a list of uploaded items and a listener. If the listener is null or the items list is empty, it returns early before making any queries or allocations. Updated `uploadResource` to call `uploadAttachments` in both `UploadResult.Success` and `UploadResult.PartialSuccess` branches while preserving the distinct `notifyListener` success messages. Added unit test coverage for both branches.

Fixes #17073

---
*PR created automatically by Jules for task [14419713767936529686](https://jules.google.com/task/14419713767936529686) started by @dogi*