### PR TITLE
sync: smoother time logger summary generating (fixes #17099)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
@@ -226,8 +226,8 @@ class SyncTimeLogger @Inject constructor(
         summaryBuilder.append("=== SYNC TIME SUMMARY ===\n")
         summaryBuilder.append("Total sync time: $totalMinutes min $totalSeconds sec (${formatTime(totalDuration)})\n\n")
 
-        val allApiCallLogs = apiCallTimes.values.flatten()
-        val allDbOpLogs = dbOperationTimes.values.flatten()
+        val totalApiTime = apiCallTimes.values.sumOf { logs -> logs.sumOf { it.duration } }
+        val totalDbTime = dbOperationTimes.values.sumOf { logs -> logs.sumOf { it.duration } }
 
         // Process times
         summaryBuilder.append("PROCESS BREAKDOWN:\n")
@@ -253,8 +253,7 @@ class SyncTimeLogger @Inject constructor(
         if (apiCallTimes.isNotEmpty()) {
             summaryBuilder.append("\nAPI CALL STATISTICS:\n")
             val totalApiCalls = apiCallTimes.values.sumOf { it.size }
-            val totalApiTime = allApiCallLogs.sumOf { it.duration }
-            val successfulCalls = allApiCallLogs.count { it.success }
+            val successfulCalls = apiCallTimes.values.sumOf { logs -> logs.count { it.success } }
 
             summaryBuilder.append(String.format(Locale.US, "  Total API calls: %d (Success: %d, Failed: %d)\n",
                 totalApiCalls, successfulCalls, totalApiCalls - successfulCalls))
@@ -274,8 +273,7 @@ class SyncTimeLogger @Inject constructor(
         if (dbOperationTimes.isNotEmpty()) {
             summaryBuilder.append("\nDB OPERATION STATISTICS:\n")
             val totalDbOps = dbOperationTimes.values.sumOf { it.size }
-            val totalDbTime = allDbOpLogs.sumOf { it.duration }
-            val totalDbItems = allDbOpLogs.sumOf { it.itemCount }
+            val totalDbItems = dbOperationTimes.values.sumOf { logs -> logs.sumOf { it.itemCount } }
 
             summaryBuilder.append(String.format(Locale.US, "  Total Db operations: %d\n", totalDbOps))
             summaryBuilder.append(String.format(Locale.US, "  Total Db time: %s (%.1f%% of total sync)\n",
@@ -294,10 +292,10 @@ class SyncTimeLogger @Inject constructor(
         // Performance insights
         summaryBuilder.append("\nPERFORMANCE INSIGHTS:\n")
         val apiPercentage = if (apiCallTimes.isNotEmpty()) {
-            (allApiCallLogs.sumOf { it.duration }.toDouble() / totalDuration * 100)
+            (totalApiTime.toDouble() / totalDuration * 100)
         } else 0.0
         val dbPercentage = if (dbOperationTimes.isNotEmpty()) {
-            (allDbOpLogs.sumOf { it.duration }.toDouble() / totalDuration * 100)
+            (totalDbTime.toDouble() / totalDuration * 100)
         } else 0.0
 
         summaryBuilder.append(String.format(Locale.US, "  Network time: %.1f%%\n", apiPercentage))

--- a/app/src/test/java/org/ole/planet/myplanet/utils/SyncTimeLoggerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/SyncTimeLoggerTest.kt
@@ -112,4 +112,55 @@ class SyncTimeLoggerTest {
         assertEquals("Api", SyncTimeLogger.extractProcessName("api"))
         assertEquals("Unknown", SyncTimeLogger.extractProcessName(""))
     }
+
+    @Test
+    fun testGenerateSummaryMultipleKeysAndLogs() {
+        mockkStatic(Log::class)
+        every { Log.isLoggable(any(), any()) } returns true
+        every { Log.d(any(), any()) } returns 0
+
+        var currentTime = 0L
+        val timeProvider = mockk<TimeProvider> {
+            every { now() } answers { currentTime }
+        }
+
+        val testDispatcher = UnconfinedTestDispatcher()
+        val logger = SyncTimeLogger(
+            timeProvider = timeProvider,
+            appScope = CoroutineScope(testDispatcher),
+            dispatcherProvider = TestDispatcherProvider(testDispatcher),
+            sharedPrefManager = mockk(relaxed = true),
+            serverUrlMapper = mockk(relaxed = true),
+            diagnosticsRepository = mockk(relaxed = true),
+            serverReachabilityProvider = mockk(relaxed = true)
+        )
+
+        logger.startLogging()
+
+        currentTime = 100L
+        logger.logApiCall("http://server/api/v1/courses", duration = 300L, success = true, itemsReturned = 5)
+        logger.logApiCall("http://server/api/v1/courses", duration = 200L, success = false, itemsReturned = 0)
+        logger.logApiCall("http://server/api/v1/users", duration = 100L, success = true, itemsReturned = 2)
+        logger.logApiCall("http://server/api/v1/users", duration = 400L, success = true, itemsReturned = 8)
+
+        currentTime = 500L
+        logger.logDbOperation("INSERT", "CourseModel", duration = 200L, itemCount = 5)
+        logger.logDbOperation("UPDATE", "CourseModel", duration = 100L, itemCount = 3)
+        logger.logDbOperation("INSERT", "UserModel", duration = 300L, itemCount = 2)
+        logger.logDbOperation("UPDATE", "UserModel", duration = 200L, itemCount = 8)
+
+        currentTime = 2000L
+        logger.stopLogging()
+
+        val summary = logger.generateSummary()
+
+        assertTrue(summary.contains("Total API calls: 4 (Success: 3, Failed: 1)"))
+        assertTrue(summary.contains("Total API time: 1.00s (50.0% of total sync)"))
+        assertTrue(summary.contains("Total Db operations: 4"))
+        assertTrue(summary.contains("Total Db time: 800ms (40.0% of total sync)"))
+        assertTrue(summary.contains("Total items processed: 18"))
+        assertTrue(summary.contains("Network time: 50.0%"))
+        assertTrue(summary.contains("Database time: 40.0%"))
+        assertTrue(summary.contains("Other processing: 10.0%"))
+    }
 }


### PR DESCRIPTION
Refactored generateSummary() in SyncTimeLogger.kt to fold per-key log lists directly and reuse total API/DB times in performance insights without flattening or re-summing log maps. Added unit tests in SyncTimeLoggerTest.kt verifying summary aggregation across multiple endpoints and models.

Fixes #17099

---
*PR created automatically by Jules for task [15564120779964989514](https://jules.google.com/task/15564120779964989514) started by @dogi*