### PR TITLE
all: smoother myplanet usage stats caching (fixes #17123)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
@@ -73,15 +73,26 @@ class MyPlanet : Serializable {
             val mUsageStatsManager = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
             val queryUsageStats = mUsageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, cal.timeInMillis, now)
             if (queryUsageStats != null) {
+                val packageName = context.packageName
+                val customDeviceName = NetworkUtils.getCustomDeviceName(context)
+                val deviceName = NetworkUtils.getDeviceName()
                 for (s in queryUsageStats) {
-                    addStats(s, arr, context)
+                    addStats(s, arr, context, packageName, customDeviceName, deviceName, now)
                 }
             }
             return arr
         }
 
-        private fun addStats(s: UsageStats, arr: JsonArray, context: Context) {
-            if (s.packageName == context.packageName) {
+        private fun addStats(
+            s: UsageStats,
+            arr: JsonArray,
+            context: Context,
+            packageName: String,
+            customDeviceName: String,
+            deviceName: String,
+            now: Long
+        ) {
+            if (s.packageName == packageName) {
                 val `object` = JsonObject()
                 `object`.addProperty("lastTimeUsed", if (s.lastTimeUsed > 0) s.lastTimeUsed else 0)
                 `object`.addProperty("firstTimeUsed", if (s.firstTimeStamp > 0) s.lastTimeStamp else 0)
@@ -91,9 +102,9 @@ class MyPlanet : Serializable {
                 `object`.addProperty("version", VersionUtils.getVersionCode(context))
                 `object`.addProperty("versionName", VersionUtils.getVersionName(context))
                 `object`.addDocumentOrigin()
-                `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
-                `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-                `object`.addProperty("time", Date().time)
+                `object`.addProperty("customDeviceName", customDeviceName)
+                `object`.addProperty("deviceName", deviceName)
+                `object`.addProperty("time", now)
                 arr.add(`object`)
             }
         }

--- a/app/src/test/java/org/ole/planet/myplanet/model/MyPlanetTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/MyPlanetTest.kt
@@ -87,6 +87,54 @@ class MyPlanetTest {
         assertEquals(3000L, statJson.get("firstTimeUsed").asLong)
         assertEquals(1000L, statJson.get("totalForegroundTime").asLong)
         assertEquals(2000L, statJson.get("totalUsed").asLong)
+        assertEquals("mock_custom_device", statJson.get("customDeviceName").asString)
+        assertEquals("mock_device", statJson.get("deviceName").asString)
+        assertEquals(pinnedNow, statJson.get("time").asLong)
+    }
+
+    @Test
+    fun `getTabletUsages carries identical time across matching rows and skips non-matching packages`() {
+        val lastUsageUploaded = 1000L
+        val pinnedNow = 9999L
+        every { sharedPrefManager.getLastUsageUploaded() } returns lastUsageUploaded
+
+        val matchingStats1 = mockk<UsageStats>(relaxed = true) {
+            every { packageName } returns "org.ole.planet.myplanet"
+            every { lastTimeUsed } returns 4000L
+            every { firstTimeStamp } returns 2000L
+            every { lastTimeStamp } returns 3000L
+            every { totalTimeInForeground } returns 1000L
+        }
+
+        val nonMatchingStats = mockk<UsageStats>(relaxed = true) {
+            every { packageName } returns "com.other.app"
+        }
+
+        val matchingStats2 = mockk<UsageStats>(relaxed = true) {
+            every { packageName } returns "org.ole.planet.myplanet"
+            every { lastTimeUsed } returns 8000L
+            every { firstTimeStamp } returns 5000L
+            every { lastTimeStamp } returns 6000L
+            every { totalTimeInForeground } returns 3000L
+        }
+
+        every {
+            usageStatsManager.queryUsageStats(
+                UsageStatsManager.INTERVAL_DAILY,
+                lastUsageUploaded,
+                pinnedNow
+            )
+        } returns listOf(matchingStats1, nonMatchingStats, matchingStats2)
+
+        val result = MyPlanet.getTabletUsages(context, sharedPrefManager, now = pinnedNow)
+
+        assertEquals(2, result.size())
+        for (elem in result) {
+            val statJson = elem.asJsonObject
+            assertEquals(pinnedNow, statJson.get("time").asLong)
+            assertEquals("mock_custom_device", statJson.get("customDeviceName").asString)
+            assertEquals("mock_device", statJson.get("deviceName").asString)
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR hoists per-row invariant computations out of the `addStats` usage-stats loop in `MyPlanet.getTabletUsages`.

### Changes Made:
- In `MyPlanet.getTabletUsages`, pre-computes `packageName`, `customDeviceName`, and `deviceName` once before iterating through `queryUsageStats`.
- Passes `packageName`, `customDeviceName`, `deviceName`, and `now` into `addStats`.
- Replaces per-row calls to `context.packageName`, `NetworkUtils.getCustomDeviceName(context)`, `NetworkUtils.getDeviceName()`, and `Date().time` inside `addStats` with the pre-computed arguments.
- Updated `MyPlanetTest.kt` to verify that all emitted usage records carry identical timestamps matching `now` and that non-matching package rows are correctly filtered.

### Performance & Consistency Note:
Except for the package name check, per-row calls inside `addStats` were guarded by `if (s.packageName == context.packageName)`, so only the app's own row paid those costs. The primary gain here is ensuring a consistent timestamp (`now`) across all emitted usage stats rows rather than potentially distinct system timestamps per row.

Fixes #17123

---
*PR created automatically by Jules for task [2478884537605841352](https://jules.google.com/task/2478884537605841352) started by @dogi*