### PR TITLE
resources: smoother repository offline metadata loading (fixes #17089)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -853,7 +853,12 @@ class ResourcesRepositoryImpl @Inject constructor(
 
         val titleMap = getResourceTitlesMap()
 
-        val grouped = mutableMapOf<String, MutableList<File>>()
+        class ResourceAccumulator {
+            val filePaths = mutableListOf<String>()
+            var totalSize = 0L
+        }
+
+        val grouped = mutableMapOf<String, ResourceAccumulator>()
         oleDir.walkTopDown().filter { it.isFile }.forEach { file ->
             val ext = file.extension.lowercase()
             val matchesCategory = if (extensions.isEmpty()) {
@@ -863,14 +868,15 @@ class ResourcesRepositoryImpl @Inject constructor(
             }
             if (matchesCategory) {
                 val resourceId = file.parentFile?.name ?: return@forEach
-                grouped.getOrPut(resourceId) { mutableListOf() }.add(file)
+                val accumulator = grouped.getOrPut(resourceId) { ResourceAccumulator() }
+                accumulator.filePaths.add(file.absolutePath)
+                accumulator.totalSize += file.length()
             }
         }
 
-        return@withContext grouped.map { (resourceId, files) ->
-            val totalSize = files.sumOf { it.length() }
+        return@withContext grouped.map { (resourceId, accumulator) ->
             val title = titleMap[resourceId]?.takeIf { it.isNotBlank() } ?: context.getString(R.string.storage_unknown_resource)
-            OfflineResourceItem(resourceId, title, files.map { it.absolutePath }, totalSize)
+            OfflineResourceItem(resourceId, title, accumulator.filePaths, accumulator.totalSize)
         }.sortedBy { it.title }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -1137,6 +1137,56 @@ class ResourcesRepositoryImplTest {
         coVerify(exactly = 0) { myLibraryDao.upsert(any()) }
     }
 
+    @Test
+    fun `getOfflineResourceItems returns empty list if ole directory does not exist or is not a directory`() = runTest {
+        val nonExistentDir = File(temporaryFolder.root, "non_existent")
+        val result1 = repository.getOfflineResourceItems(nonExistentDir.absolutePath, emptySet(), emptySet())
+        assertTrue(result1.isEmpty())
+
+        val regularFile = temporaryFolder.newFile("regular_file.txt")
+        val result2 = repository.getOfflineResourceItems(regularFile.absolutePath, emptySet(), emptySet())
+        assertTrue(result2.isEmpty())
+    }
+
+    @Test
+    fun `getOfflineResourceItems calculates size and path order in single pass`() = runTest {
+        val oleDir = temporaryFolder.newFolder("ole")
+        val res1Dir = File(oleDir, "res1").apply { mkdirs() }
+        val res2Dir = File(oleDir, "res2").apply { mkdirs() }
+
+        val file1 = File(res1Dir, "a.mp4").apply { writeText("12345") } // 5 bytes
+        val file2 = File(res1Dir, "b.mp4").apply { writeText("1234567890") } // 10 bytes
+        val file3 = File(res2Dir, "c.pdf").apply { writeText("123") } // 3 bytes
+        val file4 = File(res2Dir, "d.txt").apply { writeText("1") } // 1 byte
+
+        val projections = listOf(
+            ResourceTitleProjection("res1", "Video Resource"),
+            ResourceTitleProjection("res2", "")
+        )
+        coEvery { myLibraryDao.getResourceTitles() } returns projections
+        every { context.getString(org.ole.planet.myplanet.R.string.storage_unknown_resource) } returns "Unknown Resource"
+
+        val knownExtensions = setOf("mp4", "pdf")
+
+        // Test matching specific category (mp4)
+        val videoItems = repository.getOfflineResourceItems(oleDir.absolutePath, setOf("mp4"), knownExtensions)
+        assertEquals(1, videoItems.size)
+        val res1Item = videoItems[0]
+        assertEquals("res1", res1Item.resourceId)
+        assertEquals("Video Resource", res1Item.title)
+        assertEquals(15L, res1Item.totalSize)
+        assertEquals(listOf(file1.absolutePath, file2.absolutePath), res1Item.filePaths)
+
+        // Test fallback extension category (extensions.isEmpty() -> not in knownExtensions)
+        val otherItems = repository.getOfflineResourceItems(oleDir.absolutePath, emptySet(), knownExtensions)
+        assertEquals(1, otherItems.size)
+        val res2Item = otherItems[0]
+        assertEquals("res2", res2Item.resourceId)
+        assertEquals("Unknown Resource", res2Item.title)
+        assertEquals(1L, res2Item.totalSize)
+        assertEquals(listOf(file4.absolutePath), res2Item.filePaths)
+    }
+
     private fun localResourceRequest(resourceUrl: String?): LocalResourceRequest {
         return LocalResourceRequest(
             title = "My Report",

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -1174,7 +1174,7 @@ class ResourcesRepositoryImplTest {
         val res1Item = videoItems[0]
         assertEquals("res1", res1Item.resourceId)
         assertEquals("Video Resource", res1Item.title)
-        assertEquals(15L, res1Item.totalSize)
+        assertEquals(15L, res1Item.totalSizeBytes)
         assertEquals(listOf(file1.absolutePath, file2.absolutePath), res1Item.filePaths)
 
         // Test fallback extension category (extensions.isEmpty() -> not in knownExtensions)
@@ -1183,7 +1183,7 @@ class ResourcesRepositoryImplTest {
         val res2Item = otherItems[0]
         assertEquals("res2", res2Item.resourceId)
         assertEquals("Unknown Resource", res2Item.title)
-        assertEquals(1L, res2Item.totalSize)
+        assertEquals(1L, res2Item.totalSizeBytes)
         assertEquals(listOf(file4.absolutePath), res2Item.filePaths)
     }
 


### PR DESCRIPTION
Refactored getOfflineResourceItems in ResourcesRepositoryImpl.kt to process offline resource directory trees in a single filesystem pass. During oleDir.walkTopDown(), matching file paths and length() values are accumulated directly into a local ResourceAccumulator per resource ID, preserving category filtering, path order, title fallback, missing directory behavior, and dispatcher context.

Fixes #17089

---
*PR created automatically by Jules for task [3721659123464850113](https://jules.google.com/task/3721659123464850113) started by @dogi*