### PR TITLE
all: smoother crash log store utils exception logging (fixes #17122)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.utils
 
 import android.content.Context
+import android.util.Log
 import java.io.File
 
 /**
@@ -10,6 +11,7 @@ import java.io.File
  * next app start.
  */
 object CrashLogStore {
+    private const val TAG = "CrashLogStore"
     private const val DIR_NAME = "pending_logs"
     private const val FILE_EXTENSION = ".log"
     private const val MAX_PENDING_FILES = 20
@@ -42,7 +44,7 @@ object CrashLogStore {
             file.writeText(error)
             file
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.e(TAG, "failed to save crash log", e)
             null
         }
     }
@@ -54,7 +56,7 @@ object CrashLogStore {
             try {
                 PendingLog(file, parsed.type, parsed.time, file.readText())
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.e(TAG, "failed to read pending crash log", e)
                 null
             }
         }


### PR DESCRIPTION
Updates CrashLogStore to log swallowed write/read exceptions using Android's Log.e with static message literals instead of printStackTrace().

Fixes #17122

---
*PR created automatically by Jules for task [916669657837271074](https://jules.google.com/task/916669657837271074) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when saving or loading crash logs, making failures easier to diagnose.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->