### PR TITLE
all: smoother diagnostics repository app version utils providing (fixes #17098)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
@@ -2,17 +2,18 @@ package org.ole.planet.myplanet.repository
 
 import java.util.UUID
 import javax.inject.Inject
-import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.AppVersionProvider
 import org.ole.planet.myplanet.utils.CrashLogStore
 
 class DiagnosticsRepositoryImpl @Inject constructor(
     private val apkLogDao: ApkLogDao,
     private val userRepository: UserRepository,
-    private val sharedPrefManager: SharedPrefManager
+    private val sharedPrefManager: SharedPrefManager,
+    private val appVersionProvider: AppVersionProvider
 ) : DiagnosticsRepository {
 
     override suspend fun getPendingApkLogs(): List<ApkLog> {
@@ -59,7 +60,7 @@ class DiagnosticsRepositoryImpl @Inject constructor(
             val log = buildApkLog(
                 resolveParentCode(model),
                 resolvePlanetCode(model),
-                BuildConfig.VERSION_NAME,
+                appVersionProvider.versionName,
                 model?.id,
                 time,
                 type,
@@ -77,7 +78,7 @@ class DiagnosticsRepositoryImpl @Inject constructor(
         if (pendingLogs.isEmpty()) return true
         return try {
             val model = userRepository.getUserModel()
-            val versionName = BuildConfig.VERSION_NAME
+            val versionName = appVersionProvider.versionName
             val parentCode = resolveParentCode(model)
             val planetCode = resolvePlanetCode(model)
 

--- a/app/src/main/java/org/ole/planet/myplanet/utils/AppVersionProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/AppVersionProvider.kt
@@ -1,0 +1,8 @@
+package org.ole.planet.myplanet.utils
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.BuildConfig
+
+class AppVersionProvider @Inject constructor() {
+    val versionName: String get() = BuildConfig.VERSION_NAME
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImplTest.kt
@@ -18,11 +18,11 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.AppVersionProvider
 import org.ole.planet.myplanet.utils.CrashLogStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -30,7 +30,10 @@ class DiagnosticsRepositoryImplTest {
     private lateinit var apkLogDao: ApkLogDao
     private lateinit var sharedPrefManager: SharedPrefManager
     private lateinit var userRepository: UserRepository
+    private lateinit var appVersionProvider: AppVersionProvider
     private lateinit var repository: DiagnosticsRepositoryImpl
+
+    private val testVersionName = "1.2.3-test"
 
     @After
     fun tearDown() {
@@ -42,11 +45,13 @@ class DiagnosticsRepositoryImplTest {
         apkLogDao = mockk(relaxed = true)
         sharedPrefManager = mockk()
         userRepository = mockk()
+        appVersionProvider = mockk()
 
         every { sharedPrefManager.getParentCode() } returns "parent-123"
         every { sharedPrefManager.getPlanetCode() } returns "planet-456"
+        every { appVersionProvider.versionName } returns testVersionName
 
-        repository = DiagnosticsRepositoryImpl(apkLogDao, userRepository, sharedPrefManager)
+        repository = DiagnosticsRepositoryImpl(apkLogDao, userRepository, sharedPrefManager, appVersionProvider)
     }
 
     @Test
@@ -67,7 +72,7 @@ class DiagnosticsRepositoryImplTest {
         assertEquals("", log.page)
         assertEquals("parent-123", log.parentCode)
         assertEquals("planet-456", log.createdOn)
-        assertEquals(BuildConfig.VERSION_NAME, log.version)
+        assertEquals(testVersionName, log.version)
         assertEquals("user-1", log.userId)
         assertNotNull(log.id)
         assertTrue(log.id.isNotEmpty())
@@ -129,7 +134,7 @@ class DiagnosticsRepositoryImplTest {
         assertEquals("", first.page)
         assertEquals("parent-123", first.parentCode)
         assertEquals("planet-456", first.createdOn)
-        assertEquals(BuildConfig.VERSION_NAME, first.version)
+        assertEquals(testVersionName, first.version)
         assertEquals("user-1", first.userId)
         assertNotNull(first.id)
         assertTrue(first.id.isNotEmpty())


### PR DESCRIPTION
Injects AppVersionProvider into DiagnosticsRepositoryImpl, replacing direct references to BuildConfig.VERSION_NAME, and updates DiagnosticsRepositoryImplTest to mock the provider and test version propagation.

Fixes #17098

---
*PR created automatically by Jules for task [2934915899477006427](https://jules.google.com/task/2934915899477006427) started by @dogi*