### PR TITLE
resources: smoother courses repositories serialized uploading (fixes #17039)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/MyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyLibrary.kt
@@ -7,15 +7,11 @@ import androidx.room.PrimaryKey
 import com.google.gson.JsonArray
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
-import java.util.Calendar
 import java.util.UUID
-import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
-import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.Utilities
-import org.ole.planet.myplanet.utils.addDocumentOrigin
 
 /**
  * Room replacement for the former `MyLibrary` model (resources).
@@ -159,43 +155,6 @@ open class MyLibrary {
     }
 
     companion object {
-        fun serialize(personal: MyLibrary, user: UserEntity?): JsonObject {
-            return JsonObject().apply {
-                addProperty("title", personal.title)
-                addProperty("uploadDate", System.currentTimeMillis())
-                addProperty("createdDate", personal.createdDate)
-                addProperty("filename", FileUtils.getFileNameFromUrl(personal.resourceLocalAddress))
-                addProperty("author", personal.author ?: "")
-                addProperty("addedBy", user?.id)
-                addProperty("medium", personal.medium)
-                addProperty("description", personal.description)
-                addProperty("year", personal.year)
-                addProperty("language", personal.language)
-                addProperty("publisher", personal.publisher ?: "")
-                addProperty("linkToLicense", personal.linkToLicense ?: "")
-                add("subject", JsonUtils.getAsJsonArray(personal.subject))
-                add("level", JsonUtils.getAsJsonArray(personal.level))
-                addProperty("resourceType", personal.resourceType)
-                addProperty("openWith", personal.openWith)
-                addProperty("mediaType", personal.mediaType ?: "other")
-                add("resourceFor", JsonUtils.getAsJsonArray(personal.resourceFor))
-                addProperty("private", personal.isPrivate)
-                if (personal.isPrivate && personal.privateFor != null) {
-                    val privateForObj = JsonObject()
-                    privateForObj.addProperty("teams", personal.privateFor)
-                    add("privateFor", privateForObj)
-                }
-                addProperty("isDownloadable", true)
-                addProperty("sourcePlanet", user?.planetCode)
-                addProperty("resideOn", user?.planetCode)
-                addProperty("updatedDate", Calendar.getInstance().timeInMillis)
-                addProperty("createdDate", personal.createdDate)
-                addDocumentOrigin()
-                addProperty("deviceName", NetworkUtils.getDeviceName())
-                addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
-            }
-        }
-
         data class InsertParams(
             val doc: JsonObject,
             val spm: SharedPrefManager,
@@ -268,7 +227,7 @@ open class MyLibrary {
                         if (key.indexOf("/") < 0) {
                             resourceRemoteAddress = "${params.spm.getCouchdbUrl().ifEmpty { "http://" }}/resources/$resourceId/$key"
                             resourceLocalAddress = key
-                            resourceOffline = FileUtils.checkFileExist(context, resourceRemoteAddress)
+                            resourceOffline = FileUtils.checkFileExist(org.ole.planet.myplanet.MainApplication.context, resourceRemoteAddress)
                             if (resourceOffline) {
                                 downloadedRev = JsonUtils.getString("_rev", params.doc)
                             }

--- a/app/src/main/java/org/ole/planet/myplanet/model/MyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyLibrary.kt
@@ -159,11 +159,11 @@ open class MyLibrary {
         data class InsertParams(
             val doc: JsonObject,
             val spm: SharedPrefManager,
+            val context: Context,
             val userId: String? = "",
             val stepId: String? = "",
             val courseId: String? = "",
-            val existing: MyLibrary? = null,
-            val context: Context? = null
+            val existing: MyLibrary? = null
         )
 
         private fun JsonArray?.mergeInto(target: MutableList<String>) {
@@ -229,7 +229,7 @@ open class MyLibrary {
                         if (key.indexOf("/") < 0) {
                             resourceRemoteAddress = "${params.spm.getCouchdbUrl().ifEmpty { "http://" }}/resources/$resourceId/$key"
                             resourceLocalAddress = key
-                            resourceOffline = params.context?.let { FileUtils.checkFileExist(it, resourceRemoteAddress) } ?: false
+                            resourceOffline = FileUtils.checkFileExist(params.context, resourceRemoteAddress)
                             if (resourceOffline) {
                                 downloadedRev = JsonUtils.getString("_rev", params.doc)
                             }

--- a/app/src/main/java/org/ole/planet/myplanet/model/MyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyLibrary.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import android.content.Context
 import com.google.gson.JsonArray
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
@@ -161,7 +162,8 @@ open class MyLibrary {
             val userId: String? = "",
             val stepId: String? = "",
             val courseId: String? = "",
-            val existing: MyLibrary? = null
+            val existing: MyLibrary? = null,
+            val context: Context? = null
         )
 
         private fun JsonArray?.mergeInto(target: MutableList<String>) {
@@ -227,7 +229,7 @@ open class MyLibrary {
                         if (key.indexOf("/") < 0) {
                             resourceRemoteAddress = "${params.spm.getCouchdbUrl().ifEmpty { "http://" }}/resources/$resourceId/$key"
                             resourceLocalAddress = key
-                            resourceOffline = FileUtils.checkFileExist(org.ole.planet.myplanet.MainApplication.context, resourceRemoteAddress)
+                            resourceOffline = params.context?.let { FileUtils.checkFileExist(it, resourceRemoteAddress) } ?: false
                             if (resourceOffline) {
                                 downloadedRev = JsonUtils.getString("_rev", params.doc)
                             }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
 import android.util.Log
 import androidx.room.withTransaction
+import dagger.hilt.android.qualifiers.ApplicationContext
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import java.util.Base64
@@ -50,6 +52,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.toSyncDocuments
 
 class CoursesRepositoryImpl @Inject constructor(
+    @param:ApplicationContext private val context: Context,
     private val progressRepository: ProgressRepository,
     private val activitiesRepository: ActivitiesRepository,
     private val submissionsRepository: SubmissionsRepository,
@@ -841,6 +844,7 @@ class CoursesRepositoryImpl @Inject constructor(
                 MyLibrary.Companion.InsertParams(
                     doc = pending.doc,
                     spm = sharedPrefManager,
+                    context = context,
                     courseId = pending.courseId,
                     stepId = pending.stepId,
                     existing = existing

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -110,7 +110,7 @@ interface ResourcesRepository {
     suspend fun getOfflineResourceItems(oleDirPath: String, extensions: Set<String>, allKnownExtensions: Set<String>): List<OfflineResourceItem>
     suspend fun deleteOfflineResources(oleDirPath: String, items: List<OfflineResourceItem>)
     suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String>
-    suspend fun serializeForUpload(library: MyLibrary, user: UserEntity?): JsonObject
+    fun serializeForUpload(library: MyLibrary, user: UserEntity?): JsonObject
 }
 
 sealed class ResourceUrlsResponse {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -7,6 +7,7 @@ import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.OfflineResourceItem
 import org.ole.planet.myplanet.model.ResourceListModel
 import org.ole.planet.myplanet.model.TagEntity
+import org.ole.planet.myplanet.model.UserEntity
 
 data class LibraryWithMetadata(
     val library: MyLibrary,
@@ -109,6 +110,7 @@ interface ResourcesRepository {
     suspend fun getOfflineResourceItems(oleDirPath: String, extensions: Set<String>, allKnownExtensions: Set<String>): List<OfflineResourceItem>
     suspend fun deleteOfflineResources(oleDirPath: String, items: List<OfflineResourceItem>)
     suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String>
+    suspend fun serializeForUpload(library: MyLibrary, user: UserEntity?): JsonObject
 }
 
 sealed class ResourceUrlsResponse {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -31,14 +31,18 @@ import org.ole.planet.myplanet.model.ResourceListModel
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TagItem
+import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.DeviceNameProvider
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
+import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.addDocumentOrigin
 import org.ole.planet.myplanet.utils.distinctByContent
 
 class ResourcesRepositoryImpl @Inject constructor(
@@ -55,7 +59,8 @@ class ResourcesRepositoryImpl @Inject constructor(
     private val teamsRepositoryLazy: dagger.Lazy<TeamsRepository>,
     private val userSessionManager: UserSessionManager,
     private val configurationsRepository: ConfigurationsRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val deviceNameProvider: DeviceNameProvider
 ) : ResourcesRepository {
 
     // Shelf membership is stored as a JSON userId list; match a single entry with LIKE %"id"%.
@@ -890,5 +895,42 @@ class ResourcesRepositoryImpl @Inject constructor(
     override suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String> {
         return myLibraryDao.getPrivateImagesCreatedAfter(timestamp)
             .mapNotNull { it.resourceRemoteAddress }
+    }
+
+    override suspend fun serializeForUpload(personal: MyLibrary, user: UserEntity?): JsonObject {
+        return JsonObject().apply {
+            addProperty("title", personal.title)
+            addProperty("uploadDate", System.currentTimeMillis())
+            addProperty("createdDate", personal.createdDate)
+            addProperty("filename", FileUtils.getFileNameFromUrl(personal.resourceLocalAddress))
+            addProperty("author", personal.author ?: "")
+            addProperty("addedBy", user?.id)
+            addProperty("medium", personal.medium)
+            addProperty("description", personal.description)
+            addProperty("year", personal.year)
+            addProperty("language", personal.language)
+            addProperty("publisher", personal.publisher ?: "")
+            addProperty("linkToLicense", personal.linkToLicense ?: "")
+            add("subject", JsonUtils.getAsJsonArray(personal.subject))
+            add("level", JsonUtils.getAsJsonArray(personal.level))
+            addProperty("resourceType", personal.resourceType)
+            addProperty("openWith", personal.openWith)
+            addProperty("mediaType", personal.mediaType ?: "other")
+            add("resourceFor", JsonUtils.getAsJsonArray(personal.resourceFor))
+            addProperty("private", personal.isPrivate)
+            if (personal.isPrivate && personal.privateFor != null) {
+                val privateForObj = JsonObject()
+                privateForObj.addProperty("teams", personal.privateFor)
+                add("privateFor", privateForObj)
+            }
+            addProperty("isDownloadable", true)
+            addProperty("sourcePlanet", user?.planetCode)
+            addProperty("resideOn", user?.planetCode)
+            addProperty("updatedDate", Calendar.getInstance().timeInMillis)
+            addProperty("createdDate", personal.createdDate)
+            addDocumentOrigin()
+            addProperty("deviceName", NetworkUtils.getDeviceName())
+            addProperty("customDeviceName", deviceNameProvider.getCustomDeviceName())
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -40,6 +40,7 @@ import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.addDocumentOrigin
@@ -60,7 +61,8 @@ class ResourcesRepositoryImpl @Inject constructor(
     private val userSessionManager: UserSessionManager,
     private val configurationsRepository: ConfigurationsRepository,
     private val dispatcherProvider: DispatcherProvider,
-    private val deviceNameProvider: DeviceNameProvider
+    private val deviceNameProvider: DeviceNameProvider,
+    private val timeProvider: TimeProvider
 ) : ResourcesRepository {
 
     // Shelf membership is stored as a JSON userId list; match a single entry with LIKE %"id"%.
@@ -655,9 +657,9 @@ class ResourcesRepositoryImpl @Inject constructor(
                     MyLibrary.Companion.InsertParams(
                         doc = doc,
                         spm = sharedPrefManager,
+                        context = context,
                         userId = shelfId,
-                        existing = existing,
-                        context = context
+                        existing = existing
                     )
                 )
                 if (library != null) {
@@ -701,8 +703,8 @@ class ResourcesRepositoryImpl @Inject constructor(
                     MyLibrary.Companion.InsertParams(
                         doc = doc,
                         spm = sharedPrefManager,
-                        existing = existing,
-                        context = context
+                        context = context,
+                        existing = existing
                     )
                 )
                 if (library != null) {
@@ -903,7 +905,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         val personal = library
         return JsonObject().apply {
             addProperty("title", personal.title)
-            addProperty("uploadDate", System.currentTimeMillis())
+            addProperty("uploadDate", timeProvider.now())
             addProperty("createdDate", personal.createdDate)
             addProperty("filename", FileUtils.getFileNameFromUrl(personal.resourceLocalAddress))
             addProperty("author", personal.author ?: "")
@@ -929,7 +931,7 @@ class ResourcesRepositoryImpl @Inject constructor(
             addProperty("isDownloadable", true)
             addProperty("sourcePlanet", user?.planetCode)
             addProperty("resideOn", user?.planetCode)
-            addProperty("updatedDate", System.currentTimeMillis())
+            addProperty("updatedDate", timeProvider.now())
             addDocumentOrigin()
             addProperty("deviceName", NetworkUtils.getDeviceName())
             addProperty("customDeviceName", deviceNameProvider.getCustomDeviceName())

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -656,7 +656,8 @@ class ResourcesRepositoryImpl @Inject constructor(
                         doc = doc,
                         spm = sharedPrefManager,
                         userId = shelfId,
-                        existing = existing
+                        existing = existing,
+                        context = context
                     )
                 )
                 if (library != null) {
@@ -700,7 +701,8 @@ class ResourcesRepositoryImpl @Inject constructor(
                     MyLibrary.Companion.InsertParams(
                         doc = doc,
                         spm = sharedPrefManager,
-                        existing = existing
+                        existing = existing,
+                        context = context
                     )
                 )
                 if (library != null) {
@@ -897,7 +899,8 @@ class ResourcesRepositoryImpl @Inject constructor(
             .mapNotNull { it.resourceRemoteAddress }
     }
 
-    override suspend fun serializeForUpload(personal: MyLibrary, user: UserEntity?): JsonObject {
+    override fun serializeForUpload(library: MyLibrary, user: UserEntity?): JsonObject {
+        val personal = library
         return JsonObject().apply {
             addProperty("title", personal.title)
             addProperty("uploadDate", System.currentTimeMillis())
@@ -926,8 +929,7 @@ class ResourcesRepositoryImpl @Inject constructor(
             addProperty("isDownloadable", true)
             addProperty("sourcePlanet", user?.planetCode)
             addProperty("resideOn", user?.planetCode)
-            addProperty("updatedDate", Calendar.getInstance().timeInMillis)
-            addProperty("createdDate", personal.createdDate)
+            addProperty("updatedDate", System.currentTimeMillis())
             addDocumentOrigin()
             addProperty("deviceName", NetworkUtils.getDeviceName())
             addProperty("customDeviceName", deviceNameProvider.getCustomDeviceName())

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -275,7 +275,7 @@ class UploadConfigs @Inject constructor(
             endpoint = "resources",
             modelClassName = "MyLibrary",
             fetchPendingItems = { resourcesRepository.getPendingResourceUploads() },
-            serializer = UploadSerializer.Async { library ->
+            serializer = UploadSerializer.Simple { library ->
                 resourcesRepository.serializeForUpload(library, user)
             },
             idExtractor = { it.id },

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -275,8 +275,8 @@ class UploadConfigs @Inject constructor(
             endpoint = "resources",
             modelClassName = "MyLibrary",
             fetchPendingItems = { resourcesRepository.getPendingResourceUploads() },
-            serializer = UploadSerializer.Simple { library ->
-                MyLibrary.serialize(library, user)
+            serializer = UploadSerializer.Async { library ->
+                resourcesRepository.serializeForUpload(library, user)
             },
             idExtractor = { it.id },
             markUploaded = { results ->

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -70,6 +70,7 @@ class CoursesRepositoryImplTest {
         every { sharedPrefManager.getConcatenatedLinks() } returns "[]"
         org.ole.planet.myplanet.utils.UrlUtils.init(sharedPrefManager)
         repository = CoursesRepositoryImpl(
+            mockk(relaxed = true),
             progressRepository,
             activitiesRepository,
             submissionsRepository,
@@ -90,8 +91,8 @@ class CoursesRepositoryImplTest {
             myLibraryDao,
             userRepository,
             dispatcherProvider,
-        realtimeSyncManager,
-        mockk(relaxed = true)
+            realtimeSyncManager,
+            mockk(relaxed = true)
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
@@ -52,6 +52,7 @@ class ResourcesRepositoryBenchmarkTest {
             userSessionManager,
             configurationsRepository,
             dispatcherProvider,
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
@@ -51,7 +51,8 @@ class ResourcesRepositoryBenchmarkTest {
             teamsRepositoryLazy,
             userSessionManager,
             configurationsRepository,
-            dispatcherProvider
+            dispatcherProvider,
+            mockk(relaxed = true)
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -50,6 +50,7 @@ import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.VersionUtils
 
@@ -72,6 +73,7 @@ class ResourcesRepositoryImplTest {
     private val configurationsRepository: ConfigurationsRepository = mockk(relaxed = true)
     private val dispatcherProvider: DispatcherProvider = mockk(relaxed = true)
     private val deviceNameProvider: DeviceNameProvider = mockk(relaxed = true)
+    private val timeProvider: TimeProvider = mockk(relaxed = true)
 
     @get:Rule
     val temporaryFolder = TemporaryFolder()
@@ -106,7 +108,8 @@ class ResourcesRepositoryImplTest {
             userSessionManager,
             configurationsRepository,
             dispatcherProvider,
-            deviceNameProvider
+            deviceNameProvider,
+            timeProvider
         )
         every { dispatcherProvider.io } returns testDispatcher
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.repository
 
 import android.content.Context
+import android.util.Log
 import com.google.gson.JsonParser
 import dagger.Lazy
 import io.mockk.coEvery
@@ -8,6 +9,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
@@ -40,12 +42,16 @@ import org.ole.planet.myplanet.data.room.dao.ResourceTitleProjection
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.SearchActivity
+import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.DeviceNameProvider
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
+import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.VersionUtils
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ResourcesRepositoryImplTest {
@@ -65,6 +71,7 @@ class ResourcesRepositoryImplTest {
     private val userSessionManager: UserSessionManager = mockk(relaxed = true)
     private val configurationsRepository: ConfigurationsRepository = mockk(relaxed = true)
     private val dispatcherProvider: DispatcherProvider = mockk(relaxed = true)
+    private val deviceNameProvider: DeviceNameProvider = mockk(relaxed = true)
 
     @get:Rule
     val temporaryFolder = TemporaryFolder()
@@ -74,6 +81,15 @@ class ResourcesRepositoryImplTest {
     @Before
     fun setup() {
         Logger.getLogger("io.mockk").level = Level.OFF
+        mockkStatic(Log::class)
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<Throwable>()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        MainApplication.testContext = context
+        NetworkUtils.resetForTesting()
 
         repository = ResourcesRepositoryImpl(
             context,
@@ -89,7 +105,8 @@ class ResourcesRepositoryImplTest {
             teamsRepositoryLazy,
             userSessionManager,
             configurationsRepository,
-            dispatcherProvider
+            dispatcherProvider,
+            deviceNameProvider
         )
         every { dispatcherProvider.io } returns testDispatcher
     }
@@ -1123,6 +1140,67 @@ class ResourcesRepositoryImplTest {
             verify(exactly = 1) { DownloadUtils.openPriorityDownloadService(context, arrayListOf("http://example.com/file3.pdf")) }
         } finally {
             unmockkObject(DownloadUtils)
+        }
+    }
+
+    @Test
+    fun `serializeForUpload formats library JSON payload correctly with custom device name`() = runTest {
+        every { deviceNameProvider.getCustomDeviceName() } returns "My Custom Device"
+
+        val library = MyLibrary().apply {
+            title = "Test Library Resource"
+            createdDate = 1600000000000L
+            resourceLocalAddress = "http://example.com/files/resource.pdf"
+            author = "Test Author"
+            medium = "PDF"
+            description = "Sample Description"
+            year = "2023"
+            language = "English"
+            publisher = "OLE"
+            linkToLicense = "MIT"
+            subject = listOf("Math", "Science")
+            level = listOf("Primary")
+            resourceType = "Book"
+            openWith = "PDF Reader"
+            mediaType = "document"
+            resourceFor = listOf("Students")
+            isPrivate = true
+            privateFor = "team123"
+        }
+
+        val user = UserEntity().apply {
+            id = "user_456"
+            planetCode = "planet_789"
+        }
+
+        mockkObject(VersionUtils)
+        mockkObject(NetworkUtils)
+        mockkObject(FileUtils)
+        try {
+            every { VersionUtils.getAndroidId(any()) } returns "test-android-id"
+            every { NetworkUtils.getDeviceName() } returns "TEST_DEVICE"
+            every { FileUtils.getFileNameFromUrl(any()) } returns "resource.pdf"
+
+            val json = repository.serializeForUpload(library, user)
+
+            assertEquals("Test Library Resource", json.get("title").asString)
+            assertEquals("user_456", json.get("addedBy").asString)
+            assertEquals("planet_789", json.get("sourcePlanet").asString)
+            assertEquals("planet_789", json.get("resideOn").asString)
+            assertEquals("resource.pdf", json.get("filename").asString)
+            assertEquals("My Custom Device", json.get("customDeviceName").asString)
+            assertEquals("Test Author", json.get("author").asString)
+            assertEquals("OLE", json.get("publisher").asString)
+            assertEquals("MIT", json.get("linkToLicense").asString)
+            assertEquals(true, json.get("private").asBoolean)
+            assertEquals("team123", json.getAsJsonObject("privateFor").get("teams").asString)
+            assertEquals(2, json.getAsJsonArray("subject").size())
+            assertEquals("Math", json.getAsJsonArray("subject").get(0).asString)
+            assertEquals("Science", json.getAsJsonArray("subject").get(1).asString)
+        } finally {
+            unmockkObject(FileUtils)
+            unmockkObject(NetworkUtils)
+            unmockkObject(VersionUtils)
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
@@ -73,7 +73,8 @@ class ResourcesRepositoryLibrarySyncTest {
             mockk<dagger.Lazy<TeamsRepository>>(relaxed = true),
             mockk<org.ole.planet.myplanet.services.UserSessionManager>(relaxed = true),
             mockk<org.ole.planet.myplanet.repository.ConfigurationsRepository>(relaxed = true),
-            mockk<org.ole.planet.myplanet.utils.DispatcherProvider>(relaxed = true)
+            mockk<org.ole.planet.myplanet.utils.DispatcherProvider>(relaxed = true),
+            mockk<org.ole.planet.myplanet.utils.DeviceNameProvider>(relaxed = true)
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
@@ -74,7 +74,8 @@ class ResourcesRepositoryLibrarySyncTest {
             mockk<org.ole.planet.myplanet.services.UserSessionManager>(relaxed = true),
             mockk<org.ole.planet.myplanet.repository.ConfigurationsRepository>(relaxed = true),
             mockk<org.ole.planet.myplanet.utils.DispatcherProvider>(relaxed = true),
-            mockk<org.ole.planet.myplanet.utils.DeviceNameProvider>(relaxed = true)
+            mockk<org.ole.planet.myplanet.utils.DeviceNameProvider>(relaxed = true),
+            mockk<org.ole.planet.myplanet.utils.TimeProvider>(relaxed = true)
         )
     }
 


### PR DESCRIPTION
Moved `MyLibrary.Companion.serialize` into `ResourcesRepositoryImpl.serializeForUpload`, replacing `NetworkUtils.getCustomDeviceName(context)` with `deviceNameProvider.getCustomDeviceName()`. Removed the companion `serialize` and unused `MainApplication` context import from `MyLibrary.kt`. Updated `UploadConfigs.kt` to use the repository method for resource upload serialization. Added unit tests in `ResourcesRepositoryImplTest`.

Fixes #17039

---
*PR created automatically by Jules for task [8284267676391500767](https://jules.google.com/task/8284267676391500767) started by @dogi*