### PR TITLE
all: smoother markdown utils image markup checking (fixes #17096)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
@@ -86,6 +86,7 @@ object MarkdownUtils {
         height: Int = 100
     ): String {
         val content = markdownContent ?: return markdownContent.orEmpty()
+        if (!content.contains("![")) return content
         val matcher = imagePattern.matcher(content)
         val result = StringBuilder()
         var last = 0

--- a/app/src/test/java/org/ole/planet/myplanet/utils/MarkdownUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/MarkdownUtilsTest.kt
@@ -131,4 +131,16 @@ class MarkdownUtilsTest {
 
         assertSame(firstMovementMethod, secondMovementMethod)
     }
+
+    @Test
+    fun prependBaseUrlToImages_returns_identical_string_when_no_bracket_present() {
+        val markdown = "plain text with no bracket at all"
+        assertSame(markdown, MarkdownUtils.prependBaseUrlToImages(markdown, "http://base.url/"))
+    }
+
+    @Test
+    fun prependBaseUrlToImages_returns_identical_string_when_brackets_present_without_image_markup() {
+        val markdown = "plain text with (parens) and a ! and [brackets]"
+        assertSame(markdown, MarkdownUtils.prependBaseUrlToImages(markdown, "http://base.url/"))
+    }
 }


### PR DESCRIPTION
Short-circuited `MarkdownUtils.prependBaseUrlToImages` when input contains no `![` image markup sequence and added unit tests in `MarkdownUtilsTest`.

Fixes #17096

---
*PR created automatically by Jules for task [6676706134332339384](https://jules.google.com/task/6676706134332339384) started by @dogi*