### PR TITLE
all: smoother user repository searching (fixes #17151)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
@@ -14,7 +14,8 @@ interface UserDao {
     @Query("SELECT * FROM users") suspend fun getAll(): List<UserEntity>
     @Query("SELECT * FROM users WHERE name = :name LIMIT 1") suspend fun getByName(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name = :name COLLATE NOCASE LIMIT 1") suspend fun getByNameIgnoreCase(name: String): UserEntity?
-    @Query("SELECT * FROM users WHERE name LIKE '%' || :query || '%' OR firstName LIKE '%' || :query || '%' OR lastName LIKE '%' || :query || '%'") suspend fun search(query: String): List<UserEntity>
+    @Query("SELECT * FROM users WHERE name LIKE :namePattern ESCAPE '\\' OR firstName LIKE :namePattern ESCAPE '\\' OR lastName LIKE :namePattern ESCAPE '\\'")
+    suspend fun search(namePattern: String): List<UserEntity>
     @Query("SELECT COUNT(*) FROM users") suspend fun count(): Int
     @Query("DELETE FROM users WHERE id = :id") suspend fun deleteById(id: String): Int
     @Query("DELETE FROM users WHERE id IN (:ids)") suspend fun deleteByIds(ids: List<String>): Int

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -166,8 +166,16 @@ class UserRepositoryImpl @Inject constructor(
         return sortUsers(getAllUsers(), fieldName, descending)
     }
 
+    private fun searchPattern(query: String): String {
+        val escaped = query
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        return "%$escaped%"
+    }
+
     override suspend fun searchUsers(query: String, sortField: String, descending: Boolean): List<UserEntity> {
-        val users = userDao.search(query)
+        val users = userDao.search(searchPattern(query))
         return sortUsers(users, sortField, descending)
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/UserDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/UserDaoTest.kt
@@ -115,6 +115,21 @@ class UserDaoTest {
     }
 
     @Test
+    fun search_escapesWildcardsCorrectly() = runBlocking {
+        userDao.upsert(createUser("u1", "r1", "50%off"))
+        userDao.upsert(createUser("u2", "r2", "a_b"))
+        userDao.upsert(createUser("u3", "r3", "john"))
+
+        val percentResults = userDao.search("%\\%%")
+        assertEquals(1, percentResults.size)
+        assertEquals("50%off", percentResults[0].name)
+
+        val underscoreResults = userDao.search("%a\\_b%")
+        assertEquals(1, underscoreResults.size)
+        assertEquals("a_b", underscoreResults[0].name)
+    }
+
+    @Test
     fun getDuplicateUsers_groupsByNullNamesCorrectly() = runBlocking {
         userDao.upsert(createUser("id1", "r1", "John"))
         userDao.upsert(createUser("id2", "r2", "John")) // Duplicate of John

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
@@ -371,6 +371,28 @@ class UserRepositoryImplTest {
     }
 
     @Test
+    fun `searchUsers escapes LIKE wildcards before querying`() = runTest(testDispatcher) {
+        coEvery { userDao.search(any()) } returns emptyList()
+
+        repository.searchUsers("100%_a\\b", "joinDate", true)
+
+        val slot = slot<String>()
+        coVerify { userDao.search(capture(slot)) }
+        assertEquals("%100\\%\\_a\\\\b%", slot.captured)
+    }
+
+    @Test
+    fun `searchUsers leaves a plain query unchanged apart from surrounding wildcards`() = runTest(testDispatcher) {
+        coEvery { userDao.search(any()) } returns emptyList()
+
+        repository.searchUsers("john", "joinDate", true)
+
+        val slot = slot<String>()
+        coVerify { userDao.search(capture(slot)) }
+        assertEquals("%john%", slot.captured)
+    }
+
+    @Test
     fun `updateProfileFields handles empty objects and converts primitive values while skipping nulls`() = runTest(testDispatcher) {
         val user = UserEntity().apply {
             id = "user1"


### PR DESCRIPTION
Escapes backslash, percent, and underscore characters in free-text user search queries in UserRepositoryImpl before querying UserDao, and adds ESCAPE '\' clauses to UserDao.search @Query. Also includes UserRepositoryImplTest and UserDaoTest tests verifying search wildcard escaping.

Fixes #17151

---
*PR created automatically by Jules for task [18157886742544623293](https://jules.google.com/task/18157886742544623293) started by @dogi*