### PR TITLE
all: smoother configurations repository storage path resolving (fixes #17111)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -7,7 +7,6 @@ import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.File
 import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
@@ -35,10 +34,10 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DispatcherProvider
-import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.Sha256Utils
+import org.ole.planet.myplanet.utils.StoragePathResolver
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.VersionUtils
@@ -52,6 +51,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
     private val serverUrlMapper: ServerUrlMapper,
     private val dispatcherProvider: DispatcherProvider,
     private val timeProvider: TimeProvider,
+    private val storagePathResolver: StoragePathResolver,
     @PlainGson private val gson: Gson
 ) : ConfigurationsRepository {
     private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
@@ -246,7 +246,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
             if (response.isSuccessful) {
                 val checksum = withContext(dispatcherProvider.io) { response.body()?.string() }
                 if (!checksum.isNullOrEmpty()) {
-                    val f = FileUtils.getSDPathFromUrl(context, path)
+                    val f = storagePathResolver.resolveFileFromUrl(path)
                     if (f.exists()) {
                         val sha256 = withContext(dispatcherProvider.io) {
                             Sha256Utils().getCheckSumFromFile(f)
@@ -413,7 +413,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
     override suspend fun clearFirstRunStorageAndSetFlag(hasWritePermission: Boolean) {
         withContext(dispatcherProvider.io) {
             if (hasWritePermission && sharedPrefManager.getFirstRun()) {
-                val myDir = File(FileUtils.getOlePath(context))
+                val myDir = storagePathResolver.resolveOleDirectory()
                 if (myDir.isDirectory) {
                     myDir.listFiles()?.forEach { it.deleteRecursively() }
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/StoragePathResolver.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/StoragePathResolver.kt
@@ -1,0 +1,13 @@
+package org.ole.planet.myplanet.utils
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+
+class StoragePathResolver @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    fun resolveFileFromUrl(url: String?): File = FileUtils.getSDPathFromUrl(context, url)
+    fun resolveOleDirectory(): File = File(FileUtils.getOlePath(context))
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -47,9 +47,9 @@ import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
-import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.Sha256Utils
+import org.ole.planet.myplanet.utils.StoragePathResolver
 import org.ole.planet.myplanet.utils.TestTimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.VersionUtils
@@ -66,6 +66,7 @@ class ConfigurationsRepositoryImplTest {
     private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
     private val appDatabase: AppDatabase = mockk(relaxed = true)
     private val serverUrlMapper: ServerUrlMapper = mockk(relaxed = true)
+    private val storagePathResolver: StoragePathResolver = mockk(relaxed = true)
     // Handed to the repository under test; cancelled in @After so nothing escapes the fork.
     private val serviceScope = CoroutineScope(SupervisorJob() + testDispatcher)
 
@@ -101,6 +102,7 @@ class ConfigurationsRepositoryImplTest {
             serverUrlMapper,
             dispatcherProvider,
             TestTimeProvider(),
+            storagePathResolver,
             Gson()
         )
     }
@@ -489,9 +491,8 @@ class ConfigurationsRepositoryImplTest {
         val response = Response.success(200, mockBody)
         coEvery { apiInterface.getChecksum(any()) } returns response
 
-        io.mockk.mockkObject(FileUtils)
         val mockFile = mockk<java.io.File>()
-        every { FileUtils.getSDPathFromUrl(context, path) } returns mockFile
+        every { storagePathResolver.resolveFileFromUrl(path) } returns mockFile
         every { mockFile.exists() } returns true
 
         io.mockk.mockkConstructor(Sha256Utils::class)
@@ -501,7 +502,6 @@ class ConfigurationsRepositoryImplTest {
 
         assertTrue(result)
 
-        io.mockk.unmockkObject(FileUtils)
         io.mockk.unmockkConstructor(Sha256Utils::class)
     }
 
@@ -522,9 +522,8 @@ class ConfigurationsRepositoryImplTest {
         val response = Response.success(200, mockBody)
         coEvery { apiInterface.getChecksum(any()) } returns response
 
-        io.mockk.mockkObject(FileUtils)
         val mockFile = mockk<java.io.File>()
-        every { FileUtils.getSDPathFromUrl(context, path) } returns mockFile
+        every { storagePathResolver.resolveFileFromUrl(path) } returns mockFile
         every { mockFile.exists() } returns true
 
         io.mockk.mockkConstructor(Sha256Utils::class)
@@ -534,7 +533,6 @@ class ConfigurationsRepositoryImplTest {
 
         assertFalse(result)
 
-        io.mockk.unmockkObject(FileUtils)
         io.mockk.unmockkConstructor(Sha256Utils::class)
     }
 
@@ -556,9 +554,8 @@ class ConfigurationsRepositoryImplTest {
         io.mockk.mockkStatic(android.util.Log::class)
         every { android.util.Log.w(any(), any<String>()) } returns 0
 
-        io.mockk.mockkObject(FileUtils)
         val mockFile = mockk<java.io.File>()
-        every { FileUtils.getSDPathFromUrl(context, path) } returns mockFile
+        every { storagePathResolver.resolveFileFromUrl(path) } returns mockFile
         every { mockFile.exists() } returns true
 
         io.mockk.mockkConstructor(Sha256Utils::class)
@@ -569,7 +566,6 @@ class ConfigurationsRepositoryImplTest {
         assertFalse(result)
 
         io.mockk.unmockkStatic(android.util.Log::class)
-        io.mockk.unmockkObject(FileUtils)
         io.mockk.unmockkConstructor(Sha256Utils::class)
     }
 
@@ -589,16 +585,13 @@ class ConfigurationsRepositoryImplTest {
         val response = Response.success(200, mockBody)
         coEvery { apiInterface.getChecksum(any()) } returns response
 
-        io.mockk.mockkObject(FileUtils)
         val mockFile = mockk<java.io.File>()
-        every { FileUtils.getSDPathFromUrl(context, path) } returns mockFile
+        every { storagePathResolver.resolveFileFromUrl(path) } returns mockFile
         every { mockFile.exists() } returns false
 
         val result = repository.checkCheckSum(path)
 
         assertFalse(result)
-
-        io.mockk.unmockkObject(FileUtils)
     }
 
     @Test
@@ -767,20 +760,15 @@ class ConfigurationsRepositoryImplTest {
         every { sharedPrefManager.getFirstRun() } returns true
         every { sharedPrefManager.setFirstRun(false) } just runs
 
-        mockkObject(FileUtils)
-        every { FileUtils.getOlePath(context) } returns oleDir.absolutePath
+        every { storagePathResolver.resolveOleDirectory() } returns oleDir
 
-        try {
-            repository.clearFirstRunStorageAndSetFlag(true)
+        repository.clearFirstRunStorageAndSetFlag(true)
 
-            assertFalse(looseFile.exists())
-            assertFalse(nestedFile.exists())
-            assertFalse(nested.exists())
-            assertTrue(oleDir.exists())
-            verify { sharedPrefManager.setFirstRun(false) }
-        } finally {
-            unmockkObject(FileUtils)
-        }
+        assertFalse(looseFile.exists())
+        assertFalse(nestedFile.exists())
+        assertFalse(nested.exists())
+        assertTrue(oleDir.exists())
+        verify { sharedPrefManager.setFirstRun(false) }
     }
 
     @Test


### PR DESCRIPTION
Added StoragePathResolver class with Hilt @Inject constructor delegating path resolution to FileUtils.
Injected StoragePathResolver into ConfigurationsRepositoryImpl and replaced direct FileUtils/File calls.
Updated ConfigurationsRepositoryImplTest to mock StoragePathResolver instead of FileUtils.

Fixes #17111

---
*PR created automatically by Jules for task [4802198934201231465](https://jules.google.com/task/4802198934201231465) started by @dogi*