### PR TITLE
courses: less ratings repository methods is more (fixes #17024)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
@@ -4,10 +4,7 @@ import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.UserEntity
 
 interface RatingsRepository {
-    suspend fun getRatings(type: String?, userId: String?): HashMap<String?, JsonObject>
     suspend fun getRatingsById(type: String, resourceId: String?, userId: String?): RatingSummary?
-    suspend fun getCourseRatings(userId: String?): HashMap<String?, JsonObject>
-    suspend fun getResourceRatings(userId: String?): HashMap<String?, JsonObject>
     suspend fun getRatingSummary(type: String, itemId: String, userId: String?): RatingSummary
     suspend fun isRatingPrompted(userId: String, resourceId: String): Boolean
     suspend fun setRatingPrompted(userId: String, resourceId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
@@ -17,27 +17,9 @@ class RatingsRepositoryImpl @Inject constructor(
     private val ratingDao: RatingDao,
 ) : RatingsRepository {
 
-    override suspend fun getRatings(type: String?, userId: String?): HashMap<String?, JsonObject> {
-        val ratings = ratingDao.getByType(type)
-        val aggregated = aggregateRatings(ratings, userId)
-        val map = HashMap<String?, JsonObject>(Math.ceil(aggregated.size / 0.75).toInt())
-        for ((item, aggregation) in aggregated) {
-            map[item] = aggregation.toJson()
-        }
-        return map
-    }
-
     override suspend fun getRatingsById(type: String, resourceId: String?, userId: String?): RatingSummary? {
         if (resourceId == null) return null
         return getRatingSummary(type, resourceId, userId)
-    }
-
-    override suspend fun getCourseRatings(userId: String?): HashMap<String?, JsonObject> {
-        return getRatings("course", userId)
-    }
-
-    override suspend fun getResourceRatings(userId: String?): HashMap<String?, JsonObject> {
-        return getRatings("resource", userId)
     }
 
     override suspend fun isRatingPrompted(userId: String, resourceId: String): Boolean {
@@ -170,41 +152,6 @@ class RatingsRepositoryImpl @Inject constructor(
             this.type = type
             item = itemId
             this.title = title
-        }
-    }
-
-    private fun aggregateRatings(
-        ratings: Iterable<Rating>,
-        userId: String?
-    ): Map<String?, RatingAggregation> {
-        val aggregationMap = LinkedHashMap<String?, RatingAggregation>()
-        for (rating in ratings) {
-            val item = rating.item
-            val aggregation = aggregationMap.getOrPut(item) { RatingAggregation() }
-            aggregation.totalRating += rating.rate
-            aggregation.totalCount += 1
-            if (userId != null && userId == rating.userId) {
-                aggregation.ratingByUser = rating.rate
-            }
-        }
-        return aggregationMap
-    }
-
-    private data class RatingAggregation(
-        var totalRating: Int = 0,
-        var totalCount: Int = 0,
-        var ratingByUser: Int? = null
-    ) {
-        fun toJson(): JsonObject {
-            val `object` = JsonObject()
-            if (ratingByUser != null) {
-                `object`.addProperty("ratingByUser", ratingByUser)
-            }
-            if (totalCount > 0) {
-                `object`.addProperty("averageRating", totalRating.toFloat() / totalCount)
-                `object`.addProperty("total", totalCount)
-            }
-            return `object`
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RatingsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RatingsRepositoryImplTest.kt
@@ -47,22 +47,6 @@ class RatingsRepositoryImplTest {
     }
 
     @Test
-    fun `getRatings aggregates ratings properly`() = runTest {
-        val rating1 = Rating().apply { type = "course"; item = "course1"; rate = 4; userId = "user1" }
-        val rating2 = Rating().apply { type = "course"; item = "course1"; rate = 5; userId = "user2" }
-        coEvery { ratingDao.getByType("course") } returns listOf(rating1, rating2)
-
-        val result = repository.getRatings("course", "user1")
-
-        assertEquals(1, result.size)
-        val aggregated = result["course1"]
-        assertNotNull(aggregated)
-        assertEquals(4, aggregated!!.get("ratingByUser").asInt)
-        assertEquals(2, aggregated.get("total").asInt)
-        assertEquals(4.5f, aggregated.get("averageRating").asFloat)
-    }
-
-    @Test
     fun `getRatingsById returns specific aggregated rating summary`() = runTest {
         val rating = Rating().apply { id = "rating1"; type = "course"; item = "course1"; rate = 5; userId = "user1"; comment = "Great" }
         coEvery { ratingDao.getAggregate("course", "course1") } returns RatingAggregate(1, 5.0)
@@ -75,28 +59,6 @@ class RatingsRepositoryImplTest {
         assertEquals(1, result.totalRatings)
         assertEquals(5.0f, result.averageRating)
         assertEquals("Great", result.existingRating?.comment)
-    }
-
-    @Test
-    fun `getCourseRatings returns aggregated course ratings`() = runTest {
-        val rating = Rating().apply { type = "course"; item = "course1"; rate = 3; userId = "user1" }
-        coEvery { ratingDao.getByType("course") } returns listOf(rating)
-
-        val result = repository.getCourseRatings("user1")
-
-        assertEquals(1, result.size)
-        assertNotNull(result["course1"])
-    }
-
-    @Test
-    fun `getResourceRatings returns aggregated resource ratings`() = runTest {
-        val rating = Rating().apply { type = "resource"; item = "resource1"; rate = 5; userId = "user1" }
-        coEvery { ratingDao.getByType("resource") } returns listOf(rating)
-
-        val result = repository.getResourceRatings("user1")
-
-        assertEquals(1, result.size)
-        assertNotNull(result["resource1"])
     }
 
     @Test


### PR DESCRIPTION
Deletes unreachable `JsonObject`-based rating aggregation methods (`getRatings`, `getCourseRatings`, `getResourceRatings`) and associated dead private helpers and unit tests.

Fixes #17024

---
*PR created automatically by Jules for task [15963222046645160183](https://jules.google.com/task/15963222046645160183) started by @dogi*