### PR TITLE
community: smoother configurations repository tab view modelling (fixes #17120)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -4,6 +4,12 @@ import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.SharedPrefManager
 
+data class CommunityConfiguration(
+    val parentCode: String,
+    val communityName: String,
+    val planetType: String?
+)
+
 interface ConfigurationsRepository {
     suspend fun checkHealth(): String
     fun checkVersion(callback: CheckVersionCallback, spm: SharedPrefManager)
@@ -15,6 +21,7 @@ interface ConfigurationsRepository {
     fun getPlanetType(): String?
     fun getParentCode(): String
     fun getCommunityName(): String
+    fun getCommunityConfiguration(): CommunityConfiguration
     fun getCommunityLeaders(): List<UserEntity>
     fun clearPreferences()
     suspend fun ensureServerUrlUpdated()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -402,6 +402,14 @@ class ConfigurationsRepositoryImpl @Inject constructor(
         return sharedPrefManager.getCommunityName()
     }
 
+    override fun getCommunityConfiguration(): CommunityConfiguration {
+        return CommunityConfiguration(
+            parentCode = getParentCode(),
+            communityName = getCommunityName(),
+            planetType = getPlanetType()
+        )
+    }
+
     override fun getCommunityLeaders(): List<UserEntity> {
         return UserEntity.parseLeadersJson(sharedPrefManager.getCommunityLeaders())
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModel.kt
@@ -29,17 +29,15 @@ class CommunityTabViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val parentCode = configurationsRepository.getParentCode()
-            val communityName = configurationsRepository.getCommunityName()
-            val planetType = configurationsRepository.getPlanetType()
+            val config = configurationsRepository.getCommunityConfiguration()
             val user = userRepository.getUserModel()
             val planetCode = user?.planetCode.orEmpty()
 
             _state.value = CommunityTabState(
                 planetCode = planetCode,
-                parentCode = parentCode,
-                communityName = communityName,
-                planetType = planetType
+                parentCode = config.parentCode,
+                communityName = config.communityName,
+                planetType = config.planetType
             )
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -823,6 +823,22 @@ class ConfigurationsRepositoryImplTest {
     }
 
     @Test
+    fun `getCommunityConfiguration returns snapshot with all fields matching individual getters`() {
+        every { sharedPrefManager.getParentCode() } returns "parent_123"
+        every { sharedPrefManager.getCommunityName() } returns "community_abc"
+        every { sharedPrefManager.getRawString("planetType") } returns "planet_xyz"
+
+        val config = repository.getCommunityConfiguration()
+
+        assertEquals("parent_123", config.parentCode)
+        assertEquals("community_abc", config.communityName)
+        assertEquals("planet_xyz", config.planetType)
+        assertEquals(repository.getParentCode(), config.parentCode)
+        assertEquals(repository.getCommunityName(), config.communityName)
+        assertEquals(repository.getPlanetType(), config.planetType)
+    }
+
+    @Test
     fun `getParentCode delegates to sharedPrefManager`() {
         every { sharedPrefManager.getParentCode() } returns "parent_123"
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModelTest.kt
@@ -29,9 +29,11 @@ class CommunityTabViewModelTest {
 
     @Before
     fun setup() {
-        every { configurationsRepository.getParentCode() } returns "parent_code_123"
-        every { configurationsRepository.getCommunityName() } returns "community_abc"
-        every { configurationsRepository.getPlanetType() } returns "planet_xyz"
+        every { configurationsRepository.getCommunityConfiguration() } returns org.ole.planet.myplanet.repository.CommunityConfiguration(
+            parentCode = "parent_code_123",
+            communityName = "community_abc",
+            planetType = "planet_xyz"
+        )
     }
 
     @Test
@@ -48,9 +50,29 @@ class CommunityTabViewModelTest {
         assertEquals("community_abc", state?.communityName)
         assertEquals("planet_xyz", state?.planetType)
 
-        verify { configurationsRepository.getParentCode() }
-        verify { configurationsRepository.getCommunityName() }
-        verify { configurationsRepository.getPlanetType() }
+        verify { configurationsRepository.getCommunityConfiguration() }
+        coVerify { userRepository.getUserModel() }
+    }
+
+    @Test
+    fun `init takes planetCode from user model and handles null planetType from configuration snapshot`() = runTest {
+        every { configurationsRepository.getCommunityConfiguration() } returns org.ole.planet.myplanet.repository.CommunityConfiguration(
+            parentCode = "parent_code_123",
+            communityName = "community_abc",
+            planetType = null
+        )
+        coEvery { userRepository.getUserModel() } returns null
+
+        val viewModel = CommunityTabViewModel(configurationsRepository, userRepository)
+        advanceUntilIdle()
+
+        val state = viewModel.state.first()
+        assertEquals("", state?.planetCode)
+        assertEquals("parent_code_123", state?.parentCode)
+        assertEquals("community_abc", state?.communityName)
+        assertEquals(null, state?.planetType)
+
+        verify { configurationsRepository.getCommunityConfiguration() }
         coVerify { userRepository.getUserModel() }
     }
 }


### PR DESCRIPTION
Add CommunityConfiguration snapshot data class to ConfigurationsRepository and ConfigurationsRepositoryImpl, and update CommunityTabViewModel to read community configurations as a single repository snapshot while preserving individual getters and existing user planetCode behavior.

Fixes #17120

---
*PR created automatically by Jules for task [10302018287139874253](https://jules.google.com/task/10302018287139874253) started by @dogi*