### PR TITLE
courses: smoother detail markdown context view modelling (fixes #17091)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailViewModel.kt
@@ -1,15 +1,16 @@
 package org.ole.planet.myplanet.ui.courses
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.model.MyCourse
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.StepItem
@@ -33,6 +34,7 @@ sealed interface CourseDetailUiState {
 
 @HiltViewModel
 class CourseDetailViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val courseDetailProvider: CourseDetailProvider,
     private val ratingSummaryProvider: RatingSummaryProvider
 ) : ViewModel() {
@@ -64,7 +66,7 @@ class CourseDetailViewModel @Inject constructor(
 
                     val markdownDescription = MarkdownUtils.prependBaseUrlToImages(
                         courseDetail.course.description,
-                        "file://${MainApplication.context.getExternalFilesDir(null)}/ole/",
+                        "file://${context.getExternalFilesDir(null)}/ole/",
                         600, 350
                     )
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CourseDetailViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CourseDetailViewModelTest.kt
@@ -10,14 +10,12 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.model.CourseDetailModel
 import org.ole.planet.myplanet.model.CourseStep
 import org.ole.planet.myplanet.model.MyCourse
@@ -47,25 +45,17 @@ class CourseDetailViewModelTest {
         override val unconfined: CoroutineDispatcher = testDispatcher
     }
 
+    private val context: Context = mockk(relaxed = true)
+
     private lateinit var viewModel: CourseDetailViewModel
     private lateinit var courseDetailProvider: CourseDetailProvider
     private lateinit var ratingSummaryProvider: RatingSummaryProvider
 
     private val courseId = "course_1"
 
-    private var originalContext: Context? = null
-
     @Before
     fun setUp() {
-        // loadCourseDetail builds the markdown base URL from MainApplication.context, which is
-        // otherwise uninitialized in a plain JVM unit test and would surface as an Error state.
-        try {
-            originalContext = MainApplication.context
-        } catch (e: Exception) {
-            // UninitializedPropertyAccessException if context was never set
-        }
-        MainApplication.testContext = mockk<Context>(relaxed = true)
-        io.mockk.every { MainApplication.context.getExternalFilesDir(null) } returns null
+        every { context.getExternalFilesDir(null) } returns null
 
         courseDetailProvider = CourseDetailProvider(coursesRepository)
 
@@ -74,14 +64,10 @@ class CourseDetailViewModelTest {
         )
 
         viewModel = CourseDetailViewModel(
+            context,
             courseDetailProvider,
             ratingSummaryProvider
         )
-    }
-
-    @After
-    fun tearDown() {
-        MainApplication.testContext = originalContext
     }
 
     private fun stubCourseLoad(


### PR DESCRIPTION
Inject `@ApplicationContext context: Context` into `CourseDetailViewModel` to replace static `MainApplication.context` access for markdown image base URL construction, and update unit tests accordingly.

Fixes #17091

---
*PR created automatically by Jules for task [15330760396166775794](https://jules.google.com/task/15330760396166775794) started by @dogi*