### PR TITLE
life: smoother health users payload view holding (fixes #17127)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthUsersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthUsersAdapter.kt
@@ -74,20 +74,28 @@ class HealthUsersAdapter(private val clickListener: ((UserEntity) -> Unit)? = nu
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
-        val diffs = payloads.filterIsInstance<List<*>>().flatten()
-        if (diffs.isEmpty()) {
+        var name = false
+        var userImage = false
+        var joinDate = false
+        for (payload in payloads) {
+            if (payload is List<*>) {
+                for (key in payload) {
+                    when (key) {
+                        "name" -> name = true
+                        "userImage" -> userImage = true
+                        "joinDate" -> joinDate = true
+                    }
+                }
+            }
+        }
+
+        if (!name && !userImage && !joinDate) {
             super.onBindViewHolder(holder, position, payloads)
         } else {
             val user = getItem(position)
-            if ("name" in diffs) {
-                holder.bindName(user)
-            }
-            if ("userImage" in diffs) {
-                holder.bindImage(user)
-            }
-            if ("joinDate" in diffs) {
-                holder.bindDate(user)
-            }
+            if (name) holder.bindName(user)
+            if (userImage) holder.bindImage(user)
+            if (joinDate) holder.bindDate(user)
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthUsersAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthUsersAdapterTest.kt
@@ -1,0 +1,105 @@
+package org.ole.planet.myplanet.ui.health
+
+import android.content.Context
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.clearMocks
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.model.UserEntity
+
+@RunWith(AndroidJUnit4::class)
+class HealthUsersAdapterTest {
+
+    private lateinit var adapter: HealthUsersAdapter
+    private lateinit var context: Context
+    private val testUser = UserEntity(
+        id = "user1",
+        name = "John Doe",
+        userImage = "profile.png",
+        joinDate = 1000L
+    )
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        adapter = HealthUsersAdapter()
+        adapter.submitList(listOf(testUser))
+    }
+
+    @Test
+    fun testPayload_listOfName_callsOnlyBindName() {
+        val parent = FrameLayout(context)
+        val viewHolder = spyk(adapter.onCreateViewHolder(parent, 0))
+        clearMocks(viewHolder)
+
+        val payloads = mutableListOf<Any>(listOf("name"))
+        adapter.onBindViewHolder(viewHolder, 0, payloads)
+
+        verify(exactly = 1) { viewHolder.bindName(testUser) }
+        verify(exactly = 0) { viewHolder.bindImage(any()) }
+        verify(exactly = 0) { viewHolder.bindDate(any()) }
+        verify(exactly = 0) { viewHolder.bind(any(), any()) }
+    }
+
+    @Test
+    fun testPayload_twoKeys_callsBothBindsInOrder() {
+        val parent = FrameLayout(context)
+        val viewHolder = spyk(adapter.onCreateViewHolder(parent, 0))
+        clearMocks(viewHolder)
+
+        val payloads = mutableListOf<Any>(listOf("name", "joinDate"))
+        adapter.onBindViewHolder(viewHolder, 0, payloads)
+
+        verifyOrder {
+            viewHolder.bindName(testUser)
+            viewHolder.bindDate(testUser)
+        }
+        verify(exactly = 0) { viewHolder.bindImage(any()) }
+        verify(exactly = 0) { viewHolder.bind(any(), any()) }
+    }
+
+    @Test
+    fun testPayload_somethingElse_fallsBackToFullBind() {
+        val parent = FrameLayout(context)
+        val viewHolder = spyk(adapter.onCreateViewHolder(parent, 0))
+        clearMocks(viewHolder)
+
+        val payloads = mutableListOf<Any>(listOf("somethingElse"))
+        adapter.onBindViewHolder(viewHolder, 0, payloads)
+
+        verify(exactly = 1) { viewHolder.bind(testUser, any()) }
+    }
+
+    @Test
+    fun testPayload_nonListPayload_fallsBackToFullBind() {
+        val parent = FrameLayout(context)
+        val viewHolder = spyk(adapter.onCreateViewHolder(parent, 0))
+        clearMocks(viewHolder)
+
+        val payloads = mutableListOf<Any>("somethingElse")
+        adapter.onBindViewHolder(viewHolder, 0, payloads)
+
+        verify(exactly = 1) { viewHolder.bind(testUser, any()) }
+    }
+
+    @Test
+    fun testPayload_duplicateKeysAcrossTwoPayloadEntries_bindsOnceEach() {
+        val parent = FrameLayout(context)
+        val viewHolder = spyk(adapter.onCreateViewHolder(parent, 0))
+        clearMocks(viewHolder)
+
+        val payloads = mutableListOf<Any>(listOf("name"), listOf("name"))
+        adapter.onBindViewHolder(viewHolder, 0, payloads)
+
+        verify(exactly = 1) { viewHolder.bindName(testUser) }
+        verify(exactly = 0) { viewHolder.bindImage(any()) }
+        verify(exactly = 0) { viewHolder.bindDate(any()) }
+        verify(exactly = 0) { viewHolder.bind(any(), any()) }
+    }
+}


### PR DESCRIPTION
Optimized HealthUsersAdapter.onBindViewHolder partial payload processing by removing intermediate list allocations and linear lookups, replacing them with a single pass through payloads. Added unit tests in HealthUsersAdapterTest to verify single key, multi-key ordering, duplicate keys, unrecognized payload lists, and non-list fallback behavior.

Fixes #17127

---
*PR created automatically by Jules for task [1956609268085775098](https://jules.google.com/task/1956609268085775098) started by @dogi*