### PR TITLE
resources: smoother collections tag indexing (fixes #17090)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -67,10 +67,7 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
                 is CollectionsState.Success -> {
                     list = state.list
                     childMap = state.childMap
-                    val allTags = list + childMap.values.flatten()
-                    val reconciledList = selectedItemsList.map { selected ->
-                        allTags.find { selected.matches(it) } ?: selected
-                    }
+                    val reconciledList = reconcileSelections(selectedItemsList, list, childMap)
                     selectedItemsList.clear()
                     selectedItemsList.addAll(reconciledList)
                     currentTagDataList = buildTagDataList(list)
@@ -122,6 +119,39 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         adapter.submitList(currentTagDataList)
     }
 
+    internal fun reconcileSelections(
+        selectedItems: List<TagEntity>,
+        list: List<TagEntity>,
+        childMap: Map<String, List<TagEntity>>
+    ): List<TagEntity> {
+        val tagsById = HashMap<String, TagEntity>()
+        val tagsByName = HashMap<String, TagEntity>()
+
+        fun indexTag(tag: TagEntity) {
+            if (tag.id.isNotEmpty()) {
+                tagsById.putIfAbsent(tag.id, tag)
+            }
+            if (!tag.name.isNullOrEmpty()) {
+                tagsByName.putIfAbsent(tag.name!!, tag)
+            }
+        }
+
+        for (parent in list) {
+            indexTag(parent)
+        }
+        for (children in childMap.values) {
+            for (child in children) {
+                indexTag(child)
+            }
+        }
+
+        return selectedItems.map { selected ->
+            (if (selected.id.isNotEmpty()) tagsById[selected.id] else null)
+                ?: (if (!selected.name.isNullOrEmpty()) tagsByName[selected.name] else null)
+                ?: selected
+        }
+    }
+
     private fun buildTagDataList(parents: List<TagEntity>): List<TagData> {
         val tagDataList = mutableListOf<TagData>()
         val isSelectMultiple = MainApplication.isCollectionSwitchOn
@@ -131,15 +161,27 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
                 parentMap[it.tag.id] = it
             }
         }
+        val selectedIds = HashSet<String>()
+        val selectedNames = HashSet<String>()
+        for (selected in selectedItemsList) {
+            if (selected.id.isNotEmpty()) {
+                selectedIds.add(selected.id)
+            }
+            if (!selected.name.isNullOrEmpty()) {
+                selectedNames.add(selected.name!!)
+            }
+        }
         for (parentTag in parents) {
-            val isSelected = selectedItemsList.any { it.matches(parentTag) }
+            val isSelected = (parentTag.id.isNotEmpty() && selectedIds.contains(parentTag.id)) ||
+                    (!parentTag.name.isNullOrEmpty() && selectedNames.contains(parentTag.name))
             val parent = parentMap[parentTag.id] ?: TagData.Parent(parentTag, false, isSelected, isSelectMultiple)
 
             tagDataList.add(parent.copy(isSelected = isSelected, isSelectMultiple = isSelectMultiple))
 
             if (parent.isExpanded) {
                 childMap[parent.tag.id]?.forEach { childTag ->
-                    val isChildSelected = selectedItemsList.any { it.matches(childTag) }
+                    val isChildSelected = (childTag.id.isNotEmpty() && selectedIds.contains(childTag.id)) ||
+                            (!childTag.name.isNullOrEmpty() && selectedNames.contains(childTag.name))
                     tagDataList.add(TagData.Child(childTag, isChildSelected, isSelectMultiple))
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -125,14 +125,17 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         childMap: Map<String, List<TagEntity>>
     ): List<TagEntity> {
         val tagsById = HashMap<String, TagEntity>()
-        val tagsByName = HashMap<String, TagEntity>()
+        val namesOfEmptyIdTags = HashMap<String, TagEntity>()
+        val allTagsByName = HashMap<String, TagEntity>()
 
         fun indexTag(tag: TagEntity) {
             if (tag.id.isNotEmpty()) {
                 tagsById.putIfAbsent(tag.id, tag)
+            } else if (!tag.name.isNullOrEmpty()) {
+                namesOfEmptyIdTags.putIfAbsent(tag.name!!, tag)
             }
             if (!tag.name.isNullOrEmpty()) {
-                tagsByName.putIfAbsent(tag.name!!, tag)
+                allTagsByName.putIfAbsent(tag.name!!, tag)
             }
         }
 
@@ -146,9 +149,14 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         }
 
         return selectedItems.map { selected ->
-            (if (selected.id.isNotEmpty()) tagsById[selected.id] else null)
-                ?: (if (!selected.name.isNullOrEmpty()) tagsByName[selected.name] else null)
-                ?: selected
+            if (selected.id.isNotEmpty()) {
+                tagsById[selected.id]
+                    ?: (if (!selected.name.isNullOrEmpty()) namesOfEmptyIdTags[selected.name] else null)
+                    ?: selected
+            } else {
+                (if (!selected.name.isNullOrEmpty()) allTagsByName[selected.name] else null)
+                    ?: selected
+            }
         }
     }
 
@@ -162,26 +170,35 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
             }
         }
         val selectedIds = HashSet<String>()
