### PR TITLE
courses: smoother answer dao querying (fixes #17138)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/AnswerDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/AnswerDao.kt
@@ -8,9 +8,25 @@ import org.ole.planet.myplanet.model.Answer
 @Dao
 interface AnswerDao {
     @Query("SELECT * FROM answers WHERE submissionId = :submissionId") suspend fun getBySubmissionId(submissionId: String): List<Answer>
-    @Query("SELECT * FROM answers WHERE submissionId IN (:submissionIds)") suspend fun getBySubmissionIds(submissionIds: List<String>): List<Answer>
+
+    @Query("SELECT * FROM answers WHERE submissionId IN (:submissionIds)")
+    suspend fun getBySubmissionIdsInternal(submissionIds: List<String>): List<Answer>
+
+    suspend fun getBySubmissionIds(submissionIds: List<String>): List<Answer> {
+        if (submissionIds.isEmpty()) return emptyList()
+        return submissionIds.chunked(900).flatMap { getBySubmissionIdsInternal(it) }
+    }
+
     @Query("SELECT * FROM answers WHERE submissionId = :submissionId AND questionId = :questionId LIMIT 1") suspend fun getBySubmissionAndQuestion(submissionId: String, questionId: String?): Answer?
-    @Query("DELETE FROM answers WHERE submissionId IN (:submissionIds)") suspend fun deleteBySubmissionIds(submissionIds: List<String>): Int
+
+    @Query("DELETE FROM answers WHERE submissionId IN (:submissionIds)")
+    suspend fun deleteBySubmissionIdsInternal(submissionIds: List<String>): Int
+
+    suspend fun deleteBySubmissionIds(submissionIds: List<String>): Int {
+        if (submissionIds.isEmpty()) return 0
+        return submissionIds.chunked(900).sumOf { deleteBySubmissionIdsInternal(it) }
+    }
+
     @Upsert suspend fun upsertAll(items: List<Answer>)
     @Upsert fun upsertAllBlocking(items: List<Answer>)
 }

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/AnswerDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/AnswerDaoTest.kt
@@ -1,0 +1,109 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.data.room.AppDatabase
+import org.ole.planet.myplanet.model.Answer
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = Application::class)
+class AnswerDaoTest {
+
+    private lateinit var database: AppDatabase
+    private lateinit var answerDao: AnswerDao
+
+    @Before
+    fun initDb() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        answerDao = database.answerDao()
+    }
+
+    @After
+    fun closeDb() {
+        database.close()
+    }
+
+    private fun createAnswer(id: String, submissionId: String): Answer {
+        return Answer(id = id, submissionId = submissionId)
+    }
+
+    @Test
+    fun getBySubmissionIds_with1200SubmissionIds_returnsAllAnswersWithoutThrowing() = runBlocking {
+        val answers = (1..1200).map { i ->
+            createAnswer("ans_$i", "sub_$i")
+        }
+        answerDao.upsertAll(answers)
+
+        val allSubmissionIds = answers.map { it.submissionId!! }
+        val results = answerDao.getBySubmissionIds(allSubmissionIds)
+
+        assertEquals(1200, results.size)
+        assertEquals(answers.map { it.id }.toSet(), results.map { it.id }.toSet())
+    }
+
+    @Test
+    fun deleteBySubmissionIds_with1200SubmissionIds_deletesAllAndReturnsTotalCount() = runBlocking {
+        val answers = (1..1200).map { i ->
+            createAnswer("ans_$i", "sub_$i")
+        }
+        answerDao.upsertAll(answers)
+
+        val allSubmissionIds = answers.map { it.submissionId!! }
+        val deletedCount = answerDao.deleteBySubmissionIds(allSubmissionIds)
+
+        assertEquals(1200, deletedCount)
+
+        val remainingAnswers = answerDao.getBySubmissionIds(allSubmissionIds)
+        assertTrue(remainingAnswers.isEmpty())
+    }
+
+    @Test
+    fun getBySubmissionIds_and_deleteBySubmissionIds_withEmptyList_shortCircuitAndReturnEmptyOrZero() = runBlocking {
+        val answer = createAnswer("ans_1", "sub_1")
+        answerDao.upsertAll(listOf(answer))
+
+        val selectResult = answerDao.getBySubmissionIds(emptyList())
+        assertTrue(selectResult.isEmpty())
+
+        val deleteCount = answerDao.deleteBySubmissionIds(emptyList())
+        assertEquals(0, deleteCount)
+
+        // Verify existing answer in database was not affected
+        val existing = answerDao.getBySubmissionId("sub_1")
+        assertEquals(1, existing.size)
+    }
+
+    @Test
+    fun getBySubmissionIds_and_deleteBySubmissionIds_withMixedList_handlesExistingAndNonExistingIds() = runBlocking {
+        val answers = (1..5).map { i ->
+            createAnswer("ans_$i", "sub_$i")
+        }
+        answerDao.upsertAll(answers)
+
+        val querySubmissionIds = listOf("sub_1", "sub_3", "non_existing_1", "non_existing_2")
+        val selectResults = answerDao.getBySubmissionIds(querySubmissionIds)
+
+        assertEquals(2, selectResults.size)
+        assertEquals(setOf("ans_1", "ans_3"), selectResults.map { it.id }.toSet())
+
+        val deleteCount = answerDao.deleteBySubmissionIds(querySubmissionIds)
+        assertEquals(2, deleteCount)
+
+        val remaining = answerDao.getBySubmissionIds(listOf("sub_1", "sub_2", "sub_3", "sub_4", "sub_5"))
+        assertEquals(3, remaining.size)
+        assertEquals(setOf("ans_2", "ans_4", "ans_5"), remaining.map { it.id }.toSet())
+    }
+}


### PR DESCRIPTION
Chunks AnswerDao's IN (:submissionIds) queries inside the DAO in batches of 900 to prevent SQLite host parameter limit crashes while preserving the existing public interface and adding comprehensive unit tests.

Fixes #17138

---
*PR created automatically by Jules for task [18190622294553902591](https://jules.google.com/task/18190622294553902591) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved answer retrieval and deletion when processing large numbers of submissions.
  - Prevented failures caused by oversized requests by automatically processing submissions in manageable batches.
  - Empty submission lists now return no results or perform no deletion without errors.
  - Deletion results accurately report the total number of answers removed, including requests containing both existing and non-existing submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->