### PR TITLE
Index collection tags once when reconciling selections

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -53,6 +53,10 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         return binding.root
     }
 
+    private fun getMatchKey(tag: TagEntity): String? {
+        return tag.id.ifEmpty { tag.name?.takeIf { it.isNotEmpty() } }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -67,9 +71,18 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
                 is CollectionsState.Success -> {
                     list = state.list
                     childMap = state.childMap
-                    val allTags = list + childMap.values.flatten()
+                    val tagMap = HashMap<String, TagEntity>()
+                    list.forEach { tag ->
+                        getMatchKey(tag)?.let { tagMap.putIfAbsent(it, tag) }
+                    }
+                    childMap.values.forEach { children ->
+                        children.forEach { tag ->
+                            getMatchKey(tag)?.let { tagMap.putIfAbsent(it, tag) }
+                        }
+                    }
                     val reconciledList = selectedItemsList.map { selected ->
-                        allTags.find { selected.matches(it) } ?: selected
+                        val key = getMatchKey(selected)
+                        if (key != null) tagMap[key] ?: selected else selected
                     }
                     selectedItemsList.clear()
                     selectedItemsList.addAll(reconciledList)
@@ -131,15 +144,18 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
                 parentMap[it.tag.id] = it
             }
         }
+        val selectedKeys = selectedItemsList.mapNotNullTo(HashSet()) { getMatchKey(it) }
         for (parentTag in parents) {
-            val isSelected = selectedItemsList.any { it.matches(parentTag) }
+            val parentKey = getMatchKey(parentTag)
+            val isSelected = parentKey != null && selectedKeys.contains(parentKey)
             val parent = parentMap[parentTag.id] ?: TagData.Parent(parentTag, false, isSelected, isSelectMultiple)
 
             tagDataList.add(parent.copy(isSelected = isSelected, isSelectMultiple = isSelectMultiple))
 
             if (parent.isExpanded) {
                 childMap[parent.tag.id]?.forEach { childTag ->
-                    val isChildSelected = selectedItemsList.any { it.matches(childTag) }
+                    val childKey = getMatchKey(childTag)
+                    val isChildSelected = childKey != null && selectedKeys.contains(childKey)
                     tagDataList.add(TagData.Child(childTag, isChildSelected, isSelectMultiple))
                 }
             }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/CollectionsFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/CollectionsFragmentTest.kt
@@ -91,6 +91,62 @@ class CollectionsFragmentTest {
         assertFalse((result[0] as TagData.Parent).isSelected)
         assertTrue((result[1] as TagData.Parent).isSelected)
     }
+
+    @Test
+    fun `buildTagDataList reflects child selection state correctly`() {
+        val parents = listOf(tag("p1", "Math"))
+        val child = tag("c1", "Algebra")
+        val childMap = mapOf("p1" to listOf(child))
+        val fragment = newFragment(parents, childMap, selected = listOf(tag("c1", "Algebra")))
+
+        val initialResult = buildTagDataList(fragment, parents)
+        val parent = initialResult[0] as TagData.Parent
+        parent.isExpanded = true
+        setCurrentTagDataList(fragment, initialResult)
+
+        val result = buildTagDataList(fragment, parents)
+        assertEquals(2, result.size)
+        assertFalse((result[0] as TagData.Parent).isSelected)
+        assertTrue((result[1] as TagData.Child).isSelected)
+    }
+
+    @Test
+    fun `reconcile tags preserves order and keeps unmatched tags`() {
+        val loadedParent = tag("p1", "Math (Loaded)")
+        val loadedChild = tag("c1", "Algebra (Loaded)")
+        val parents = listOf(loadedParent)
+        val childMap = mapOf("p1" to listOf(loadedChild))
+
+        val unmappedSelected = tag("x99", "Unknown")
+        val staleChildSelected = tag("c1", "Algebra (Stale)")
+        val staleParentSelected = tag("p1", "Math (Stale)")
+
+        val selected = listOf(unmappedSelected, staleChildSelected, staleParentSelected)
+        val fragment = newFragment(parents, childMap, selected)
+
+        val getMatchKeyMethod = CollectionsFragment::class.java.getDeclaredMethod("getMatchKey", TagEntity::class.java).apply { isAccessible = true }
+
+        val tagMap = HashMap<String, TagEntity>()
+        parents.forEach { tag ->
+            (getMatchKeyMethod.invoke(fragment, tag) as? String)?.let { tagMap.putIfAbsent(it, tag) }
+        }
+        childMap.values.forEach { children ->
+            children.forEach { tag ->
+                (getMatchKeyMethod.invoke(fragment, tag) as? String)?.let { tagMap.putIfAbsent(it, tag) }
+            }
+        }
+
+        val reconciled = selected.map { sel ->
+            val key = getMatchKeyMethod.invoke(fragment, sel) as? String
+            if (key != null) tagMap[key] ?: sel else sel
+        }
+
+        assertEquals(3, reconciled.size)
+        // Order preserved: [unmapped, c1, p1]
+        assertEquals(unmappedSelected, reconciled[0])
+        assertEquals(loadedChild, reconciled[1])
+        assertEquals(loadedParent, reconciled[2])
+    }
 }
 
 private fun setField(target: Any, name: String, value: Any) {


### PR DESCRIPTION
Optimizes tag reconciliation and selection checking in CollectionsFragment by indexing parent and child tags into an id/matchKey map and set in a single pass. This eliminates linear scans per tag row while preserving item order and fallback behavior.

Fixes #17090

---
*PR created automatically by Jules for task [9466225621157342713](https://jules.google.com/task/9466225621157342713) started by @dogi*