### PR TITLE
teams: smoother requests members view modelling (fixes #17165)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
@@ -90,73 +90,60 @@ class MembersFragment : BaseTeamFragment() {
             onMemberChangeListener?.onChanged()
             loadMembers()
         }
+        collectWhenStarted(requestsViewModel.membersState) { state ->
+            membersAdapter?.setUserId(state.currentUserId)
+            membersAdapter?.updateData(state.members, state.isLeader)
+            BaseRecyclerFragment.showNoData(binding.tvNodata, state.members.size, "")
+        }
+        collectWhenStarted(requestsViewModel.actionResults) { result ->
+            when (result) {
+                MemberActionResult.LeftTeam -> {
+                    Toast.makeText(requireContext(), getString(R.string.left_team), Toast.LENGTH_SHORT).show()
+                    requireActivity().supportFragmentManager.popBackStack()
+                }
+                MemberActionResult.MemberRemoved -> {
+                    onMemberChangeListener?.onChanged()
+                    requestsViewModel.fetchMembers(teamId)
+                }
+                MemberActionResult.CannotRemoveLastLeader -> {
+                    Toast.makeText(requireContext(), R.string.cannot_remove_user, Toast.LENGTH_SHORT).show()
+                }
+                MemberActionResult.LeaderChanged -> {
+                    Toast.makeText(requireContext(), getString(R.string.leader_selected), Toast.LENGTH_SHORT).show()
+                    onMemberChangeListener?.onChanged()
+                }
+                is MemberActionResult.Failed -> {
+                    val actionStr = when (result.action) {
+                        MemberAction.LEAVE_TEAM -> "leaving team"
+                        MemberAction.REMOVE_MEMBER -> "removing member"
+                        MemberAction.MAKE_LEADER -> "making leader"
+                    }
+                    Toast.makeText(requireContext(), "Error $actionStr: ${result.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 
     private fun loadMembers() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            val members = teamsRepository.getJoinedMembersWithVisitInfo(teamId)
-            val currentUserId = ensureUserResolved()?.id
-            val isLeader = members.any { it.user.id == currentUserId && it.isLeader }
-            membersAdapter?.setUserId(currentUserId)
-            membersAdapter?.updateData(members, isLeader)
-            BaseRecyclerFragment.showNoData(binding.tvNodata, members.size, "")
-        }
+        requestsViewModel.loadJoinedMembers(teamId)
     }
 
     private fun handleLeaveTeam() {
         requireContext().confirmDialog(
             message = getString(R.string.confirm_exit),
             onPositive = {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    try {
-                        val nextLeader = teamsRepository.getNextLeaderCandidate(teamId, user?.id)
-                        nextLeader?.id?.let { teamsRepository.updateTeamLeader(teamId, it) }
-                        user?.id?.let { teamsRepository.removeMember(teamId, it) }
-                        loadMembers()
-                        Toast.makeText(requireContext(), getString(R.string.left_team), Toast.LENGTH_SHORT).show()
-                        requireActivity().supportFragmentManager.popBackStack()
-                    } catch (e: Exception) {
-                        Toast.makeText(requireContext(), "Error leaving team: ${e.message}", Toast.LENGTH_SHORT).show()
-                    }
-                }
+                requestsViewModel.leaveTeam(teamId)
             }
         )
     }
 
     private fun handleRemoveMember(member: JoinedMemberData) {
         val memberId = member.user.id ?: return
-        viewLifecycleOwner.lifecycleScope.launch {
-            try {
-                if (user?.id == memberId) {
-                    val nextLeader = teamsRepository.getNextLeaderCandidate(teamId, memberId)
-                    if (nextLeader != null) {
-                        nextLeader.id?.let { teamsRepository.updateTeamLeader(teamId, it) }
-                    } else {
-                        Toast.makeText(requireContext(), R.string.cannot_remove_user, Toast.LENGTH_SHORT).show()
-                        return@launch
-                    }
-                }
-                teamsRepository.removeMember(teamId, memberId)
-                loadMembers()
-                onMemberChangeListener?.onChanged()
-                requestsViewModel.fetchMembers(teamId)
-            } catch (e: Exception) {
-                Toast.makeText(requireContext(), "Error removing member: ${e.message}", Toast.LENGTH_SHORT).show()
-            }
-        }
+        requestsViewModel.removeMember(teamId, memberId)
     }
 
     private fun handleMakeLeader(userId: String) {
-        viewLifecycleOwner.lifecycleScope.launch {
-            try {
-                teamsRepository.updateTeamLeader(teamId, userId)
-                loadMembers()
-                Toast.makeText(requireContext(), getString(R.string.leader_selected), Toast.LENGTH_SHORT).show()
-                onMemberChangeListener?.onChanged()
-            } catch (e: Exception) {
-                Toast.makeText(requireContext(), "Error making leader: ${e.message}", Toast.LENGTH_SHORT).show()
-            }
-        }
+        requestsViewModel.makeLeader(teamId, userId)
     }
 
     override fun onNewsItemClick(news: News?) {}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/RequestsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/RequestsViewModel.kt
@@ -8,10 +8,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.JoinedMemberData
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.TeamsMembersRepository
 import org.ole.planet.myplanet.repository.UserRepository
@@ -21,6 +23,26 @@ data class RequestsUiState(
     val isLeader: Boolean = false,
     val memberCount: Int = 0
 )
+
+data class MembersUiState(
+    val members: List<JoinedMemberData> = emptyList(),
+    val currentUserId: String? = null,
+    val isLeader: Boolean = false
+)
+
+enum class MemberAction {
+    LEAVE_TEAM,
+    REMOVE_MEMBER,
+    MAKE_LEADER
+}
+
+sealed interface MemberActionResult {
+    data object LeftTeam : MemberActionResult
+    data object MemberRemoved : MemberActionResult
+    data object CannotRemoveLastLeader : MemberActionResult
+    data object LeaderChanged : MemberActionResult
+    data class Failed(val action: MemberAction, val message: String?) : MemberActionResult
+}
 
 @HiltViewModel
 class RequestsViewModel @Inject constructor(
@@ -32,6 +54,73 @@ class RequestsViewModel @Inject constructor(
     val uiState: StateFlow<RequestsUiState> = _uiState.asStateFlow()
     private val _successAction = MutableSharedFlow<Unit>()
     val successAction = _successAction.asSharedFlow()
+
+    private val _membersState = MutableStateFlow(MembersUiState())
+    val membersState: StateFlow<MembersUiState> = _membersState.asStateFlow()
+
+    private val _actionResults = MutableSharedFlow<MemberActionResult>()
+    val actionResults: SharedFlow<MemberActionResult> = _actionResults.asSharedFlow()
+
+    fun loadJoinedMembers(teamId: String) {
+        viewModelScope.launch {
+            val members = teamsRepository.getJoinedMembersWithVisitInfo(teamId)
+            val currentUserId = userRepository.getUserModel()?.id
+            _membersState.value = MembersUiState(
+                members = members,
+                currentUserId = currentUserId,
+                isLeader = members.any { it.user.id == currentUserId && it.isLeader }
+            )
+        }
+    }
+
+    fun leaveTeam(teamId: String) {
+        viewModelScope.launch {
+            try {
+                val currentUserId = userRepository.getUserModel()?.id
+                val nextLeader = teamsRepository.getNextLeaderCandidate(teamId, currentUserId)
+                nextLeader?.id?.let { teamsRepository.updateTeamLeader(teamId, it) }
+                currentUserId?.let { teamsRepository.removeMember(teamId, it) }
+                loadJoinedMembers(teamId)
+                _actionResults.emit(MemberActionResult.LeftTeam)
+            } catch (e: Exception) {
+                _actionResults.emit(MemberActionResult.Failed(MemberAction.LEAVE_TEAM, e.message))
+            }
+        }
+    }
+
+    fun removeMember(teamId: String, memberId: String) {
+        viewModelScope.launch {
+            try {
+                val currentUserId = userRepository.getUserModel()?.id
+                if (currentUserId == memberId) {
+                    val nextLeader = teamsRepository.getNextLeaderCandidate(teamId, memberId)
+                    if (nextLeader != null) {
+                        nextLeader.id?.let { teamsRepository.updateTeamLeader(teamId, it) }
+                    } else {
+                        _actionResults.emit(MemberActionResult.CannotRemoveLastLeader)
+                        return@launch
+                    }
+                }
+                teamsRepository.removeMember(teamId, memberId)
+                loadJoinedMembers(teamId)
+                _actionResults.emit(MemberActionResult.MemberRemoved)
+            } catch (e: Exception) {
+                _actionResults.emit(MemberActionResult.Failed(MemberAction.REMOVE_MEMBER, e.message))
+            }
+        }
+    }
+
+    fun makeLeader(teamId: String, userId: String) {
+        viewModelScope.launch {
+            try {
+                teamsRepository.updateTeamLeader(teamId, userId)
+                loadJoinedMembers(teamId)
+                _actionResults.emit(MemberActionResult.LeaderChanged)
+            } catch (e: Exception) {
+                _actionResults.emit(MemberActionResult.Failed(MemberAction.MAKE_LEADER, e.message))
+            }
+        }
+    }
 
     fun fetchMembers(teamId: String) {
         viewModelScope.launch {

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/members/RequestsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/members/RequestsViewModelTest.kt
@@ -2,19 +2,24 @@ package org.ole.planet.myplanet.ui.teams.members
 
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifySequence
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.ole.planet.myplanet.model.JoinedMemberData
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.TeamsMembersRepository
 import org.ole.planet.myplanet.repository.UserRepository
@@ -82,17 +87,14 @@ class RequestsViewModelTest {
 
         assertEquals(2, viewModel.uiState.value.members.size)
 
-        coEvery { teamsRepository.respondToMemberRequest(teamId, user1.id!!, true) } returns Result.success(Unit)
+        coEvery { teamsRepository.respondToMemberRequest(teamId, user1.id, true) } returns Result.success(Unit)
         coEvery { teamsRepository.recordTeamActivity() } returns Unit
 
-        // Setup fetchMembers for the success path
         val newMembers = listOf(user2)
         coEvery { teamsRepository.getRequestedMembers(teamId) } returns newMembers
 
         viewModel.respondToRequest(teamId, user1, true)
 
-        // Assert optimistic update before coroutines finish.
-        // This relies on the ViewModel applying it synchronously before the coroutine suspension.
         val uiStateBeforeCompletion = viewModel.uiState.value
         assertEquals(1, uiStateBeforeCompletion.members.size)
         assertEquals(user2.id, uiStateBeforeCompletion.members[0].id)
@@ -121,12 +123,10 @@ class RequestsViewModelTest {
 
         assertEquals(2, viewModel.uiState.value.members.size)
 
-        coEvery { teamsRepository.respondToMemberRequest(teamId, user1.id!!, true) } returns Result.failure(Exception("err"))
+        coEvery { teamsRepository.respondToMemberRequest(teamId, user1.id, true) } returns Result.failure(Exception("err"))
 
         viewModel.respondToRequest(teamId, user1, true)
 
-        // Assert optimistic update before coroutines finish.
-        // This relies on the ViewModel applying it synchronously before the coroutine suspension.
         val uiStateBeforeCompletion = viewModel.uiState.value
         assertEquals(1, uiStateBeforeCompletion.members.size)
         assertEquals(user2.id, uiStateBeforeCompletion.members[0].id)
@@ -162,5 +162,145 @@ class RequestsViewModelTest {
         assertTrue(uiState.isLeader)
         assertEquals(1, uiState.memberCount)
         coVerify(exactly = 1) { teamsRepository.isTeamLeader(teamId, currentUser.id) }
+    }
+
+    @Test
+    fun `loadJoinedMembers publishes members and derives isLeader from loaded list`() = runTest(testDispatcher) {
+        val teamId = "team1"
+        val currentUserId = "currentUser"
+        val currentUser = UserEntity().apply { id = currentUserId }
+        val user2 = UserEntity().apply { id = "user2" }
+        val user3 = UserEntity().apply { id = "user3" }
+
+        val member1 = JoinedMemberData(currentUser, 0L, null, "", "", isLeader = true)
+        val member2 = JoinedMemberData(user2, 0L, null, "", "", isLeader = false)
+        val member3 = JoinedMemberData(user3, 0L, null, "", "", isLeader = false)
+        val membersLeader = listOf(member1, member2, member3)
+
+        coEvery { userRepository.getUserModel() } returns currentUser
+        coEvery { teamsRepository.getJoinedMembersWithVisitInfo(teamId) } returns membersLeader
+
+        viewModel.loadJoinedMembers(teamId)
+        advanceUntilIdle()
+
+        val stateLeader = viewModel.membersState.value
+        assertEquals(membersLeader, stateLeader.members)
+        assertEquals(currentUserId, stateLeader.currentUserId)
+        assertTrue(stateLeader.isLeader)
+
+        val member1NotLeader = JoinedMemberData(currentUser, 0L, null, "", "", isLeader = false)
+        val membersNotLeader = listOf(member1NotLeader, member2, member3)
+
+        coEvery { teamsRepository.getJoinedMembersWithVisitInfo(teamId) } returns membersNotLeader
+
+        viewModel.loadJoinedMembers(teamId)
+        advanceUntilIdle()
+
+        val stateNotLeader = viewModel.membersState.value
+        assertEquals(membersNotLeader, stateNotLeader.members)
+        assertEquals(currentUserId, stateNotLeader.currentUserId)
+        assertFalse(stateNotLeader.isLeader)
+
+        coVerify(exactly = 0) { teamsRepository.isTeamLeader(any(), any()) }
+    }
+
+    @Test
+    fun `removeMember promotes next leader when user removes themselves`() = runTest(testDispatcher) {
+        val teamId = "team1"
+        val currentUserId = "currentUser"
+        val currentUser = UserEntity().apply { id = currentUserId }
+        val candidate = UserEntity().apply { id = "candidate1" }
+
+        coEvery { userRepository.getUserModel() } returns currentUser
+        coEvery { teamsRepository.getNextLeaderCandidate(teamId, currentUserId) } returns candidate
+        coEvery { teamsRepository.updateTeamLeader(teamId, "candidate1") } returns true
+        coEvery { teamsRepository.removeMember(teamId, currentUserId) } returns Unit
+        coEvery { teamsRepository.getJoinedMembersWithVisitInfo(teamId) } returns emptyList()
+
+        val results = mutableListOf<MemberActionResult>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.actionResults.collect { results.add(it) }
+        }
+
+        viewModel.removeMember(teamId, currentUserId)
+        advanceUntilIdle()
+
+        coVerifySequence {
+            teamsRepository.getNextLeaderCandidate(teamId, currentUserId)
+            teamsRepository.updateTeamLeader(teamId, "candidate1")
+            teamsRepository.removeMember(teamId, currentUserId)
+            teamsRepository.getJoinedMembersWithVisitInfo(teamId)
+        }
+        assertEquals(listOf(MemberActionResult.MemberRemoved), results)
+    }
+
+    @Test
+    fun `removeMember refuses to remove last leader`() = runTest(testDispatcher) {
+        val teamId = "team1"
+        val currentUserId = "currentUser"
+        val currentUser = UserEntity().apply { id = currentUserId }
+
+        coEvery { userRepository.getUserModel() } returns currentUser
+        coEvery { teamsRepository.getNextLeaderCandidate(teamId, currentUserId) } returns null
+
+        val results = mutableListOf<MemberActionResult>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.actionResults.collect { results.add(it) }
+        }
+
+        viewModel.removeMember(teamId, currentUserId)
+        advanceUntilIdle()
+
+        assertEquals(listOf(MemberActionResult.CannotRemoveLastLeader), results)
+        coVerify(exactly = 0) { teamsRepository.removeMember(any(), any()) }
+    }
+
+    @Test
+    fun `removeMember skips leader logic for another user`() = runTest(testDispatcher) {
+        val teamId = "team1"
+        val currentUserId = "currentUser"
+        val otherUserId = "otherUser"
+        val currentUser = UserEntity().apply { id = currentUserId }
+
+        coEvery { userRepository.getUserModel() } returns currentUser
+        coEvery { teamsRepository.removeMember(teamId, otherUserId) } returns Unit
+        coEvery { teamsRepository.getJoinedMembersWithVisitInfo(teamId) } returns emptyList()
+
+        val results = mutableListOf<MemberActionResult>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.actionResults.collect { results.add(it) }
+        }
+
+        viewModel.removeMember(teamId, otherUserId)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { teamsRepository.getNextLeaderCandidate(any(), any()) }
+        coVerify(exactly = 1) { teamsRepository.removeMember(teamId, otherUserId) }
+        assertEquals(listOf(MemberActionResult.MemberRemoved), results)
+    }
+
+    @Test
+    fun `repository failure surfaces as Failed with message`() = runTest(testDispatcher) {
+        val teamId = "team1"
+        val currentUserId = "currentUser"
+        val currentUser = UserEntity().apply { id = currentUserId }
+        val errorMessage = "Database error"
+
+        coEvery { userRepository.getUserModel() } returns currentUser
+        coEvery { teamsRepository.getNextLeaderCandidate(teamId, currentUserId) } throws RuntimeException(errorMessage)
+
+        val results = mutableListOf<MemberActionResult>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.actionResults.collect { results.add(it) }
+        }
+
+        viewModel.leaveTeam(teamId)
+        advanceUntilIdle()
+
+        assertEquals(1, results.size)
+        assertTrue(results[0] is MemberActionResult.Failed)
+        val failedResult = results[0] as MemberActionResult.Failed
+        assertEquals(MemberAction.LEAVE_TEAM, failedResult.action)
+        assertEquals(errorMessage, failedResult.message)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.api.tasks.Delete
 
 buildscript {
     repositories {
+        maven { url = uri("https://maven-central.storage-download.googleapis.com/maven2/") }
         google()
         mavenCentral()
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import org.gradle.api.tasks.Delete
 
 buildscript {
     repositories {
-        maven { url = uri("https://maven-central.storage-download.googleapis.com/maven2/") }
         google()
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         google()
         mavenCentral()
         gradlePluginPortal()
@@ -10,6 +11,7 @@ plugins {
 }
 dependencyResolutionManagement {
     repositories {
+        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         google()
         mavenCentral()
         maven { url = uri('https://jitpack.io') }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         google()
         mavenCentral()
         gradlePluginPortal()
@@ -11,7 +10,6 @@ plugins {
 }
 dependencyResolutionManagement {
     repositories {
-        maven { url = uri('https://maven-central.storage-download.googleapis.com/maven2/') }
         google()
         mavenCentral()
         maven { url = uri('https://jitpack.io') }


### PR DESCRIPTION
Hoisted MembersFragment team-member loading and mutation logic into RequestsViewModel. Added state flows and action result events, updated MembersFragment, and added comprehensive unit tests.

Fixes #17165

---
*PR created automatically by Jules for task [6383845198477946207](https://jules.google.com/task/6383845198477946207) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team member management now supports leaving a team, removing members, and promoting members to leaders.
  * Leader protections prevent removing the last team leader and support leader reassignment when needed.
  * Member lists and leadership status refresh automatically after actions, with clear success or failure feedback.

* **Bug Fixes**
  * Improved handling of member-loading and team-action failures.

* **Tests**
  * Added coverage for member actions, leader transitions, protections, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->