-        val selectedNames = HashSet<String>()
+        val namesOfEmptyIdSelected = HashSet<String>()
+        val allSelectedNames = HashSet<String>()
         for (selected in selectedItemsList) {
             if (selected.id.isNotEmpty()) {
                 selectedIds.add(selected.id)
+            } else if (!selected.name.isNullOrEmpty()) {
+                namesOfEmptyIdSelected.add(selected.name!!)
             }
             if (!selected.name.isNullOrEmpty()) {
-                selectedNames.add(selected.name!!)
+                allSelectedNames.add(selected.name!!)
+            }
+        }
+        fun isTagSelected(tag: TagEntity): Boolean {
+            return if (tag.id.isNotEmpty()) {
+                selectedIds.contains(tag.id) ||
+                        (!tag.name.isNullOrEmpty() && namesOfEmptyIdSelected.contains(tag.name))
+            } else {
+                !tag.name.isNullOrEmpty() && allSelectedNames.contains(tag.name)
             }
         }
         for (parentTag in parents) {
-            val isSelected = (parentTag.id.isNotEmpty() && selectedIds.contains(parentTag.id)) ||
-                    (!parentTag.name.isNullOrEmpty() && selectedNames.contains(parentTag.name))
+            val isSelected = isTagSelected(parentTag)
             val parent = parentMap[parentTag.id] ?: TagData.Parent(parentTag, false, isSelected, isSelectMultiple)
 
             tagDataList.add(parent.copy(isSelected = isSelected, isSelectMultiple = isSelectMultiple))
 
             if (parent.isExpanded) {
                 childMap[parent.tag.id]?.forEach { childTag ->
-                    val isChildSelected = (childTag.id.isNotEmpty() && selectedIds.contains(childTag.id)) ||
-                            (!childTag.name.isNullOrEmpty() && selectedNames.contains(childTag.name))
+                    val isChildSelected = isTagSelected(childTag)
                     tagDataList.add(TagData.Child(childTag, isChildSelected, isSelectMultiple))
                 }
             }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/CollectionsFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/CollectionsFragmentTest.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.ui.resources
 import java.lang.reflect.Field
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.ole.planet.myplanet.MainApplication
@@ -90,6 +91,81 @@ class CollectionsFragmentTest {
         assertEquals(2, result.size)
         assertFalse((result[0] as TagData.Parent).isSelected)
         assertTrue((result[1] as TagData.Parent).isSelected)
+    }
+
+    @Test
+    fun `reconciliation matches selection with empty id to loaded tag with non-empty id and shows as selected`() {
+        val selectedTag = tag("", "Math")
+        val loadedTag = tag("t1", "Math")
+        val parents = listOf(loadedTag)
+        val fragment = newFragment(parents, selected = listOf(selectedTag))
+
+        val reconciled = fragment.reconcileSelections(listOf(selectedTag), parents, emptyMap())
+        assertEquals(1, reconciled.size)
+        assertSame(loadedTag, reconciled[0])
+
+        setField(fragment, "selectedItemsList", ArrayList(reconciled))
+        val tagDataList = buildTagDataList(fragment, parents)
+        assertEquals(1, tagDataList.size)
+        assertTrue((tagDataList[0] as TagData.Parent).isSelected)
+    }
+
+    @Test
+    fun `reconciliation matches selection with id to loaded tag with empty id and shows as selected`() {
+        val selectedTag = tag("t1", "Math")
+        val loadedTag = tag("", "Math")
+        val parents = listOf(loadedTag)
+        val fragment = newFragment(parents, selected = listOf(selectedTag))
+
+        val reconciled = fragment.reconcileSelections(listOf(selectedTag), parents, emptyMap())
+        assertEquals(1, reconciled.size)
+        assertSame(loadedTag, reconciled[0])
+
+        setField(fragment, "selectedItemsList", ArrayList(reconciled))
+        val tagDataList = buildTagDataList(fragment, parents)
+        assertEquals(1, tagDataList.size)
+        assertTrue((tagDataList[0] as TagData.Parent).isSelected)
+    }
+
+    @Test
+    fun `reconciliation matches selection with same id`() {
+        val selectedTag = tag("t1", "Math")
+        val loadedTag = tag("t1", "Mathematics")
+        val parents = listOf(loadedTag)
+        val fragment = newFragment(parents, selected = listOf(selectedTag))
+
+        val reconciled = fragment.reconcileSelections(listOf(selectedTag), parents, emptyMap())
+        assertEquals(1, reconciled.size)
+        assertSame(loadedTag, reconciled[0])
+
+        setField(fragment, "selectedItemsList", ArrayList(reconciled))
+        val tagDataList = buildTagDataList(fragment, parents)
+        assertEquals(1, tagDataList.size)
+        assertTrue((tagDataList[0] as TagData.Parent).isSelected)
+    }
+
+    @Test
+    fun `reconciliation keeps unmatched selection as prior object in place`() {
+        val unmatchedTag = tag("u1", "Unmatched")
+        val selectedTag = tag("t1", "Math")
+        val loadedTag = tag("t1", "Math")
+        val parents = listOf(loadedTag)
+        val fragment = newFragment(parents, selected = listOf(unmatchedTag, selectedTag))
+
+        val reconciled = fragment.reconcileSelections(listOf(unmatchedTag, selectedTag), parents, emptyMap())
+        assertEquals(2, reconciled.size)
+        assertSame(unmatchedTag, reconciled[0])
+        assertSame(loadedTag, reconciled[1])
+    }
+
+    @Test
+    fun `reconciliation handles empty tag list without error`() {
+        val selectedTag = tag("t1", "Math")
+        val fragment = newFragment(emptyList(), selected = listOf(selectedTag))
+
+        val reconciled = fragment.reconcileSelections(listOf(selectedTag), emptyList(), emptyMap())
+        assertEquals(1, reconciled.size)
+        assertSame(selectedTag, reconciled[0])
     }
 }
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/CollectionsFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/CollectionsFragmentTest.kt
@@ -167,6 +167,41 @@ class CollectionsFragmentTest {
         assertEquals(1, reconciled.size)
         assertSame(selectedTag, reconciled[0])
     }
