### PR TITLE
enterprises: smoother report csv dao exporting (fixes #17084)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
+import org.ole.planet.myplanet.model.EnterpriseReportCsvProjection
 import org.ole.planet.myplanet.model.MyTeam
 
 @Dao
@@ -22,6 +23,7 @@ interface TeamDao {
     @Query("SELECT * FROM teams WHERE teamId = :teamId AND docType = :docType") fun observeByTeamIdAndDocType(teamId: String, docType: String): Flow<List<MyTeam>>
     @Query("SELECT * FROM teams WHERE teamId = :teamId AND docType = 'report' AND IFNULL(status, '') != 'archived' ORDER BY createdDate DESC") fun observeNonArchivedReportsByTeamId(teamId: String): Flow<List<MyTeam>>
     @Query("SELECT * FROM teams WHERE teamId = :teamId AND docType = 'report' AND IFNULL(status, '') != 'archived' ORDER BY createdDate DESC") suspend fun getNonArchivedReportsByTeamId(teamId: String): List<MyTeam>
+    @Query("SELECT startDate, endDate, createdDate, updatedDate, beginningBalance, sales, otherIncome, wages, otherExpenses FROM teams WHERE teamId = :teamId AND docType = 'report' AND IFNULL(status, '') != 'archived' ORDER BY createdDate DESC") suspend fun getNonArchivedReportCsvProjectionsByTeamId(teamId: String): List<EnterpriseReportCsvProjection>
     @Query("SELECT * FROM teams WHERE teamId = :teamId AND userId = :userId AND docType = :docType LIMIT 1") suspend fun getByTeamIdUserIdAndDocType(teamId: String, userId: String, docType: String): MyTeam?
     @Query("SELECT COUNT(*) FROM teams WHERE teamId = :teamId AND userId = :userId AND docType = :docType") suspend fun countByTeamIdUserIdAndDocType(teamId: String, userId: String, docType: String): Int
     @Query("SELECT COUNT(DISTINCT userId) FROM teams WHERE teamId = :teamId AND docType = :docType AND isDeletePending = 0 AND userId IS NOT NULL AND EXISTS (SELECT 1 FROM users u WHERE u.id = teams.userId OR u._id = teams.userId)") suspend fun countByTeamIdAndDocType(teamId: String, docType: String): Int

--- a/app/src/main/java/org/ole/planet/myplanet/model/EnterpriseReportCsvProjection.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/EnterpriseReportCsvProjection.kt
@@ -1,0 +1,13 @@
+package org.ole.planet.myplanet.model
+
+data class EnterpriseReportCsvProjection(
+    val startDate: Long,
+    val endDate: Long,
+    val createdDate: Long,
+    val updatedDate: Long,
+    val beginningBalance: Int,
+    val sales: Int,
+    val otherIncome: Int,
+    val wages: Int,
+    val otherExpenses: Int
+)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImpl.kt
@@ -100,7 +100,7 @@ class EnterprisesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun exportReportsAsCsv(teamId: String, teamName: String): String {
-        val reports = teamDao.getNonArchivedReportsByTeamId(teamId)
+        val reports = teamDao.getNonArchivedReportCsvProjectionsByTeamId(teamId)
         val csvBuilder = StringBuilder()
         csvBuilder.append(teamName).append(" Financial Report Summary\n\n")
         csvBuilder.append("Start Date, End Date, Created Date, Updated Date, Beginning Balance, Sales, Other Income, Wages, Other Expenses, Profit/Loss, Ending Balance\n")

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/TeamDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/TeamDaoTest.kt
@@ -163,4 +163,55 @@ class TeamDaoTest {
 
         assertEquals(listOf("mine"), result.map { it._id })
     }
+
+    @Test
+    fun `getNonArchivedReportCsvProjectionsByTeamId projects fields and orders descending`() = runBlocking {
+        val r1 = report("r1", createdDate = 100L).apply {
+            startDate = 10L
+            endDate = 20L
+            updatedDate = 30L
+            beginningBalance = 100
+            sales = 50
+            otherIncome = 20
+            wages = 10
+            otherExpenses = 15
+        }
+        val r2 = report("r2", createdDate = 200L).apply {
+            startDate = 40L
+            endDate = 50L
+            updatedDate = 60L
+            beginningBalance = 200
+            sales = 80
+            otherIncome = 30
+            wages = 20
+            otherExpenses = 25
+        }
+        val archived = report("archived", createdDate = 300L, status = "archived")
+        val otherTeam = report("otherTeam", teamId = "team2", createdDate = 400L)
+
+        teamDao.upsertAll(listOf(r1, r2, archived, otherTeam))
+
+        val projections = teamDao.getNonArchivedReportCsvProjectionsByTeamId("team1")
+
+        assertEquals(2, projections.size)
+        assertEquals(200L, projections[0].createdDate)
+        assertEquals(40L, projections[0].startDate)
+        assertEquals(50L, projections[0].endDate)
+        assertEquals(60L, projections[0].updatedDate)
+        assertEquals(200, projections[0].beginningBalance)
+        assertEquals(80, projections[0].sales)
+        assertEquals(30, projections[0].otherIncome)
+        assertEquals(20, projections[0].wages)
+        assertEquals(25, projections[0].otherExpenses)
+
+        assertEquals(100L, projections[1].createdDate)
+        assertEquals(10L, projections[1].startDate)
+        assertEquals(20L, projections[1].endDate)
+        assertEquals(30L, projections[1].updatedDate)
+        assertEquals(100, projections[1].beginningBalance)
+        assertEquals(50, projections[1].sales)
+        assertEquals(20, projections[1].otherIncome)
+        assertEquals(10, projections[1].wages)
+        assertEquals(15, projections[1].otherExpenses)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.TeamDao
+import org.ole.planet.myplanet.model.EnterpriseReportCsvProjection
 import org.ole.planet.myplanet.model.FinanceReportParams
 import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -70,23 +71,19 @@ class EnterprisesRepositoryImplTest {
     @Test
     fun `exportReportsAsCsv calculates correct profitLoss and endingBalance`() = runTest {
         val teamId = "team123"
-        val report = MyTeam().apply {
-            startDate = 1000L
-            endDate = 2000L
-            createdDate = 3000L
-            updatedDate = 4000L
-            beginningBalance = 100
-            sales = 50
-            otherIncome = 20
-            wages = 10
+        val reportProjection = EnterpriseReportCsvProjection(
+            startDate = 1000L,
+            endDate = 2000L,
+            createdDate = 3000L,
+            updatedDate = 4000L,
+            beginningBalance = 100,
+            sales = 50,
+            otherIncome = 20,
+            wages = 10,
             otherExpenses = 15
-        }
-        val archivedReport = MyTeam().apply {
-            status = "archived"
-            createdDate = 4000L
-        }
+        )
 
-        coEvery { teamDao.getNonArchivedReportsByTeamId(teamId) } returns listOf(report)
+        coEvery { teamDao.getNonArchivedReportCsvProjectionsByTeamId(teamId) } returns listOf(reportProjection)
 
         val result = repository.exportReportsAsCsv(teamId, "Test Team")
 


### PR DESCRIPTION
Switched Enterprise report CSV export from loading full MyTeam entities to using a lightweight Room DAO projection selecting only the nine required columns (startDate, endDate, createdDate, updatedDate, beginningBalance, sales, otherIncome, wages, otherExpenses).

Fixes #17084

---
*PR created automatically by Jules for task [13993010551484025708](https://jules.google.com/task/13993010551484025708) started by @dogi*