### PR TITLE
all: smoother docs code style testing (fixes #17156)

### DIFF
--- a/docs/CODE_STYLE_GUIDE.md
+++ b/docs/CODE_STYLE_GUIDE.md
@@ -210,7 +210,7 @@ companion object {
 | Repository interface | `*Repository.kt` | `CoursesRepository.kt` |
 | Repository implementation | `*RepositoryImpl.kt` | `CoursesRepositoryImpl.kt` |
 | Room entity | plain name in `model/` | `MyCourse.kt`, `Submission.kt`, `UserEntity.kt` |
-| Room DAO | `*Dao.kt` in `data/room/dao/` | `RatingDao.kt` (several small DAOs share `LegacyEntityDaos.kt`) |
+| Room DAO | `*Dao.kt` in `data/room/dao/` | `RatingDao.kt` (37 DAO interfaces in 37 files; each DAO lives in its own file) |
 | Worker | `*Worker.kt` | `AutoSyncWorker.kt` |
 | Callback interface | `On` prefix | `OnCourseItemSelectedListener.kt` |
 | DI module | `Module` suffix | `RepositoryModule.kt` |
@@ -401,7 +401,7 @@ For internal-only network calls use `NetworkResult<T>` (the sealed class in `dat
 
 ## Room Database
 
-All local persistence goes through Room: `AppDatabase` (`data/room/AppDatabase.kt`, 37 entities, `version = 6`), DAOs in `data/room/dao/`, and `Converters` (`data/room/Converters.kt`). There is no other local store.
+All local persistence goes through Room: `AppDatabase` (`data/room/AppDatabase.kt`, 38 entities, `version = 12`), DAOs in `data/room/dao/`, and `Converters` (`data/room/Converters.kt`). There is no other local store.
 
 ### Entity Classes
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,7 +29,7 @@ There is currently **no `app/src/androidTest/` (instrumented) source set** — t
 
 When you need to verify real database behavior (actual SQL, `Converters`, transactions), you don't need a device: use **Robolectric + `Room.inMemoryDatabaseBuilder`** inside `src/test/` — see [DAO / Room round-trip tests](#daos--room-round-trip-tests) below.
 
-Package breakdown (166 files = 163 test classes + 3 shared infra): `utils/` 44, `ui/` 39, `repository/` 32, `services/` 22, `model/` 11, `data/` 8, `base/` 7, `di/` 2, root 1.
+Package breakdown (269 files = 265 test classes + 4 shared infra; `.kt` files under subpackages are counted recursively): `utils/` 57, `ui/` 90, `repository/` 37, `services/` 34, `model/` 21, `data/` 18, `base/` 9, `di/` 2, root 1.
 
 ---
 
@@ -40,7 +40,7 @@ From `app/build.gradle` (`testImplementation` block) and what's actually importe
 | Library | Purpose | Notes |
 |---------|---------|-------|
 | JUnit 4 (`org.junit.Test`, `org.junit.Assert.*`) | Test runner and assertions | Used everywhere |
-| **MockK** (`io.mockk.*`) | Mocking | **The standard.** Used in 113 of the 166 files. |
+| **MockK** (`io.mockk.*`) | Mocking | **The standard.** Used in 173 of the 269 files. |
 | Mockito (`org.mockito.*`) | Mocking | Legacy — exactly 2 files (`CoursesAdapterTest`, `SubmissionViewModelTest`). Don't introduce new Mockito usage; use MockK. |
 | Robolectric (`org.robolectric.*`) | Android framework on the JVM | 43 files — wherever a test needs real Android classes (`Context`, `View`, resource strings, Room) without an emulator |
 | `kotlinx-coroutines-test` | `runTest`, `TestDispatcher`, `UnconfinedTestDispatcher`, `StandardTestDispatcher` | For suspend functions and Flow/StateFlow-based ViewModels |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,7 +42,7 @@ From `app/build.gradle` (`testImplementation` block) and what's actually importe
 | JUnit 4 (`org.junit.Test`, `org.junit.Assert.*`) | Test runner and assertions | Used everywhere |
 | **MockK** (`io.mockk.*`) | Mocking | **The standard.** Used in 173 of the 269 files. |
 | Mockito (`org.mockito.*`) | Mocking | Legacy — exactly 2 files (`CoursesAdapterTest`, `SubmissionViewModelTest`). Don't introduce new Mockito usage; use MockK. |
-| Robolectric (`org.robolectric.*`) | Android framework on the JVM | 43 files — wherever a test needs real Android classes (`Context`, `View`, resource strings, Room) without an emulator |
+| Robolectric (`org.robolectric.*`) | Android framework on the JVM | 78 files — wherever a test needs real Android classes (`Context`, `View`, resource strings, Room) without an emulator |
 | `kotlinx-coroutines-test` | `runTest`, `TestDispatcher`, `UnconfinedTestDispatcher`, `StandardTestDispatcher` | For suspend functions and Flow/StateFlow-based ViewModels |
 | `androidx.test` (`ApplicationProvider`, `AndroidJUnit4`) | Application context access | Used inside Robolectric JVM tests |
 | `androidx.room:room-testing` | Room test helpers | Backs the in-memory Room tests |


### PR DESCRIPTION
Updated stale documentation figures and removed non-existent file reference in `docs/CODE_STYLE_GUIDE.md` and `docs/TESTING.md`.

Fixes #17156

---
*PR created automatically by Jules for task [12336741542029416239](https://jules.google.com/task/12336741542029416239) started by @dogi*