### PR TITLE
courses: smoother progress repository dao querying (fixes #17085)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDao.kt
@@ -2,7 +2,10 @@ package org.ole.planet.myplanet.data.room.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.RawQuery
 import androidx.room.Upsert
+import androidx.sqlite.db.SimpleSQLiteQuery
+import androidx.sqlite.db.SupportSQLiteQuery
 import org.ole.planet.myplanet.model.CourseProgress
 
 @Dao
@@ -22,8 +25,26 @@ interface CourseProgressDao {
     @Query("SELECT * FROM course_progress WHERE id IN (:ids)")
     suspend fun getByIds(ids: List<String>): List<CourseProgress>
 
-    @Query("SELECT * FROM course_progress WHERE courseId IN (:courseIds) AND userId IN (:userIds) AND stepNum IN (:stepNums)")
-    suspend fun getByCourseUsersAndSteps(courseIds: List<String>, userIds: List<String>, stepNums: List<Int>): List<CourseProgress>
+    @RawQuery
+    suspend fun getByExactKeysRaw(query: SupportSQLiteQuery): List<CourseProgress>
+
+    suspend fun getByCourseUsersAndSteps(tuples: List<Triple<String, String, Int>>): List<CourseProgress> {
+        if (tuples.isEmpty()) return emptyList()
+        val distinctTuples = tuples.distinct()
+        val results = ArrayList<CourseProgress>()
+        distinctTuples.chunked(250).forEach { chunk ->
+            val clauses = chunk.joinToString(" OR ") { "(courseId IS ? AND userId IS ? AND stepNum = ?)" }
+            val sql = "SELECT * FROM course_progress WHERE $clauses"
+            val bindArgs = ArrayList<Any?>(chunk.size * 3)
+            for ((courseId, userId, stepNum) in chunk) {
+                bindArgs.add(courseId)
+                bindArgs.add(userId)
+                bindArgs.add(stepNum)
+            }
+            results.addAll(getByExactKeysRaw(SimpleSQLiteQuery(sql, bindArgs.toTypedArray())))
+        }
+        return results
+    }
 
     @Query("SELECT * FROM course_progress WHERE _id IS NULL AND userId NOT LIKE 'guest%'")
     suspend fun getPendingUploads(): List<CourseProgress>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -286,9 +286,13 @@ class ProgressRepositoryImpl @Inject constructor(
         }
 
         val docIds = syncKeys.mapNotNullTo(LinkedHashSet()) { keys -> keys.docId.takeIf { it.isNotEmpty() } }.toList()
-        val courseIds = syncKeys.mapNotNullTo(LinkedHashSet()) { keys -> keys.courseId.takeIf { it.isNotEmpty() } }.toList()
-        val userIds = syncKeys.mapNotNullTo(LinkedHashSet()) { keys -> keys.userId.takeIf { it.isNotEmpty() } }.toList()
-        val stepNums = syncKeys.mapTo(LinkedHashSet()) { keys -> keys.stepNum }.toList()
+        val requestedTuples = syncKeys.mapNotNull { keys ->
+            if (keys.courseId.isNotEmpty() && keys.userId.isNotEmpty()) {
+                Triple(keys.courseId, keys.userId, keys.stepNum)
+            } else {
+                null
+            }
+        }.distinct()
 
         val existingProgresses = if (docIds.isNotEmpty()) {
             courseProgressDao.getByIds(docIds).associateBy { it.id }
@@ -296,8 +300,8 @@ class ProgressRepositoryImpl @Inject constructor(
             emptyMap()
         }
 
-        val localRecords = if (courseIds.isNotEmpty() && userIds.isNotEmpty() && stepNums.isNotEmpty()) {
-            courseProgressDao.getByCourseUsersAndSteps(courseIds, userIds, stepNums)
+        val localRecords = if (requestedTuples.isNotEmpty()) {
+            courseProgressDao.getByCourseUsersAndSteps(requestedTuples)
         } else {
             emptyList()
         }

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDaoTest.kt
@@ -1,0 +1,105 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.data.room.AppDatabase
+import org.ole.planet.myplanet.model.CourseProgress
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = Application::class)
+class CourseProgressDaoTest {
+
+    private lateinit var database: AppDatabase
+    private lateinit var courseProgressDao: CourseProgressDao
+
+    @Before
+    fun initDb() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        courseProgressDao = database.courseProgressDao()
+    }
+
+    @After
+    fun closeDb() {
+        database.close()
+    }
+
+    private fun createProgress(
+        id: String,
+        courseId: String,
+        userId: String,
+        stepNum: Int,
+        passed: Boolean = true
+    ): CourseProgress {
+        return CourseProgress().apply {
+            this.id = id
+            this.courseId = courseId
+            this.userId = userId
+            this.stepNum = stepNum
+            this.passed = passed
+        }
+    }
+
+    @Test
+    fun getByCourseUsersAndSteps_returnsExactTuplesAndExcludesCrossProduct() = runBlocking {
+        val cp1 = createProgress("id1", "c1", "u1", 1)
+        val cp2 = createProgress("id2", "c2", "u2", 2)
+        val cpCross1 = createProgress("id3", "c1", "u2", 1)
+        val cpCross2 = createProgress("id4", "c2", "u1", 2)
+
+        courseProgressDao.upsertAll(listOf(cp1, cp2, cpCross1, cpCross2))
+
+        val requestedTuples = listOf(
+            Triple("c1", "u1", 1),
+            Triple("c2", "u2", 2)
+        )
+
+        val results = courseProgressDao.getByCourseUsersAndSteps(requestedTuples)
+
+        assertEquals(2, results.size)
+        val resultIds = results.map { it.id }.toSet()
+        assertTrue(resultIds.contains("id1"))
+        assertTrue(resultIds.contains("id2"))
+        assertFalse(resultIds.contains("id3"))
+        assertFalse(resultIds.contains("id4"))
+    }
+
+    @Test
+    fun getByCourseUsersAndSteps_emptyInput_returnsEmptyList() = runBlocking {
+        val cp = createProgress("id1", "c1", "u1", 1)
+        courseProgressDao.upsert(cp)
+
+        val results = courseProgressDao.getByCourseUsersAndSteps(emptyList())
+
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun getByCourseUsersAndSteps_handlesLargeTupleChunking() = runBlocking {
+        val items = (1..300).map { i ->
+            createProgress("id_$i", "course_$i", "user_$i", i)
+        }
+        courseProgressDao.upsertAll(items)
+
+        val requestedTuples = (1..300).map { i ->
+            Triple("course_$i", "user_$i", i)
+        }
+
+        val results = courseProgressDao.getByCourseUsersAndSteps(requestedTuples)
+
+        assertEquals(300, results.size)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -373,7 +373,7 @@ class ProgressRepositoryImplTest {
             addProperty("passed", true)
         }
         coEvery { courseProgressDao.getByIds(listOf("doc1")) } returns emptyList()
-        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf("course1"), listOf("user1"), listOf(1)) } returns emptyList()
+        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf(Triple("course1", "user1", 1))) } returns emptyList()
 
         repository.insertCourseProgressFromSync(listOf(doc1))
 
@@ -408,7 +408,7 @@ class ProgressRepositoryImplTest {
             stepNum = 1
         }
         coEvery { courseProgressDao.getByIds(listOf("doc1")) } returns emptyList()
-        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf("course1"), listOf("user1"), listOf(1)) } returns listOf(existingProgress)
+        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf(Triple("course1", "user1", 1))) } returns listOf(existingProgress)
 
         repository.insertCourseProgressFromSync(listOf(doc1))
 
