### PR TITLE
courses: smoother submissions repository date exporting (fixes #17097)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
@@ -7,8 +7,9 @@ import android.graphics.pdf.PdfDocument
 import android.os.Environment
 import java.io.File
 import java.io.FileOutputStream
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 import org.json.JSONObject
@@ -31,7 +32,9 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
 ) {
 
     companion object {
-        private val dateFormatter = ThreadLocal.withInitial { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()) }
+        private val dateFormatter: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.getDefault())
+                .withZone(ZoneId.systemDefault())
 
         private const val PAGE_WIDTH = 595
         private const val PAGE_HEIGHT = 842
@@ -172,7 +175,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
 
                 canvas.drawText("Total Submissions: ${submissions.size}", MARGIN, yPosition, normalPaint)
                 yPosition += LINE_HEIGHT
-                canvas.drawText("Generated: ${dateFormatter.get()?.format(Date())}", MARGIN, yPosition, normalPaint)
+                canvas.drawText("Generated: ${dateFormatter.format(Instant.now())}", MARGIN, yPosition, normalPaint)
                 yPosition += LINE_HEIGHT * 3
 
                 val examId = getExamId(submissions.firstOrNull()?.parentId)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporterTest.kt
@@ -1,0 +1,23 @@
+package org.ole.planet.myplanet.repository
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubmissionsRepositoryExporterTest {
+
+    @Test
+    fun `dateFormatter formats Instant correctly in fixed timezone`() {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.getDefault())
+            .withZone(ZoneId.of("UTC"))
+
+        // 2023-10-15T14:30:00Z -> 1697380200L
+        val instant = Instant.ofEpochSecond(1697380200L)
+        val formatted = formatter.format(instant)
+
+        assertEquals("2023-10-15 14:30", formatted)
+    }
+}


### PR DESCRIPTION
Replaced ThreadLocal<SimpleDateFormat> with thread-safe java.time.format.DateTimeFormatter and Instant.now() in SubmissionsRepositoryExporter. Cleaned up unused java.text.SimpleDateFormat and java.util.Date imports. Added unit test for DateTimeFormatter.

Fixes #17097

---
*PR created automatically by Jules for task [9061686378388374206](https://jules.google.com/task/9061686378388374206) started by @dogi*