### PR TITLE
community: smoother services view modelling (fixes #17076)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
@@ -61,6 +61,7 @@ class CommunityServicesFragment : BaseTeamFragment() {
         binding?.let { setMarkdownText(it.tvDescription, markdownContentWithLocalPaths) }
 
         collectWhenStarted(viewModel.teamLinks) { links ->
+            if (links == null) return@collectWhenStarted
             val currentBinding = binding ?: return@collectWhenStarted
             if (links.isEmpty()) {
                 currentBinding.llServices.visibility = View.GONE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
@@ -19,9 +20,11 @@ import org.ole.planet.myplanet.ui.viewer.WebViewActivity
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.MarkdownUtils.prependBaseUrlToImages
 import org.ole.planet.myplanet.utils.MarkdownUtils.setMarkdownText
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 class CommunityServicesFragment : BaseTeamFragment() {
     private var binding: FragmentCommunityServicesBinding? = null
+    private val viewModel: CommunityServicesViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val b = FragmentCommunityServicesBinding.inflate(inflater, container, false)
@@ -57,9 +60,8 @@ class CommunityServicesFragment : BaseTeamFragment() {
         )
         binding?.let { setMarkdownText(it.tvDescription, markdownContentWithLocalPaths) }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            val links = teamsRepository.getTeamLinks()
-            val currentBinding = binding ?: return@launch
+        collectWhenStarted(viewModel.teamLinks) { links ->
+            val currentBinding = binding ?: return@collectWhenStarted
             if (links.isEmpty()) {
                 currentBinding.llServices.visibility = View.GONE
                 currentBinding.tvNoLinks.visibility = View.VISIBLE
@@ -96,7 +98,7 @@ class CommunityServicesFragment : BaseTeamFragment() {
                     }
                     is CommunityServicesRoute.TeamLink -> {
                         viewLifecycleOwner.lifecycleScope.launch {
-                            val isMyTeam = teamsRepository.isMember(user?.id, route.teamId)
+                            val isMyTeam = viewModel.isMember(user?.id, route.teamId)
                             val f = TeamDetailFragment()
                             f.arguments = Bundle().apply {
                                 putString("id", route.teamId)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModel.kt
@@ -11,13 +11,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class CommunityServicesViewModel @Inject constructor(
     private val teamsRepository: TeamsRepository,
-    private val userRepository: UserRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModel.kt
@@ -19,8 +19,8 @@ class CommunityServicesViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
-    private val _teamLinks = MutableStateFlow<List<MyTeam>>(emptyList())
-    val teamLinks: StateFlow<List<MyTeam>> = _teamLinks.asStateFlow()
+    private val _teamLinks = MutableStateFlow<List<MyTeam>?>(null)
+    val teamLinks: StateFlow<List<MyTeam>?> = _teamLinks.asStateFlow()
 
     init {
         loadTeamLinks()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModel.kt
@@ -1,0 +1,40 @@
+package org.ole.planet.myplanet.ui.community
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.model.MyTeam
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.utils.DispatcherProvider
+
+@HiltViewModel
+class CommunityServicesViewModel @Inject constructor(
+    private val teamsRepository: TeamsRepository,
+    private val userRepository: UserRepository,
+    private val dispatcherProvider: DispatcherProvider
+) : ViewModel() {
+
+    private val _teamLinks = MutableStateFlow<List<MyTeam>>(emptyList())
+    val teamLinks: StateFlow<List<MyTeam>> = _teamLinks.asStateFlow()
+
+    init {
+        loadTeamLinks()
+    }
+
+    fun loadTeamLinks() {
+        viewModelScope.launch(dispatcherProvider.io) {
+            _teamLinks.value = teamsRepository.getTeamLinks()
+        }
+    }
+
+    suspend fun isMember(userId: String?, teamId: String): Boolean = withContext(dispatcherProvider.io) {
+        teamsRepository.isMember(userId, teamId)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModelTest.kt
@@ -1,0 +1,68 @@
+package org.ole.planet.myplanet.ui.community
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.ole.planet.myplanet.model.MyTeam
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.utils.MainDispatcherRule
+import org.ole.planet.myplanet.utils.TestDispatcherProvider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommunityServicesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val teamsRepository: TeamsRepository = mockk()
+    private val userRepository: UserRepository = mockk()
+    private val dispatcherProvider = TestDispatcherProvider(mainDispatcherRule.testDispatcher)
+
+    @Before
+    fun setup() {
+        coEvery { teamsRepository.getTeamLinks() } returns emptyList()
+    }
+
+    @Test
+    fun `init populates teamLinks flow with values from teamsRepository`() = runTest {
+        val mockTeam = MyTeam().apply { title = "Health Services" }
+        coEvery { teamsRepository.getTeamLinks() } returns listOf(mockTeam)
+
+        val viewModel = CommunityServicesViewModel(teamsRepository, userRepository, dispatcherProvider)
+        advanceUntilIdle()
+
+        val links = viewModel.teamLinks.first()
+        assertEquals(1, links.size)
+        assertEquals("Health Services", links[0].title)
+        coVerify { teamsRepository.getTeamLinks() }
+    }
+
+    @Test
+    fun `isMember queries teamsRepository with user id and team id`() = runTest {
+        coEvery { teamsRepository.isMember("user_123", "team_456") } returns true
+        coEvery { teamsRepository.isMember(null, "team_456") } returns false
+
+        val viewModel = CommunityServicesViewModel(teamsRepository, userRepository, dispatcherProvider)
+        advanceUntilIdle()
+
+        val isMemberUser = viewModel.isMember("user_123", "team_456")
+        assertTrue(isMemberUser)
+
+        val isMemberNull = viewModel.isMember(null, "team_456")
+        assertFalse(isMemberNull)
+
+        coVerify { teamsRepository.isMember("user_123", "team_456") }
+        coVerify { teamsRepository.isMember(null, "team_456") }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModelTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -40,9 +41,10 @@ class CommunityServicesViewModelTest {
         val viewModel = CommunityServicesViewModel(teamsRepository, dispatcherProvider)
         advanceUntilIdle()
 
-        val links = viewModel.teamLinks.first()
-        assertEquals(1, links.size)
-        assertEquals("Health Services", links[0].title)
+        val links = viewModel.teamLinks.first { it != null }
+        assertNotNull(links)
+        assertEquals(1, links?.size)
+        assertEquals("Health Services", links?.get(0)?.title)
         coVerify { teamsRepository.getTeamLinks() }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityServicesViewModelTest.kt
@@ -15,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
@@ -26,7 +25,6 @@ class CommunityServicesViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val teamsRepository: TeamsRepository = mockk()
-    private val userRepository: UserRepository = mockk()
     private val dispatcherProvider = TestDispatcherProvider(mainDispatcherRule.testDispatcher)
 
     @Before
@@ -39,7 +37,7 @@ class CommunityServicesViewModelTest {
         val mockTeam = MyTeam().apply { title = "Health Services" }
         coEvery { teamsRepository.getTeamLinks() } returns listOf(mockTeam)
 
-        val viewModel = CommunityServicesViewModel(teamsRepository, userRepository, dispatcherProvider)
+        val viewModel = CommunityServicesViewModel(teamsRepository, dispatcherProvider)
         advanceUntilIdle()
 
         val links = viewModel.teamLinks.first()
@@ -53,7 +51,7 @@ class CommunityServicesViewModelTest {
         coEvery { teamsRepository.isMember("user_123", "team_456") } returns true
         coEvery { teamsRepository.isMember(null, "team_456") } returns false
 
-        val viewModel = CommunityServicesViewModel(teamsRepository, userRepository, dispatcherProvider)
+        val viewModel = CommunityServicesViewModel(teamsRepository, dispatcherProvider)
         advanceUntilIdle()
 
         val isMemberUser = viewModel.isMember("user_123", "team_456")


### PR DESCRIPTION
Introduced CommunityServicesViewModel for team-link data access, refactored CommunityServicesFragment to use it, and added CommunityServicesViewModelTest unit tests.

Fixes #17076

---
*PR created automatically by Jules for task [10064867603795298000](https://jules.google.com/task/10064867603795298000) started by @dogi*