### PR TITLE
all: smoother activities feedback repositories time providing (fixes #17130)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
-import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.async
@@ -97,7 +96,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
                 type = "visit"
                 this.title = title
                 this.courseId = courseId
-                time = Date().time
+                time = timeProvider.now()
                 this.user = userId
 
                 if (user != null) {
@@ -125,14 +124,14 @@ class ActivitiesRepositoryImpl @Inject constructor(
                 _rev = null
                 _id = null
                 description = "Member login on offline application"
-                loginTime = Date().time
+                loginTime = timeProvider.now()
             }
         )
     }
 
     override suspend fun logLogout(userName: String?) {
         offlineActivityDao.getLatestByType(UserSessionManager.KEY_LOGIN)?.let { activity ->
-            offlineActivityDao.updateLogoutTime(activity.id, Date().time)
+            offlineActivityDao.updateLogoutTime(activity.id, timeProvider.now())
         }
     }
 
@@ -161,7 +160,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
                 this.type = type
                 this.title = title
                 this.resourceId = resourceId
-                time = Date().time
+                time = timeProvider.now()
             }
         )
     }
@@ -253,7 +252,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
                 this.parentCode = parentCode
                 this.createdOn = createdOn
                 type = "sync"
-                time = Date().time
+                time = timeProvider.now()
             }
         )
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -12,12 +11,14 @@ import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.utils.JsonUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.distinctByContent
 
 @Singleton
 class FeedbackRepositoryImpl @Inject constructor(
     private val feedbackDao: FeedbackDao,
-    private val gson: Gson
+    private val gson: Gson,
+    private val timeProvider: TimeProvider
 ) : FeedbackRepository, FeedbackSyncWriter {
 
     override suspend fun createAndSaveFeedback(
@@ -51,7 +52,7 @@ class FeedbackRepositoryImpl @Inject constructor(
             feedback.title = "Question regarding /"
             feedback.url = "/"
         }
-        val timestamp = Date().time
+        val timestamp = timeProvider.now()
         feedback.openTime = timestamp
         feedback.owner = user
         feedback.source = user
@@ -99,7 +100,7 @@ class FeedbackRepositoryImpl @Inject constructor(
             val feedback = feedbackDao.findById(it) ?: return
             val obj = JsonObject().apply {
                 addProperty("message", message)
-                addProperty("time", Date().time.toString())
+                addProperty("time", timeProvider.now().toString())
                 addProperty("user", user ?: "")
             }
             val messages = feedback.messages

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
@@ -181,6 +181,7 @@ class ActivitiesRepositoryImplTest {
 
     @Test
     fun `logCourseVisit inserts course activity`() = runTest {
+        every { timeProvider.now() } returns 123456789L
         val mockUser = UserEntity().apply {
             parentCode = "parent"
             planetCode = "planet"
@@ -197,10 +198,12 @@ class ActivitiesRepositoryImplTest {
         assertEquals("visit", slot.captured.type)
         assertEquals("parent", slot.captured.parentCode)
         assertEquals("planet", slot.captured.createdOn)
+        assertEquals(123456789L, slot.captured.time)
     }
 
     @Test
     fun `logLogin inserts offline activity`() = runTest {
+        every { timeProvider.now() } returns 123456789L
         val slot = slot<OfflineActivity>()
         repository.logLogin("user1", "john", "parent", "planet")
 
@@ -211,16 +214,18 @@ class ActivitiesRepositoryImplTest {
         assertEquals("planet", slot.captured.createdOn)
         assertEquals(UserSessionManager.KEY_LOGIN, slot.captured.type)
         assertEquals("Member login on offline application", slot.captured.description)
+        assertEquals(123456789L, slot.captured.loginTime)
     }
 
     @Test
     fun `logLogout updates logout time`() = runTest {
+        every { timeProvider.now() } returns 987654321L
         val mockActivity = OfflineActivity().apply { id = "act1" }
         coEvery { offlineActivityDao.getLatestByType(UserSessionManager.KEY_LOGIN) } returns mockActivity
 
         repository.logLogout("john")
 
-        coVerify { offlineActivityDao.updateLogoutTime(eq("act1"), any()) }
+        coVerify { offlineActivityDao.updateLogoutTime("act1", 987654321L) }
     }
 
     @Test
@@ -239,6 +244,7 @@ class ActivitiesRepositoryImplTest {
 
     @Test
     fun `logResourceOpen inserts resource activity`() = runTest {
+        every { timeProvider.now() } returns 123456789L
         val slot = slot<ResourceActivity>()
         repository.logResourceOpen("john", "parent", "planet", "Res Title", "res1", "pdf")
 
@@ -249,6 +255,7 @@ class ActivitiesRepositoryImplTest {
         assertEquals("Res Title", slot.captured.title)
         assertEquals("res1", slot.captured.resourceId)
         assertEquals("pdf", slot.captured.type)
+        assertEquals(123456789L, slot.captured.time)
     }
 
     @Test
@@ -327,6 +334,7 @@ class ActivitiesRepositoryImplTest {
 
     @Test
     fun `recordSyncActivity inserts resource activity`() = runTest {
+        every { timeProvider.now() } returns 123456789L
         val mockUser = UserEntity().apply {
             id = "user1"
             name = "john"
@@ -343,6 +351,7 @@ class ActivitiesRepositoryImplTest {
         assertEquals("parent", slot.captured.parentCode)
         assertEquals("planet", slot.captured.createdOn)
         assertEquals("sync", slot.captured.type)
+        assertEquals(123456789L, slot.captured.time)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImplTest.kt
@@ -19,17 +19,32 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.model.UserEntity
+import org.ole.planet.myplanet.utils.TimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FeedbackRepositoryImplTest {
 
     private lateinit var feedbackDao: FeedbackDao
+    private lateinit var timeProvider: TimeProvider
     private lateinit var repository: FeedbackRepositoryImpl
 
     @Before
     fun setup() {
         feedbackDao = mockk(relaxed = true)
-        repository = FeedbackRepositoryImpl(feedbackDao, Gson())
+        timeProvider = mockk(relaxed = true)
+        repository = FeedbackRepositoryImpl(feedbackDao, Gson(), timeProvider)
+    }
+
+    @Test
+    fun createFeedback_usesTimeProviderNow() {
+        every { timeProvider.now() } returns 123456789L
+
+        val feedback = repository.createFeedback("user1", "High", "Bug", "Test message", null, null)
+
+        assertEquals(123456789L, feedback.openTime)
+        val messages = Gson().fromJson(feedback.messages, JsonArray::class.java)
+        assertEquals(1, messages.size())
+        assertEquals("123456789", messages[0].asJsonObject["time"].asString)
     }
 
     @Test
@@ -46,6 +61,7 @@ class FeedbackRepositoryImplTest {
 
     @Test
     fun addReply_marksFeedbackPendingSoItGetsUploaded() = runTest {
+        every { timeProvider.now() } returns 987654321L
         val feedback = Feedback().apply {
             id = "fb1"
             isUploaded = true
@@ -61,6 +77,7 @@ class FeedbackRepositoryImplTest {
         val messages = Gson().fromJson(updated.captured.messages, JsonArray::class.java)
         assertEquals(1, messages.size())
         assertEquals("a reply", messages[0].asJsonObject["message"].asString)
+        assertEquals("987654321", messages[0].asJsonObject["time"].asString)
     }
 
     @Test


### PR DESCRIPTION
Replaced wall-clock `Date().time` calls in `ActivitiesRepositoryImpl` and `FeedbackRepositoryImpl` with `timeProvider.now()`. Added `TimeProvider` injection to `FeedbackRepositoryImpl` and removed unused `java.util.Date` imports. Extended unit tests for both repositories to verify the stubbed time values.

Fixes #17130

---
*PR created automatically by Jules for task [5317014135234012686](https://jules.google.com/task/5317014135234012686) started by @dogi*