### PR TITLE
all: smoother free space recursive delete working (fixes #17126)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/FreeSpaceWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/FreeSpaceWorker.kt
@@ -64,19 +64,17 @@ class FreeSpaceWorker @AssistedInject constructor(
         fileOrDirectory.walkBottomUp().forEach { file ->
             if (isStopped) return
 
-            if (file.exists()) {
-                val length = file.length()
-                if (file.delete()) {
-                    deletedFiles++
-                    freedBytes += length
+            val length = file.length()
+            if (file.delete()) {
+                deletedFiles++
+                freedBytes += length
 
-                    // Report progress every 10 files or so to avoid spamming updates
-                    if (deletedFiles % 10 == 0) {
-                         setProgress(workDataOf(
-                             "deletedFiles" to deletedFiles,
-                             "freedBytes" to freedBytes
-                         ))
-                    }
+                // Report progress every 10 files or so to avoid spamming updates
+                if (deletedFiles % 10 == 0) {
+                     setProgress(workDataOf(
+                         "deletedFiles" to deletedFiles,
+                         "freedBytes" to freedBytes
+                     ))
                 }
             }
         }

--- a/app/src/test/java/org/ole/planet/myplanet/services/FreeSpaceWorkerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/FreeSpaceWorkerTest.kt
@@ -139,4 +139,52 @@ class FreeSpaceWorkerTest {
 
         assertTrue(result is Result.Failure)
     }
+
+    @Test
+    fun `doWork removes nested directory structure and accurately tracks deleted files and freed bytes`() = runTest(testDispatcher) {
+        val resDir = File(oleDir, "res1").apply { mkdirs() }
+        val file1 = File(resDir, "file1.txt").apply { writeText("hello") }
+        val subDir = File(resDir, "subdir").apply { mkdirs() }
+        val file2 = File(subDir, "file2.txt").apply { writeText("world") }
+        val file3 = File(resDir, "file3.txt").apply { writeText("foo") }
+
+        val expectedFreedBytes = file1.length() + file2.length() + file3.length() + subDir.length() + resDir.length()
+
+        val result = worker.doWork()
+        advanceUntilIdle()
+
+        assertTrue(result is Result.Success)
+        assertFalse(file1.exists())
+        assertFalse(file2.exists())
+        assertFalse(file3.exists())
+        assertFalse(subDir.exists())
+        assertFalse(resDir.exists())
+
+        val outputData = (result as Result.Success).outputData
+        // Nodes deleted: file1.txt, file2.txt, file3.txt, subdir, res1 -> 5 items
+        assertEquals(5, outputData.getInt("deletedFiles", -1))
+        assertEquals(expectedFreedBytes, outputData.getLong("freedBytes", -1L))
+    }
+
+    @Test
+    fun `doWork handles file deleted out from under the walk without corrupting accounting`() = runTest(testDispatcher) {
+        val resDir = File(oleDir, "res1").apply { mkdirs() }
+        val file1 = File(resDir, "file1.txt").apply { writeText("hello") }
+        val file2 = File(resDir, "file2.txt").apply { writeText("disappearing") }
+
+        val expectedFreedBytes = file1.length() + resDir.length()
+        file2.delete() // File disappears before walk processes it
+
+        val result = worker.doWork()
+        advanceUntilIdle()
+
+        assertTrue(result is Result.Success)
+        assertFalse(file1.exists())
+        assertFalse(resDir.exists())
+
+        val outputData = (result as Result.Success).outputData
+        // Nodes deleted: file1.txt, res1 -> 2 items (file2 was already gone)
+        assertEquals(2, outputData.getInt("deletedFiles", -1))
+        assertEquals(expectedFreedBytes, outputData.getLong("freedBytes", -1L))
+    }
 }


### PR DESCRIPTION
Removes the redundant exists() check in FreeSpaceWorker.deleteRecursive to eliminate extra stat syscalls per node during free space worker cleanup.

Fixes #17126

---
*PR created automatically by Jules for task [2343735942768662849](https://jules.google.com/task/2343735942768662849) started by @dogi*