@@ -696,13 +696,13 @@ class ProgressRepositoryImplTest {
         }
 
         coEvery { courseProgressDao.getByIds(listOf("doc1", "doc2")) } returns emptyList()
-        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf("course1", "course2"), listOf("user1"), listOf(1, 2)) } returns emptyList()
+        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf(Triple("course1", "user1", 1), Triple("course2", "user1", 2))) } returns emptyList()
 
         repository.insertCourseProgressFromSync(listOf(doc1, doc2, doc3))
 
         coVerify {
             courseProgressDao.getByIds(listOf("doc1", "doc2"))
-            courseProgressDao.getByCourseUsersAndSteps(listOf("course1", "course2"), listOf("user1"), listOf(1, 2))
+            courseProgressDao.getByCourseUsersAndSteps(listOf(Triple("course1", "user1", 1), Triple("course2", "user1", 2)))
             courseProgressDao.upsertAll(match { progresses ->
                 progresses.size == 3 &&
                     progresses[0].id == "doc1" &&


### PR DESCRIPTION
Replaced three-way IN cross product course-progress query with exact tuple lookup. Deduplicated tuples in repository and chunked raw queries to respect SQLite variable limits. Added in-memory Room unit tests verifying that non-requested cross-product combinations are not returned.

Fixes #17085

---
*PR created automatically by Jules for task [13777070494925251531](https://jules.google.com/task/13777070494925251531) started by @dogi*