### PR TITLE
all: smoother settings storage category finding (fixes #17100)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
@@ -224,12 +224,7 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
 
         oleDir.walkTopDown().filter { it.isFile }.forEach { file ->
             val ext = file.extension
-            val index = if (ext.isEmpty()) {
-                StorageCategories.OTHER_INDEX
-            } else {
-                val idx = StorageCategories.indexOf(ext)
-                if (idx != StorageCategories.OTHER_INDEX) idx else StorageCategories.indexOf(ext.lowercase())
-            }
+            val index = if (ext.isEmpty()) StorageCategories.OTHER_INDEX else StorageCategories.indexOf(ext)
             val size = file.length()
             total += size
             sizes[index] += size

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategories.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategories.kt
@@ -29,5 +29,5 @@ object StorageCategories {
         }
     }
 
-    fun indexOf(extension: String): Int = extensionToIndex[extension] ?: OTHER_INDEX
+    fun indexOf(extension: String): Int = extensionToIndex[extension.lowercase()] ?: OTHER_INDEX
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/settings/StorageCategoriesTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/settings/StorageCategoriesTest.kt
@@ -52,11 +52,20 @@ class StorageCategoriesTest {
     }
 
     @Test
+    fun `indexOf is case-insensitive for known extensions`() {
+        assertEquals(3, StorageCategories.indexOf("JPG"))
+        assertEquals(3, StorageCategories.indexOf("Jpg"))
+        assertEquals(3, StorageCategories.indexOf("jpg"))
+        assertEquals(2, StorageCategories.indexOf("PDF"))
+    }
+
+    @Test
     fun `indexOf falls back to the other category for unknown extensions`() {
         assertEquals(StorageCategories.OTHER_INDEX, StorageCategories.indexOf("zip"))
         assertEquals(StorageCategories.OTHER_INDEX, StorageCategories.indexOf("txt"))
         assertEquals(StorageCategories.OTHER_INDEX, StorageCategories.indexOf(""))
-        assertEquals(StorageCategories.OTHER_INDEX, StorageCategories.indexOf("MKV"))
+        assertEquals(StorageCategories.OTHER_INDEX, StorageCategories.indexOf("xyz"))
+        assertEquals(StorageCategories.OTHER_INDEX, StorageCategories.indexOf("XYZ"))
     }
 
     @Test


### PR DESCRIPTION
Make StorageCategories.indexOf normalize file extensions to lowercase once and drop the redundant second lookup in StorageBreakdownFragment.scanStorage.

Fixes #17100

---
*PR created automatically by Jules for task [308662362518331284](https://jules.google.com/task/308662362518331284) started by @dogi*