+
+    @Test
+    fun `reconciliation does not match selection with id t1 to loaded tag with id t3 even if same name`() {
+        val selectedTag = tag("t1", "Math")
+        val loadedTag = tag("t3", "Math")
+        val parents = listOf(loadedTag)
+        val fragment = newFragment(parents, selected = listOf(selectedTag))
+
+        val reconciled = fragment.reconcileSelections(listOf(selectedTag), parents, emptyMap())
+        assertEquals(1, reconciled.size)
+        assertSame(selectedTag, reconciled[0])
+
+        setField(fragment, "selectedItemsList", ArrayList(reconciled))
+        val tagDataList = buildTagDataList(fragment, parents)
+        assertEquals(1, tagDataList.size)
+        assertFalse((tagDataList[0] as TagData.Parent).isSelected)
+    }
+
+    @Test
+    fun `reconciliation matches selection with id t1 to loaded tag B with empty id when loaded tag A has id t3`() {
+        val selectedTag = tag("t1", "Math")
+        val tagA = tag("t3", "Math")
+        val tagB = tag("", "Math")
+        val parents = listOf(tagA, tagB)
+        val fragment = newFragment(parents, selected = listOf(selectedTag))
+
+        val reconciled = fragment.reconcileSelections(listOf(selectedTag), parents, emptyMap())
+        assertEquals(1, reconciled.size)
+        assertSame(tagB, reconciled[0])
+
+        setField(fragment, "selectedItemsList", ArrayList(reconciled))
+        val tagDataList = buildTagDataList(fragment, parents)
+        assertEquals(2, tagDataList.size)
+        assertTrue((tagDataList[1] as TagData.Parent).isSelected)
+    }
 }
 
 private fun setField(target: Any, name: String, value: Any) {


### PR DESCRIPTION
Optimized tag selection reconciliation in CollectionsFragment by building candidate tag index maps (tagsById and tagsByName) in one pass over loaded tags using putIfAbsent. Lookups try ID first, then fall back to name, matching tags with empty IDs or names correctly. Pre-derived key sets (selectedIds and selectedNames) are used in buildTagDataList to check selection state for parent and child rows in O(1) time. Added comprehensive unit tests covering all mixed selection cases.

Fixes #17090

---
*PR created automatically by Jules for task [18352000736825933781](https://jules.google.com/task/18352000736825933781) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag selection reconciliation using tag IDs and names.
  * Preserved selected tags when matching loaded tags have missing or empty IDs.
  * Prevented incorrectly matching tags that share a name but have conflicting IDs.
  * Ensured parent and child selection states accurately reflect reconciled tags.
  * Handled empty tag lists without errors.

* **Tests**
  * Added coverage for matching, unmatched selections, conflicting IDs, duplicate names, and empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->