### PR TITLE
community: smoother leaders name binding (fixes #17083)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityLeadersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityLeadersAdapter.kt
@@ -35,11 +35,10 @@ internal class CommunityLeadersAdapter(
 
     override fun onBindViewHolder(holder: CommunityLeadersViewHolder, position: Int) {
         val leader = getItem(position)
-        if (leader.firstName == null) {
-            holder.title.text = leader.name
-        } else {
-            holder.title.text = context.getString(R.string.message_placeholder, leader)
-        }
+        holder.title.text = listOfNotNull(leader.firstName, leader.middleName, leader.lastName)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+            .ifBlank { leader.name }
         holder.tvDescription.text = leader.email
 
         holder.itemView.setOnClickListener {

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityLeadersAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityLeadersAdapterTest.kt
@@ -1,11 +1,79 @@
 package org.ole.planet.myplanet.ui.community
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.ole.planet.myplanet.model.UserEntity
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class CommunityLeadersAdapterTest {
+
+    private lateinit var context: Context
+    private lateinit var adapter: CommunityLeadersAdapter
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        adapter = CommunityLeadersAdapter(context)
+    }
+
+    @Test
+    fun testOnBindViewHolder_fullNamesAndFallbacks() {
+        val userWithFirstNameOnly = UserEntity().apply {
+            id = "1"
+            firstName = "John"
+            name = "john_username"
+        }
+        val userWithFirstAndLastName = UserEntity().apply {
+            id = "2"
+            firstName = "Jane"
+            lastName = "Doe"
+            name = "jane_username"
+        }
+        val userWithMiddleName = UserEntity().apply {
+            id = "3"
+            firstName = "Alice"
+            middleName = "M."
+            lastName = "Smith"
+            name = "alice_username"
+        }
+        val userWithNoFirstName = UserEntity().apply {
+            id = "4"
+            name = "fallback_username"
+        }
+        val userWithBlankNameFields = UserEntity().apply {
+            id = "5"
+            firstName = "  "
+            lastName = ""
+            name = "fallback_for_blank"
+        }
+
+        val parent = android.widget.FrameLayout(context)
+        val viewHolder = adapter.onCreateViewHolder(parent, 0)
+
+        adapter.submitList(listOf(userWithFirstNameOnly, userWithFirstAndLastName, userWithMiddleName, userWithNoFirstName, userWithBlankNameFields))
+
+        adapter.onBindViewHolder(viewHolder, 0)
+        assertEquals("John", viewHolder.title.text.toString())
+
+        adapter.onBindViewHolder(viewHolder, 1)
+        assertEquals("Jane Doe", viewHolder.title.text.toString())
+
+        adapter.onBindViewHolder(viewHolder, 2)
+        assertEquals("Alice M. Smith", viewHolder.title.text.toString())
+
+        adapter.onBindViewHolder(viewHolder, 3)
+        assertEquals("fallback_username", viewHolder.title.text.toString())
+
+        adapter.onBindViewHolder(viewHolder, 4)
+        assertEquals("fallback_for_blank", viewHolder.title.text.toString())
+    }
 
     @Test
     fun testAreContentsTheSame() {


### PR DESCRIPTION
Fixed the message_placeholder misuse in CommunityLeadersAdapter where leaders' full names were not being rendered. Replaced the logic with direct composition of firstName, middleName, and lastName, falling back to leader.name when blank. Updated unit tests to verify full name composition and fallback behavior.

Fixes #17083

---
*PR created automatically by Jules for task [1933806550040205928](https://jules.google.com/task/1933806550040205928) started by @dogi*