### PR TITLE
resources: smoother repository batch inserting (fixes #17104)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -674,11 +674,15 @@ class ResourcesRepositoryImpl @Inject constructor(
     override suspend fun batchInsertResources(documents: List<JsonObject>): List<String> {
         val savedIds = mutableListOf<String>()
 
-        val validDocs = documents.filter {
-            val _id = JsonUtils.getString("_id", it)
-            _id.isNotBlank() && !_id.startsWith("_design")
+        val validDocs = ArrayList<Pair<JsonObject, String>>(documents.size)
+        val resourceIds = ArrayList<String>(documents.size)
+        for (doc in documents) {
+            val id = JsonUtils.getString("_id", doc)
+            if (id.isNotBlank() && !id.startsWith("_design")) {
+                validDocs.add(doc to id)
+                resourceIds.add(id)
+            }
         }
-        val resourceIds = validDocs.map { JsonUtils.getString("_id", it) }
         val existingItems = mutableMapOf<String, MyLibrary>()
         if (resourceIds.isNotEmpty()) {
             resourceIds.chunked(900).forEach { chunk ->
@@ -687,9 +691,8 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
 
         val librariesToUpsert = mutableListOf<MyLibrary>()
-        validDocs.forEach { doc ->
+        validDocs.forEach { (doc, _id) ->
             try {
-                val _id = JsonUtils.getString("_id", doc)
                 val existing = existingItems[_id]
                 val library = MyLibrary.insertMyLibrary(
                     MyLibrary.Companion.InsertParams(

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -730,6 +730,66 @@ class ResourcesRepositoryImplTest {
     }
 
     @Test
+    fun `batchInsertResources skips blank ids and design docs and returns accepted ids in input order`() = runTest {
+        val docBlank = com.google.gson.JsonObject().apply { addProperty("_id", "  ") }
+        val docDesign = com.google.gson.JsonObject().apply { addProperty("_id", "_design/lib") }
+        val doc1 = com.google.gson.JsonObject().apply {
+            addProperty("_id", "id_1")
+            addProperty("_rev", "1-rev")
+            addProperty("title", "Resource 1")
+        }
+        val doc2 = com.google.gson.JsonObject().apply {
+            addProperty("_id", "id_2")
+            addProperty("_rev", "1-rev")
+            addProperty("title", "Resource 2")
+        }
+
+        val documents = listOf(docBlank, doc1, docDesign, doc2)
+
+        coEvery { myLibraryDao.getByIds(listOf("id_1", "id_2")) } returns emptyList()
+        coEvery { myLibraryDao.upsertAll(any()) } returns Unit
+
+        val savedIds = repository.batchInsertResources(documents)
+
+        assertEquals(listOf("id_1", "id_2"), savedIds)
+        coVerify(exactly = 1) { myLibraryDao.getByIds(listOf("id_1", "id_2")) }
+        coVerify(exactly = 1) { myLibraryDao.upsertAll(match { it.size == 2 }) }
+    }
+
+    @Test
+    fun `batchInsertResources continues when insertMyLibrary returns null or throws and excludes failed ids from savedIds`() = runTest {
+        val docValid1 = com.google.gson.JsonObject().apply {
+            addProperty("_id", "valid_1")
+            addProperty("_rev", "1-rev")
+            addProperty("title", "Valid 1")
+        }
+        val docNull = mockk<com.google.gson.JsonObject>()
+        every { docNull.entrySet() } returns mutableSetOf()
+        every { docNull.has("_id") } returns true
+        every { docNull.get("_id") } returns com.google.gson.JsonPrimitive("null_doc")
+        val docThrow = com.google.gson.JsonObject().apply {
+            addProperty("_id", "throw_doc")
+            addProperty("_attachments", "invalid_type_causes_throw")
+        }
+        val docValid2 = com.google.gson.JsonObject().apply {
+            addProperty("_id", "valid_2")
+            addProperty("_rev", "1-rev")
+            addProperty("title", "Valid 2")
+        }
+
+        val documents = listOf(docValid1, docNull, docThrow, docValid2)
+
+        coEvery { myLibraryDao.getByIds(listOf("valid_1", "null_doc", "throw_doc", "valid_2")) } returns emptyList()
+        coEvery { myLibraryDao.upsertAll(any()) } returns Unit
+
+        val savedIds = repository.batchInsertResources(documents)
+
+        assertEquals(listOf("valid_1", "valid_2"), savedIds)
+        coVerify(exactly = 1) { myLibraryDao.getByIds(listOf("valid_1", "null_doc", "throw_doc", "valid_2")) }
+        coVerify(exactly = 1) { myLibraryDao.upsertAll(match { it.size == 2 }) }
+    }
+
+    @Test
     fun `batchInsertMyLibrary avoids N plus one queries`() = runTest {
         val documents = (1..5).map {
             val doc = com.google.gson.JsonObject()


### PR DESCRIPTION
Refactors batchInsertResources in ResourcesRepositoryImpl to extract document IDs and filter valid documents in a single pass over documents, reusing paired IDs during entity processing loop. Extends ResourcesRepositoryImplTest to cover filtering, order retention, DAO calls, and error handling.

Fixes #17104

---
*PR created automatically by Jules for task [16614049430035301888](https://jules.google.com/task/16614049430035301888) started by @dogi*