### PR TITLE
login: smoother server config utils server caching (fixes #17110)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/ServerConfigUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ServerConfigUtils.kt
@@ -137,8 +137,8 @@ object ServerConfigUtils {
         return CommunityConfig(domain, protocol, pin, isPinEnabled)
     }
 
-    fun getTrustedServerHosts(): List<String> {
-        return listOfNotNull(
+    private val _trustedServerHosts: List<String> by lazy {
+        listOfNotNull(
             BuildConfig.PLANET_LEARNING_URL.takeIf { it.isNotEmpty() },
             BuildConfig.PLANET_GUATEMALA_URL.takeIf { it.isNotEmpty() },
             BuildConfig.PLANET_SANPABLO_URL.takeIf { it.isNotEmpty() },
@@ -156,8 +156,10 @@ object ServerConfigUtils {
         )
     }
 
-    fun getChallengeServerUrls(): List<String> {
-        return listOfNotNull(
+    fun getTrustedServerHosts(): List<String> = _trustedServerHosts
+
+    private val _challengeServerUrls: List<String> by lazy {
+        listOfNotNull(
             BuildConfig.PLANET_GUATEMALA_URL.takeIf { it.isNotEmpty() }?.let { "https://$it" },
             BuildConfig.PLANET_XELA_URL.takeIf { it.isNotEmpty() }?.let { "http://$it" },
             BuildConfig.PLANET_URIUR_URL.takeIf { it.isNotEmpty() }?.let { "http://$it" },
@@ -166,4 +168,6 @@ object ServerConfigUtils {
             BuildConfig.PLANET_VI_URL.takeIf { it.isNotEmpty() }?.let { "https://$it" }
         )
     }
+
+    fun getChallengeServerUrls(): List<String> = _challengeServerUrls
 }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
@@ -172,4 +172,48 @@ class ServerConfigUtilsTest {
             assertEquals("expected https for $host", "https://", ServerConfigUtils.getDefaultProtocol(host))
         }
     }
+
+    @Test
+    fun getTrustedServerHosts_returnsMemoizedListMatchingBuildConfig() {
+        val list1 = ServerConfigUtils.getTrustedServerHosts()
+        val list2 = ServerConfigUtils.getTrustedServerHosts()
+
+        org.junit.Assert.assertSame(list1, list2)
+
+        val expectedHosts = listOfNotNull(
+            org.ole.planet.myplanet.BuildConfig.PLANET_LEARNING_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_GUATEMALA_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_SANPABLO_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_SANPABLO_CLONE_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_EARTH_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_SOMALIA_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_VI_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_XELA_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_URIUR_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_URIUR_CLONE_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_RUIRU_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_EMBAKASI_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_EMBAKASI_CLONE_URL.takeIf { it.isNotEmpty() },
+            org.ole.planet.myplanet.BuildConfig.PLANET_CAMBRIDGE_URL.takeIf { it.isNotEmpty() }
+        )
+        assertEquals(expectedHosts, list1)
+    }
+
+    @Test
+    fun getChallengeServerUrls_returnsMemoizedListMatchingBuildConfig() {
+        val list1 = ServerConfigUtils.getChallengeServerUrls()
+        val list2 = ServerConfigUtils.getChallengeServerUrls()
+
+        org.junit.Assert.assertSame(list1, list2)
+
+        val expectedUrls = listOfNotNull(
+            org.ole.planet.myplanet.BuildConfig.PLANET_GUATEMALA_URL.takeIf { it.isNotEmpty() }?.let { "https://$it" },
+            org.ole.planet.myplanet.BuildConfig.PLANET_XELA_URL.takeIf { it.isNotEmpty() }?.let { "http://$it" },
+            org.ole.planet.myplanet.BuildConfig.PLANET_URIUR_URL.takeIf { it.isNotEmpty() }?.let { "http://$it" },
+            org.ole.planet.myplanet.BuildConfig.PLANET_SANPABLO_URL.takeIf { it.isNotEmpty() }?.let { "http://$it" },
+            org.ole.planet.myplanet.BuildConfig.PLANET_EMBAKASI_URL.takeIf { it.isNotEmpty() }?.let { "http://$it" },
+            org.ole.planet.myplanet.BuildConfig.PLANET_VI_URL.takeIf { it.isNotEmpty() }?.let { "https://$it" }
+        )
+        assertEquals(expectedUrls, list1)
+    }
 }


### PR DESCRIPTION
Backs getTrustedServerHosts and getChallengeServerUrls with private lazy properties in ServerConfigUtils and adds unit tests covering memoization and correctness.

Fixes #17110

---
*PR created automatically by Jules for task [8122358952103144360](https://jules.google.com/task/8122358952103144360) started by @dogi*