### PR TITLE
Short-circuit prependBaseUrlToImages when markdown has no image markup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
@@ -86,6 +86,7 @@ object MarkdownUtils {
         height: Int = 100
     ): String {
         val content = markdownContent ?: return markdownContent.orEmpty()
+        if (!content.contains("[")) return content
         val matcher = imagePattern.matcher(content)
         val result = StringBuilder()
         var last = 0

--- a/app/src/test/java/org/ole/planet/myplanet/utils/MarkdownUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/MarkdownUtilsTest.kt
@@ -131,4 +131,11 @@ class MarkdownUtilsTest {
 
         assertSame(firstMovementMethod, secondMovementMethod)
     }
+
+    @Test
+    fun prependBaseUrlToImages_returns_identical_string_when_no_image_markup() {
+        val markdown = "plain text with (parens) and a ! and [brackets]"
+        val result = MarkdownUtils.prependBaseUrlToImages(markdown, "http://base.url/")
+        assertEquals(markdown, result)
+    }
 }


### PR DESCRIPTION
Short-circuit prependBaseUrlToImages when the markdown has no image markup to avoid StringBuilder allocation and regex matcher execution on image-free descriptions.

Fixes #17096

---
*PR created automatically by Jules for task [2799752734640767146](https://jules.google.com/task/2799752734640767146) started by @dogi*