### PR TITLE
courses: smoother progress repository steps counting (fixes #17103)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -191,11 +191,9 @@ class ProgressRepositoryImpl @Inject constructor(
             val courseProgressRecords = progressByCourse[course.courseId].orEmpty()
 
             // Count UNIQUE steps that are passed (matches web: step.passed === true)
-            val passedStepNumbers = courseProgressRecords
-                .filter { it.passed }
-                .map { it.stepNum }
-                .toSet()
-            val passedSteps = passedStepNumbers.size
+            val passedSteps = courseProgressRecords
+                .mapNotNullTo(HashSet()) { if (it.passed) it.stepNum else null }
+                .size
             val totalSteps = course.courseSteps?.size ?: 0
 
             // Web logic: ALL steps must be passed AND course must have at least one step

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -446,6 +446,85 @@ class ProgressRepositoryImplTest {
     }
 
     @Test
+    fun testGetCompletedCourses_duplicatePassedRecordsCountOnce() = testScope.runTest {
+        val myCourses = listOf(
+            MyCourse().apply {
+                courseId = "course1"
+                courseTitle = "Course 1"
+                courseSteps = mutableListOf(
+                    CourseStep().apply { courseId = "course1" },
+                    CourseStep().apply { courseId = "course1" }
+                )
+            }
+        )
+
+        val progresses = listOf(
+            CourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true },
+            CourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true },
+            CourseProgress().apply { courseId = "course1"; stepNum = 2; passed = true }
+        )
+
+        coEvery { mockCoursesRepository.getMyCourses("user1") } returns myCourses
+        coEvery { courseProgressDao.getByUser("user1") } returns progresses
+
+        val result = repository.getCompletedCourses("user1")
+        advanceUntilIdle()
+
+        assertEquals(1, result.size)
+        assertEquals("course1", result[0].courseId)
+    }
+
+    @Test
+    fun testGetCompletedCourses_failedRecordsIgnored() = testScope.runTest {
+        val myCourses = listOf(
+            MyCourse().apply {
+                courseId = "course1"
+                courseTitle = "Course 1"
+                courseSteps = mutableListOf(
+                    CourseStep().apply { courseId = "course1" },
+                    CourseStep().apply { courseId = "course1" }
+                )
+            }
+        )
+
+        val progresses = listOf(
+            CourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true },
+            CourseProgress().apply { courseId = "course1"; stepNum = 2; passed = false }
+        )
+
+        coEvery { mockCoursesRepository.getMyCourses("user1") } returns myCourses
+        coEvery { courseProgressDao.getByUser("user1") } returns progresses
+
+        val result = repository.getCompletedCourses("user1")
+        advanceUntilIdle()
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun testGetCompletedCourses_zeroTotalStepsExcluded() = testScope.runTest {
+        val myCourses = listOf(
+            MyCourse().apply {
+                courseId = "course1"
+                courseTitle = "Course 1"
+                courseSteps = mutableListOf()
+            }
+        )
+
+        val progresses = listOf(
+            CourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true }
+        )
+
+        coEvery { mockCoursesRepository.getMyCourses("user1") } returns myCourses
+        coEvery { courseProgressDao.getByUser("user1") } returns progresses
+
+        val result = repository.getCompletedCourses("user1")
+        advanceUntilIdle()
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
     fun testFindProgressForCourse() {
         val jsonArray = JsonArray()
         val course1 = JsonObject().apply {


### PR DESCRIPTION
Replaced intermediate list and set allocations in `ProgressRepositoryImpl.getCompletedCourses` with a single-pass `mapNotNullTo(HashSet())` traversal, reducing intermediate allocations per course while maintaining unique passed step counting logic. Extended test coverage in `ProgressRepositoryImplTest`.

Fixes #17103

---
*PR created automatically by Jules for task [2166263424886531981](https://jules.google.com/task/2166263424886531981) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when calculating completed courses, ensuring duplicate progress records are counted only once.
  - Courses with failed steps or no required steps are excluded from completion results.

- **Tests**
  - Added coverage for duplicate passed steps, failed steps, and courses with zero total steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->