### PR TITLE
courses: smoother dao querying (fixes #17152)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseDao.kt
@@ -10,7 +10,16 @@ import org.ole.planet.myplanet.model.MyCourse
 interface CourseDao {
     @Query("SELECT * FROM courses") suspend fun getAll(): List<MyCourse>
     @Query("SELECT * FROM courses WHERE courseId = :courseId OR id = :courseId LIMIT 1") suspend fun getByCourseId(courseId: String): MyCourse?
-    @Query("SELECT * FROM courses WHERE courseId IN (:courseIds) OR id IN (:courseIds) OR _id IN (:courseIds)") suspend fun getByCourseIds(courseIds: List<String>): List<MyCourse>
+    @Query("SELECT * FROM courses WHERE courseId IN (:courseIds) OR id IN (:courseIds) OR _id IN (:courseIds)")
+    suspend fun getByCourseIdsInternal(courseIds: List<String>): List<MyCourse>
+
+    suspend fun getByCourseIds(courseIds: List<String>): List<MyCourse> {
+        if (courseIds.isEmpty()) return emptyList()
+        // Chunk size 300: query uses 3 IN clauses over courseIds, so 300 * 3 = 900 parameters < SQLITE_MAX_VARIABLE_NUMBER (999).
+        return courseIds.chunked(300)
+            .flatMap { getByCourseIdsInternal(it) }
+            .distinctBy { it.id }
+    }
     @Query("SELECT * FROM courses") fun observeAll(): Flow<List<MyCourse>>
     @Query("SELECT * FROM courses WHERE courseId = :courseId OR id = :courseId LIMIT 1") fun observeByCourseId(courseId: String): Flow<MyCourse?>
 

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/CourseDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/CourseDaoTest.kt
@@ -95,4 +95,59 @@ class CourseDaoTest {
         assertEquals(1, resultUser1Percent.size)
         assertTrue(resultUser1Percent.any { it.id == course5.id })
     }
+
+    @Test
+    fun getByCourseIds_withLargeList_returnsAllWithoutThrowing() = runBlocking {
+        val courses = (1..1200).map { i ->
+            MyCourse(
+                id = "id_$i",
+                courseId = "courseId_$i",
+                _id = "_id_$i"
+            )
+        }
+        courseDao.upsertAll(courses)
+
+        val searchIds = (1..1200).map { "id_$it" }
+        val result = courseDao.getByCourseIds(searchIds)
+        assertEquals(1200, result.size)
+    }
+
+    @Test
+    fun getByCourseIds_doesNotDuplicateWhenMatchedByDifferentColumnsInDifferentChunks() = runBlocking {
+        val course = MyCourse(
+            id = "course_pk",
+            courseId = "course_cid",
+            _id = "course_doc_id"
+        )
+        courseDao.upsertAll(listOf(course))
+
+        // Build list of >300 IDs such that "course_cid" is in chunk 1 and "course_doc_id" is in chunk 2
+        val idsChunk1 = listOf("course_cid") + (1..299).map { "dummy_chunk1_$it" }
+        val idsChunk2 = listOf("course_doc_id") + (1..100).map { "dummy_chunk2_$it" }
+        val allIds = idsChunk1 + idsChunk2
+
+        val result = courseDao.getByCourseIds(allIds)
+        assertEquals(1, result.size)
+        assertEquals("course_pk", result[0].id)
+    }
+
+    @Test
+    fun getByCourseIds_withEmptyList_returnsEmptyList() = runBlocking {
+        val result = courseDao.getByCourseIds(emptyList())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun getByCourseIds_matchesAcrossAllThreeColumns() = runBlocking {
+        val courseByCourseId = MyCourse(id = "pk1", courseId = "cid1", _id = "doc1")
+        val courseById = MyCourse(id = "pk2", courseId = "cid2", _id = "doc2")
+        val courseByDocId = MyCourse(id = "pk3", courseId = "cid3", _id = "doc3")
+
+        courseDao.upsertAll(listOf(courseByCourseId, courseById, courseByDocId))
+
+        val result = courseDao.getByCourseIds(listOf("cid1", "pk2", "doc3"))
+        assertEquals(3, result.size)
+        val resultIds = result.map { it.id }.toSet()
+        assertEquals(setOf("pk1", "pk2", "pk3"), resultIds)
+    }
 }


### PR DESCRIPTION
Chunk course ID lists in CourseDao.getByCourseIds into chunks of 300 to prevent SQLite variable limit crashes (300 * 3 = 900 < 999). Add unit tests in CourseDaoTest.kt covering large lists, cross-chunk deduplication, empty lists, and column matching.

Fixes #17152

---
*PR created automatically by Jules for task [3201346614717213747](https://jules.google.com/task/3201346614717213747) started by @dogi*