### PR TITLE
chat: smoother history voices share view modelling (fixes #16314)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -226,6 +226,7 @@ class ChatHistoryFragment : Fragment() {
                     if (isAdded && _binding != null) {
                         if (user?.planetCode != null) {
                             sharedNewsMessages = sharedNewsMessages + result.news
+                            sharedViewInIds = sharedViewModel.extractSharedViewInIds(sharedNewsMessages)
                         }
                         (binding.recyclerView.adapter as? ChatHistoryAdapter)?.let { adapter ->
                             adapter.updateCachedData(user, sharedNewsMessages, sharedViewInIds)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -316,4 +316,7 @@ class ChatViewModel @Inject constructor(
     suspend fun getUserById(userId: String): UserEntity? {
         return userRepository.getUserById(userId)
     }
+    fun extractSharedViewInIds(sharedNewsMessages: List<News>): Map<String, Set<String>> {
+        return chatRepository.extractSharedViewInIds(sharedNewsMessages)
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -82,7 +82,8 @@ class VoicesAdapter(
                         oldItem.userName == newItem.userName && oldItem.userId == newItem.userId &&
                         oldItem.sharedBy == newItem.sharedBy && oldItem.labels == newItem.labels &&
                         oldItem.avatar == newItem.avatar && oldItem.imageUrls == newItem.imageUrls &&
-                        oldItem.images == newItem.images && oldItem.replyTo == newItem.replyTo
+                        oldItem.images == newItem.images && oldItem.replyTo == newItem.replyTo &&
+                        oldItem.viewIn == newItem.viewIn
             } catch (e: Exception) {
                 false
             }
@@ -103,6 +104,10 @@ class VoicesAdapter(
                 payloads.add(PAYLOAD_EDIT_ACTION)
             }
 
+            if (oldItem.viewIn != newItem.viewIn) {
+                payloads.add(PAYLOAD_VIEW_IN_CHANGED)
+            }
+
             // Every field checked in areContentsTheSame is covered by the buckets above.
             // If payloads is empty here, it means a future field was added to areContentsTheSame
             // without a corresponding bucket. We MUST return null to trigger a full rebind to prevent stale UI.
@@ -119,6 +124,7 @@ class VoicesAdapter(
         const val PAYLOAD_EDIT_ACTION = "PAYLOAD_EDIT_ACTION"
         const val PAYLOAD_LABELS_CHANGED = "PAYLOAD_LABELS_CHANGED"
         const val PAYLOAD_IMAGES_CHANGED = "PAYLOAD_IMAGES_CHANGED"
+        const val PAYLOAD_VIEW_IN_CHANGED = "PAYLOAD_VIEW_IN_CHANGED"
     }
 
     private data class RowState(
@@ -312,6 +318,11 @@ class VoicesAdapter(
                         configureEditDeleteButtons(holder, news)
                         showReplyButton(holder, news, position)
                         handleChat(holder, news)
+                    }
+                    PAYLOAD_VIEW_IN_CHANGED -> {
+                        showShareButton(holder, news)
+                        val sharedTeamName = news.parsedSharedTeamName ?: JsonUtils.extractSharedTeamName(news)
+                        setMessageAndDate(holder, news, sharedTeamName)
                     }
                 }
             }


### PR DESCRIPTION

https://github.com/user-attachments/assets/8b67cdb9-b71c-4bd4-bf1a-35541d659fbf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Shared chat messages now refresh their view-in mappings after successful sharing.
  - Voice message rows update correctly when view-in information changes.
  - Share controls and message details now reflect updated sharing information without requiring a full refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->