### PR TITLE
all: smoother submissions repository counting (fixes #17135)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -210,8 +210,8 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         userIds.chunked(500).forEach { chunk ->
             val existingSubmissions = submissionDao.getPendingByUsersAndParent(chunk, parentId)
             val existingUserIds = existingSubmissions.mapNotNull { it.userId }.toSet()
-            val newSubmissions = chunk.filter { it !in existingUserIds }.map { userId ->
-                Submission().apply {
+            val newSubmissions = chunk.mapNotNull { userId ->
+                if (userId in existingUserIds) null else Submission().apply {
                     id = UUID.randomUUID().toString()
                     this.userId = userId
                     this.parentId = parentId

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -164,8 +164,8 @@ class ResourcesAdapter(
     }
 
     fun setLibraryList(libraryList: List<ResourceListModel?>, onComplete: (() -> Unit)? = null) {
-        val updatedList = libraryList.filterNotNull().map {
-            it.copy(
+        val updatedList = libraryList.mapNotNull {
+            it?.copy(
                 isOpened = openedResourceIds.contains(it.item.id),
                 isLocallyOffline = locallyOfflineIds.contains(it.item.id)
             )

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
@@ -259,7 +259,7 @@ class TeamsVoicesFragment : BaseTeamFragment() {
             realmNewsList?.let { adapterNews?.submitList(it.filterNotNull()) }
             binding.rvDiscussion.adapter = adapterNews
             shouldScrollToTopNextUpdate = false
-            showNoData(binding.tvNodata, realmNewsList?.filterNotNull()?.size ?: 0, "discussions")
+            showNoData(binding.tvNodata, realmNewsList?.count { it != null } ?: 0, "discussions")
         } else {
             (existingAdapter as? VoicesAdapter)?.let { adapter ->
                 adapter.setCurrentUser(user)
@@ -270,7 +270,7 @@ class TeamsVoicesFragment : BaseTeamFragment() {
                             shouldScrollToTopNextUpdate = false
                         }
                     }
-                    showNoData(binding.tvNodata, it.filterNotNull().size, "discussions")
+                    showNoData(binding.tvNodata, it.count { news -> news != null }, "discussions")
                 }
             }
         }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -252,7 +252,7 @@ class SubmissionsRepositoryImplTest {
     }
 
     @Test
-    fun `createBulkSurveySubmissions with mixed users only inserts new users`() = runTest {
+    fun `createBulkSurveySubmissions with mixed users only inserts new users preserving input order`() = runTest {
         val examId = "examId"
         val userIds = listOf("user1", "user2", "user3")
         val parentId = "examId@courseId"
@@ -266,7 +266,8 @@ class SubmissionsRepositoryImplTest {
         coVerify(exactly = 1) {
             submissionDao.upsertAll(match {
                 it.size == 2 &&
-                it.map { sub -> sub.userId }.containsAll(listOf("user1", "user3"))
+                it[0].userId == "user1" &&
+                it[1].userId == "user3"
             })
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapterTest.kt
@@ -107,4 +107,35 @@ class ResourcesAdapterTest {
         assertEquals(android.view.View.GONE, holder.binding.checkbox.visibility)
         assertEquals(false, holder.binding.checkbox.hasOnClickListeners())
     }
+
+    @Test
+    fun `test setLibraryList drops null elements and updates flags on valid elements`() {
+        adapter.markItemAsOffline("2")
+        adapter.setOpenedResourceIds(setOf("1"))
+
+        val item1 = ResourceItem(
+            id = "1", title = "Res 1", description = "desc", createdDate = 0L, averageRating = "0",
+            timesRated = 0, resourceId = "res1", isOffline = false, _rev = "rev1", uploadDate = "date",
+            filename = "file"
+        )
+        val item2 = ResourceItem(
+            id = "2", title = "Res 2", description = "desc", createdDate = 0L, averageRating = "0",
+            timesRated = 0, resourceId = "res2", isOffline = false, _rev = "rev2", uploadDate = "date",
+            filename = "file"
+        )
+        val model1 = ResourceListModel(MyLibrary().apply { id = "1" }, item1, emptyList())
+        val model2 = ResourceListModel(MyLibrary().apply { id = "2" }, item2, emptyList())
+
+        adapter.setLibraryList(listOf(model1, null, model2))
+
+        val currentList = adapter.currentList
+        assertEquals(2, currentList.size)
+        assertEquals("1", currentList[0].item.id)
+        assertEquals(true, currentList[0].isOpened)
+        assertEquals(false, currentList[0].isLocallyOffline)
+
+        assertEquals("2", currentList[1].item.id)
+        assertEquals(false, currentList[1].isOpened)
+        assertEquals(true, currentList[1].isLocallyOffline)
+    }
 }


### PR DESCRIPTION
Consolidates redundant intermediate collection allocations in ResourcesAdapter, TeamsVoicesFragment, and SubmissionsRepositoryImpl into single-pass operations and count functions.

Fixes #17135

---
*PR created automatically by Jules for task [9418384464688522180](https://jules.google.com/task/9418384464688522180) started by @dogi*