### PR TITLE
life: smoother repository preferences caching (fixes #17074)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datasource/MyLifeCacheDataSource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datasource/MyLifeCacheDataSource.kt
@@ -1,0 +1,42 @@
+package org.ole.planet.myplanet.datasource
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.ole.planet.myplanet.di.AppPreferences
+import org.ole.planet.myplanet.model.MyLife
+
+data class CachedMyLifeItem(
+    var imageId: String?,
+    var title: String?,
+    var isVisible: Boolean,
+    var weight: Int
+)
+
+@Singleton
+class MyLifeCacheDataSource @Inject constructor(
+    @AppPreferences private val preferences: SharedPreferences,
+    private val gson: Gson
+) {
+    fun read(cacheKey: String): List<CachedMyLifeItem>? {
+        val json = preferences.getString("$MY_LIFE_CACHE_PREFIX$cacheKey", null) ?: return null
+        return try {
+            gson.fromJson(json, cachedListType)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun write(cacheKey: String, items: List<MyLife>) {
+        val cached = items.map { CachedMyLifeItem(it.imageId, it.title, it.isVisible, it.weight) }
+        preferences.edit { putString("$MY_LIFE_CACHE_PREFIX$cacheKey", gson.toJson(cached)) }
+    }
+
+    companion object {
+        private const val MY_LIFE_CACHE_PREFIX = "myLifeCache_"
+        private val cachedListType = object : TypeToken<List<CachedMyLifeItem>>() {}.type
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/SharedPreferencesModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/SharedPreferencesModule.kt
@@ -10,6 +10,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import com.google.gson.Gson
+import org.ole.planet.myplanet.datasource.MyLifeCacheDataSource
 import org.ole.planet.myplanet.services.DownloadService
 import org.ole.planet.myplanet.utils.Constants.PREFS_NAME
 
@@ -48,5 +50,14 @@ object SharedPreferencesModule {
     @DownloadPreferences
     fun provideDownloadSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
         return context.getSharedPreferences(DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    @Provides
+    @Singleton
+    fun provideMyLifeCacheDataSource(
+        @AppPreferences preferences: SharedPreferences,
+        gson: Gson
+    ): MyLifeCacheDataSource {
+        return MyLifeCacheDataSource(preferences, gson)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
@@ -1,29 +1,20 @@
 package org.ole.planet.myplanet.repository
 
-import androidx.core.content.edit
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
+import org.ole.planet.myplanet.datasource.MyLifeCacheDataSource
 import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.services.SharedPrefManager
 
-data class CachedMyLifeItem(
-    var imageId: String?,
-    var title: String?,
-    var isVisible: Boolean,
-    var weight: Int
-)
 class LifeRepositoryImpl @Inject constructor(
     private val myLifeDao: MyLifeDao,
     private val sharedPrefManager: SharedPrefManager,
-    private val gson: Gson
+    private val myLifeCacheDataSource: MyLifeCacheDataSource
 ) : LifeRepository {
 
-    private val MY_LIFE_CACHE_PREFIX = "myLifeCache_"
     private val seedMutex = Mutex()
 
     private fun normalizeUserId(userId: String?): String? {
@@ -36,7 +27,7 @@ class LifeRepositoryImpl @Inject constructor(
         val rawUserId = managedLives.firstOrNull()?.userId ?: sharedPrefManager.getUserId()
         val effectiveUserId = normalizeUserId(rawUserId)
         val updatedLives = getMyLifeByUserId(effectiveUserId)
-        cacheMyLifeItems(effectiveUserId ?: "--", updatedLives)
+        myLifeCacheDataSource.write(effectiveUserId ?: "--", updatedLives)
         return updatedLives
     }
 
@@ -67,7 +58,7 @@ class LifeRepositoryImpl @Inject constructor(
             myLifeDao.update(changed)
         }
         val updatedLives = getMyLifeByUserId(effectiveUserId)
-        cacheMyLifeItems(effectiveUserId ?: "--", updatedLives)
+        myLifeCacheDataSource.write(effectiveUserId ?: "--", updatedLives)
     }
 
     private fun MyLife.dedupKey(): Any {
@@ -106,38 +97,25 @@ class LifeRepositoryImpl @Inject constructor(
         }
 
         val cacheKey = effectiveUserId ?: "--"
-        val json = sharedPrefManager.rawPreferences.getString("$MY_LIFE_CACHE_PREFIX$cacheKey", null)
-        if (json != null) {
-            val cached: List<CachedMyLifeItem>? = try {
-                val type = object : TypeToken<List<CachedMyLifeItem>>() {}.type
-                gson.fromJson(json, type)
-            } catch (e: Exception) {
-                null
-            }
-            if (cached != null) {
-                return cached.mapNotNull { item ->
-                    if (item.isVisible) {
-                        MyLife(item.imageId, effectiveUserId, item.title).apply {
-                            isVisible = item.isVisible
-                            weight = item.weight
-                        }
-                    } else {
-                        null
+        val cached = myLifeCacheDataSource.read(cacheKey)
+        if (cached != null) {
+            return cached.mapNotNull { item ->
+                if (item.isVisible) {
+                    MyLife(item.imageId, effectiveUserId, item.title).apply {
+                        isVisible = item.isVisible
+                        weight = item.weight
                     }
-                }.sortedBy { it.weight }
-            }
+                } else {
+                    null
+                }
+            }.sortedBy { it.weight }
         }
 
         val seeded = seedMyLifeIfEmpty(effectiveUserId, seedBase).ifEmpty {
             getMyLifeByUserId(effectiveUserId)
         }
-        cacheMyLifeItems(cacheKey, seeded)
+        myLifeCacheDataSource.write(cacheKey, seeded)
         return seeded.filter { it.isVisible }.sortedBy { it.weight }
-    }
-
-    private fun cacheMyLifeItems(userId: String, items: List<MyLife>) {
-        val cached = items.map { CachedMyLifeItem(it.imageId, it.title, it.isVisible, it.weight) }
-        sharedPrefManager.rawPreferences.edit { putString("$MY_LIFE_CACHE_PREFIX$userId", gson.toJson(cached)) }
     }
 
     override suspend fun seedMyLifeIfEmpty(userId: String?, items: List<MyLife>): List<MyLife> {

--- a/app/src/test/java/org/ole/planet/myplanet/datasource/MyLifeCacheDataSourceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/datasource/MyLifeCacheDataSourceTest.kt
@@ -1,0 +1,108 @@
+package org.ole.planet.myplanet.datasource
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.model.MyLife
+
+class MyLifeCacheDataSourceTest {
+
+    private lateinit var mockSharedPreferences: SharedPreferences
+    private lateinit var mockEditor: SharedPreferences.Editor
+    private lateinit var gson: Gson
+    private lateinit var dataSource: MyLifeCacheDataSource
+
+    @Before
+    fun setUp() {
+        mockSharedPreferences = mockk(relaxed = true)
+        mockEditor = mockk(relaxed = true)
+        gson = Gson()
+
+        every { mockSharedPreferences.edit() } returns mockEditor
+        every { mockEditor.putString(any(), any()) } returns mockEditor
+
+        dataSource = MyLifeCacheDataSource(mockSharedPreferences, gson)
+    }
+
+    @Test
+    fun read_returnsNull_whenNoJsonFound() {
+        every { mockSharedPreferences.getString("myLifeCache_user1", null) } returns null
+
+        val result = dataSource.read("user1")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun read_returnsParsedList_whenValidJson() {
+        val items = listOf(
+            CachedMyLifeItem("img1", "Title 1", true, 1),
+            CachedMyLifeItem("img2", "Title 2", false, 2)
+        )
+        val json = gson.toJson(items)
+        every { mockSharedPreferences.getString("myLifeCache_user1", null) } returns json
+
+        val result = dataSource.read("user1")
+
+        assertNotNull(result)
+        assertEquals(2, result!!.size)
+        assertEquals("img1", result[0].imageId)
+        assertEquals("Title 1", result[0].title)
+        assertTrue(result[0].isVisible)
+        assertEquals(1, result[0].weight)
+    }
+
+    @Test
+    fun read_returnsNull_whenMalformedJson() {
+        every { mockSharedPreferences.getString("myLifeCache_user1", null) } returns "corrupt_json_string"
+
+        val result = dataSource.read("user1")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun write_serializesItemsToSharedPreferences() {
+        val item1 = MyLife().apply {
+            imageId = "img1"
+            title = "Title 1"
+            isVisible = true
+            weight = 10
+        }
+        val keySlot = slot<String>()
+        val jsonSlot = slot<String>()
+
+        every { mockEditor.putString(capture(keySlot), capture(jsonSlot)) } returns mockEditor
+
+        dataSource.write("user1", listOf(item1))
+
+        verify(exactly = 1) { mockEditor.putString(any(), any()) }
+        assertEquals("myLifeCache_user1", keySlot.captured)
+
+        val readBack = gson.fromJson(jsonSlot.captured, Array<CachedMyLifeItem>::class.java).toList()
+        assertEquals(1, readBack.size)
+        assertEquals("img1", readBack[0].imageId)
+        assertEquals("Title 1", readBack[0].title)
+        assertTrue(readBack[0].isVisible)
+        assertEquals(10, readBack[0].weight)
+    }
+
+    @Test
+    fun write_handlesFallbackCacheKey() {
+        val keySlot = slot<String>()
+        every { mockEditor.putString(capture(keySlot), any()) } returns mockEditor
+
+        dataSource.write("--", emptyList())
+
+        assertEquals("myLifeCache_--", keySlot.captured)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryImplTest.kt
@@ -16,6 +16,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
+import org.ole.planet.myplanet.datasource.CachedMyLifeItem
+import org.ole.planet.myplanet.datasource.MyLifeCacheDataSource
 import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.services.SharedPrefManager
 
@@ -26,6 +28,7 @@ class LifeRepositoryImplTest {
     private lateinit var mockSharedPreferences: SharedPreferences
     private lateinit var mockEditor: SharedPreferences.Editor
     private lateinit var gson: Gson
+    private lateinit var myLifeCacheDataSource: MyLifeCacheDataSource
     private lateinit var repository: LifeRepositoryImpl
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -42,11 +45,11 @@ class LifeRepositoryImplTest {
         every { mockEditor.apply() } returns Unit
 
         gson = Gson()
+        myLifeCacheDataSource = MyLifeCacheDataSource(mockSharedPreferences, gson)
         repository = LifeRepositoryImpl(
             myLifeDao,
             sharedPrefManager,
-            gson
-
+            myLifeCacheDataSource
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryTest.kt
@@ -1,9 +1,7 @@
 package org.ole.planet.myplanet.repository
 
-import com.google.gson.Gson
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -14,6 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
+import org.ole.planet.myplanet.datasource.MyLifeCacheDataSource
 import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.services.SharedPrefManager
 
@@ -29,12 +28,11 @@ class LifeRepositoryTest {
         Logger.getLogger("io.mockk").level = Level.OFF
         myLifeDao = mockk(relaxed = true)
         val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
-        every { sharedPrefManager.rawPreferences } returns mockk(relaxed = true)
+        val myLifeCacheDataSource: MyLifeCacheDataSource = mockk(relaxed = true)
         repository = LifeRepositoryImpl(
             myLifeDao,
             sharedPrefManager,
-            Gson()
-
+            myLifeCacheDataSource
         )
     }
 


### PR DESCRIPTION
- Extracted CachedMyLifeItem and cache read/write logic from LifeRepositoryImpl into MyLifeCacheDataSource.
- Hoisted TypeToken<List<CachedMyLifeItem>>() to a companion object property in MyLifeCacheDataSource.
- Provided MyLifeCacheDataSource in SharedPreferencesModule.
- Refactored LifeRepositoryImpl to use MyLifeCacheDataSource and removed direct rawPreferences/Gson/edit usage.
- Updated existing tests and added MyLifeCacheDataSourceTest.

Fixes #17074

---
*PR created automatically by Jules for task [14455662441056787301](https://jules.google.com/task/14455662441056787301) started by @dogi*