### PR TITLE
sync: smoother url utils credential logging (fixes #17137)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -48,7 +48,7 @@ import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.FileUtils.availableExternalMemorySize
 import org.ole.planet.myplanet.utils.FileUtils.externalMemoryAvailable
 import org.ole.planet.myplanet.utils.FileUtils.getFileNameFromUrl
-import org.ole.planet.myplanet.utils.UrlUtils.header
+import org.ole.planet.myplanet.utils.UrlUtils
 
 @AndroidEntryPoint
 class DownloadService : Service() {
@@ -234,7 +234,7 @@ class DownloadService : Service() {
                 return true
             }
 
-            val authHeader = header
+            val authHeader = UrlUtils.header
             if (authHeader.isBlank()) {
                 Log.e(TAG, "initDownload: auth header is blank — user may not be logged in")
                 downloadFailed("Authentication header not available", fromSync)
@@ -248,7 +248,7 @@ class DownloadService : Service() {
                 Log.w(TAG, "initDownload: primary failed with network error (${primaryResult.message}), checking for alternative URL")
                 val altUrl = resolveAlternativeUrl(url, fileName)
                 if (altUrl != null) {
-                    Log.d(TAG, "initDownload: retrying with $altUrl")
+                    Log.d(TAG, "initDownload: retrying with ${UrlUtils.redactForLog(altUrl)}")
                     currentDownloadUrl = altUrl
                     val altResult = downloadRepository.downloadFileResponse(altUrl, authHeader)
                     return tryDownloadFromResult(altResult, altUrl, fromSync, fileName, isAlternative = true)

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -282,7 +282,7 @@ class DownloadService : Service() {
             if (storedAlt.isNotEmpty() && primaryBase != null) {
                 resolvedAltBase = storedAlt.trimEnd('/')
                 resolvedPrimaryBase = primaryBase
-                Log.d(TAG, "initDownload: no hardcoded mapping for $primaryBase — using stored alternative $resolvedAltBase")
+                Log.d(TAG, "initDownload: no hardcoded mapping for $primaryBase — using stored alternative ${UrlUtils.redactForLog(resolvedAltBase)}")
             } else {
                 resolvedAltBase = null
                 resolvedPrimaryBase = null
@@ -295,7 +295,7 @@ class DownloadService : Service() {
             val path = parsed.path.orEmpty()
             val query = if (parsed.query != null) "?${parsed.query}" else ""
             val altUrl = resolvedAltBase + path + query
-            Log.d(TAG, "initDownload: switching $fileName — primary=$resolvedPrimaryBase → alternative=$resolvedAltBase")
+            Log.d(TAG, "initDownload: switching $fileName — primary=$resolvedPrimaryBase → alternative=${UrlUtils.redactForLog(resolvedAltBase)}")
             return altUrl
         }
         return null

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -65,7 +65,7 @@ class DownloadWorker @AssistedInject constructor(
                 val success = try {
                     downloadFile(url, authHeader, index, urls.size)
                 } catch (e: Exception) {
-                    Log.e(TAG, "Failed to download $url", e)
+                    Log.e(TAG, "Failed to download ${getFileNameFromUrl(url)}", e)
                     false
                 }
                 results.add(success)
@@ -74,12 +74,12 @@ class DownloadWorker @AssistedInject constructor(
                 try {
                     showProgressNotification(completedCount - 1, urls.size, context.getString(R.string.downloaded_files, "$completedCount", "${urls.size}"), 100)
                 } catch (e: Exception) {
-                    Log.e(TAG, "Failed to update progress notification for $url", e)
+                    Log.e(TAG, "Failed to update progress notification for ${getFileNameFromUrl(url)}", e)
                 }
                 try {
                     sendDownloadUpdate(url, success, completedCount >= urls.size, fromSync)
                 } catch (e: Exception) {
-                    Log.e(TAG, "Failed to send download update for $url", e)
+                    Log.e(TAG, "Failed to send download update for ${getFileNameFromUrl(url)}", e)
                 }
             }
 
@@ -96,7 +96,7 @@ class DownloadWorker @AssistedInject constructor(
             try {
                 resourcesRepository.markResourceOfflineByUrl(url)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to mark existing resource offline: $url", e)
+                Log.e(TAG, "Failed to mark existing resource offline: ${UrlUtils.redactForLog(url)}", e)
             }
             return true
         }
@@ -108,12 +108,12 @@ class DownloadWorker @AssistedInject constructor(
                     true
                 }
                 is DownloadResult.Error -> {
-                    Log.e(TAG, "Failed to download file: $url (code=${response.code}) ${response.message}")
+                    Log.e(TAG, "Failed to download file: ${getFileNameFromUrl(url)} (code=${response.code}) ${response.message}")
                     false
                 }
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to download file: $url", e)
+            Log.e(TAG, "Failed to download file: ${UrlUtils.redactForLog(url)}", e)
             false
         }
     }
@@ -149,7 +149,7 @@ class DownloadWorker @AssistedInject constructor(
         try {
             resourcesRepository.markResourceOfflineByUrl(url)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to mark downloaded resource offline: $url", e)
+            Log.e(TAG, "Failed to mark downloaded resource offline: ${UrlUtils.redactForLog(url)}", e)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/BulkDocsUploader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/BulkDocsUploader.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.ole.planet.myplanet.repository.UploadRepository
+import org.ole.planet.myplanet.utils.UrlUtils
 
 object BulkDocsUploader {
     private const val TAG = "BulkDocsUploader"
@@ -32,7 +33,7 @@ object BulkDocsUploader {
 
             if (response.isSuccessful && responseBody != null) {
                 if (responseBody.size() < items.size) {
-                    Log.w(TAG, "Bulk upload to $url returned ${responseBody.size()} result(s) for a batch of ${items.size}; ${items.size - responseBody.size()} item(s) were not processed and will retry next sync")
+                    Log.w(TAG, "Bulk upload to ${UrlUtils.redactForLog(url)} returned ${responseBody.size()} result(s) for a batch of ${items.size}; ${items.size - responseBody.size()} item(s) were not processed and will retry next sync")
                 }
                 for (i in 0 until responseBody.size()) {
                     val element = responseBody.get(i).asJsonObject
@@ -48,7 +49,7 @@ object BulkDocsUploader {
                 items.forEach { (item, _) -> onResult(item, Outcome.RequestFailed(response.code(), null)) }
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Exception during bulk upload to $url", e)
+            Log.e(TAG, "Exception during bulk upload to ${UrlUtils.redactForLog(url)}", e)
             items.forEach { (item, _) -> onResult(item, Outcome.RequestFailed(null, e)) }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
@@ -208,6 +208,27 @@ object UrlUtils {
         return "$url$path"
     }
 
+    /** Strips the userinfo (user:password@) from a URL so it is safe to log. */
+    fun redactForLog(url: String?): String {
+        if (url.isNullOrBlank()) return "<unparseable url>"
+        return try {
+            val uri = android.net.Uri.parse(url)
+            val scheme = uri.scheme
+            val host = uri.host
+            if (scheme.isNullOrEmpty() || host.isNullOrEmpty()) {
+                "<unparseable url>"
+            } else {
+                val portStr = if (uri.port != -1) ":${uri.port}" else ""
+                val path = uri.path.orEmpty()
+                val queryStr = if (uri.query != null) "?${uri.query}" else ""
+                val fragmentStr = if (uri.fragment != null) "#${uri.fragment}" else ""
+                "$scheme://$host$portStr$path$queryStr$fragmentStr"
+            }
+        } catch (e: Exception) {
+            "<unparseable url>"
+        }
+    }
+
     fun getUserInfo(userInfo: String?): Pair<String, String> {
         val info = userInfo?.split(":")?.dropLastWhile { it.isEmpty() }
         return if (info != null && info.size > 1) {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/UrlUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/UrlUtilsTest.kt
@@ -450,4 +450,54 @@ class UrlUtilsTest {
         assertEquals("http://example.com/db/resources/r2/f2", urls[1])
         verify(exactly = 1) { spm.getCouchdbUrl() }
     }
+
+    @Test
+    fun `redactForLog strips userinfo from standard CouchDB URL`() {
+        unmockkObject(UrlUtils)
+        val input = "http://satellite:1234@host.org:5984/db/resources/abc/file.pdf"
+        val result = UrlUtils.redactForLog(input)
+        assertEquals("http://host.org:5984/db/resources/abc/file.pdf", result)
+        assert(!result.contains("satellite"))
+        assert(!result.contains("1234"))
+        assert(!result.contains("@"))
+    }
+
+    @Test
+    fun `redactForLog handles https URL with port`() {
+        unmockkObject(UrlUtils)
+        val input = "https://user:pass@securehost.com:8443/db/teams/_bulk_docs"
+        val result = UrlUtils.redactForLog(input)
+        assertEquals("https://securehost.com:8443/db/teams/_bulk_docs", result)
+        assert(!result.contains("user"))
+        assert(!result.contains("pass"))
+        assert(!result.contains("@"))
+    }
+
+    @Test
+    fun `redactForLog returns URL without userinfo unchanged in substance`() {
+        unmockkObject(UrlUtils)
+        val input = "http://host.org:5984/db/resources/abc/file.pdf"
+        val result = UrlUtils.redactForLog(input)
+        assertEquals("http://host.org:5984/db/resources/abc/file.pdf", result)
+    }
+
+    @Test
+    fun `redactForLog handles empty and malformed URLs safely`() {
+        unmockkObject(UrlUtils)
+        assertEquals("<unparseable url>", UrlUtils.redactForLog(""))
+        assertEquals("<unparseable url>", UrlUtils.redactForLog(null))
+        assertEquals("<unparseable url>", UrlUtils.redactForLog("not a url"))
+        assertEquals("<unparseable url>", UrlUtils.redactForLog(":::invalid::"))
+    }
+
+    @Test
+    fun `redactForLog redacts password containing at sign or colon`() {
+        unmockkObject(UrlUtils)
+        val input = "http://admin:p%40ss%3Aword@server.com/db"
+        val result = UrlUtils.redactForLog(input)
+        assertEquals("http://server.com/db", result)
+        assert(!result.contains("admin"))
+        assert(!result.contains("p%40ss%3Aword"))
+        assert(!result.contains("@"))
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.tasks.Delete
 buildscript {
     repositories {
         google()
+        maven { url = uri("https://maven-central.storage-download.googleapis.com/maven2/") }
         mavenCentral()
     }
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.api.tasks.Delete
 buildscript {
     repositories {
         google()
-        maven { url = uri("https://maven-central.storage-download.googleapis.com/maven2/") }
         mavenCentral()
     }
     dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         google()
+        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -11,6 +12,7 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         google()
+        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         maven { url = uri('https://jitpack.io') }
         maven { url = uri('https://oss.sonatype.org/content/repositories/snapshots') }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
     repositories {
         google()
-        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -12,7 +11,6 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         google()
-        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         mavenCentral()
         maven { url = uri('https://jitpack.io') }
         maven { url = uri('https://oss.sonatype.org/content/repositories/snapshots') }


### PR DESCRIPTION
Redact credential-bearing URLs written to logcat across download and bulk upload paths using UrlUtils.redactForLog and getFileNameFromUrl, preventing credential leaks while keeping diagnostic logs intact.

Fixes #17137

---
*PR created automatically by Jules for task [9423076105100888388](https://jules.google.com/task/9423076105100888388) started by @dogi*