### PR TITLE
login: smoother become member toast handling (fixes #17121)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseActivity
 import org.ole.planet.myplanet.callback.OnChangedListener
@@ -124,7 +123,7 @@ class BecomeMemberActivity : BaseActivity() {
                     startUpload("becomeMember", userName, securityCallback)
 
                     if (result.second == getString(R.string.not_connect_to_planet_created_user_offline)) {
-                        Utilities.toast(MainApplication.context, result.second)
+                        Utilities.toast(this@BecomeMemberActivity, result.second)
                         securityCallback.onChanged()
                     }
                     Utilities.toast(this@BecomeMemberActivity, result.second)


### PR DESCRIPTION
Replaced global MainApplication.context with explicit Activity context reference (this@BecomeMemberActivity) in BecomeMemberActivity.kt and removed unused MainApplication import.

Fixes #17121

---
*PR created automatically by Jules for task [12638011418949867802](https://jules.google.com/task/12638011418949867802) started by @dogi*